### PR TITLE
[REST] az rest: fix "endpoint not set" 

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -574,8 +574,12 @@ def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  #
     if not skip_authorization_header and uri.lower().startswith('https://'):
         if not resource:
             endpoints = cli_ctx.cloud.endpoints
+            from azure.cli.core.cloud import CloudEndpointNotSetException
             for p in [x for x in dir(endpoints) if not x.startswith('_')]:
-                value = getattr(endpoints, p)
+                try:
+                    value = getattr(endpoints, p)
+                except CloudEndpointNotSetException:
+                    continue
                 if isinstance(value, six.string_types) and uri.lower().startswith(value.lower()):
                     resource = value
                     break


### PR DESCRIPTION
Fix #11424: `az rest` in AzureChinaCloud fails on missing `active_directory_data_lake_resource_id`

This is because `send_raw_request` can't handle `CloudEndpointNotSetException` when the endpoint is `None`.
