### PR TITLE
remove single quote from acr task credential example

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -624,26 +624,26 @@ examples:
   - name: Add a registry login credential to a task using a plain text username and password.
     text: |
         az acr task credential add -n taskname -r registryname --login-server myregistry.docker.io \\
-            -u 'myusername' -p 'mysecret'
+            -u myusername -p mysecret
   - name: Add a registry login credential to a task using key vault secret URIs for the username and password and the task system-assigned identity.
     text: |
         az acr task credential add -n taskname -r registryname --login-server myregistry.docker.io \\
-            -u 'https://mykeyvault.vault.azure.net/secrets/secretusername' -p 'https://mykeyvault.vault.azure.net/secrets/secretpassword' \\
+            -u https://mykeyvault.vault.azure.net/secrets/secretusername -p https://mykeyvault.vault.azure.net/secrets/secretpassword \\
             --use-identity [system]
   - name: Add a registry login credential to a task using key vault secret URIs for the username and password and a task user-assigned identity given by its client id.
     text: |
         az acr task credential add -n taskname -r registryname --login-server myregistry.docker.io \\
-            -u 'https://mykeyvault.vault.azure.net/secrets/secretusername' -p 'https://mykeyvault.vault.azure.net/secrets/secretpassword' \\
+            -u https://mykeyvault.vault.azure.net/secrets/secretusername -p https://mykeyvault.vault.azure.net/secrets/secretpassword \\
             --use-identity 00000000-0000-0000-0000-000000000000
   - name: Add a registry login credential to a task using a plain text username and key vault secret URI for the password and the task user-assigned identity given by its client id.
     text: |
         az acr task credential add -n taskname -r registryname --login-server myregistry.docker.io \\
-            -u 'myusername' -p 'https://mykeyvault.vault.azure.net/secrets/secretpassword' \\
+            -u myusername -p https://mykeyvault.vault.azure.net/secrets/secretpassword \\
             --use-identity 00000000-0000-0000-0000-000000000000
   - name: Add a registry login credential to a task using a plain text username and key vault secret URI for the password and the default managed identity for the task if one exists.
     text: |
         az acr task credential add -n taskname -r registryname --login-server myregistry.docker.io \\
-            -u 'myusername' -p 'https://mykeyvault.vault.azure.net/secrets/secretpassword'
+            -u myusername -p https://mykeyvault.vault.azure.net/secrets/secretpassword
   - name: Add a registry login credential to a task that uses only the task system-assigned identity to authenticate to the registry.
     text: |
         az acr task credential add -n taskname -r registryname --login-server myregistry.docker.io \\
@@ -675,7 +675,7 @@ examples:
   - name: Update the credential for a task
     text: |
         az acr task credential update -n taskname -r registryname --login-server myregistry.docker.io \\
-            -u 'myusername2' -p 'mysecret'
+            -u myusername2 -p mysecret
 """
 
 helps['acr task delete'] = """


### PR DESCRIPTION
Single quote is included in the value string passed into the command in windows cmd shell. No need to use quote in the command so remove it from the examples.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
