### PR TITLE
Fix property name for Kubernetes version to show in az aks nodepool list

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_format.py
@@ -19,7 +19,7 @@ def _aks_agentpool_table_format(result):
     parsed = compile_jmes("""{
         name: name,
         osType: osType,
-        kubernetesVersion: kubernetesVersion,
+        kubernetesVersion: orchestratorVersion,
         vmSize: vmSize,
         osDiskSizeGB: osDiskSizeGB,
         count: count,


### PR DESCRIPTION
This PR fixes the `az aks nodepool list` custom formatter to reference the correct property name for the Kubernetes version, which is `orchestratorVersion`. This ensures that the Kubernetes version actually shows up when nodepools are listed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
