### PR TITLE
Fix #11084: Confusing encoding information

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -26,6 +26,7 @@ Release History
 **Key Vault**
 
 * Fix #10846: Calling az keyvault secret show-deleted --id <value> still says secret_name "can not" be none
+* Fix #11084: Confusing encoding information
 
 **Network**
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -181,7 +181,7 @@ def load_arguments(self, _):
 
     with self.argument_context('keyvault secret download') as c:
         c.argument('file_path', options_list=['--file', '-f'], type=file_type, completer=FilesCompleter(), help='File to receive the secret contents.')
-        c.argument('encoding', arg_type=get_enum_type(secret_encoding_values), options_list=['--encoding', '-e'], help="Encoding of the destination file. By default, will look for the 'file-encoding' tag on the secret. Otherwise will assume 'utf-8'.", default=None)
+        c.argument('encoding', arg_type=get_enum_type(secret_encoding_values), options_list=['--encoding', '-e'], help="Encoding of the secret. By default, will look for the 'file-encoding' tag on the secret. Otherwise will assume 'utf-8'.", default=None)
 
     for scope in ['backup', 'restore']:
         with self.argument_context('keyvault secret {}'.format(scope)) as c:


### PR DESCRIPTION
---
Fix #11084

The help message of `--encoding` param in command `az keyvault secret download` is a little bit confused. 

This is a good example: 
https://github.com/Azure/azure-cli/blob/4f89b707cc28658d41b38a1e03bb240894975f15/src/azure-cli/azure/cli/command_modules/keyvault/_params.py#L256-L258


This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
