### PR TITLE
[Storage] Fix#11043: Support remove whole container/share in az storage remove command

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -61,6 +61,7 @@ Release History
 * GA Release Large File Shares property for storage account create and update command
 * GA Release User Delegation SAS token Support
 * Add new commands `az storage account blob-service-properties show` and `az storage account blob-service-properties update --enable-change-feed` to manage blob service properties for storage account.
+* Fix issue #11043: Support to remove container/share contents in `az storage remove` command
 
 2.0.77
 ++++++

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -61,7 +61,7 @@ Release History
 * GA Release Large File Shares property for storage account create and update command
 * GA Release User Delegation SAS token Support
 * Add new commands `az storage account blob-service-properties show` and `az storage account blob-service-properties update --enable-change-feed` to manage blob service properties for storage account.
-* Fix issue #11043: Support to remove container/share contents in `az storage remove` command
+* Fix issue #11043: Support to remove whole container/share in `az storage remove` command
 
 2.0.77
 ++++++

--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -1147,6 +1147,8 @@ examples:
   - name: Remove an entire virtual directory.
     text: az storage remove -c MyContainer -n path/to/directory --recursive
   - name: Remove only the top blobs inside a virtual directory but not its sub-directories.
+    text: az storage remove -c MyContainer --recursive
+  - name: Remove all the blobs in a Storage Container.
     text: az storage remove -c MyContainer -n path/to/directory
   - name: Remove a subset of blobs in a virtual directory (For example, only jpg and pdf files, or if the blob name is "exactName").
     text: az storage remove -c MyContainer -n path/to/directory --recursive --include "*.jpg;*.pdf;exactName"
@@ -1156,6 +1158,8 @@ examples:
     text: az storage remove -s MyShare -p MyFile
   - name: Remove an entire directory.
     text: az storage remove -s MyShare -p path/to/directory --recursive
+  - name: Remove all the files in a Storage File Share.
+    text: az storage remove -s MyShare --recursive
 """
 
 helps['storage share'] = """

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -1072,8 +1072,8 @@ def validate_azcopy_remove_arguments(cmd, namespace):
     path = ns.pop('path', None)
 
     # ensure either a file or blob source is specified
-    valid_blob = container and blob and not share and not path
-    valid_file = share and path and not container and not blob
+    valid_blob = container and not share
+    valid_file = share and not container
 
     if not valid_blob and not valid_file:
         raise ValueError(usage_string.format('Neither a valid blob or file source is specified'))
@@ -1083,6 +1083,8 @@ def validate_azcopy_remove_arguments(cmd, namespace):
     if valid_blob:
         client = blob_data_service_factory(cmd.cli_ctx, {
             'account_name': namespace.account_name})
+        if not blob:
+            blob = ''
         url = client.make_blob_url(container, blob)
         namespace.service = 'blob'
         namespace.target = url

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -1058,8 +1058,8 @@ def validate_azcopy_upload_destination_url(cmd, namespace):
 def validate_azcopy_remove_arguments(cmd, namespace):
     usage_string = \
         'Invalid usage: {}. Supply only one of the following argument sets to specify source:' \
-        '\n\t   --container-name  --name' \
-        '\n\tOR --share-name --path'
+        '\n\t   --container-name  (--name)' \
+        '\n\tOR --share-name (--path)'
 
     ns = vars(namespace)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -1058,8 +1058,8 @@ def validate_azcopy_upload_destination_url(cmd, namespace):
 def validate_azcopy_remove_arguments(cmd, namespace):
     usage_string = \
         'Invalid usage: {}. Supply only one of the following argument sets to specify source:' \
-        '\n\t   --container-name  (--name)' \
-        '\n\tOR --share-name (--path)'
+        '\n\t   --container-name  [--name]' \
+        '\n\tOR --share-name [--path]'
 
     ns = vars(namespace)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -154,6 +154,11 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 21))
 
+        self.cmd('storage remove -c {} --account-name {} --recursive'.format(
+            container, storage_account))
+        self.cmd('storage blob list -c {} --account-name {}'.format(
+            container, storage_account), checks=JMESPathCheck('length(@)', 0))
+
     @ResourceGroupPreparer()
     @StorageAccountPreparer()
     def test_storage_file_azcopy_remove(self, resource_group, storage_account):
@@ -189,6 +194,11 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
                          account_info, s2, d2)
         self.storage_cmd('storage file exists -p "{}" -s {}', account_info, src2_file, s2) \
             .assert_with_checks(JMESPathCheck('exists', False))
+
+        self.storage_cmd('storage remove --share-name {}',
+                         account_info, s2)
+        self.storage_cmd('storage file list -s {}', account_info, s2) \
+            .assert_with_checks(JMESPathCheck('length(@)', 1))
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='first_account')

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -198,7 +198,8 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.storage_cmd('storage remove --share-name {}',
                          account_info, s2)
         self.storage_cmd('storage file list -s {}', account_info, s2) \
-            .assert_with_checks(JMESPathCheck('length(@)', 1))
+            .assert_with_checks(JMESPathCheck('length(@)', 1)) \
+            .assert_with_checks(JMESPathCheck('[0].type', 'dir'))
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='first_account')


### PR DESCRIPTION
Fix #11043
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
