### PR TITLE
Fix outdated reference to dc/os in az aks install-cli parameters help…

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -228,7 +228,7 @@ def load_arguments(self, _):
     for scope in ['aks', 'acs kubernetes', 'acs dcos']:
         with self.argument_context('{} install-cli'.format(scope)) as c:
             c.argument('client_version', validator=validate_k8s_client_version, help='Version of the client to install.')
-            c.argument('install_location', default=_get_default_install_location('kubectl'), help='Path at which to install DC/OS.')
+            c.argument('install_location', default=_get_default_install_location('kubectl'), help='Path at which to install kubectl.')
 
     with self.argument_context('aks install-connector') as c:
         c.argument('aci_resource_group', help='The resource group to create the ACI container groups')


### PR DESCRIPTION
The help text for `az aks install-cli` still referred to the DC/OS CLI instead of kubectl. Fixes #11191 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
