### PR TITLE
[login] apply configure_common_settings when creating SubscriptionClient

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,6 +3,8 @@
 Release History
 ===============
 
+* Fix #11586: `az login` is not recorded in server telemetry
+
 2.0.78
 
 * Plug in HaTS survey

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -755,11 +755,13 @@ class SubscriptionFinder(object):
                 return arm_client_factory(credentials)
             from azure.cli.core.profiles._shared import get_client_class
             from azure.cli.core.profiles import ResourceType, get_api_version
-            from azure.cli.core._debug import change_ssl_cert_verification
+            from azure.cli.core.commands.client_factory import configure_common_settings
             client_type = get_client_class(ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS)
             api_version = get_api_version(cli_ctx, ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS)
-            return change_ssl_cert_verification(client_type(credentials, api_version=api_version,
-                                                            base_url=self.cli_ctx.cloud.endpoints.resource_manager))
+            client = client_type(credentials, api_version=api_version,
+                                 base_url=self.cli_ctx.cloud.endpoints.resource_manager)
+            configure_common_settings(cli_ctx, client)
+            return client
 
         self._arm_client_factory = create_arm_client_factory
         self.tenants = []

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -934,6 +934,7 @@ class TestProfile(unittest.TestCase):
                 self.subscriptions = mock.MagicMock()
                 self.subscriptions.list.return_value = [TestProfile.subscription1]
                 self.config = mock.MagicMock()
+                self._client = mock.MagicMock()
 
         mock_get_client_class.return_value = ClientStub
         cli = DummyCli()
@@ -971,6 +972,7 @@ class TestProfile(unittest.TestCase):
                 self.subscriptions = mock.MagicMock()
                 self.subscriptions.list.return_value = []
                 self.config = mock.MagicMock()
+                self._client = mock.MagicMock()
 
         mock_get_client_class.return_value = ClientStub
         cli = DummyCli()
@@ -1008,6 +1010,7 @@ class TestProfile(unittest.TestCase):
                 self.subscriptions = mock.MagicMock()
                 self.subscriptions.list.return_value = [TestProfile.subscription1]
                 self.config = mock.MagicMock()
+                self._client = mock.MagicMock()
 
         mock_get_client_class.return_value = ClientStub
         cli = DummyCli()
@@ -1094,6 +1097,7 @@ class TestProfile(unittest.TestCase):
                 self.subscriptions = mock.MagicMock()
                 self.subscriptions.list.return_value = [TestProfile.subscription1]
                 self.config = mock.MagicMock()
+                self._client = mock.MagicMock()
 
         mock_get_client_class.return_value = ClientStub
         cli = DummyCli()


### PR DESCRIPTION
Fix #11586: `az login`'s **list subscription** requests not appearing in server telemetry

Root cause: when [creating `SubscriptionClient`](https://github.com/Azure/azure-cli/blob/465c0e9707d665ad9183522fae40a4b00c5cf7d8/src/azure-cli-core/azure/cli/core/_profile.py#L753-L762), CLI is not calling [`configure_common_settings`](https://github.com/Azure/azure-cli/blob/d1613b0d235327c766e448f89362526e2c15fb90/src/azure-cli-core/azure/cli/core/commands/client_factory.py#L79), where `User-Agent` is configured and additional header `CommandName`, `ParameterSetName` are added.

CLI can't use `azure.cli.core.commands.client_factory.get_mgmt_service_client` like other modules because `SubscriptionClient` has different `__init__` signature, and without a successful login, `get_mgmt_service_client` [fails to retrieve the credential](https://github.com/Azure/azure-cli/blob/d1613b0d235327c766e448f89362526e2c15fb90/src/azure-cli-core/azure/cli/core/commands/client_factory.py#L126). 

This PR applies `configure_common_settings` when creating `SubscriptionClient`.

For test cases, `ClientStub` needs `_client` attribute because it is directly [referenced in `configure_common_settings`](https://github.com/Azure/azure-cli/blob/d1613b0d235327c766e448f89362526e2c15fb90/src/azure-cli-core/azure/cli/core/commands/client_factory.py#L104).

To test, use `az login --debug` and check the stderr:

```
msrest.http_logger : Request URL: 'https://management.azure.com/subscriptions?api-version=2016-06-01'
msrest.http_logger : Request method: 'GET'
msrest.http_logger : Request headers:
msrest.http_logger :     'Accept': 'application/json'
msrest.http_logger :     'accept-language': 'en-US'
msrest.http_logger :     'User-Agent': 'python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2 azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.77'
```

To furtherly verify additional headers, [use Fiddler to capture network trace](https://github.com/Azure/azure-cli/blob/dev/doc/use_cli_effectively.md#working-behind-a-proxy). 

Sample request:

```http
GET https://management.azure.com/subscriptions?api-version=2016-06-01 HTTP/1.1
Host: management.azure.com
User-Agent: python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2 azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.77
Accept-Encoding: gzip, deflate
Accept: application/json
Connection: keep-alive
Authorization: Bearer xxx
CommandName: login
ParameterSetName: --service-principal -u -p -t --debug
accept-language: en-US
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
