### PR TITLE
[ACR] check-health regex fix for Helm3

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -23,7 +23,7 @@ IMAGE = "mcr.microsoft.com/mcr/hello-world:latest"
 FAQ_MESSAGE = "\nPlease refer to https://aka.ms/acr/health-check for more information."
 ERROR_MSG_DEEP_LINK = "\nPlease refer to https://aka.ms/acr/errors#{} for more information."
 MIN_HELM_VERSION = "2.11.0"
-HELM_VERSION_REGEX = re.compile(r'SemVer:"v([.\d]+)"', re.I)
+HELM_VERSION_REGEX = re.compile(r'(SemVer|Version):"v([.\d]+)"')
 ACR_CHECK_HEALTH_MSG = "Try running 'az acr check-health -n {} --yes' to diagnose this issue."
 
 
@@ -156,7 +156,7 @@ def _get_helm_version(ignore_errors):
     # Retrieve the helm version if regex pattern is found
     match_obj = HELM_VERSION_REGEX.search(output)
     if match_obj:
-        output = match_obj.group(1)
+        output = match_obj.group(2)
 
     print("Helm version: {}".format(output), file=sys.stderr)
 


### PR DESCRIPTION
Removed `re.I` flag since it's better to enforce a case sensitive regex match (`re.I` will have a case insensitive regex match). 

helm2 version:  `Client: &version.Version{SemVer:"v2.14.1", GitCommit:"5270352a09c7e8b6e8c9593002a73535276507c0", GitTreeState:"clean"}`

helm3 version: `version.BuildInfo{Version:"v3.0.1", GitCommit:"7c22ef9ce89e0ebeb7125ba2ebf7d421f3e82ffa", GitTreeState:"clean", GoVersion:"go1.13.4"}`

### Before fix
![image](https://user-images.githubusercontent.com/20955088/71201425-d8e68180-224e-11ea-8ad0-e344259150b1.png)

### After fix - Helm2 and Helm3
![image](https://user-images.githubusercontent.com/20955088/71201479-f61b5000-224e-11ea-83be-c4caf43e807d.png)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
