### PR TITLE
deprecate os parameter

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+**ACR**
+
+* [BREAKING CHANGE] Remove '--os' parameter for 'acr build', 'acr task create/update', 'acr run', and 'acr pack'. Use '--platform' instead.
+
 **AppConfig**
 
 * Add support for importing/exporting feature flags

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -59,7 +59,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('no_logs', help="Do not show logs after successfully queuing the build.", action='store_true')
         c.argument('no_wait', help="Do not wait for the run to complete and return immediately after queuing the run.", action='store_true')
         c.argument('no_format', help="Indicates whether the logs should be displayed in raw format", action='store_true')
-        c.argument('platform', options_list=['--platform', c.deprecate(target='--os', redirect='--platform', hide=True)], help="The platform where build/task is run, Eg, 'windows' and 'linux'. When it's used in build commands, it also can be specified in 'os/arch/variant' format for the resulting image. Eg, linux/arm/v7. The 'arch' and 'variant' parts are optional.")
+        c.argument('platform', help="The platform where build/task is run, Eg, 'windows' and 'linux'. When it's used in build commands, it also can be specified in 'os/arch/variant' format for the resulting image. Eg, linux/arm/v7. The 'arch' and 'variant' parts are optional.")
         c.argument('target', help='The name of the target build stage.')
         c.argument('auth_mode', help='Auth mode of the source registry.', arg_type=get_enum_type(SourceRegistryLoginMode))
         # Overwrite default shorthand of cmd to make availability for acr usage

--- a/src/azure-cli/azure/cli/command_modules/acr/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_utils.py
@@ -216,10 +216,8 @@ def get_validate_platform(cmd, platform):
     if platform:
         platform_split = platform.split('/')
         platform_os = platform_split[0]
-        platform_arch = platform_split[1] if len(
-            platform_split) > 1 else Architecture.amd64.value
-        platform_variant = platform_split[2] if len(
-            platform_split) > 2 else None
+        platform_arch = platform_split[1] if len(platform_split) > 1 else Architecture.amd64.value
+        platform_variant = platform_split[2] if len(platform_split) > 2 else None
 
     platform_os = platform_os.lower()
     platform_arch = platform_arch.lower()
@@ -230,7 +228,7 @@ def get_validate_platform(cmd, platform):
 
     if platform_os not in valid_os:
         raise CLIError(
-            "'{0}' is not a valid value for OS specified in --os or --platform. "
+            "'{0}' is not a valid value for OS specified in --platform. "
             "Valid options are {1}.".format(platform_os, ','.join(valid_os))
         )
     if platform_arch not in valid_arch:

--- a/src/azure-cli/azure/cli/command_modules/acr/pack.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/pack.py
@@ -18,9 +18,9 @@ from ._utils import (
 from ._client_factory import cf_acr_registries_tasks
 from .run import prepare_source_location
 
-PACK_TASK_YAML_FMT = '''version: v1.0.0
+PACK_TASK_YAML_FMT = '''version: v1.1.0
 steps:
-  - cmd: mcr.microsoft.com/oryx/pack:{pack_image_tag} build {image_name} --builder {builder} {no_pull} --env REGISTRY_NAME={{{{.Run.Registry}}}} -p .
+  - cmd: mcr.microsoft.com/oryx/pack:{pack_image_tag} build {image_name} --builder {builder} {no_pull} --env REGISTRY_NAME=$Registry -p .
     timeout: 28800
   - push: ["{image_name}"]
     timeout: 1800
@@ -60,7 +60,7 @@ def acr_pack_build(cmd,  # pylint: disable=too-many-locals
     if builder not in ACR_CACHED_BUILDER_IMAGES and not pull:
         logger.warning('Using a non-cached builder image; `--pull` is probably needed as well')
 
-    registry_prefixes = '{{.Run.Registry}}/', registry.login_server + '/'
+    registry_prefixes = '$Registry/', registry.login_server + '/'
     # If the image name doesn't have any required prefix, add it
     if all((not image_name.startswith(prefix) for prefix in registry_prefixes)):
         original_image_name = image_name


### PR DESCRIPTION
---

- Deprecate os parameter completely.
- use task v1.1.0 template for `pack` command

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
