### PR TITLE
[ARM] Fix the test of test_resource_policyset

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/sample_policy_set.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/sample_policy_set.json
@@ -1,1 +1,1 @@
-[{"policyDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/policyDefinitions/azure-cli-test-policylpnkfmrse", "parameters": {"allowedLocations": {"value": ["australiaeast", "eastus", "japaneast", "westus"]}}}]
+[{"policyDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/policyDefinitions/azure-cli-test-policytl5ocnpv2", "parameters": {"allowedLocations": {"value": ["australiaeast", "eastus", "japaneast", "westus"]}}}]

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_resource.py
@@ -475,9 +475,8 @@ class PolicyScenarioTest(ScenarioTest):
         self.cmd('policy definition list',
                  checks=self.check("length([?name=='{pn}'])", 0))
 
-    # remove and re-record once issue #6008 is fixed
-    @live_only()
     @ResourceGroupPreparer(name_prefix='cli_test_policy')
+    @AllowLargeResponse
     def test_resource_policyset(self, resource_group):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
Fix the test of test_resource_policyset
issue: #6008
I ran the test again and found that the problem could not be repeated. So I removed @live_only to add this test case to the CI process.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
