### PR TITLE
[RBAC] Return exit code 3 if app or sp doesn't exist

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -32,7 +32,7 @@ Release History
 
 **RBAC**
 
-* Fix #11712: `az ad sp show` does not return exit code 3 when the sp does not exist
+* Fix #11712: `az ad app/sp show` does not return exit code 3 when the application or service principal does not exist
 
 **Storage**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -30,6 +30,10 @@ Release History
 * Fix `vm create` failure in Azure Stack profile.
 * vm monitor metrics tail/list-definitions: support query metric and list definitions for a vm.
 
+**RBAC**
+
+* Fix #11712: `az ad sp show` does not return exit code 3 when the sp does not exist
+
 **Storage**
 
 * `az storage account create`: Remove preview flag for --enable-hierarchical-namespace parameter

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1040,7 +1040,9 @@ def _resolve_application(client, identifier):
             # it is either app id or object id, let us verify
             result = list(client.list(filter="appId eq '{}'".format(identifier)))
         else:
-            raise CLIError("Application '{}' doesn't exist".format(identifier))
+            error = CLIError("Application '{}' doesn't exist".format(identifier))
+            error.status_code = 404  # Make sure CLI returns 3
+            raise error
 
     return result[0].object_id if result else identifier
 
@@ -1194,7 +1196,9 @@ def _resolve_service_principal(client, identifier):
         return result[0].object_id
     if _is_guid(identifier):
         return identifier  # assume an object id
-    raise CLIError("service principal '{}' doesn't exist".format(identifier))
+    error = CLIError("Service principal '{}' doesn't exist".format(identifier))
+    error.status_code = 404  # Make sure CLI returns 3
+    raise error
 
 
 def _process_service_principal_creds(cli_ctx, years, app_start_date, app_end_date, cert, create_cert,

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_app_show_exit_code.yaml
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_app_show_exit_code.yaml
@@ -7,7 +7,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - ad sp show
+      - ad app show
       Connection:
       - keep-alive
       ParameterSetName:
@@ -18,7 +18,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27non-exist-identifierUris%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27non-exist-identifierUris%27%29&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -34,19 +34,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 31 Dec 2019 08:25:48 GMT
+      - Tue, 31 Dec 2019 08:50:43 GMT
       duration:
-      - '2380963'
+      - '2335233'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - muJ6EuMuix/oLvLKHDDXTN/XnmFqQCOAfYItMW8s9os=
+      - fP4NK2gNaIdDNhBv8pKeGATgIpn16XzVoGGpzH0I8Co=
       ocp-aad-session-key:
-      - 1DFvoe1RTsKGMiQnIZ60yYoOS00IcXpGsOmJYAAtQa8QpzqvST16eVI3g3qEcclpyov_NkQduJirfJoafoPC8Y2Z-1va5mmrDOeHx-JEEllwxqd-4kNy9UzyMyijPOUk.0TofMytkyE7vmaxl0p5CJh_I_jQDCCA8-3MlOJRFLlg
+      - AioSBiwvp9u_J6TeWYtW8cW77VwJSOhvIfuKHJTnU2Sr-kCn1hVXi5gtrs8jzg1AQhV7r3QOILw6npxwdkA3Q3oi4rlSWhcW1XDRuI640ztwUnWfsL3XQMIH1Ys7oQoK.b6n85CWcWrkYDhW8wF8F7rVMhgfXw1-_9Rp8I5_SAdk
       pragma:
       - no-cache
       request-id:
-      - a16e0be0-337c-461f-939f-717490f1f163
+      - c6d7cbcc-66a9-41c0-9b96-2a41b49c8dff
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_app_show_exit_code.yaml
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_app_show_exit_code.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad sp show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.78
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27non-exist-identifierUris%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '121'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Tue, 31 Dec 2019 08:25:48 GMT
+      duration:
+      - '2380963'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - muJ6EuMuix/oLvLKHDDXTN/XnmFqQCOAfYItMW8s9os=
+      ocp-aad-session-key:
+      - 1DFvoe1RTsKGMiQnIZ60yYoOS00IcXpGsOmJYAAtQa8QpzqvST16eVI3g3qEcclpyov_NkQduJirfJoafoPC8Y2Z-1va5mmrDOeHx-JEEllwxqd-4kNy9UzyMyijPOUk.0TofMytkyE7vmaxl0p5CJh_I_jQDCCA8-3MlOJRFLlg
+      pragma:
+      - no-cache
+      request-id:
+      - a16e0be0-337c-461f-939f-717490f1f163
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_sp_show_exit_code.yaml
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_sp_show_exit_code.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad sp show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.0.78
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27non-exist-sp-name%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '121'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Tue, 31 Dec 2019 08:25:42 GMT
+      duration:
+      - '2360053'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - rKom6PMPEZ0rGSbK0aHZnJgbvmwPbE1xDrhvOPMIKQ0=
+      ocp-aad-session-key:
+      - Wk8Em0gF2ex8YY-978BBlS4P3SR0aI1krQk-kUwcLf29u9DbqfFTrSku8DHTzVix2o4As2AwBhbxxO4AWriaF8E5XlDVH2oLAmfz-F5c5cYb6-Ai4GzOxmIga65ybkdS.GfCX4PXpl8yyAB0NwZHA0VcUx5YiyBG7MthjDXQ6kuQ
+      pragma:
+      - no-cache
+      request-id:
+      - 1f961ed9-d944-4be3-8675-50fc5c404cc7
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -208,8 +208,8 @@ class ApplicationSetScenarioTest(ScenarioTest):
 
     def test_app_show_exit_code(self):
         with self.assertRaises(SystemExit):
-            self.assertEqual(self.cmd('ad sp show --id non-exist-identifierUris').exit_code, 3)
-            self.assertEqual(self.cmd('ad sp show --id 00000000-0000-0000-0000-000000000000').exit_code, 3)
+            self.assertEqual(self.cmd('ad app show --id non-exist-identifierUris').exit_code, 3)
+            self.assertEqual(self.cmd('ad app show --id 00000000-0000-0000-0000-000000000000').exit_code, 3)
 
 
 class CreateForRbacScenarioTest(ScenarioTest):

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -113,6 +113,11 @@ class ServicePrincipalExpressCreateScenarioTest(ScenarioTest):
         finally:
             self.cmd("ad app delete --id " + app_id)
 
+    def test_sp_show_exit_code(self):
+        with self.assertRaises(SystemExit):
+            self.assertEqual(self.cmd('ad sp show --id non-exist-sp-name').exit_code, 3)
+            self.assertEqual(self.cmd('ad sp show --id 00000000-0000-0000-0000-000000000000').exit_code, 3)
+
 
 class ApplicationSetScenarioTest(ScenarioTest):
 
@@ -200,6 +205,11 @@ class ApplicationSetScenarioTest(ScenarioTest):
         finally:
             if app_id:
                 self.cmd("ad app delete --id " + app_id)
+
+    def test_app_show_exit_code(self):
+        with self.assertRaises(SystemExit):
+            self.assertEqual(self.cmd('ad sp show --id non-exist-identifierUris').exit_code, 3)
+            self.assertEqual(self.cmd('ad sp show --id 00000000-0000-0000-0000-000000000000').exit_code, 3)
 
 
 class CreateForRbacScenarioTest(ScenarioTest):


### PR DESCRIPTION
Fix #11712: `az ad sp show` does not return exit code 3 when the sp does not exist 

**Root cause**: `_resolve_application` and `_resolve_service_principal` don't raise `CLIError` with attribute `status_code=404`

https://github.com/Azure/azure-cli/blob/4d5b1a942e48ce6f8674420f2b18d50f19ed860e/src/azure-cli/azure/cli/command_modules/role/custom.py#L1043

https://github.com/Azure/azure-cli/blob/4d5b1a942e48ce6f8674420f2b18d50f19ed860e/src/azure-cli/azure/cli/command_modules/role/custom.py#L1197

Thus `show_exception_handler` fails to handle the exception: https://github.com/Azure/azure-cli/blob/e47ee99ea2ff1476d3943d81f0403b4dcc638221/src/azure-cli-core/azure/cli/core/commands/arm.py#L755

For manual test, run
```sh
az ad app show --id non-exist-identifierUris
echo %ERRORLEVEL%
az ad app show --id 00000000-0000-0000-0000-000000000000
echo %ERRORLEVEL%
az ad sp show --id non-exist-sp-name
echo %ERRORLEVEL%
az ad sp show --id 00000000-0000-0000-0000-000000000000
echo %ERRORLEVEL%
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
