### PR TITLE
[Docker] add libc6-compat in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ LABEL maintainer="Microsoft" \
 # libintl and icu-libs - required by azure devops artifact (az extension add --name azure-devops)
 RUN apk add --no-cache bash openssh ca-certificates jq curl openssl git zip \
  && apk add --no-cache --virtual .build-deps gcc make openssl-dev libffi-dev musl-dev linux-headers \
- && apk add --no-cache libintl icu-libs \
+ && apk add --no-cache libintl icu-libs libc6-compat \
  && update-ca-certificates
 
 ARG JP_VERSION="0.1.3"


### PR DESCRIPTION
Fix #10381. 