### PR TITLE
[core] Support `--output yamlc` for colorized YAML

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -199,8 +199,8 @@ Release History
 ++++++
 * Minor fixes
 
-2.0.36
-++++++
+2.0.36	
+++++++	
 * Minor fixes
 
 2.0.35

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,6 +3,8 @@
 Release History
 ===============
 
+* Fix #7878: Support `--output yamlc` for colorized YAML
+
 2.0.80
 ++++++
 * No changes

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,8 +3,6 @@
 Release History
 ===============
 
-* Fix #7878: Support `--output yamlc` for colorized YAML
-
 2.0.80
 ++++++
 * No changes
@@ -201,8 +199,8 @@ Release History
 ++++++
 * Minor fixes
 
-2.0.36	
-++++++	
+2.0.36
+++++++
 * Minor fixes
 
 2.0.35

--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -11,6 +11,7 @@ class AzOutputProducer(knack.output.OutputProducer):
         super(AzOutputProducer, self).__init__(cli_ctx)
         additional_formats = {
             'yaml': self.format_yaml,
+            'yamlc': self.format_yaml_color,
             'none': self.format_none
         }
         super(AzOutputProducer, self)._FORMAT_DICT.update(additional_formats)
@@ -25,6 +26,11 @@ class AzOutputProducer(knack.output.OutputProducer):
         except representer.RepresenterError:
             # yaml.safe_dump fails when obj.result is an OrderedDict. knack's --query implementation converts the result to an OrderedDict. https://github.com/microsoft/knack/blob/af674bfea793ff42ae31a381a21478bae4b71d7f/knack/query.py#L46. # pylint: disable=line-too-long
             return safe_dump(json.loads(json.dumps(obj.result)), default_flow_style=False)
+
+    @staticmethod
+    def format_yaml_color(obj):
+        from pygments import highlight, lexers, formatters
+        return highlight(AzOutputProducer.format_yaml(obj), lexers.YamlLexer(), formatters.TerminalFormatter())  # pylint: disable=no-member
 
     @staticmethod
     def format_none(_):

--- a/src/azure-cli-core/azure/cli/core/tests/test_output.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_output.py
@@ -12,7 +12,7 @@ class TestCoreCLIOutput(unittest.TestCase):
         from azure.cli.core.mock import DummyCli
 
         output_producer = AzOutputProducer(DummyCli())
-        self.assertEqual(6, len(output_producer._FORMAT_DICT))  # six types: json, jsonc, table, tsv, yaml, none
+        self.assertEqual(7, len(output_producer._FORMAT_DICT))  # six types: json, jsonc, table, tsv, yaml, yamlc, none
         self.assertIn('yaml', output_producer._FORMAT_DICT)
         self.assertIn('none', output_producer._FORMAT_DICT)
 

--- a/src/azure-cli/azure/cli/command_modules/configure/_consts.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/_consts.py
@@ -12,6 +12,7 @@ OUTPUT_LIST = [
     {'name': 'table', 'desc': 'Human-readable output format.'},
     {'name': 'tsv', 'desc': 'Tab- and Newline-delimited. Great for GREP, AWK, etc.'},
     {'name': 'yaml', 'desc': 'YAML formatted output. An alternative to JSON. Great for configuration files.'},
+    {'name': 'yamlc', 'desc': 'Colored YAML formatted output. An alternative to JSON. Great for configuration files.'},
     {'name': 'none', 'desc': 'No output, except for errors and warnings.'}
 ]
 


### PR DESCRIPTION
Fix #7878

Support `--output yamlc` for colorized YAML. The code is copied from Knack's [`format_json_color`](https://github.com/microsoft/knack/blob/master/knack/output.py#L43-L45).

To test, run any command with `--output yamlc`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
