### PR TITLE
[SQL] az sql db audit-policy: Fix for empty audit actions and groups

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -84,6 +84,7 @@ Release History
 
 * [BREAKING CHANGE] `az sql db create`: Remove "WideWorldImportersStd" and "WideWorldImportersFull" as documented allowed values for "az sql db create --sample-name". These sample databases would always cause creation to fail.
 * Add New commands `sql db classification show/list/update/delete` and `sql db classification recommendation list/enable/disable` to manage sensitivity classifications for SQL databases.
+* `az sql db audit-policy`: Fix for empty audit actions and groups
 
 **Storage**
 

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -1434,6 +1434,14 @@ def db_audit_policy_update(
     if audit_actions_and_groups:
         instance.audit_actions_and_groups = audit_actions_and_groups
 
+    # If auditing is enabled, make sure that the actions and groups are set to default
+    # value in case they were removed previously (When disabling auditing)
+    if enabled and (not instance.audit_actions_and_groups or instance.audit_actions_and_groups == []):
+        instance.audit_actions_and_groups = [
+            "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
+            "FAILED_DATABASE_AUTHENTICATION_GROUP",
+            "BATCH_COMPLETED_GROUP"]
+
     if retention_days:
         instance.retention_days = retention_days
 


### PR DESCRIPTION
In case the policy is enabled and there are no audit actions and groups (Was overridden when disabling the policy, or removed while enabling), set the default value

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
