### PR TITLE
Fix: tox can find system-wide default Python 2.7 in ADO

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -382,10 +382,13 @@ jobs:
     matrix:
       Python27:
         python.version: '2.7'
+        tox_env: 'py27'
       Python36:
         python.version: '3.6'
+        tox_env: 'py36'
       Python38:
         python.version: '3.8'
+        tox_env: 'py38'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python $(python.version)'
@@ -395,6 +398,8 @@ jobs:
       displayName: 'Install pip and tox'
     - bash: ./scripts/ci/unittest.sh
       displayName: 'Run Unit Test'
+      env:
+        TOXENV: $(tox_env)
 
 - job: IntegrationTestAgainstProfiles
   displayName: Integration Test against Profiles


### PR DESCRIPTION
Fix: https://github.com/Azure/azure-cli/pull/11798#issuecomment-571942554

tox can find system-wide Python which is Python 2.7 in ubuntu 16.04. 
Even though CI job "**Unit Test for Core and Telemetry**" can run pre-set Python version to test but also run an extra test on system-wide Python which is Python 2.7

So I add environment variable to let tox use the specific Python version I want.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
