### PR TITLE
python3.8 migration for homebrew

### DIFF
--- a/scripts/release/homebrew/docker/formula_template.txt
+++ b/scripts/release/homebrew/docker/formula_template.txt
@@ -11,7 +11,7 @@ class AzureCli < Formula
 {{ bottle_hash }}
 
   depends_on "openssl@1.1"
-  depends_on "python"
+  depends_on "python@3.8"
 
 {{ resources }}
 


### PR DESCRIPTION
Requested by Homebrew to use python 3.8 in the formulae. Ref: https://github.com/Homebrew/homebrew-core/issues/47274