### PR TITLE
[Core] Support filename and environment variable completion

### DIFF
--- a/az.completion
+++ b/az.completion
@@ -18,4 +18,4 @@ _python_argcomplete() {
         compopt -o nospace
     fi
 }
-complete -o nospace -F _python_argcomplete "az"
+complete -o nospace -o default -o bashdefault -F _python_argcomplete "az"

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -7,6 +7,10 @@ Release History
 
 * Support app creation/update with the new sku name ST0, ST1, ST2.
 
+**Misc**
+
+* Fix #6371: Support filename and environment variable completion in Bash
+
 2.0.80
 ++++++
 


### PR DESCRIPTION
Fix #6371

According to [Bach spec](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html), 

> **bashdefault**
> Perform the rest of the default Bash completions if the compspec generates no matches.
>
> **default**
> Use Readline’s default filename completion if the compspec generates no matches.

Thus `-o default` enables filename completion and `-o bashdefault` enables environment variable completion.

**argcomplete** currently by default doesn't use `-o bashdefault` for individual commands. After PR https://github.com/kislyuk/argcomplete/pull/284 gets merged, CLI needs to update **argcomplete**'s version so that `src/azure-cli/az.completion.sh` uses the latest **argcomplete**.

Related discussion on https://github.com/kislyuk/argcomplete/issues/67

To test, manually run `az.completion` in Bash and run 

(Filename completion)
`$ az /` <kbd>Tab</kbd><kbd>Tab</kbd>
```
bin/   dev/   home/  lib/   media/ opt/   root/  sbin/  srv/   tmp/   var/
boot/  etc/   init   lib64/ mnt/   proc/  run/   snap/  sys/   usr/
```

(Environment variable completion)
`$ az $` <kbd>Tab</kbd><kbd>Tab</kbd>
```
$BASH                      $DIRSTACK                  $LOGNAME                   $SHELL
$BASHOPTS                  $EUID                      $LS_COLORS                 $SHELLOPTS
```

BTW, `az.completion` gets installed via

https://github.com/Azure/azure-cli/blob/6354cce02b013bb7e25ab7fee8cba19124a087d3/scripts/release/debian/build.sh#L43

https://github.com/Azure/azure-cli/blob/ec3cb4c34f08f582cb82e16223712f92a49ff074/scripts/release/debian/prepare.sh#L34

https://github.com/Azure/azure-cli/blob/ec3cb4c34f08f582cb82e16223712f92a49ff074/scripts/release/debian/prepare.sh#L112

Files under `/etc/bash_completion.d/` are [automatically executed by Bash](https://debian-administration.org/article/316/An_introduction_to_bash_completion_part_1):

> When the bash_completion file is sourced (or loaded) everything inside the /etc/bash_completion.d directory is also loaded. This makes it a simple matter to add your own hooks.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
