### PR TITLE
Chore: disable invalid password usage in unnecessary Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,11 @@ jobs:
       python: 3.6
       env: PURPOSE='Nightly Edge Build'
       if: branch = dev and type = push
-    - stage: publish
-      script: ./scripts/ci/build_droid.sh
-      python: 3.6
-      env: PURPOSE='Automation Docker'
-      if: repo = Azure/azure-cli and type = push
+#    - stage: publish
+#      script: ./scripts/ci/build_droid.sh
+#      python: 3.6
+#      env: PURPOSE='Automation Docker'
+#      if: repo = Azure/azure-cli and type = push
 stages:
   - precheck
   - unittest


### PR DESCRIPTION
Password in script `./scripts/ci/build_droid.sh` is in valid, which failed when commit advances in release and master branch.

This job **Automation Docker**  has no effect, just take it down temporary for next release 02/04/2020 in case of failed in release and master branch.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
