### PR TITLE
[Rest] Make --method -m optional

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -2011,7 +2011,7 @@ def list_resource_links(cmd, scope=None, filter_string=None):
 # endregion
 
 
-def rest_call(cmd, method, uri, headers=None, uri_parameters=None,
+def rest_call(cmd, uri, method=None, headers=None, uri_parameters=None,
               body=None, skip_authorization_header=False, resource=None, output_file=None):
     from azure.cli.core.util import send_raw_request
     r = send_raw_request(cmd.cli_ctx, method, uri, headers, uri_parameters, body,


### PR DESCRIPTION
`--method -m` in `az rest`  is self-contradictory. It has default value but is `[Required]`.
```
--method -m      [Required] : HTTP request method.  Allowed values: delete, get, head, options,
                              patch, post, put.  Default: get.
```

This is fixed by making `method` optional in `rest_call`. 

To test, run 

```
> az rest -h
--method -m                 : HTTP request method.  Allowed values: delete, get, head, options,
                              patch, post, put.  Default: get.

> az rest --uri https://management.azure.com/
```
