### PR TITLE
Chore: disable CredScan job temporary for ADO security concern

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,33 +19,33 @@ jobs:
         echo "Reject pull request directly to master branch"
         exit 1
 
-- job: CredScan
-  displayName: "Credential Scan"
-
-  pool:
-    vmImage: "windows-2019"
-  steps:
-  - task: CredScan@2
-    inputs:
-      toolMajorVersion: 'V2'
-      suppressionsFile: ./scripts/ci/credscan/CredScanSuppressions.json
-
-  - task: PostAnalysis@1
-    inputs:
-      AllTools: false
-      APIScan: false
-      BinSkim: false
-      CodesignValidation: false
-      CredScan: true
-      FortifySCA: false
-      FxCop: false
-      ModernCop: false
-      PoliCheck: false
-      RoslynAnalyzers: false
-      SDLNativeRules: false
-      Semmle: false
-      TSLint: false
-      ToolLogsNotFoundAction: 'Standard'
+#- job: CredScan
+#  displayName: "Credential Scan"
+#
+#  pool:
+#    vmImage: "windows-2019"
+#  steps:
+#  - task: CredScan@2
+#    inputs:
+#      toolMajorVersion: 'V2'
+#      suppressionsFile: ./scripts/ci/credscan/CredScanSuppressions.json
+#
+#  - task: PostAnalysis@1
+#    inputs:
+#      AllTools: false
+#      APIScan: false
+#      BinSkim: false
+#      CodesignValidation: false
+#      CredScan: true
+#      FortifySCA: false
+#      FxCop: false
+#      ModernCop: false
+#      PoliCheck: false
+#      RoslynAnalyzers: false
+#      SDLNativeRules: false
+#      Semmle: false
+#      TSLint: false
+#      ToolLogsNotFoundAction: 'Standard'
 
 - job: ExtractMetadata
   displayName: Extract Metadata


### PR DESCRIPTION
Disable temporary until CredScan task of **Microsoft Security Code Analysis (Preview)** installed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
