### PR TITLE
refact: update global --tags help content

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -262,11 +262,11 @@ deployment_name_type = CLIArgumentType(
 )
 
 quotes = '""' if platform.system() == 'Windows' else "''"
-quote_text = 'Use {} to clear existing tags.'.format(quotes)
+quote_text = 'Use {} to clear existing tags. Usage: --tags key[=value] [key[=value] ...]'.format(quotes)
 
 tags_type = CLIArgumentType(
     validator=validate_tags,
-    help="space-separated tags in 'key[=value]' format. {}".format(quote_text),
+    help="space-separated list of tags. {}".format(quote_text),
     nargs='*'
 )
 

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -262,11 +262,11 @@ deployment_name_type = CLIArgumentType(
 )
 
 quotes = '""' if platform.system() == 'Windows' else "''"
-quote_text = 'Use {} to clear existing tags. Usage: --tags key[=value] [key[=value] ...]'.format(quotes)
+quote_text = 'Use {} to clear existing tags.'.format(quotes)
 
 tags_type = CLIArgumentType(
     validator=validate_tags,
-    help="space-separated list of tags. {}".format(quote_text),
+    help="space-separated tags: key[=value] [key[=value] ...]. {}".format(quote_text),
     nargs='*'
 )
 


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/7112 , feature request about updating --tags help content.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
