### PR TITLE
Chore: add code owner for command module appconfig

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 /src/azure-cli/azure/cli/command_modules/acr/ @djyou
 /src/azure-cli/azure/cli/command_modules/acs/ @rjtsdl
 /src/azure-cli/azure/cli/command_modules/advisor/ @Prasanna-Padmanabhan
+/src/azure-cli/azure/cli/command_modules/appconfig/ @shenmuxiaosen @avanigupta
 /src/azure-cli/azure/cli/command_modules/appservice/ @qwordy @Juliehzl
 /src/azure-cli/azure/cli/command_modules/backup/ @dragonfly91
 /src/azure-cli/azure/cli/command_modules/batch/ @bgklein


### PR DESCRIPTION
As mentioned in PR https://github.com/Azure/azure-cli/pull/11795#issuecomment-574464985, add  @shenmuxiaosen and @avanigupta as owners (reviewers) for appconfig command

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
