### PR TITLE
[Core] Fix test_get_clouds_concurrent on python 3.8 windows

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
@@ -219,7 +219,11 @@ class TestCloud(unittest.TestCase):
 
     def test_get_clouds_concurrent(self):
         with mock.patch('azure.cli.core.cloud.CLOUD_CONFIG_FILE', tempfile.mkstemp()[1]) as config_file:
-            pool_size = 100
+            # Max pool_size is 61, otherwise exception will be thrown on Python 3.8 Windows:
+            #     File "...Python38\lib\multiprocessing\connection.py", line 810, in _exhaustive_wait
+            #       res = _winapi.WaitForMultipleObjects(L, False, timeout)
+            #   ValueError: need at most 63 handles, got a sequence of length 102
+            pool_size = 20
             p = multiprocessing.Pool(pool_size)
             p.map(_helper_get_clouds, range(pool_size))
             p.close()


### PR DESCRIPTION
To repro, activate a Python 3.8 virtual env on Windows and run

```
pytest azure-cli\src\azure-cli-core\azure\cli\core\tests\test_cloud.py::TestCloud::test_get_clouds_concurrent -s
```
`-s` stands for `--capture=no` - no stream redirection. If `-s` is not provided, pytest will simply hang forever. 

With the original `pool_size = 100`, error will rise:

```
azure-cli\src\azure-cli-core\azure\cli\core\tests\test_cloud.py Exception in thread Thread-1:
Traceback (most recent call last):
  File "C:\Users\{}\AppData\Local\Programs\Python\Python38\lib\threading.py", line 932, in _bootstrap_inner
    self.run()
  File "C:\Users\{}\AppData\Local\Programs\Python\Python38\lib\threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\{}\AppData\Local\Programs\Python\Python38\lib\multiprocessing\pool.py", line 519, in _handle_workers
    cls._wait_for_updates(current_sentinels, change_notifier)
  File "C:\Users\{}\AppData\Local\Programs\Python\Python38\lib\multiprocessing\pool.py", line 499, in _wait_for_updates
    wait(sentinels, timeout=timeout)
  File "C:\Users\{}\AppData\Local\Programs\Python\Python38\lib\multiprocessing\connection.py", line 878, in wait
    ready_handles = _exhaustive_wait(waithandle_to_obj.keys(), timeout)
  File "C:\Users\{}\AppData\Local\Programs\Python\Python38\lib\multiprocessing\connection.py", line 810, in _exhaustive_wait
    res = _winapi.WaitForMultipleObjects(L, False, timeout)
ValueError: need at most 63 handles, got a sequence of length 102
```

This is because Python 3.8 switched to use Win32 API [WaitForMultipleObjects](https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitformultipleobjects) which has a max wait count of `MAXIMUM_WAIT_OBJECTS`. 

`pool_size` is adjusted to `20` to fix this error, while maintaining the test's purpose. 

