### PR TITLE
[Core] Bump argcomplete version

### DIFF
--- a/src/azure-cli/requirements.py2.Darwin.txt
+++ b/src/azure-cli/requirements.py2.Darwin.txt
@@ -1,7 +1,7 @@
 adal==1.2.1
 antlr4-python2-runtime==4.7.2
 applicationinsights==0.11.9
-argcomplete==1.10.0
+argcomplete==1.11.1
 asn1crypto==0.24.0
 azure-batch==8.0.0
 azure-cli==2.0.80

--- a/src/azure-cli/requirements.py2.Linux.txt
+++ b/src/azure-cli/requirements.py2.Linux.txt
@@ -1,7 +1,7 @@
 adal==1.2.1
 antlr4-python2-runtime==4.7.2
 applicationinsights==0.11.9
-argcomplete==1.10.0
+argcomplete==1.11.1
 asn1crypto==0.24.0
 azure-batch==8.0.0
 azure-cli==2.0.80

--- a/src/azure-cli/requirements.py2.windows.txt
+++ b/src/azure-cli/requirements.py2.windows.txt
@@ -1,7 +1,7 @@
 adal==1.2.1
 antlr4-python2-runtime==4.7.2
 applicationinsights==0.11.7
-argcomplete==1.10.0
+argcomplete==1.11.1
 asn1crypto==0.24.0
 azure-batch==8.0.0
 azure-cli==2.0.80

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -1,7 +1,7 @@
 adal==1.2.1
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.9
-argcomplete==1.10.0
+argcomplete==1.11.1
 asn1crypto==0.24.0
 azure-batch==8.0.0
 azure-cli==2.0.80

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -1,7 +1,7 @@
 adal==1.2.1
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.9
-argcomplete==1.10.0
+argcomplete==1.11.1
 asn1crypto==0.24.0
 azure-batch==8.0.0
 azure-cli==2.0.80

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -1,7 +1,7 @@
 adal==1.2.1
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.7
-argcomplete==1.10.0
+argcomplete==1.11.1
 asn1crypto==0.24.0
 azure-batch==8.0.0
 azure-cli==2.0.80


### PR DESCRIPTION
Bump argcomplete version to 1.11.1 to incorporate https://github.com/kislyuk/argcomplete/pull/284

As instructed by [configuring_your_machine.md](https://github.com/Azure/azure-cli/blob/dev/doc/configuring_your_machine.md#preparing-your-machine), [az.completion.sh](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/az.completion.sh) can use the latest registration script from argcomplete. 

Since `azdev setup -c` doesn't update dependencies, to update the installed argcomplete, we can use `-U --upgrade-strategy eager` to forcely update dependencies while satisfying the requirements. 

```
pip install -U --upgrade-strategy eager -e azure-cli/src/azure-cli-core
```

Then run `source <clone root>/src/azure-cli/az.completion.sh` and verify auto-complete for Azure CLI commands, parameters, resources, file names and environment variables. 

⚠ Auto-complete is not available on Windows.

Also see: https://github.com/Azure/azure-cli/pull/11817