### PR TITLE
[Storage] Upgrade Azcopy for storage copy/remove and blob sync

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -47,6 +47,7 @@ Release History
 * Integrate Azcopy 10.3.3 and support Win32.
 * `az storage copy`: Add `--include-path`, `--include-pattern`, `--exclude-path` and`--exclude-pattern` parameters
 * `az storage remove`: Change `--inlcude` and `--exclude` parameters to `--include-path`, `--include-pattern`, `--exclude-path` and`--exclude-pattern` parameters
+* `az storage sync`: Add `--include-pattern`, `--exclude-path` and`--exclude-pattern` parameters
 
 2.0.80
 ++++++

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -44,7 +44,7 @@ Release History
 
 * Add a new command group `az storage share-rm` to use the Microsoft.Storage resource provider for Azure file share management operations.
 * Fix issue #11415: permission error for `az storage blob update`
-* Integrate Azcopy 10.3.3.
+* Integrate Azcopy 10.3.3 and support Win32.
 * `az storage copy`: Add `--include-path`, `--include-pattern`, `--exclude-path` and`--exclude-pattern` parameters
 * `az storage remove`: Change `--inlcude` and `--exclude` parameters to `--include-path`, `--include-pattern`, `--exclude-path` and`--exclude-pattern` parameters
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -44,6 +44,9 @@ Release History
 
 * Add a new command group `az storage share-rm` to use the Microsoft.Storage resource provider for Azure file share management operations.
 * Fix issue #11415: permission error for `az storage blob update`
+* Integrate Azcopy 10.3.3.
+* `az storage copy`: Add `--include-path`, `--include-pattern`, `--exclude-path` and`--exclude-pattern` parameters
+* `az storage remove`: Change `--inlcude` and `--exclude` parameters to `--include-path`, `--include-pattern`, `--exclude-path` and`--exclude-pattern` parameters
 
 2.0.80
 ++++++

--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -743,8 +743,10 @@ examples:
     text: az storage copy -s https://[account].blob.core.windows.net/[container]/[path/to/blob] -d /path/to/file.txt
   - name: Download an entire directory from Azure Blob, and you can also specify your storage account and container information as above.
     text: az storage copy -s https://[account].blob.core.windows.net/[container]/[path/to/directory] -d /path/to/dir --recursive
-  - name: Download a set of files from Azure Blob using wildcards, and you can also specify your storage account and container information as above.
-    text: az storage copy -s https://[account].blob.core.windows.net/[container]/foo* -d /path/to/dir --recursive
+  - name: Download a subset of containers within a storage account by using a wildcard symbol (*) in the container name, and you can also specify your storage account and container information as above.
+    text: az storage copy -s https://[account].blob.core.windows.net/[container*name] -d /path/to/dir --recursive
+  - name: Download a set of files from Azure Blob using --include-pattern, and you can also specify your storage account and container information as above.
+    text: az storage copy -s https://[account].blob.core.windows.net/[container] --include-pattern foo* -d /path/to/dir --recursive
   - name: Copy a single blob to another blob, and you can also specify the storage account and container information of source and destination as above.
     text: az storage copy -s https://[srcaccount].blob.core.windows.net/[container]/[path/to/blob] -d https://[destaccount].blob.core.windows.net/[container]/[path/to/blob]
   - name: Copy an entire account data from blob account to another blob account, and you can also specify the storage account and container information of source and destination as above.

--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -534,7 +534,6 @@ examples:
 helps['storage blob sync'] = """
 type: command
 short-summary: Sync blobs recursively to a storage blob container.
-long-summary: Sync command depends on Azcopy, which will be upgraded to v10.3 soon to support 32-bit Operating System and utilize new features.
 examples:
   - name: Sync a single blob to a container.
     text: az storage blob sync -c mycontainer -s "path/to/file" -d NewBlob
@@ -721,12 +720,6 @@ short-summary: Manage container stored access policies.
 helps['storage copy'] = """
 type: command
 short-summary: Copy files or directories to or from Azure storage.
-long-summary: >
-    Copy command depends on Azcopy, which will be upgraded to v10.3 soon to support 32-bit Operating System and
-    utilize new features.
-
-    [COMING BREAKING CHANGE] With Azcopy v10.3, `*` character is no longer supported as a wildcard in URL, but new
-    parameters --include-pattern and --exclude-pattern will be added with `*` wildcard support.
 examples:
   - name: Upload a single file to Azure Blob using url.
     text: az storage copy -s /path/to/file.txt -d https://[account].blob.core.windows.net/[container]/[path/to/blob]
@@ -1204,10 +1197,6 @@ short-summary: Manage shared access policies for a storage queue.
 helps['storage remove'] = """
 type: command
 short-summary: Delete blobs or files from Azure Storage.
-long-summary: >
-    To delete blobs, both the source must either be public or be authenticated by using a shared access signature.
-    Remove command depends on Azcopy, which will be upgraded to v10.3 soon to support 32-bit Operating System and
-    utilize new features.
 examples:
   - name: Remove a single blob.
     text: az storage remove -c MyContainer -n MyBlob

--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -778,7 +778,7 @@ examples:
   - name: Download an entire directory from Azure File Share, and you can also specify your storage account and share information as above.
     text: az storage copy -s https://[account].file.core.windows.net/[share]/[path/to/directory] -d /path/to/dir --recursive
   - name: Download a set of files from Azure File Share using wildcards, and you can also specify your storage account and share information as above.
-    text: az storage copy -s https://[account].file.core.windows.net/[share]/foo* -d /path/to/dir --recursive
+    text: az storage copy -s https://[account].file.core.windows.net/[share]/ --include-pattern foo* -d /path/to/dir --recursive
 """
 
 helps['storage cors'] = """
@@ -1209,9 +1209,9 @@ examples:
   - name: Remove all the blobs in a Storage Container.
     text: az storage remove -c MyContainer -n path/to/directory
   - name: Remove a subset of blobs in a virtual directory (For example, only jpg and pdf files, or if the blob name is "exactName").
-    text: az storage remove -c MyContainer -n path/to/directory --recursive --include "*.jpg;*.pdf;exactName"
+    text: az storage remove -c MyContainer --include-path path/to/directory --include-pattern "*.jpg;*.pdf;exactName" --recursive 
   - name: Remove an entire virtual directory but exclude certain blobs from the scope (For example, every blob that starts with foo or ends with bar).
-    text: az storage remove -c MyContainer -n path/to/directory --recursive --include "foo*;*bar"
+    text: az storage remove -c MyContainer --include-path path/to/directory --exclude-pattern "foo*;*bar" --recursive
   - name: Remove a single file.
     text: az storage remove -s MyShare -p MyFile
   - name: Remove an entire directory.

--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -1209,7 +1209,7 @@ examples:
   - name: Remove all the blobs in a Storage Container.
     text: az storage remove -c MyContainer -n path/to/directory
   - name: Remove a subset of blobs in a virtual directory (For example, only jpg and pdf files, or if the blob name is "exactName").
-    text: az storage remove -c MyContainer --include-path path/to/directory --include-pattern "*.jpg;*.pdf;exactName" --recursive 
+    text: az storage remove -c MyContainer --include-path path/to/directory --include-pattern "*.jpg;*.pdf;exactName" --recursive
   - name: Remove an entire virtual directory but exclude certain blobs from the scope (For example, every blob that starts with foo or ends with bar).
     text: az storage remove -c MyContainer --include-path path/to/directory --exclude-pattern "foo*;*bar" --recursive
   - name: Remove a single file.

--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -745,8 +745,8 @@ examples:
     text: az storage copy -s https://[account].blob.core.windows.net/[container]/[path/to/directory] -d /path/to/dir --recursive
   - name: Download a subset of containers within a storage account by using a wildcard symbol (*) in the container name, and you can also specify your storage account and container information as above.
     text: az storage copy -s https://[account].blob.core.windows.net/[container*name] -d /path/to/dir --recursive
-  - name: Download a set of files from Azure Blob using --include-pattern, and you can also specify your storage account and container information as above.
-    text: az storage copy -s https://[account].blob.core.windows.net/[container] --include-pattern foo* -d /path/to/dir --recursive
+  - name: Download a subset of files from Azure Blob. (Only jpg files and file names don't start with test will be included.)
+    text: az storage copy -s https://[account].blob.core.windows.net/[container] --include-pattern "*.jpg" --exclude-pattern test* -d /path/to/dir --recursive
   - name: Copy a single blob to another blob, and you can also specify the storage account and container information of source and destination as above.
     text: az storage copy -s https://[srcaccount].blob.core.windows.net/[container]/[path/to/blob] -d https://[destaccount].blob.core.windows.net/[container]/[path/to/blob]
   - name: Copy an entire account data from blob account to another blob account, and you can also specify the storage account and container information of source and destination as above.
@@ -1208,8 +1208,8 @@ examples:
     text: az storage remove -c MyContainer --recursive
   - name: Remove all the blobs in a Storage Container.
     text: az storage remove -c MyContainer -n path/to/directory
-  - name: Remove a subset of blobs in a virtual directory (For example, only jpg and pdf files, or if the blob name is "exactName").
-    text: az storage remove -c MyContainer --include-path path/to/directory --include-pattern "*.jpg;*.pdf;exactName" --recursive
+  - name: Remove a subset of blobs in a virtual directory (For example, only jpg and pdf files, or if the blob name is "exactName" and file names don't start with "test").
+    text: az storage remove -c MyContainer --include-path path/to/directory --include-pattern "*.jpg;*.pdf;exactName" --exclude-pattern "test*" --recursive
   - name: Remove an entire virtual directory but exclude certain blobs from the scope (For example, every blob that starts with foo or ends with bar).
     text: az storage remove -c MyContainer --include-path path/to/directory --exclude-pattern "foo*;*bar" --recursive
   - name: Remove a single file.

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -488,6 +488,17 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                    'to ensure destination storage account support setting access tier. In the cases that setting '
                    'access tier is not supported, please use `--preserve-s2s-access-tier false` to bypass copying '
                    'access tier. (Default true)')
+        c.argument('exclude_pattern', arg_group='Additional Flags',
+                   help='Exclude these files when copying. This option supports wildcard characters (*)')
+        c.argument('include_pattern', arg_group='Additional Flags',
+                   help='Include only these files when copying. This option supports wildcard characters (*). '
+                   'Separate files by using a ";"')
+        c.argument('exclude_path', arg_group='Additional Flags',
+                   help='Exclude these paths when copying. This option does not support wildcard characters (*). '
+                   'Checks relative path prefix. For example: myFolder;myFolder/subDirName/file.pdf.')
+        c.argument('include_path', arg_group='Additional Flags',
+                   help='Include only these paths when copying. This option does not support wildcard characters (*). '
+                   'Checks relative path prefix. For example: myFolder;myFolder/subDirName/file.pdf')
 
     with self.argument_context('storage blob copy') as c:
         for item in ['destination', 'source']:
@@ -895,8 +906,17 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.extra('path', options_list=('--path', '-p'),
                 help='The path to the file within the file share.',
                 completer=file_path_completer)
-        c.argument('exclude', help='Exclude files whose name matches the pattern list.')
-        c.argument('include', help='Only include files whose name matches the pattern list.')
+        c.argument('exclude_pattern', arg_group='Additional Flags',
+                   help='Exclude these files when copying. This option supports wildcard characters (*)')
+        c.argument('include_pattern', arg_group='Additional Flags',
+                   help='Include only these files when copying. This option supports wildcard characters (*). '
+                        'Separate files by using a ";"')
+        c.argument('exclude_path', arg_group='Additional Flags',
+                   help='Exclude these paths when copying. This option does not support wildcard characters (*). '
+                        'Checks relative path prefix. For example: myFolder;myFolder/subDirName/file.pdf.')
+        c.argument('include_path', arg_group='Additional Flags',
+                   help='Include only these paths when copying. This option does not support wildcard characters (*). '
+                        'Checks relative path prefix. For example: myFolder;myFolder/subDirName/file.pdf')
         c.argument('recursive', options_list=['--recursive', '-r'], action='store_true',
                    help='Look into sub-directories recursively when deleting between directories.')
         c.ignore('destination')

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -101,6 +101,20 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                                                   "Required when --enable-files-adds is set to True")
     sas_help = 'The permissions the SAS grants. Allowed values: {}. Do not use if a stored access policy is ' \
                'referenced with --id that specifies this value. Can be combined.'
+    exclude_pattern_type = CLIArgumentType(arg_group='Additional Flags', help='Exclude these files where the name '
+                                           'matches the pattern list. For example: *.jpg;*.pdf;exactName. This '
+                                           'option supports wildcard characters (*)')
+    include_pattern_type = CLIArgumentType(arg_group='Additional Flags', help='Include only these files where the name '
+                                           'matches the pattern list. For example: *.jpg;*.pdf;exactName. This '
+                                           'option supports wildcard characters (*)')
+    exclude_path_type = CLIArgumentType(arg_group='Additional Flags', help='Exclude these paths. This option does not '
+                                        'support wildcard characters (*). Checks relative path prefix. For example: '
+                                        'myFolder;myFolder/subDirName/file.pdf.')
+    include_path_type = CLIArgumentType(arg_group='Additional Flags', help='Include only these paths. This option does '
+                                        'not support wildcard characters (*). Checks relative path prefix. For example:'
+                                        'myFolder;myFolder/subDirName/file.pdf')
+    recursive_type = CLIArgumentType(options_list=['--recursive', '-r'], action='store_true',
+                                     help='Look into sub-directories recursively.')
 
     with self.argument_context('storage') as c:
         c.argument('container_name', container_name_type)
@@ -474,8 +488,6 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                        help='File path in file share of copy {} storage account'.format(item))
             c.argument('{}_local_path'.format(item), arg_group='Copy {}'.format(item),
                        help='Local file path')
-        c.argument('recursive', arg_group='Additional Flags', action='store_true', help='Look into sub-directories \
-                    recursively when uploading from local file system.')
         c.argument('put_md5', arg_group='Additional Flags', action='store_true',
                    help='Create an MD5 hash of each file, and save the hash as the Content-MD5 property of the '
                    'destination blob/file.Only available when uploading.')
@@ -488,17 +500,11 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                    'to ensure destination storage account support setting access tier. In the cases that setting '
                    'access tier is not supported, please use `--preserve-s2s-access-tier false` to bypass copying '
                    'access tier. (Default true)')
-        c.argument('exclude_pattern', arg_group='Additional Flags',
-                   help='Exclude these files when copying. This option supports wildcard characters (*)')
-        c.argument('include_pattern', arg_group='Additional Flags',
-                   help='Include only these files when copying. This option supports wildcard characters (*). '
-                   'Separate files by using a ";"')
-        c.argument('exclude_path', arg_group='Additional Flags',
-                   help='Exclude these paths when copying. This option does not support wildcard characters (*). '
-                   'Checks relative path prefix. For example: myFolder;myFolder/subDirName/file.pdf.')
-        c.argument('include_path', arg_group='Additional Flags',
-                   help='Include only these paths when copying. This option does not support wildcard characters (*). '
-                   'Checks relative path prefix. For example: myFolder;myFolder/subDirName/file.pdf')
+        c.argument('exclude_pattern', exclude_pattern_type)
+        c.argument('include_pattern', include_pattern_type)
+        c.argument('exclude_path', exclude_path_type)
+        c.argument('include_path', include_path_type)
+        c.argument('recursive', recursive_type)
 
     with self.argument_context('storage blob copy') as c:
         for item in ['destination', 'source']:
@@ -550,6 +556,10 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('source', options_list=['--source', '-s'],
                    help='The source file path to sync from.')
         c.ignore('destination')
+        c.argument('exclude_pattern', exclude_pattern_type)
+        c.argument('include_pattern', include_pattern_type)
+        c.argument('exclude_path', exclude_path_type)
+        c.argument('recursive', recursive_type)
 
     with self.argument_context('storage container') as c:
         from .sdkutil import get_container_access_type_names
@@ -906,19 +916,11 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.extra('path', options_list=('--path', '-p'),
                 help='The path to the file within the file share.',
                 completer=file_path_completer)
-        c.argument('exclude_pattern', arg_group='Additional Flags',
-                   help='Exclude these files when copying. This option supports wildcard characters (*)')
-        c.argument('include_pattern', arg_group='Additional Flags',
-                   help='Include only these files when copying. This option supports wildcard characters (*). '
-                        'Separate files by using a ";"')
-        c.argument('exclude_path', arg_group='Additional Flags',
-                   help='Exclude these paths when copying. This option does not support wildcard characters (*). '
-                        'Checks relative path prefix. For example: myFolder;myFolder/subDirName/file.pdf.')
-        c.argument('include_path', arg_group='Additional Flags',
-                   help='Include only these paths when copying. This option does not support wildcard characters (*). '
-                        'Checks relative path prefix. For example: myFolder;myFolder/subDirName/file.pdf')
-        c.argument('recursive', options_list=['--recursive', '-r'], action='store_true',
-                   help='Look into sub-directories recursively when deleting between directories.')
+        c.argument('exclude_pattern', exclude_pattern_type)
+        c.argument('include_pattern', include_pattern_type)
+        c.argument('exclude_path', exclude_path_type)
+        c.argument('include_path', include_path_type)
+        c.argument('recursive', recursive_type)
         c.ignore('destination')
         c.ignore('service')
         c.ignore('target')

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -99,8 +99,6 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
     azure_storage_sid_type = CLIArgumentType(min_api='2019-04-01', arg_group="Azure Active Directory Properties",
                                              help="Specify the security identifier (SID) for Azure Storage. "
                                                   "Required when --enable-files-adds is set to True")
-    sas_help = 'The permissions the SAS grants. Allowed values: {}. Do not use if a stored access policy is ' \
-               'referenced with --id that specifies this value. Can be combined.'
     exclude_pattern_type = CLIArgumentType(arg_group='Additional Flags', help='Exclude these files where the name '
                                            'matches the pattern list. For example: *.jpg;*.pdf;exactName. This '
                                            'option supports wildcard characters (*)')
@@ -115,6 +113,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                                         'myFolder;myFolder/subDirName/file.pdf')
     recursive_type = CLIArgumentType(options_list=['--recursive', '-r'], action='store_true',
                                      help='Look into sub-directories recursively.')
+    sas_help = 'The permissions the SAS grants. Allowed values: {}. Do not use if a stored access policy is ' \
+               'referenced with --id that specifies this value. Can be combined.'
 
     with self.argument_context('storage') as c:
         c.argument('container_name', container_name_type)
@@ -559,7 +559,6 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('exclude_pattern', exclude_pattern_type)
         c.argument('include_pattern', include_pattern_type)
         c.argument('exclude_path', exclude_path_type)
-        c.argument('recursive', recursive_type)
 
     with self.argument_context('storage container') as c:
         from .sdkutil import get_container_access_type_names

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 
 STORAGE_RESOURCE_ENDPOINT = "https://storage.azure.com"
 SERVICES = {'blob', 'file'}
-AZCOPY_VERSION = '10.1.0'
+AZCOPY_VERSION = '10.3.3'
 
 
 class AzCopy(object):
@@ -34,13 +34,17 @@ class AzCopy(object):
             install_dir = os.path.dirname(install_location)
             if not os.path.exists(install_dir):
                 os.makedirs(install_dir)
-            base_url = 'https://azcopyvnext.azureedge.net/release20190423/azcopy_{}_amd64_10.1.0.{}'
+            base_url = 'https://azcopyvnext.azureedge.net/release20191212/azcopy_{}_{}_{}.{}'
+
             if self.system == 'Windows':
-                file_url = base_url.format('windows', 'zip')
+                if platform.machine().endswith('64'):
+                    file_url = base_url.format('windows', 'amd64', AZCOPY_VERSION, 'zip')
+                else:
+                    file_url = base_url.format('windows', '386', AZCOPY_VERSION, 'zip')
             elif self.system == 'Linux':
-                file_url = base_url.format('linux', 'tar.gz')
+                file_url = base_url.format('linux', 'amd64', AZCOPY_VERSION,'tar.gz')
             elif self.system == 'Darwin':
-                file_url = base_url.format('darwin', 'zip')
+                file_url = base_url.format('darwin', 'amd64', AZCOPY_VERSION, 'zip')
             else:
                 raise CLIError('Azcopy ({}) does not exist.'.format(self.system))
             try:

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -32,11 +32,8 @@ class AzCopy(object):
         install_location = _get_default_install_location()
         self.executable = install_location
         self.creds = creds
-        version = self.check_version()
-        if not os.path.isfile(install_location) or version != AZCOPY_VERSION:
+        if not os.path.isfile(install_location) or self.check_version() != AZCOPY_VERSION:
             self.install_azcopy(install_location)
-        if os.path.isfile(install_location) and version == AZCOPY_VERSION:
-            print("ok")
 
     def install_azcopy(self, install_location):
         install_dir = os.path.dirname(install_location)

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -47,7 +47,7 @@ class AzCopy(object):
             else:
                 file_url = base_url.format('windows', '386', AZCOPY_VERSION, 'zip')
         elif self.system == 'Linux':
-            file_url = base_url.format('linux', 'amd64', AZCOPY_VERSION,'tar.gz')
+            file_url = base_url.format('linux', 'amd64', AZCOPY_VERSION, 'tar.gz')
         elif self.system == 'Darwin':
             file_url = base_url.format('darwin', 'amd64', AZCOPY_VERSION, 'zip')
         else:

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -126,8 +126,18 @@ def storage_remove(cmd, client, service, target, recursive=None, exclude_pattern
     azcopy.remove(_add_url_sas(target, azcopy.creds.sas_token), flags=flags)
 
 
-def storage_blob_sync(cmd, client, source, destination):
+def storage_blob_sync(cmd, client, source, destination, recursive=None, exclude_pattern=None, include_pattern=None,
+                      exclude_path=None):
     azcopy = _azcopy_blob_client(cmd, client)
+    flags = []
+    if recursive is not None:
+        flags.append('--recursive')
+    if include_pattern is not None:
+        flags.append('--include-pattern=' + include_pattern)
+    if exclude_pattern is not None:
+        flags.append('--exclude-pattern=' + exclude_pattern)
+    if exclude_path is not None:
+        flags.append('--exclude-path=' + exclude_path)
     azcopy.sync(source, _add_url_sas(destination, azcopy.creds.sas_token), flags=['--delete-destination', 'true'])
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -126,12 +126,10 @@ def storage_remove(cmd, client, service, target, recursive=None, exclude_pattern
     azcopy.remove(_add_url_sas(target, azcopy.creds.sas_token), flags=flags)
 
 
-def storage_blob_sync(cmd, client, source, destination, recursive=None, exclude_pattern=None, include_pattern=None,
+def storage_blob_sync(cmd, client, source, destination, exclude_pattern=None, include_pattern=None,
                       exclude_path=None):
     azcopy = _azcopy_blob_client(cmd, client)
     flags = ['--delete-destination=true']
-    if recursive is not None:
-        flags.append('--recursive')
     if include_pattern is not None:
         flags.append('--include-pattern=' + include_pattern)
     if exclude_pattern is not None:

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 from ..azcopy.util import AzCopy, client_auth_for_azcopy, login_auth_for_azcopy
 from azure.cli.command_modules.storage._client_factory import blob_data_service_factory, file_data_service_factory
 
-# pylint: disable=too-many-statements
+# pylint: disable=too-many-statements, too-many-locals
 
 
 def storage_copy(cmd, source=None,

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -27,7 +27,8 @@ def storage_copy(cmd, source=None,
                  destination_blob=None,
                  destination_share=None,
                  destination_file_path=None,
-                 destination_local_path=None):
+                 destination_local_path=None,
+                 exclude_pattern=None, include_pattern=None, exclude_path=None, include_path=None):
     def get_url_with_sas(source, account_name, container, blob, share, file_path, local_path):
         import re
         import os
@@ -94,11 +95,19 @@ def storage_copy(cmd, source=None,
         flags.append('--blob-type=' + blob_type)
     if preserve_s2s_access_tier is not None:
         flags.append('--s2s-preserve-access-tier=' + str(preserve_s2s_access_tier))
-
+    if include_pattern is not None:
+        flags.append('--include-pattern=' + include_pattern)
+    if exclude_pattern is not None:
+        flags.append('--exclude-pattern=' + exclude_pattern)
+    if include_path is not None:
+        flags.append('--include-path=' + include_path)
+    if exclude_pattern is not None:
+        flags.append('--exclude-path=' + exclude_path)
     azcopy.copy(full_source, full_destination, flags=flags)
 
 
-def storage_remove(cmd, client, service, target, exclude=None, include=None, recursive=None):
+def storage_remove(cmd, client, service, target, recursive=None, exclude_pattern=None, include_pattern=None,
+                   exclude_path=None, include_path=None):
     if service == 'file':
         azcopy = _azcopy_file_client(cmd, client)
     else:
@@ -106,10 +115,14 @@ def storage_remove(cmd, client, service, target, exclude=None, include=None, rec
     flags = []
     if recursive is not None:
         flags.append('--recursive')
-    if include is not None:
-        flags.append('--include=' + include)
-    if exclude is not None:
-        flags.append('--exclude=' + exclude)
+    if include_pattern is not None:
+        flags.append('--include-pattern=' + include_pattern)
+    if exclude_pattern is not None:
+        flags.append('--exclude-pattern=' + exclude_pattern)
+    if include_path is not None:
+        flags.append('--include-path=' + include_path)
+    if exclude_path is not None:
+        flags.append('--exclude-path=' + exclude_path)
     azcopy.remove(_add_url_sas(target, azcopy.creds.sas_token), flags=flags)
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -129,7 +129,7 @@ def storage_remove(cmd, client, service, target, recursive=None, exclude_pattern
 def storage_blob_sync(cmd, client, source, destination, recursive=None, exclude_pattern=None, include_pattern=None,
                       exclude_path=None):
     azcopy = _azcopy_blob_client(cmd, client)
-    flags = []
+    flags = ['--delete-destination=true']
     if recursive is not None:
         flags.append('--recursive')
     if include_pattern is not None:
@@ -138,7 +138,7 @@ def storage_blob_sync(cmd, client, source, destination, recursive=None, exclude_
         flags.append('--exclude-pattern=' + exclude_pattern)
     if exclude_path is not None:
         flags.append('--exclude-path=' + exclude_path)
-    azcopy.sync(source, _add_url_sas(destination, azcopy.creds.sas_token), flags=['--delete-destination', 'true'])
+    azcopy.sync(source, _add_url_sas(destination, azcopy.creds.sas_token), flags=flags)
 
 
 def storage_run_command(cmd, command_args):

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -60,7 +60,7 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 30))
 
-        # syn with another folder
+        # sync with another folder
         self.cmd('storage blob sync -s "{}" -c {} --account-name {}'.format(
             os.path.join(test_dir, 'butter'), container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(
@@ -71,6 +71,19 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         shutil.rmtree(os.path.join(test_dir, 'duff'))
         self.cmd('storage blob sync -s "{}" -c {} --account-name {}'.format(
             test_dir, container, storage_account))
+        self.cmd('storage blob list -c {} --account-name {}'.format(
+            container, storage_account), checks=JMESPathCheck('length(@)', 0))
+
+        # sync a subset of files in a directory
+        with open(os.path.join(test_dir, 'test.json'), 'w') as f:
+            f.write('updated.')
+        self.cmd('storage blob sync -s "{}" -c {} --account-name {} --include-pattern *.json'.format(
+            test_dir, container, storage_account))
+        self.cmd('storage blob list -c {} --account-name {}'.format(
+            container, storage_account), checks=JMESPathCheck('length(@)', 1))
+
+        self.cmd('storage blob delete-batch -s {} --account-name {}'.format(
+            container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 0))
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -118,17 +118,17 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 41))
 
-        self.cmd('storage remove -c {} -n butter --account-name {} --recursive --exclude "file_*"'.format(
+        self.cmd('storage remove -c {} -n butter --account-name {} --recursive --exclude-pattern "file_*"'.format(
             container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 41))
 
-        self.cmd('storage remove -c {} -n butter --account-name {} --exclude "file_1"'.format(
+        self.cmd('storage remove -c {} -n butter --account-name {} --exclude-pattern "file_1"'.format(
             container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 32))
 
-        self.cmd('storage remove -c {} -n butter --account-name {} --recursive --exclude "file_1"'.format(
+        self.cmd('storage remove -c {} -n butter --account-name {} --recursive --exclude-pattern "file_1"'.format(
             container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 23))
@@ -251,9 +251,9 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.assertEqual(11, sum(len(f) for r, d, f in os.walk(local_folder)))
 
         # Download a set of files
-        self.cmd('storage copy -s "{}" -d "{}" --recursive'.format(
-            '{}/file*'.format(first_container_url), local_folder))
-        self.assertEqual(1, sum(len(d) for r, d, f in os.walk(local_folder)))
+        self.cmd('storage copy -s "{}" --include-path "apple" --include-pattern file* -d "{}" --recursive'.format(
+            first_container_url, local_folder))
+        self.assertEqual(3, sum(len(d) for r, d, f in os.walk(local_folder)))
         self.assertEqual(21, sum(len(f) for r, d, f in os.walk(local_folder)))
 
         # Copy a single blob to another single blob
@@ -335,9 +335,9 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.assertEqual(11, sum(len(f) for r, d, f in os.walk(local_folder)))
 
         # Download a set of files
-        self.cmd('storage copy --source-account-name {} --source-container {} --source-blob {} --destination-local-path "{}" --recursive'
-                 .format(first_account, first_container, 'file*', local_folder))
-        self.assertEqual(1, sum(len(d) for r, d, f in os.walk(local_folder)))
+        self.cmd('storage copy --source-account-name {} --source-container {} --include-path {} --include-pattern {} --destination-local-path "{}" --recursive'
+                 .format(first_account, first_container, 'apple', 'file*', local_folder))
+        self.assertEqual(3, sum(len(d) for r, d, f in os.walk(local_folder)))
         self.assertEqual(21, sum(len(f) for r, d, f in os.walk(local_folder)))
 
         # Copy a single blob to another single blob
@@ -405,9 +405,9 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.assertEqual(11, sum(len(f) for r, d, f in os.walk(local_folder)))
 
         # Download a set of files
-        self.cmd('storage copy -s "{}" -d "{}" --recursive'.format(
-            '{}/file*'.format(share_url), local_folder))
-        self.assertEqual(1, sum(len(d) for r, d, f in os.walk(local_folder)))
+        self.cmd('storage copy -s "{}" --include-path "apple" --include-pattern file* -d "{}" --recursive'.format(
+            share_url, local_folder))
+        self.assertEqual(3, sum(len(d) for r, d, f in os.walk(local_folder)))
         self.assertEqual(21, sum(len(f) for r, d, f in os.walk(local_folder)))
 
     @ResourceGroupPreparer()
@@ -449,7 +449,7 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.assertEqual(11, sum(len(f) for r, d, f in os.walk(local_folder)))
 
         # Download a set of files
-        self.cmd('storage copy --source-account-name {} --source-share {} --source-file-path {} --destination-local-path "{}" --recursive'
-                 .format(storage_account, share, 'file*', local_folder))
-        self.assertEqual(1, sum(len(d) for r, d, f in os.walk(local_folder)))
+        self.cmd('storage copy --source-account-name {} --source-share {} --include-path "apple" --include-pattern file* --destination-local-path "{}" --recursive'
+                 .format(storage_account, share, local_folder))
+        self.assertEqual(3, sum(len(d) for r, d, f in os.walk(local_folder)))
         self.assertEqual(21, sum(len(f) for r, d, f in os.walk(local_folder)))

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -167,6 +167,11 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 21))
 
+        self.cmd('storage remove -c {} --include-path apple --account-name {} --include-pattern "file*" --exclude-pattern "file_1*" --recursive'.format(
+            container, storage_account))
+        self.cmd('storage blob list -c {} --account-name {}'.format(
+            container, storage_account), checks=JMESPathCheck('length(@)', 12))
+
         self.cmd('storage remove -c {} --account-name {} --recursive'.format(
             container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -123,12 +123,12 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 41))
 
-        self.cmd('storage remove -c {} -n butter --account-name {} --exclude-pattern "file_1"'.format(
+        self.cmd('storage remove -c {} -n butter --account-name {} --exclude-pattern "file_1*"'.format(
             container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 32))
 
-        self.cmd('storage remove -c {} -n butter --account-name {} --recursive --exclude-pattern "file_1"'.format(
+        self.cmd('storage remove -c {} -n butter --account-name {} --recursive --exclude-pattern "file_1*"'.format(
             container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 23))
@@ -139,17 +139,17 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 41))
 
-        self.cmd('storage remove -c {} -n butter --account-name {} --recursive --include "file_1"'.format(
+        self.cmd('storage remove -c {} -n butter --account-name {} --recursive --include-pattern "file_1*"'.format(
             container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 39))
 
-        self.cmd('storage remove -c {} -n butter --account-name {} --include "file_*"'.format(
+        self.cmd('storage remove -c {} -n butter --account-name {} --include-pattern "file_*"'.format(
             container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 30))
 
-        self.cmd('storage remove -c {} -n butter --account-name {} --recursive --include "file_*"'.format(
+        self.cmd('storage remove -c {} -n butter --account-name {} --recursive --include-pattern "file_*"'.format(
             container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 21))


### PR DESCRIPTION
Fix #11735
---
Feature description：
1. Upgrade Azcopy 10.3.3 to utilize some new features
2. If no azcopy in target folder or the version is not the same as what we expect, we will install for users.
3. --include-pattern/--include-path/--exclude-pattern/--exclude-path are involved to improve the performance for target operation.
The new parameters have behaviour that is better defined in complex situations (such as
recursion). The * wildcard is supported in the pattern parameters, but not in the path ones.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
