### PR TITLE
[ACR]: Add a prompt for command "az acr delete" to avoid accidental operation

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+**ACR**
+
+* [BREAKING CHANGE] `az acr delete` will prompt
+
 **AppConfig**
 
 * Support import/export of keyvault references from/to appservice

--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -68,8 +68,8 @@ def acr_create(cmd,
     return lro_poller
 
 
-def acr_delete(cmd, client, registry_name, resource_group_name=None):
-    user_confirmation("Are you sure you want to delete the registry '{}'?".format(registry_name))
+def acr_delete(cmd, client, registry_name, resource_group_name=None, yes=False):
+    user_confirmation("Are you sure you want to delete the registry '{}'?".format(registry_name), yes)
     resource_group_name = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
     return client.delete(resource_group_name, registry_name)
 

--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -11,7 +11,8 @@ from ._utils import (
     get_registry_by_name,
     validate_managed_registry,
     validate_sku_update,
-    get_resource_group_name_by_registry_name
+    get_resource_group_name_by_registry_name,
+    user_confirmation
 )
 from ._docker_utils import get_login_credentials
 from .network_rule import NETWORK_RULE_NOT_SUPPORTED
@@ -68,7 +69,7 @@ def acr_create(cmd,
 
 
 def acr_delete(cmd, client, registry_name, resource_group_name=None):
-    logger.warning('To avoid accidental removal, in a future release "az acr delete" will prompt for confirmation')
+    user_confirmation("Are you sure you want to delete the registry '{}'?".format(registry_name))
     resource_group_name = get_resource_group_name_by_registry_name(cmd.cli_ctx, registry_name, resource_group_name)
     return client.delete(resource_group_name, registry_name)
 

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands.py
@@ -80,7 +80,7 @@ class AcrCommandsTests(ScenarioTest):
         assert password2 != renewed_password2
 
         # test acr delete
-        self.cmd('acr delete -n {} -g {}'.format(registry_name, resource_group))
+        self.cmd('acr delete -n {} -g {} -y'.format(registry_name, resource_group))
 
     def test_check_name_availability(self):
         # the chance of this randomly generated name has a duplication is rare
@@ -178,7 +178,7 @@ class AcrCommandsTests(ScenarioTest):
         # test webhook delete
         self.cmd('acr webhook delete -n {webhook_name} -r {registry_name}')
         # test acr delete
-        self.cmd('acr delete -n {registry_name} -g {rg}')
+        self.cmd('acr delete -n {registry_name} -g {rg} -y')
 
     @ResourceGroupPreparer()
     def test_acr_create_replication(self, resource_group, resource_group_location):
@@ -225,7 +225,7 @@ class AcrCommandsTests(ScenarioTest):
         # test replication delete
         self.cmd('acr replication delete -n {replication_name} -r {registry_name}')
         # test acr delete
-        self.cmd('acr delete -n {registry_name} -g {rg}')
+        self.cmd('acr delete -n {registry_name} -g {rg} -y')
 
     @ResourceGroupPreparer()
     @record_only()

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_network_rule_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_network_rule_commands.py
@@ -102,5 +102,5 @@ class AcrNetworkRuleCommandsTests(ScenarioTest):
                  checks=[self.check('virtualNetworkRules', []),
                          self.check('ipRules', [])])
 
-        self.cmd('acr delete -g {rg} -n {registry_name}')
+        self.cmd('acr delete -g {rg} -n {registry_name} -y')
         self.cmd('network vnet delete -g {rg} -n {vnet_name}')

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_task_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_task_commands.py
@@ -101,4 +101,4 @@ class AcrTaskCommandsTests(ScenarioTest):
         self.cmd('acr task delete -n {task_name} -r {registry_name}')
 
         # test acr delete
-        self.cmd('acr delete -n {registry_name} -g {rg}')
+        self.cmd('acr delete -n {registry_name} -g {rg} -y')


### PR DESCRIPTION
(Resolve #11490 )
1. Add a prompt that asks user "Are you sure you want to delete the registry '$resgistryName'?" for command "az acr delete"
2. Update test cases accordingly. (Add -y to omit confirmation)

**Before:**

```
> az acr delete -n test
To avoid accidental removal, in a future release "az acr delete" will prompt for confirmation
```

**After:**

```
> az acr delete -n test
Are you sure you want to delete the registry 'test'? (y/n):
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
