### PR TITLE
[Storage] Fix errors for storage blob update

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -27,6 +27,7 @@ Release History
 **Storage**
 
 * Add a new command group `az storage share-rm` to use the Microsoft.Storage resource provider for Azure file share management operations.
+* Fix issue #11415: permission error for `az storage blob update`
 
 2.0.80
 ++++++

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -112,15 +112,16 @@ def validate_client_parameters(cmd, namespace):
         if auth_mode == 'login':
             n.token_credential = _create_token_credential(cmd.cli_ctx)
 
-            # give warning if there are account key args being ignored
-            account_key_args = [n.account_key and "--account-key", n.sas_token and "--sas-token",
-                                n.connection_string and "--connection-string"]
-            account_key_args = [arg for arg in account_key_args if arg]
+    if hasattr(n, 'token_credential') and n.token_credential:
+        # give warning if there are account key args being ignored
+        account_key_args = [n.account_key and "--account-key", n.sas_token and "--sas-token",
+                            n.connection_string and "--connection-string"]
+        account_key_args = [arg for arg in account_key_args if arg]
 
-            if account_key_args:
-                logger.warning('In "login" auth mode, the following arguments are ignored: %s',
-                               ' ,'.join(account_key_args))
-            return
+        if account_key_args:
+            logger.warning('In "login" auth mode, the following arguments are ignored: %s',
+                           ' ,'.join(account_key_args))
+        return
 
     if not n.connection_string:
         n.connection_string = get_config_value('storage', 'connection_string', None)
@@ -369,13 +370,13 @@ def get_content_setting_validator(settings_class, update, guess_from_file=None):
             key = ns.get('account_key')
             cs = ns.get('connection_string')
             sas = ns.get('sas_token')
+            token_credential = ns.get('token_credential')
             if _class_name(settings_class) == _class_name(t_blob_content_settings):
                 client = get_storage_data_service_client(cmd.cli_ctx,
-                                                         t_base_blob_service,
-                                                         account,
-                                                         key,
-                                                         cs,
-                                                         sas)
+                                                         service=t_base_blob_service,
+                                                         name=account,
+                                                         key=key, connection_string=cs, sas_token=sas,
+                                                         token_credential=token_credential)
                 container = ns.get('container_name')
                 blob = ns.get('blob_name')
                 lease_id = ns.get('lease_id')


### PR DESCRIPTION
Fix #11415
---
For `--auth-mode login`, we will use login credentials for storage client authentication. 

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
