### PR TITLE
{AppService} Refine test_linux_webapp_ssh on Windows

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3274,13 +3274,13 @@ def _start_ssh_session(hostname, port, username, password):
 
 
 def ssh_webapp(cmd, resource_group_name, name, port=None, slot=None, timeout=None):  # pylint: disable=too-many-statements
-    config = get_site_configs(cmd, resource_group_name, name, slot)
-    if config.remote_debugging_enabled:
-        raise CLIError('remote debugging is enabled, please disable')
-
     import platform
     if platform.system() == "Windows":
         raise CLIError('webapp ssh is only supported on linux and mac')
+
+    config = get_site_configs(cmd, resource_group_name, name, slot)
+    if config.remote_debugging_enabled:
+        raise CLIError('remote debugging is enabled, please disable')
     create_tunnel_and_session(cmd, resource_group_name, name, port=port, slot=slot, timeout=timeout)
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -590,10 +590,14 @@ class LinuxWebappScenarioTest(ScenarioTest):
 class LinuxWebappSSHScenarioTest(ScenarioTest):
     @ResourceGroupPreparer(location='japanwest')
     def test_linux_webapp_ssh(self, resource_group):
-        # Skip this test on Windows as it will fail at 'webapp ssh'
+        # On Windows, test 'webapp ssh' throws error
         import platform
         if platform.system() == "Windows":
+            from azure.cli.core.util import CLIError
+            with self.assertRaises(CLIError):
+                self.cmd('webapp ssh -g {} -n {} --timeout 5'.format("foo", "bar"))
             return
+
         runtime = 'node|8.11'
         plan = self.create_random_name(prefix='webapp-ssh-plan', length=24)
         webapp = self.create_random_name(prefix='webapp-ssh', length=24)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -590,6 +590,10 @@ class LinuxWebappScenarioTest(ScenarioTest):
 class LinuxWebappSSHScenarioTest(ScenarioTest):
     @ResourceGroupPreparer(location='japanwest')
     def test_linux_webapp_ssh(self, resource_group):
+        # Skip this test on Windows as it will fail at 'webapp ssh'
+        import platform
+        if platform.system() == "Windows":
+            return
         runtime = 'node|8.11'
         plan = self.create_random_name(prefix='webapp-ssh-plan', length=24)
         webapp = self.create_random_name(prefix='webapp-ssh', length=24)


### PR DESCRIPTION
Skip `test_linux_webapp_ssh` on Windows as it will fail at
https://github.com/Azure/azure-cli/blob/c5b5772ab958e755a9649e455a8e6bb17edc6400/src/azure-cli/azure/cli/command_modules/appservice/custom.py#L3282-L3283

and break the test on `pytest` or `azdev test`. 