### PR TITLE
{Packaging} Remove pydocumentdb

### DIFF
--- a/scripts/release/homebrew/docker/requirements.txt
+++ b/scripts/release/homebrew/docker/requirements.txt
@@ -2,4 +2,3 @@ homebrew-pypi-poet~=0.10.0
 jinja2~=2.10
 requests>=2.20.0
 applicationinsights >=0.11.1,<0.11.8
-pydocumentdb==2.3.3

--- a/src/azure-cli/requirements.py2.Darwin.txt
+++ b/src/azure-cli/requirements.py2.Darwin.txt
@@ -119,7 +119,6 @@ portalocker==1.4.0
 psutil==5.6.3
 pyasn1==0.4.5
 pycparser==2.19
-pydocumentdb==2.3.3
 Pygments==2.4.2
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py2.Linux.txt
+++ b/src/azure-cli/requirements.py2.Linux.txt
@@ -119,7 +119,6 @@ portalocker==1.4.0
 psutil==5.6.3
 pyasn1==0.4.5
 pycparser==2.19
-pydocumentdb==2.3.3
 Pygments==2.4.2
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py2.windows.txt
+++ b/src/azure-cli/requirements.py2.windows.txt
@@ -116,7 +116,6 @@ portalocker==1.2.1
 psutil==5.6.3
 pyasn1==0.4.5
 pycparser==2.19
-pydocumentdb==2.3.3
 Pygments==2.4.2
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -110,7 +110,6 @@ pbr==5.3.1
 portalocker==1.4.0
 psutil==5.6.3
 pycparser==2.19
-pydocumentdb==2.3.3
 Pygments==2.4.2
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -110,7 +110,6 @@ pbr==5.3.1
 portalocker==1.4.0
 psutil==5.6.3
 pycparser==2.19
-pydocumentdb==2.3.3
 Pygments==2.4.2
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -107,7 +107,6 @@ pbr==5.3.1
 portalocker==1.2.1
 psutil==5.6.3
 pycparser==2.19
-pydocumentdb==2.3.3
 Pygments==2.4.2
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -135,7 +135,6 @@ DEPENDENCIES = [
     'knack~=0.6,>=0.6.3',
     'mock~=2.0',
     'paramiko>=2.0.8,<3.0.0',
-    'pydocumentdb>=2.0.1,<3.0.0',
     'pygments~=2.4',
     'pyOpenSSL>=17.1.0',
     'pytz==2019.1',


### PR DESCRIPTION
Remove `pydocumentdb` package dependency, it's replaced by `azure-cosmos`.
See #11879

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
