### PR TITLE
{Network} az network application-gateway create: set https when key_vault_secret_id provided

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -150,7 +150,7 @@ def create_application_gateway(cmd, application_gateway_name, resource_group_nam
 
     tags = tags or {}
     sku_tier = sku.split('_', 1)[0] if 'v2' not in sku else sku
-    http_listener_protocol = 'https' if cert_data else 'http'
+    http_listener_protocol = 'https' if (cert_data or key_vault_secret_id) else 'http'
     private_ip_allocation = 'Static' if private_ip_address else 'Dynamic'
     virtual_network_name = virtual_network_name or '{}Vnet'.format(application_gateway_name)
 


### PR DESCRIPTION
http listener protocol is auto determined based on cert_data alone,
adding key_vault_secret_id to allow listener protocol to be correctly
set when cert is provided via key vault

Addresses: #11973



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
