### PR TITLE
Missing dependency - python3-brotli

### DIFF
--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -21,7 +21,7 @@ Version:        %{version}
 Release:        %{release}
 Url:            https://docs.microsoft.com/cli/azure/install-azure-cli
 BuildArch:      x86_64
-Requires:       %{python_cmd}
+Requires:       %{python_cmd} python3-brotli
 
 BuildRequires:  gcc, libffi-devel, openssl-devel, perl
 BuildRequires:  %{python_cmd}-devel


### PR DESCRIPTION
I've noticed that az has since added a brotli python3 bindings dependency which doesn't get added by the rpm.  Fedora 31 - not sure if all systems will have the brotli bindings available.  Suggest using COPR automatic builds.

$  az login
Traceback (most recent call last):
  File "/usr/lib64/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/__main__.py", line 33, in <module>
    az_cli = get_default_cli()
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/__init__.py", line 562, in get_default_cli
    help_cls=AzCliHelp)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/__init__.py", line 61, in __init__
    register_ids_argument(self)  # global subscription must be registered first!
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/arm.py", line 182, in register_ids_argument
    from msrestazure.tools import parse_resource_id, is_valid_resource_id
  File "/usr/lib64/az/lib/python3.6/site-packages/msrestazure/__init__.py", line 28, in <module>
    from .azure_configuration import AzureConfiguration
  File "/usr/lib64/az/lib/python3.6/site-packages/msrestazure/azure_configuration.py", line 34, in <module>
    from msrest import Configuration
  File "/usr/lib64/az/lib/python3.6/site-packages/msrest/__init__.py", line 28, in <module>
    from .configuration import Configuration
  File "/usr/lib64/az/lib/python3.6/site-packages/msrest/configuration.py", line 37, in <module>
    from .pipeline import Pipeline
  File "/usr/lib64/az/lib/python3.6/site-packages/msrest/pipeline/__init__.py", line 52, in <module>
    from requests.structures import CaseInsensitiveDict
  File "/usr/lib64/az/lib/python3.6/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/usr/lib64/az/lib/python3.6/site-packages/urllib3/__init__.py", line 7, in <module>
    from .connectionpool import (
  File "/usr/lib64/az/lib/python3.6/site-packages/urllib3/connectionpool.py", line 37, in <module>
    from .response import HTTPResponse
  File "/usr/lib64/az/lib/python3.6/site-packages/urllib3/response.py", line 151, in <module>
    class HTTPResponse(io.IOBase):
  File "/usr/lib64/az/lib/python3.6/site-packages/urllib3/response.py", line 351, in HTTPResponse
    DECODER_ERROR_CLASSES += (brotli.error,)
AttributeError: module 'brotli' has no attribute 'error'



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
