### PR TITLE
[ACR] Add a new argument '--expose-token' for 'az acr login' 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -257,8 +257,7 @@ examples:
 helps['acr login'] = """
 type: command
 short-summary: Log in to an Azure Container Registry through the Docker CLI.
-long-summary: Docker must be installed on your machine. Once done, use 'docker logout <registry url>' to log out.  
-              (If you only need an access token and do not want to install Docker, specify '--expose-token')
+long-summary: Docker must be installed on your machine. Once done, use 'docker logout <registry url>' to log out. (If you only need an access token and do not want to install Docker, specify '--expose-token')
 examples:
   - name: Log in to an Azure Container Registry
     text: >

--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -257,7 +257,8 @@ examples:
 helps['acr login'] = """
 type: command
 short-summary: Log in to an Azure Container Registry through the Docker CLI.
-long-summary: Docker must be installed on your machine. Once done, use 'docker logout <registry url>' to log out. (If you only need an access token and do not want to install Docker, specify '--expose-token'.)
+long-summary: Docker must be installed on your machine. Once done, use 'docker logout <registry url>' to log out.  
+              (If you only need an access token and do not want to install Docker, specify '--expose-token')
 examples:
   - name: Log in to an Azure Container Registry
     text: >

--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -257,11 +257,14 @@ examples:
 helps['acr login'] = """
 type: command
 short-summary: Log in to an Azure Container Registry through the Docker CLI.
-long-summary: Docker must be installed on your machine. Once done, use 'docker logout <registry url>' to log out.
+long-summary: Docker must be installed on your machine. Once done, use 'docker logout <registry url>' to log out. (If you only need an access token and do not want to install Docker, specify '--expose-token'.)
 examples:
   - name: Log in to an Azure Container Registry
     text: >
         az acr login -n MyRegistry
+  - name: Get an Azure Container Registry access token
+    text: >
+        az acr login -n MyRegistry --expose-token
 """
 
 helps['acr network-rule'] = """

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -93,6 +93,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
 
     with self.argument_context('acr login') as c:
         c.argument('resource_group_name', deprecate_info=c.deprecate(hide=True))
+        c.argument('expose_token', options_list=['--expose-token', '-t'], help='Expose access token instead of automatically logging in through Docker CLI', action='store_true', is_preview=True)
 
     with self.argument_context('acr repository') as c:
         c.argument('resource_group_name', deprecate_info=c.deprecate(hide=True))

--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -139,23 +139,23 @@ def acr_login(cmd,
             username=username,
             password=password)
 
-        logger.warning("You can perform manual login using the provided access token below, " \
-                        "for example: 'docker login loginServer -u %s -p accessToken'", EMPTY_GUID)
+        logger.warning("You can perform manual login using the provided access token below, "
+                       "for example: 'docker login loginServer -u %s -p accessToken'", EMPTY_GUID)
 
         token_info = {
-            "loginServer" : login_server,
-            "accessToken" : password
+            "loginServer": login_server,
+            "accessToken": password
         }
 
         return token_info
 
     tips = "You may want to use 'az acr login -n {} --expose-token' to get an access token, " \
-            "which does not require Docker to be installed.".format(registry_name)
+           "which does not require Docker to be installed.".format(registry_name)
 
     from azure.cli.core.util import in_cloud_console
     if in_cloud_console():
-        raise CLIError("This command requires running the docker daemon, " \
-            "which is not supported in Azure Cloud Shell. " + tips)
+        raise CLIError("This command requires running the docker daemon, "
+                       "which is not supported in Azure Cloud Shell. " + tips)
 
     try:
         docker_command, _ = get_docker_command()
@@ -202,6 +202,7 @@ def acr_login(cmd,
             output.write(stderr)
 
     return None
+
 
 def acr_show_usage(cmd, client, registry_name, resource_group_name=None):
     _, resource_group_name = validate_managed_registry(cmd,


### PR DESCRIPTION
1. Add a new argument '--expose-token' for 'az acr login' to expose access token. 
2. Update help manual accordingly.

Close #9442

**Behavior:**
[specify --expose-token]
![image](https://user-images.githubusercontent.com/8113721/74010433-72fdb700-49c0-11ea-969f-1a776ab8eb33.png)



[docker command error]
![image](https://user-images.githubusercontent.com/8113721/74010243-f9fe5f80-49bf-11ea-8eed-ee80ab2985e9.png)



[help manual]
![image](https://user-images.githubusercontent.com/8113721/74010022-75134600-49bf-11ea-934c-1d63d586a5c6.png)


**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
