### PR TITLE
[ARM] az rest: Print the header of response (#10714)

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -608,6 +608,7 @@ def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  #
     try:
         r = requests.request(method, uri, params=uri_parameters, data=body, headers=headers,
                              verify=not should_disable_connection_verify())
+        logger.debug("Response Header : %s", r.headers if r else None)
     except Exception as ex:  # pylint: disable=broad-except
         raise CLIError(ex)
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -608,7 +608,7 @@ def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  #
     try:
         r = requests.request(method, uri, params=uri_parameters, data=body, headers=headers,
                              verify=not should_disable_connection_verify())
-        logger.debug("Response Header : %s", r.headers if r else None)
+        logger.debug("Response Header : %s", r.headers if r else '')
     except Exception as ex:  # pylint: disable=broad-except
         raise CLIError(ex)
 


### PR DESCRIPTION
Issue: #10714

Some services executed asynchronously will put useful information into the header, like: location URL, Retry-After, etc. So I print the header of response for `az rest`.

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
