### PR TITLE
[ACR] Fix the incorrect output of `az acr task identity show -n Name -r Registry -o table`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_format.py
@@ -50,6 +50,10 @@ def task_output_format(result):
     return _output_format(result, _task_format_group)
 
 
+def task_identity_format(result):
+    return _output_format(result, _task_identity_format_group)
+
+
 def taskrun_output_format(result):
     return _output_format(result, _taskrun_format_group)
 
@@ -185,6 +189,18 @@ def _task_format_group(item):
         ('STATUS', _get_value(item, 'status')),
         ('SOURCE REPOSITORY', _get_value(item, 'step', 'contextPath')),
         ('TRIGGERS', _get_triggers(item))
+    ])
+
+
+def _task_identity_format_group(item):
+    identities = _get_array_value(item, 'userAssignedIdentities')
+    identities_by_line = str('\n'.join(identities)) if identities else ' '
+
+    return OrderedDict([
+        ('PRINCIPAL ID', _get_value(item, 'principalId')),
+        ('TENANT ID', _get_value(item, 'tenantId')),
+        ('TYPE', _get_value(item, 'type')),
+        ('USER ASSIGNED IDENTITIES', identities_by_line)
     ])
 
 

--- a/src/azure-cli/azure/cli/command_modules/acr/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/commands.py
@@ -17,6 +17,7 @@ from ._format import (
     replication_output_format,
     build_output_format,
     task_output_format,
+    task_identity_format,
     taskrun_output_format,
     run_output_format,
     helm_list_output_format,
@@ -223,7 +224,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.command('update', 'acr_task_update')
         g.command('identity assign', 'acr_task_identity_assign')
         g.command('identity remove', 'acr_task_identity_remove')
-        g.command('identity show', 'acr_task_identity_show')
+        g.command('identity show', 'acr_task_identity_show', table_transformer=task_identity_format)
         g.command('credential add', 'acr_task_credential_add')
         g.command('credential update', 'acr_task_credential_update')
         g.command('credential remove', 'acr_task_credential_remove')


### PR DESCRIPTION
Add a table transformer for `az acr task identity show -n Name -r Registry -o table`

(Fix #11868 )

**Before:**
![image](https://user-images.githubusercontent.com/8113721/74156020-76a76d00-4c50-11ea-91db-c1ad2be7fe19.png)

**After:**
[User Assigned Identities]
![image](https://user-images.githubusercontent.com/8113721/74156225-e289d580-4c50-11ea-9ea6-470f92fcdd27.png)

[System Assigned Identity]
![image](https://user-images.githubusercontent.com/8113721/74156365-22e95380-4c51-11ea-9ba6-af087d00235f.png)



**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
