### PR TITLE
[Compute] `az vm host`: remove preview tag for `vm host` and `vm host group`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/commands.py
@@ -359,7 +359,7 @@ def load_command_table(self, _):
         g.custom_command('reset-ssh', 'reset_linux_ssh')
 
     with self.command_group('vm host', compute_dedicated_host_sdk, client_factory=cf_dedicated_hosts,
-                            min_api='2019-03-01', is_preview=True) as g:
+                            min_api='2019-03-01') as g:
         g.show_command('show', 'get')
         g.custom_command('get-instance-view', 'get_dedicated_host_instance_view')
         g.custom_command('create', 'create_dedicated_host')
@@ -368,7 +368,7 @@ def load_command_table(self, _):
         g.command('delete', 'delete', confirmation=True)
 
     with self.command_group('vm host group', compute_dedicated_host_groups_sdk, client_factory=cf_dedicated_host_groups,
-                            min_api='2019-03-01', is_preview=True) as g:
+                            min_api='2019-03-01') as g:
         g.show_command('show', 'get')
         g.custom_command('create', 'create_dedicated_host_group')
         g.custom_command('list', 'list_dedicated_host_groups')


### PR DESCRIPTION
This PR is to fix #12026 

As api now is in stable version, we can remove the preview tag as the requests from service team.



**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
