### PR TITLE
[Compute] Increase robustness of vm image list

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_actions.py
@@ -40,15 +40,27 @@ def load_images_thru_services(cli_ctx, publisher, offer, sku, location):
         location = get_one_of_subscription_locations(cli_ctx)
 
     def _load_images_from_publisher(publisher):
-        offers = client.virtual_machine_images.list_offers(location, publisher)
+        try:
+            offers = client.virtual_machine_images.list_offers(location, publisher)
+        except Exception as e:
+            logger.warning(str(e))
+            return
         if offer:
             offers = [o for o in offers if _matched(offer, o.name)]
         for o in offers:
-            skus = client.virtual_machine_images.list_skus(location, publisher, o.name)
+            try:
+                skus = client.virtual_machine_images.list_skus(location, publisher, o.name)
+            except Exception as e:
+                logger.warning(str(e))
+                continue
             if sku:
                 skus = [s for s in skus if _matched(sku, s.name)]
             for s in skus:
-                images = client.virtual_machine_images.list(location, publisher, o.name, s.name)
+                try:
+                    images = client.virtual_machine_images.list(location, publisher, o.name, s.name)
+                except Exception as e:
+                    logger.warning(str(e))
+                    continue
                 for i in images:
                     all_images.append({
                         'publisher': publisher,

--- a/src/azure-cli/azure/cli/command_modules/vm/_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_actions.py
@@ -40,9 +40,10 @@ def load_images_thru_services(cli_ctx, publisher, offer, sku, location):
         location = get_one_of_subscription_locations(cli_ctx)
 
     def _load_images_from_publisher(publisher):
+        from msrestazure.azure_exceptions import CloudError
         try:
             offers = client.virtual_machine_images.list_offers(location, publisher)
-        except Exception as e:
+        except CloudError as e:
             logger.warning(str(e))
             return
         if offer:
@@ -50,7 +51,7 @@ def load_images_thru_services(cli_ctx, publisher, offer, sku, location):
         for o in offers:
             try:
                 skus = client.virtual_machine_images.list_skus(location, publisher, o.name)
-            except Exception as e:
+            except CloudError as e:
                 logger.warning(str(e))
                 continue
             if sku:
@@ -58,7 +59,7 @@ def load_images_thru_services(cli_ctx, publisher, offer, sku, location):
             for s in skus:
                 try:
                     images = client.virtual_machine_images.list(location, publisher, o.name, s.name)
-                except Exception as e:
+                except CloudError as e:
                     logger.warning(str(e))
                     continue
                 for i in images:


### PR DESCRIPTION
Issue #11767 

In this command's implementation,
Step 1. use `client.virtual_machine_images.list_publishers(location)` to get publishers
Step 2. use `client.virtual_machine_images.list_offers(location, publisher)` to get offers

Step 2 fails for some publishers retrieved from step 1, then the whole command fails. It's a data inconsistency from service.
Anyway, add try-catch. Use `logger.warning` if exception occurs.

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
