### PR TITLE
{Misc.} Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,6 @@
 /src/azure-cli/azure/cli/command_modules/container/ @samkreter
 /src/azure-cli/azure/cli/command_modules/consumption/ @sandeepnl
 /src/azure-cli/azure/cli/command_modules/dls/ @lewu-msft
-/src/azure-cli/azure/cli/command_modules/eventgrid/ @kalyanaj
 /src/azure-cli/azure/cli/command_modules/extension/ @zikalino
 /src/azure-cli/azure/cli/command_modules/keyvault/ @bim-msft @fengzhou-msft @jiasli
 /src/azure-cli/azure/cli/command_modules/monitor/ @MyronFanQiu


### PR DESCRIPTION
Remove outdated info for eventgrid code owner. PR https://github.com/Azure/azure-cli/pull/12095 is blocked by this. 

I will reach out to Eventgrid Team to find the right person as code owner.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
