### PR TITLE
{Core} Use caseless matching for provisioning_state

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -681,10 +681,10 @@ def _cli_wait_command(context, name, getter_op, custom_command=False, **kwargs):
                     return None
                 provisioning_state = get_provisioning_state(instance)
                 # until we have any needs to wait for 'Failed', let us bail out on this
-                if provisioning_state == 'Failed':
+                if provisioning_state.casefold() == 'failed':
                     progress_indicator.stop()
                     raise CLIError('The operation failed')
-                if ((wait_for_created or wait_for_updated) and provisioning_state == 'Succeeded') or \
+                if ((wait_for_created or wait_for_updated) and provisioning_state.casefold() == 'succeeded') or \
                         custom_condition and bool(verify_property(instance, custom_condition)):
                     progress_indicator.end()
                     return None


### PR DESCRIPTION
Some service returns lower-cased 'succeeded' provisioning state, such as blueprint assignment create. 

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
