### PR TITLE
[ACR] `az acr login`: Throw a CLIError if there are errors returned by docker command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -193,12 +193,14 @@ def acr_login(cmd,
                        login_server])
             p.wait()
         else:
+            stderr_messages = stderr.decode()
             if b'--password-stdin' in stderr:
-                errors = [err for err in stderr.decode().split('\n') if '--password-stdin' not in err and err != '']
-
-                if errors:
-                    stderr = '\n'.join(errors)
-                    raise CLIError('docker: ' + stderr)
+                errors = [err for err in stderr_messages.split('\n') if err and '--password-stdin' not in err]
+                # Will not raise CLIError if there is no error other than '--password-stdin'
+                if not errors:
+                    return None
+                stderr_messages = '\n'.join(errors)
+            raise CLIError('docker: ' + stderr_messages)
 
     return None
 

--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -194,12 +194,11 @@ def acr_login(cmd,
             p.wait()
         else:
             if b'--password-stdin' in stderr:
-                errors = [err for err in stderr.decode().split('\n') if '--password-stdin' not in err]
-                stderr = '\n'.join(errors).encode()
+                errors = [err for err in stderr.decode().split('\n') if '--password-stdin' not in err and err != '']
 
-            import sys
-            output = getattr(sys.stderr, 'buffer', sys.stderr)
-            output.write(stderr)
+                if errors:
+                    stderr = '\n'.join(errors)
+                    raise CLIError('docker: ' + stderr)
 
     return None
 


### PR DESCRIPTION
Fix #11355 

If there are errors returned by docker command, the CLI exit code will be non-zero 

![image](https://user-images.githubusercontent.com/8113721/74321579-77114680-4dbd-11ea-9820-c9f55081b1ef.png)

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
