### PR TITLE
[ARM] Fix #12199 Workround for template exception handling

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -100,7 +100,7 @@ class ArmTemplateBuilder(object):
 
 def handle_template_based_exception(ex):
     try:
-        raise CLIError(ex.inner_exception.error.message)
+        raise CLIError(ex.inner_exception.error)
     except AttributeError:
         raise CLIError(ex)
 


### PR DESCRIPTION
#12199 
Error is:
```
Traceback (most recent call last):
  File "/opt/az/lib/python3.6/site-packages/azure/cli/core/commands/arm.py", line 103, in handle_template_based_exception
    raise CLIError(ex.inner_exception.error.message)
AttributeError: 'str' object has no attribute 'message'
```
Signed-off-by: Nye T. Liu <nye@blockdaemon.com>