### PR TITLE
{azdev} Remove urllib3==1.24.2 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@
 setuptools==40.0.0
 wheel==0.31.1
 pip>=9.0.1
-urllib3==1.24.2
-


### PR DESCRIPTION
Remove `urllib3==1.24.2` from `requirements.txt` as this will let `azdev` install an old version. But CI will install (currently 1.25.8) per

https://github.com/Azure/azure-cli/blob/031525fd06169bed88d9a6547f44885c978b5f25/src/azure-cli/setup.py#L144

There is a breaking change between 1.24 and 1.25. Version 1.25 trims `.` in URL, causing issue https://github.com/Azure/azure-cli/pull/11886#issuecomment-576572788
