### PR TITLE
{Storage} az storage share-rm: Add process_resource_group for resource group

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -663,7 +663,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
 
     for item in ['create', 'delete', 'exists', 'list', 'show', 'update']:
         with self.argument_context('storage share-rm {}'.format(item), resource_type=ResourceType.MGMT_STORAGE) as c:
-            c.argument('resource_group_name', required=False)
+            c.argument('resource_group_name', required=False, validator=process_resource_group)
             c.argument('account_name', storage_account_type)
             c.argument('share_name', share_name_type, options_list=('--name', '-n'), id_part='child_name_2')
             c.argument('share_quota', type=int, options_list='--quota')

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -663,7 +663,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
 
     for item in ['create', 'delete', 'exists', 'list', 'show', 'update']:
         with self.argument_context('storage share-rm {}'.format(item), resource_type=ResourceType.MGMT_STORAGE) as c:
-            c.argument('resource_group_name', required=False, validator=process_resource_group)
+            c.argument('resource_group_name', required=False)
             c.argument('account_name', storage_account_type)
             c.argument('share_name', share_name_type, options_list=('--name', '-n'), id_part='child_name_2')
             c.argument('share_quota', type=int, options_list='--quota')

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -72,7 +72,7 @@ def parse_storage_account(cmd, namespace):
     if namespace.account_name and is_valid_resource_id(namespace.account_name):
         namespace.resource_group_name = parse_resource_id(namespace.account_name)['resource_group']
         namespace.account_name = parse_resource_id(namespace.account_name)['name']
-    elif not namespace.resource_group_name:
+    elif namespace.account_name and not namespace.resource_group_name:
         namespace.resource_group_name = _query_account_rg(cmd.cli_ctx, namespace.account_name)[0]
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -65,13 +65,15 @@ def _create_token_credential(cli_ctx):
 
 
 # region PARAMETER VALIDATORS
-def parse_storage_account(namespace):
+def parse_storage_account(cmd, namespace):
     """Parse storage account which can be either account name or account id"""
     from msrestazure.tools import parse_resource_id, is_valid_resource_id
 
     if namespace.account_name and is_valid_resource_id(namespace.account_name):
         namespace.resource_group_name = parse_resource_id(namespace.account_name)['resource_group']
         namespace.account_name = parse_resource_id(namespace.account_name)['name']
+    elif not namespace.resource_group_name:
+        namespace.resource_group_name = _query_account_rg(cmd.cli_ctx, namespace.account_name)[0]
 
 
 def process_resource_group(cmd, namespace):


### PR DESCRIPTION
**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---
`Because resource group is not required in commandline, but it is required by SDK. In this way, we need to get resource group by ourselves when no resource group name provided.`

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
