### PR TITLE
[Monitor] az monitor clone: support clone metric rules from one resource to another.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/monitor/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_client_factory.py
@@ -6,9 +6,9 @@
 
 # MANAGEMENT CLIENT FACTORIES
 def cf_monitor(cli_ctx, **kwargs):
-    from azure.mgmt.monitor import MonitorManagementClient
+    from azure.cli.core.profiles import ResourceType
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(cli_ctx, MonitorManagementClient, **kwargs)
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_MONITOR, **kwargs)
 
 
 def cf_alert_rules(cli_ctx, _):

--- a/src/azure-cli/azure/cli/command_modules/monitor/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_client_factory.py
@@ -8,7 +8,7 @@
 def cf_monitor(cli_ctx, **kwargs):
     from azure.mgmt.monitor import MonitorManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(cli_ctx, MonitorManagementClient)
+    return get_mgmt_service_client(cli_ctx, MonitorManagementClient, **kwargs)
 
 
 def cf_alert_rules(cli_ctx, _):
@@ -28,7 +28,7 @@ def cf_diagnostics(cli_ctx, _):
 
 
 def cf_diagnostics_category(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).diagnostic_settings_category
+    return cf_monitor(cli_ctx).diagnostic_settings_category
 
 
 def cf_log_profiles(cli_ctx, _):
@@ -66,7 +66,7 @@ def cf_metric_alerts(cli_ctx, _):
 def _log_analytics_client_factory(cli_ctx, **kwargs):
     from azure.mgmt.loganalytics import LogAnalyticsManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(cli_ctx, LogAnalyticsManagementClient)
+    return get_mgmt_service_client(cli_ctx, LogAnalyticsManagementClient, **kwargs)
 
 
 def cf_log_analytics_workspace(cli_ctx, _):

--- a/src/azure-cli/azure/cli/command_modules/monitor/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_client_factory.py
@@ -5,26 +5,26 @@
 
 
 # MANAGEMENT CLIENT FACTORIES
-def cf_monitor(cli_ctx, _):
+def cf_monitor(cli_ctx, **kwargs):
     from azure.mgmt.monitor import MonitorManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     return get_mgmt_service_client(cli_ctx, MonitorManagementClient)
 
 
 def cf_alert_rules(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).alert_rules
+    return cf_monitor(cli_ctx).alert_rules
 
 
 def cf_alert_rule_incidents(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).alert_rule_incidents
+    return cf_monitor(cli_ctx).alert_rule_incidents
 
 
 def cf_autoscale(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).autoscale_settings
+    return cf_monitor(cli_ctx).autoscale_settings
 
 
 def cf_diagnostics(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).diagnostic_settings
+    return cf_monitor(cli_ctx).diagnostic_settings
 
 
 def cf_diagnostics_category(cli_ctx, _):
@@ -32,42 +32,42 @@ def cf_diagnostics_category(cli_ctx, _):
 
 
 def cf_log_profiles(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).log_profiles
+    return cf_monitor(cli_ctx).log_profiles
 
 
 def cf_action_groups(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).action_groups
+    return cf_monitor(cli_ctx).action_groups
 
 
 def cf_activity_log_alerts(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).activity_log_alerts
+    return cf_monitor(cli_ctx).activity_log_alerts
 
 
 def cf_metrics(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).metrics
+    return cf_monitor(cli_ctx).metrics
 
 
 def cf_metric_def(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).metric_definitions
+    return cf_monitor(cli_ctx).metric_definitions
 
 
 def cf_activity_log(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).activity_logs
+    return cf_monitor(cli_ctx).activity_logs
 
 
 def cf_event_categories(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).event_categories
+    return cf_monitor(cli_ctx).event_categories
 
 
 def cf_metric_alerts(cli_ctx, _):
-    return cf_monitor(cli_ctx, _).metric_alerts
+    return cf_monitor(cli_ctx).metric_alerts
 
 
-def _log_analytics_client_factory(cli_ctx, _):
+def _log_analytics_client_factory(cli_ctx, **kwargs):
     from azure.mgmt.loganalytics import LogAnalyticsManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     return get_mgmt_service_client(cli_ctx, LogAnalyticsManagementClient)
 
 
 def cf_log_analytics_workspace(cli_ctx, _):
-    return _log_analytics_client_factory(cli_ctx, _).workspaces
+    return _log_analytics_client_factory(cli_ctx).workspaces

--- a/src/azure-cli/azure/cli/command_modules/monitor/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_help.py
@@ -1201,3 +1201,9 @@ examples:
         az monitor metrics list-definitions --resource /subscriptions/{subscriptionID}/resourceGroups/Space1999/providers/Microsoft.Network/networkSecurityGroups/ADDS-NSG
     crafted: true
 """
+
+helps['monitor clone'] = """
+type: command
+short-summary: Clone alert rules from one resource to another.
+long-summary: Due to the service limitation, this command would only clone the alert rules in the current subscription.
+"""

--- a/src/azure-cli/azure/cli/command_modules/monitor/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_help.py
@@ -1204,6 +1204,5 @@ examples:
 
 helps['monitor clone'] = """
 type: command
-short-summary: Clone alert rules from one resource to another.
-long-summary: Due to the service limitation, this command would only clone the alert rules in the current subscription.
+short-summary: Clone metrics alert rules from one resource to another resource.
 """

--- a/src/azure-cli/azure/cli/command_modules/monitor/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_help.py
@@ -1205,4 +1205,8 @@ examples:
 helps['monitor clone'] = """
 type: command
 short-summary: Clone metrics alert rules from one resource to another resource.
+examples:
+  - name: Clone the metric alert settings from one VM to another
+    text: |
+        az monitor clone --source-resource /subscriptions/{subscriptionID}/resourceGroups/Space1999/providers/Microsoft.Compute/virtualMachines/vm1 --target-resource /subscriptions/{subscriptionID}/resourceGroups/Space1999/providers/Microsoft.Compute/virtualMachines/vm2
 """

--- a/src/azure-cli/azure/cli/command_modules/monitor/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_params.py
@@ -351,7 +351,7 @@ def load_arguments(self, _):
         c.argument('always_clone', action='store_true',
                    help="If this argument is applied, "
                         "all monitor settings would be cloned instead of expanding its scope.")
-        from azure.cli.command_modules.monitor.operations.general_operations import TYPE_FUNCTION_MAPPTING
-        c.argument('monitor_types', options_list=['--types', '-t'], arg_type=get_enum_type(TYPE_FUNCTION_MAPPTING.keys()),
-                   nargs='+', help='List of types of monitor settings which would be cloned.')
+        # from azure.cli.command_modules.monitor.operations.general_operations import TYPE_FUNCTION_MAPPTING
+        # c.argument('monitor_types', options_list=['--types', '-t'], arg_type=get_enum_type(TYPE_FUNCTION_MAPPTING.keys()),
+        #            nargs='+', help='List of types of monitor settings which would be cloned.')
     # endregion

--- a/src/azure-cli/azure/cli/command_modules/monitor/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_params.py
@@ -351,7 +351,6 @@ def load_arguments(self, _):
         c.argument('always_clone', action='store_true',
                    help="If this argument is applied, "
                         "all monitor settings would be cloned instead of expanding its scope.")
-        # from azure.cli.command_modules.monitor.operations.general_operations import TYPE_FUNCTION_MAPPTING
-        # c.argument('monitor_types', options_list=['--types', '-t'], arg_type=get_enum_type(TYPE_FUNCTION_MAPPTING.keys()),
-        #            nargs='+', help='List of types of monitor settings which would be cloned.')
+        c.argument('monitor_types', options_list=['--types', '-t'], arg_type=get_enum_type(['metricsAlert']),
+                   nargs='+', help='List of types of monitor settings which would be cloned.')
     # endregion

--- a/src/azure-cli/azure/cli/command_modules/monitor/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_params.py
@@ -352,5 +352,5 @@ def load_arguments(self, _):
                    help="If this argument is applied, "
                         "all monitor settings would be cloned instead of expanding its scope.")
         c.argument('monitor_types', options_list=['--types', '-t'], arg_type=get_enum_type(['metricsAlert']),
-                   nargs='+', help='List of types of monitor settings which would be cloned.')
+                   nargs='+', help='List of types of monitor settings which would be cloned.', default=['metricsAlert'])
     # endregion

--- a/src/azure-cli/azure/cli/command_modules/monitor/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_params.py
@@ -343,3 +343,9 @@ def load_arguments(self, _):
         c.argument('intelligence_pack_name', options_list=['--name', '-n'])
         c.argument('workspace_name', options_list='--workspace-name')
     # endregion
+
+    # region monitor clone
+    with self.argument_context('monitor clone') as c:
+        c.argument('source_resource', help="Resource ID of the source resource.")
+        c.argument('target_resource', help="Resource ID of the target resource.")
+    # endregion

--- a/src/azure-cli/azure/cli/command_modules/monitor/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_params.py
@@ -348,4 +348,10 @@ def load_arguments(self, _):
     with self.argument_context('monitor clone') as c:
         c.argument('source_resource', help="Resource ID of the source resource.")
         c.argument('target_resource', help="Resource ID of the target resource.")
+        c.argument('always_clone', action='store_true',
+                   help="If this argument is applied, "
+                        "all monitor settings would be cloned instead of expanding its scope.")
+        from azure.cli.command_modules.monitor.operations.general_operations import TYPE_FUNCTION_MAPPTING
+        c.argument('monitor_types', options_list=['--types', '-t'], arg_type=get_enum_type(TYPE_FUNCTION_MAPPTING.keys()),
+                   nargs='+', help='List of types of monitor settings which would be cloned.')
     # endregion

--- a/src/azure-cli/azure/cli/command_modules/monitor/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/commands.py
@@ -253,4 +253,3 @@ def load_command_table(self, _):
 
     with self.command_group('monitor', metric_alert_sdk, custom_command_type=monitor_general_custom) as g:
         g.custom_command('clone', 'clone_existed_settings')
-

--- a/src/azure-cli/azure/cli/command_modules/monitor/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/commands.py
@@ -251,5 +251,5 @@ def load_command_table(self, _):
         g.command('enable', 'enable_intelligence_pack')
         g.command('disable', 'disable_intelligence_pack')
 
-    with self.command_group('monitor', metric_alert_sdk, custom_command_type=monitor_general_custom) as g:
+    with self.command_group('monitor', metric_alert_sdk, custom_command_type=monitor_general_custom, is_preview=True) as g:
         g.custom_command('clone', 'clone_existed_settings')

--- a/src/azure-cli/azure/cli/command_modules/monitor/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/commands.py
@@ -135,6 +135,12 @@ def load_command_table(self, _):
         exception_handler=monitor_exception_handler
     )
 
+    monitor_general_custom = CliCommandType(
+        operations_tmpl='azure.cli.command_modules.monitor.operations.general_operations#{}',
+        client_factory=cf_metric_alerts,
+        exception_handler=monitor_exception_handler
+    )
+
     with self.command_group('monitor action-group', action_group_sdk, custom_command_type=action_group_custom) as g:
         g.show_command('show', 'get', table_transformer=action_group_list_table)
         g.command('create', 'create_or_update', table_transformer=action_group_list_table)
@@ -244,3 +250,7 @@ def load_command_table(self, _):
         g.command('list', 'list_intelligence_packs')
         g.command('enable', 'enable_intelligence_pack')
         g.command('disable', 'disable_intelligence_pack')
+
+    with self.command_group('monitor', metric_alert_sdk, custom_command_type=monitor_general_custom) as g:
+        g.custom_command('clone', 'clone_existed_settings')
+

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -6,14 +6,17 @@ from .._client_factory import cf_monitor
 from ..util import _gen_guid
 from azure.cli.core.commands.transform import _parse_id
 from knack.log import get_logger
-from msrestazure.tools import parse_resource_id
 from knack.util import CLIError
+from msrestazure.tools import parse_resource_id
+
 
 logger = get_logger(__name__)
+
 
 def clone_existed_settings(cmd, source_resource=None, target_resource=None):
     metrics_alert_rules = _clone_monitor_metrics_alerts(cmd, source_resource, target_resource)
     return metrics_alert_rules
+
 
 def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource):
     if not _is_resource_type_same(source_resource, target_resource):
@@ -36,13 +39,15 @@ def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource):
                         alert_rule.scopes = [target_resource]
                         resource_group_name, name = _parse_id(target_resource).values()
                         name = "{}-{}".format(name, _gen_guid())
-                        alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
-                                                                                   rule_name=name, parameters=alert_rule)
+                        alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,  # pylint: disable=line-too-long
+                                                                                   rule_name=name,
+                                                                                   parameters=alert_rule)
                     else:
                         raise ex
                 updated_alert_rules.append(alert_rule)
             else:
-                logger.warning('The target resource already has alert rule {}. Skip cloning this one.'.format(alert_rule.name))
+                logger.warning('The target resource already has alert rule %s. '
+                               'Skip cloning this one.', alert_rule.name)
     if not updated_alert_rules:
         return None
     return updated_alert_rules if len(updated_alert_rules) > 1 else updated_alert_rules[0]
@@ -51,6 +56,6 @@ def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource):
 def _is_resource_type_same(source_resource, target_resource):
     source_dict = parse_resource_id(source_resource)
     source_type = "{}/{}".format(source_dict['namespace'], source_dict['type'])
-    target_dict = parse_resource_id(source_resource)
+    target_dict = parse_resource_id(target_resource)
     target_type = "{}/{}".format(target_dict['namespace'], target_dict['type'])
     return source_type == target_type

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -8,103 +8,17 @@ from azure.cli.core.commands.transform import _parse_id
 from knack.log import get_logger
 from knack.util import CLIError
 from msrestazure.tools import parse_resource_id
+from azure.cli.command_modules.monitor.operations.monitor_clone_util import _clone_monitor_metrics_alerts
+
 
 logger = get_logger(__name__)
 CLONED_NAME = "cloned-{}-{}"
 
 
 def clone_existed_settings(cmd, source_resource, target_resource, always_clone=False, monitor_types=['metricsAlert']):
-    return _clone_monitor_metrics_alerts(cmd, source_resource, target_resource, always_clone)
+    result = {}
+    monitor_types = set(monitor_types)
+    if "metricsAlert" in monitor_types:
+        result["metricsAlert"] = _clone_monitor_metrics_alerts(cmd, source_resource, target_resource, always_clone)
+    return result
 
-
-def _gen_metrics_alert_rules_clone_list(monitor_client, source_resource, target_resource):
-    alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
-    for alert_rule in alert_rules:
-        if source_resource in alert_rule.scopes:
-            if target_resource not in alert_rule.scopes:
-                yield alert_rule
-            else:
-                logger.warning('The target resource already has alert rule %s. '
-                               'Skip cloning this one.', alert_rule.name)
-
-def _add_into_existing_scopes(monitor_client, alert_rule, target_resource):
-    alert_rule.scopes.append(target_resource)
-    resource_group_name, name = _parse_id(alert_rule.id).values()
-    return monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
-                                                         rule_name=name,
-                                                         parameters=alert_rule)
-
-
-def _clone_and_replace_action_group(source_monitor_client, target_monitor_client,
-                                    cmd, alert_rule, action_group_mapping, target_resource):
-    for index, action in enumerate(alert_rule.actions):
-        if action.action_group_id in action_group_mapping:
-            alert_rule.actions[index] = action_group_mapping[action.action_group_id][1]
-        else:
-            resource_group_name, name = _parse_id(action.action_group_id).values()
-            action_group = source_monitor_client.action_groups.get(resource_group_name, name)
-            name = CLONED_NAME.format(name, _gen_guid())
-            resource_group_name, _ = _parse_id(target_resource).values()
-            new_action_group = target_monitor_client.action_groups.create_or_update(resource_group_name,
-                                                                                    name,
-                                                                                    action_group)
-            MetricAlertAction = cmd.get_models('MetricAlertAction', operation_group='metric_alerts')
-            new_action = MetricAlertAction(action_group_id=new_action_group.id,
-                                           webhook_properties=action.webhook_properties)
-            alert_rule.actions[index] = new_action
-            action_group_mapping[action.action_group_id] = [new_action_group.id, new_action]
-    return alert_rule
-
-
-def _clone_alert_rule(monitor_client, alert_rule, target_resource):
-    alert_rule.scopes = [target_resource]
-    resource_group_name, name = _parse_id(target_resource).values()
-    name = CLONED_NAME.format(name, _gen_guid())
-    return monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
-                                                         rule_name=name,
-                                                         parameters=alert_rule)
-
-
-def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource, always_clone=False):
-    same_rp, same_sub = _is_resource_type_same_and_sub_same(source_resource, target_resource)
-    if not same_rp:
-        raise CLIError('The target resource should be the same type with the source resource')
-    source_monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(source_resource)['subscription'])
-    target_monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(target_resource)['subscription'])
-    updated_metrics_alert_rules = []
-    action_group_mapping = {}
-    ErrorResponseException = cmd.get_models('ErrorResponseException', operation_group='metric_alerts')
-    for alert_rule in _gen_metrics_alert_rules_clone_list(source_monitor_client, source_resource, target_resource):
-        if always_clone or not same_sub:
-            alert_rule = _clone_and_replace_action_group(source_monitor_client,
-                                                         target_monitor_client,
-                                                         cmd,
-                                                         alert_rule,
-                                                         action_group_mapping,
-                                                         target_resource)
-            alert_rule = _clone_alert_rule(target_monitor_client,
-                                           alert_rule,
-                                           target_resource)
-        else:
-            try:
-                alert_rule = _add_into_existing_scopes(source_monitor_client,
-                                                       alert_rule,
-                                                       target_resource)
-            except ErrorResponseException as ex:  # Create new alert rule
-                if ex.response.status_code == 400:
-                    alert_rule = _clone_alert_rule(target_monitor_client,
-                                                   alert_rule,
-                                                   target_resource)
-                else:
-                    raise ex
-        updated_metrics_alert_rules.append(alert_rule)
-
-    return updated_metrics_alert_rules
-
-
-def _is_resource_type_same_and_sub_same(source_resource, target_resource):
-    source_dict = parse_resource_id(source_resource)
-    target_dict = parse_resource_id(target_resource)
-    same_rp = source_dict['namespace'] == target_dict['namespace'] and source_dict['type'] == target_dict['type']
-    same_sub = source_dict['subscription'] == target_dict['subscription']
-    return same_rp, same_sub

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -8,57 +8,19 @@ from azure.cli.core.commands.transform import _parse_id
 from knack.log import get_logger
 from knack.util import CLIError
 from msrestazure.tools import parse_resource_id
+from azure.cli.command_modules.monitor.operations.monitor_clone_util import _clone_monitor_metrics_alerts
 
 
 logger = get_logger(__name__)
+CLONED_NAME = "cloned-{}-{}"
+TYPE_FUNCTION_MAPPTING = {
+    'metricsAlert': _clone_monitor_metrics_alerts
+}
 
 
-def clone_existed_settings(cmd, source_resource, target_resource, always_clone=False, settings=None):
-    return _clone_monitor_metrics_alerts(cmd, source_resource, target_resource)
+def clone_existed_settings(cmd, source_resource, target_resource, always_clone=False, monitor_types=['metricsAlert']):
+    result = {}
+    for monitor_type in monitor_types:
+        result[monitor_type] = TYPE_FUNCTION_MAPPTING[monitor_type](cmd, source_resource, target_resource, always_clone)
+    return result
 
-
-def _gen_metrics_alert_rules_clone_list(cmd, source_resource, target_resource):
-    monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(source_resource)['subscription'])
-    # we can only clone the alert rules belonging to the source subscription.
-    alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
-    for alert_rule in alert_rules:
-        if source_resource in alert_rule.scopes:
-            if target_resource not in alert_rule.scopes:
-                yield alert_rule
-            else:
-                logger.warning('The target resource already has alert rule %s. '
-                               'Skip cloning this one.', alert_rule.name)
-
-def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource):
-    if not _is_resource_type_same_and_sub_same(source_resource, target_resource):
-        raise CLIError('The target resource should be the same type with the source resource, '
-                       'meanwhile they should be in the same subscription')
-    updated_metrics_alert_rules = []
-    ErrorResponseException = cmd.get_models('ErrorResponseException', operation_group='metric_alerts')
-    for rule in _gen_metrics_alert_rules_clone_list(cmd, source_resource, target_resource):
-        try:
-            alert_rule.scopes.append(target_resource)
-            resource_group_name, name = _parse_id(alert_rule.id).values()
-            alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
-                                                                       rule_name=name, parameters=alert_rule)
-        except ErrorResponseException as ex:  # Create new alert rule
-            if ex.response.status_code == 400:
-                alert_rule.scopes = [target_resource]
-                resource_group_name, name = _parse_id(target_resource).values()
-                name = "{}-{}".format(name, _gen_guid())
-                alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,  # pylint: disable=line-too-long
-                                                                           rule_name=name,
-                                                                           parameters=alert_rule)
-            else:
-                raise ex
-        updated_alert_rules.append(alert_rule)
-
-    return updated_alert_rules
-
-
-def _is_resource_type_same_and_sub_same(source_resource, target_resource):
-    source_dict = parse_resource_id(source_resource)
-    target_dict = parse_resource_id(target_resource)
-    same_rp = source_dict['namespace'] == target_dict['namespace'] and source_dict['type'] == target_dict['type']
-    same_sub = source_dict['subscription'] == target_dict['subscription']
-    return same_rp and same_sub

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 CLONED_NAME = "cloned-{}-{}"
 
 
-def clone_existed_settings(cmd, source_resource, target_resource, always_clone=False, monitor_types=['metricsAlert']):
+def clone_existed_settings(cmd, source_resource, target_resource, always_clone=False, monitor_types=None):
     result = {}
     monitor_types = set(monitor_types)
     if "metricsAlert" in monitor_types:

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -1,0 +1,27 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+from .._client_factory import cf_monitor
+from ..util import _gen_guid
+from azure.cli.core.commands.transform import _parse_id
+
+def clone_existed_settings(cmd, client, source_resource=None, target_resource=None):
+    monitor_client = cf_monitor(cmd.cli_ctx)
+    alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
+    updated_alert_rules = []
+    ErrorResponseException = cmd.get_models('ErrorResponseException', operation_group='metric_alerts')
+    for alert_rule in alert_rules:
+        if source_resource in alert_rule.scopes:
+            try:
+                alert_rule.scopes.append(target_resource)
+                resource_group_name, name = _parse_id(alert_rule.id).values()
+                alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name, rule_name=name, parameters=alert_rule)
+            except ErrorResponseException as ex:  # Create new alert rule
+                if ex.response.status_code == 400:
+                    alert_rule.scopes = [target_resource]
+                    resource_group_name, name = _parse_id(target_resource).values()
+                    name = "{}-{}".format(name, _gen_guid())
+                    alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name, rule_name=name, parameters=alert_rule)
+            updated_alert_rules.append(alert_rule)
+    return updated_alert_rules

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -2,17 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from .._client_factory import cf_monitor
-from ..util import _gen_guid
-from azure.cli.core.commands.transform import _parse_id
-from knack.log import get_logger
-from knack.util import CLIError
-from msrestazure.tools import parse_resource_id
 from azure.cli.command_modules.monitor.operations.monitor_clone_util import _clone_monitor_metrics_alerts
 
-
-logger = get_logger(__name__)
-CLONED_NAME = "cloned-{}-{}"
 TYPE_FUNCTION_MAPPTING = {
     'metricsAlert': _clone_monitor_metrics_alerts
 }
@@ -23,4 +14,3 @@ def clone_existed_settings(cmd, source_resource, target_resource, always_clone=F
     for monitor_type in monitor_types:
         result[monitor_type] = TYPE_FUNCTION_MAPPTING[monitor_type](cmd, source_resource, target_resource, always_clone)
     return result
-

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -6,9 +6,8 @@ from .._client_factory import cf_monitor
 from ..util import _gen_guid
 from azure.cli.core.commands.transform import _parse_id
 from knack.log import get_logger
-from azure.cli.command_modules.vm.custom import set_diagnostics_extension
-from azure.cli.command_modules.vm._client_factory import _compute_client_factory
-
+from msrestazure.tools import parse_resource_id
+from knack.util import CLIError
 
 logger = get_logger(__name__)
 
@@ -16,13 +15,11 @@ def clone_existed_settings(cmd, source_resource=None, target_resource=None):
     metrics_alert_rules = _clone_monitor_metrics_alerts(cmd, source_resource, target_resource)
     return metrics_alert_rules
 
-
-def _clone_vm_diagnostics_settings(cmd, source_resource=None, target_resource=None):
-    vm_client = _compute_client_factory(cmd.cli_ctx)
-
-
 def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource):
+    if not _is_resource_type_same(source_resource, target_resource):
+        raise CLIError('The target resource should be the same type with the source resource')
     monitor_client = cf_monitor(cmd.cli_ctx)
+    # we can only clone the alert rules belonging to the current subscription.
     alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
     updated_alert_rules = []
     ErrorResponseException = cmd.get_models('ErrorResponseException', operation_group='metric_alerts')
@@ -41,7 +38,16 @@ def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource):
                         name = "{}-{}".format(name, _gen_guid())
                         alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
                                                                                    rule_name=name, parameters=alert_rule)
+                    else:
+                        raise ex
                 updated_alert_rules.append(alert_rule)
             else:
                 logger.warning('The target resource already has alert rule {}. Skip cloning this one.'.format(alert_rule.name))
     return updated_alert_rules
+
+def _is_resource_type_same(source_resource, target_resource):
+    source_dict = parse_resource_id(source_resource)
+    source_type = "{}/{}".format(source_dict['namespace'], source_dict['type'])
+    target_dict = parse_resource_id(source_resource)
+    target_type = "{}/{}".format(target_dict['namespace'], target_dict['type'])
+    return source_type == target_type

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -2,17 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from .._client_factory import cf_monitor
-from ..util import _gen_guid
-from azure.cli.core.commands.transform import _parse_id
-from knack.log import get_logger
-from knack.util import CLIError
-from msrestazure.tools import parse_resource_id
 from azure.cli.command_modules.monitor.operations.monitor_clone_util import _clone_monitor_metrics_alerts
-
-
-logger = get_logger(__name__)
-CLONED_NAME = "cloned-{}-{}"
 
 
 def clone_existed_settings(cmd, source_resource, target_resource, always_clone=False, monitor_types=None):
@@ -21,4 +11,3 @@ def clone_existed_settings(cmd, source_resource, target_resource, always_clone=F
     if "metricsAlert" in monitor_types:
         result["metricsAlert"] = _clone_monitor_metrics_alerts(cmd, source_resource, target_resource, always_clone)
     return result
-

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -43,7 +43,10 @@ def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource):
                 updated_alert_rules.append(alert_rule)
             else:
                 logger.warning('The target resource already has alert rule {}. Skip cloning this one.'.format(alert_rule.name))
-    return updated_alert_rules
+    if not updated_alert_rules:
+        return None
+    return updated_alert_rules if len(updated_alert_rules) > 1 else updated_alert_rules[0]
+
 
 def _is_resource_type_same(source_resource, target_resource):
     source_dict = parse_resource_id(source_resource)

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -13,41 +13,46 @@ from msrestazure.tools import parse_resource_id
 logger = get_logger(__name__)
 
 
-def clone_existed_settings(cmd, source_resource, target_resource):
+def clone_existed_settings(cmd, source_resource, target_resource, always_clone=False, settings=None):
     return _clone_monitor_metrics_alerts(cmd, source_resource, target_resource)
 
+
+def _gen_metrics_alert_rules_clone_list(cmd, source_resource, target_resource):
+    monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(source_resource)['subscription'])
+    # we can only clone the alert rules belonging to the source subscription.
+    alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
+    for alert_rule in alert_rules:
+        if source_resource in alert_rule.scopes:
+            if target_resource not in alert_rule.scopes:
+                yield alert_rule
+            else:
+                logger.warning('The target resource already has alert rule %s. '
+                               'Skip cloning this one.', alert_rule.name)
 
 def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource):
     if not _is_resource_type_same_and_sub_same(source_resource, target_resource):
         raise CLIError('The target resource should be the same type with the source resource, '
                        'meanwhile they should be in the same subscription')
-    monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(source_resource)['subscription'])
-    # we can only clone the alert rules belonging to the source subscription.
-    alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
-    updated_alert_rules = []
+    updated_metrics_alert_rules = []
     ErrorResponseException = cmd.get_models('ErrorResponseException', operation_group='metric_alerts')
-    for alert_rule in alert_rules:
-        if source_resource in alert_rule.scopes:
-            if target_resource not in alert_rule.scopes:
-                try:
-                    alert_rule.scopes.append(target_resource)
-                    resource_group_name, name = _parse_id(alert_rule.id).values()
-                    alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
-                                                                               rule_name=name, parameters=alert_rule)
-                except ErrorResponseException as ex:  # Create new alert rule
-                    if ex.response.status_code == 400:
-                        alert_rule.scopes = [target_resource]
-                        resource_group_name, name = _parse_id(target_resource).values()
-                        name = "{}-{}".format(name, _gen_guid())
-                        alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,  # pylint: disable=line-too-long
-                                                                                   rule_name=name,
-                                                                                   parameters=alert_rule)
-                    else:
-                        raise ex
-                updated_alert_rules.append(alert_rule)
+    for rule in _gen_metrics_alert_rules_clone_list(cmd, source_resource, target_resource):
+        try:
+            alert_rule.scopes.append(target_resource)
+            resource_group_name, name = _parse_id(alert_rule.id).values()
+            alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
+                                                                       rule_name=name, parameters=alert_rule)
+        except ErrorResponseException as ex:  # Create new alert rule
+            if ex.response.status_code == 400:
+                alert_rule.scopes = [target_resource]
+                resource_group_name, name = _parse_id(target_resource).values()
+                name = "{}-{}".format(name, _gen_guid())
+                alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,  # pylint: disable=line-too-long
+                                                                           rule_name=name,
+                                                                           parameters=alert_rule)
             else:
-                logger.warning('The target resource already has alert rule %s. '
-                               'Skip cloning this one.', alert_rule.name)
+                raise ex
+        updated_alert_rules.append(alert_rule)
+
     return updated_alert_rules
 
 

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -5,23 +5,43 @@
 from .._client_factory import cf_monitor
 from ..util import _gen_guid
 from azure.cli.core.commands.transform import _parse_id
+from knack.log import get_logger
+from azure.cli.command_modules.vm.custom import set_diagnostics_extension
+from azure.cli.command_modules.vm._client_factory import _compute_client_factory
 
-def clone_existed_settings(cmd, client, source_resource=None, target_resource=None):
+
+logger = get_logger(__name__)
+
+def clone_existed_settings(cmd, source_resource=None, target_resource=None):
+    metrics_alert_rules = _clone_monitor_metrics_alerts(cmd, source_resource, target_resource)
+    return metrics_alert_rules
+
+
+def _clone_vm_diagnostics_settings(cmd, source_resource=None, target_resource=None):
+    vm_client = _compute_client_factory(cmd.cli_ctx)
+
+
+def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource):
     monitor_client = cf_monitor(cmd.cli_ctx)
     alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
     updated_alert_rules = []
     ErrorResponseException = cmd.get_models('ErrorResponseException', operation_group='metric_alerts')
     for alert_rule in alert_rules:
         if source_resource in alert_rule.scopes:
-            try:
-                alert_rule.scopes.append(target_resource)
-                resource_group_name, name = _parse_id(alert_rule.id).values()
-                alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name, rule_name=name, parameters=alert_rule)
-            except ErrorResponseException as ex:  # Create new alert rule
-                if ex.response.status_code == 400:
-                    alert_rule.scopes = [target_resource]
-                    resource_group_name, name = _parse_id(target_resource).values()
-                    name = "{}-{}".format(name, _gen_guid())
-                    alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name, rule_name=name, parameters=alert_rule)
-            updated_alert_rules.append(alert_rule)
+            if target_resource not in alert_rule.scopes:
+                try:
+                    alert_rule.scopes.append(target_resource)
+                    resource_group_name, name = _parse_id(alert_rule.id).values()
+                    alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
+                                                                               rule_name=name, parameters=alert_rule)
+                except ErrorResponseException as ex:  # Create new alert rule
+                    if ex.response.status_code == 400:
+                        alert_rule.scopes = [target_resource]
+                        resource_group_name, name = _parse_id(target_resource).values()
+                        name = "{}-{}".format(name, _gen_guid())
+                        alert_rule = monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
+                                                                                   rule_name=name, parameters=alert_rule)
+                updated_alert_rules.append(alert_rule)
+            else:
+                logger.warning('The target resource already has alert rule {}. Skip cloning this one.'.format(alert_rule.name))
     return updated_alert_rules

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -2,15 +2,109 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from azure.cli.command_modules.monitor.operations.monitor_clone_util import _clone_monitor_metrics_alerts
+from .._client_factory import cf_monitor
+from ..util import _gen_guid
+from azure.cli.core.commands.transform import _parse_id
+from knack.log import get_logger
+from knack.util import CLIError
+from msrestazure.tools import parse_resource_id
 
-TYPE_FUNCTION_MAPPTING = {
-    'metricsAlert': _clone_monitor_metrics_alerts
-}
+logger = get_logger(__name__)
+CLONED_NAME = "cloned-{}-{}"
 
 
 def clone_existed_settings(cmd, source_resource, target_resource, always_clone=False, monitor_types=['metricsAlert']):
-    result = {}
-    for monitor_type in monitor_types:
-        result[monitor_type] = TYPE_FUNCTION_MAPPTING[monitor_type](cmd, source_resource, target_resource, always_clone)
-    return result
+    return _clone_monitor_metrics_alerts(cmd, source_resource, target_resource, always_clone)
+
+
+def _gen_metrics_alert_rules_clone_list(monitor_client, source_resource, target_resource):
+    alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
+    for alert_rule in alert_rules:
+        if source_resource in alert_rule.scopes:
+            if target_resource not in alert_rule.scopes:
+                yield alert_rule
+            else:
+                logger.warning('The target resource already has alert rule %s. '
+                               'Skip cloning this one.', alert_rule.name)
+
+def _add_into_existing_scopes(monitor_client, alert_rule, target_resource):
+    alert_rule.scopes.append(target_resource)
+    resource_group_name, name = _parse_id(alert_rule.id).values()
+    return monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
+                                                         rule_name=name,
+                                                         parameters=alert_rule)
+
+
+def _clone_and_replace_action_group(source_monitor_client, target_monitor_client,
+                                    cmd, alert_rule, action_group_mapping, target_resource):
+    for index, action in enumerate(alert_rule.actions):
+        if action.action_group_id in action_group_mapping:
+            alert_rule.actions[index] = action_group_mapping[action.action_group_id][1]
+        else:
+            resource_group_name, name = _parse_id(action.action_group_id).values()
+            action_group = source_monitor_client.action_groups.get(resource_group_name, name)
+            name = CLONED_NAME.format(name, _gen_guid())
+            resource_group_name, _ = _parse_id(target_resource).values()
+            new_action_group = target_monitor_client.action_groups.create_or_update(resource_group_name,
+                                                                                    name,
+                                                                                    action_group)
+            MetricAlertAction = cmd.get_models('MetricAlertAction', operation_group='metric_alerts')
+            new_action = MetricAlertAction(action_group_id=new_action_group.id,
+                                           webhook_properties=action.webhook_properties)
+            alert_rule.actions[index] = new_action
+            action_group_mapping[action.action_group_id] = [new_action_group.id, new_action]
+    return alert_rule
+
+
+def _clone_alert_rule(monitor_client, alert_rule, target_resource):
+    alert_rule.scopes = [target_resource]
+    resource_group_name, name = _parse_id(target_resource).values()
+    name = CLONED_NAME.format(name, _gen_guid())
+    return monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
+                                                         rule_name=name,
+                                                         parameters=alert_rule)
+
+
+def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource, always_clone=False):
+    same_rp, same_sub = _is_resource_type_same_and_sub_same(source_resource, target_resource)
+    if not same_rp:
+        raise CLIError('The target resource should be the same type with the source resource')
+    source_monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(source_resource)['subscription'])
+    target_monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(target_resource)['subscription'])
+    updated_metrics_alert_rules = []
+    action_group_mapping = {}
+    ErrorResponseException = cmd.get_models('ErrorResponseException', operation_group='metric_alerts')
+    for alert_rule in _gen_metrics_alert_rules_clone_list(source_monitor_client, source_resource, target_resource):
+        if always_clone or not same_sub:
+            alert_rule = _clone_and_replace_action_group(source_monitor_client,
+                                                         target_monitor_client,
+                                                         cmd,
+                                                         alert_rule,
+                                                         action_group_mapping,
+                                                         target_resource)
+            alert_rule = _clone_alert_rule(target_monitor_client,
+                                           alert_rule,
+                                           target_resource)
+        else:
+            try:
+                alert_rule = _add_into_existing_scopes(source_monitor_client,
+                                                       alert_rule,
+                                                       target_resource)
+            except ErrorResponseException as ex:  # Create new alert rule
+                if ex.response.status_code == 400:
+                    alert_rule = _clone_alert_rule(target_monitor_client,
+                                                   alert_rule,
+                                                   target_resource)
+                else:
+                    raise ex
+        updated_metrics_alert_rules.append(alert_rule)
+
+    return updated_metrics_alert_rules
+
+
+def _is_resource_type_same_and_sub_same(source_resource, target_resource):
+    source_dict = parse_resource_id(source_resource)
+    target_dict = parse_resource_id(target_resource)
+    same_rp = source_dict['namespace'] == target_dict['namespace'] and source_dict['type'] == target_dict['type']
+    same_sub = source_dict['subscription'] == target_dict['subscription']
+    return same_rp, same_sub

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/general_operations.py
@@ -13,15 +13,14 @@ from msrestazure.tools import parse_resource_id
 logger = get_logger(__name__)
 
 
-def clone_existed_settings(cmd, source_resource=None, target_resource=None):
-    metrics_alert_rules = _clone_monitor_metrics_alerts(cmd, source_resource, target_resource)
-    return metrics_alert_rules
+def clone_existed_settings(cmd, source_resource, target_resource):
+    return _clone_monitor_metrics_alerts(cmd, source_resource, target_resource)
 
 
 def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource):
     if not _is_resource_type_same_and_sub_same(source_resource, target_resource):
-        raise CLIError('The target resource should be the same type with the source resource '
-                       'and they are in the same subscription')
+        raise CLIError('The target resource should be the same type with the source resource, '
+                       'meanwhile they should be in the same subscription')
     monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(source_resource)['subscription'])
     # we can only clone the alert rules belonging to the source subscription.
     alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
@@ -49,9 +48,7 @@ def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource):
             else:
                 logger.warning('The target resource already has alert rule %s. '
                                'Skip cloning this one.', alert_rule.name)
-    if not updated_alert_rules:
-        return None
-    return updated_alert_rules if len(updated_alert_rules) > 1 else updated_alert_rules[0]
+    return updated_alert_rules
 
 
 def _is_resource_type_same_and_sub_same(source_resource, target_resource):

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
@@ -2,8 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from azure.cli.command_modules.monitor._client_factory import cf_monitor
-from azure.cli.command_modules.monitor.util import _gen_guid
+from .._client_factory import cf_monitor
+from ..util import _gen_guid
 from azure.cli.core.commands.transform import _parse_id
 from knack.log import get_logger
 from knack.util import CLIError
@@ -12,94 +12,3 @@ from msrestazure.tools import parse_resource_id
 logger = get_logger(__name__)
 CLONED_NAME = "cloned-{}-{}"
 
-def _gen_metrics_alert_rules_clone_list(monitor_client, source_resource, target_resource):
-    alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
-    for alert_rule in alert_rules:
-        if source_resource in alert_rule.scopes:
-            if target_resource not in alert_rule.scopes:
-                yield alert_rule
-            else:
-                logger.warning('The target resource already has alert rule %s. '
-                               'Skip cloning this one.', alert_rule.name)
-
-def _add_into_existing_scopes(monitor_client, alert_rule, target_resource):
-    alert_rule.scopes.append(target_resource)
-    resource_group_name, name = _parse_id(alert_rule.id).values()
-    return monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
-                                                         rule_name=name,
-                                                         parameters=alert_rule)
-
-
-def _clone_and_replace_action_group(source_monitor_client, target_monitor_client,
-                                    cmd, alert_rule, action_group_mapping, target_resource):
-    for index, action in enumerate(alert_rule.actions):
-        if action.action_group_id in action_group_mapping:
-            alert_rule.actions[index] = action_group_mapping[action.action_group_id][1]
-        else:
-            resource_group_name, name = _parse_id(action.action_group_id).values()
-            action_group = source_monitor_client.action_groups.get(resource_group_name, name)
-            name = CLONED_NAME.format(name, _gen_guid())
-            resource_group_name, _ = _parse_id(target_resource).values()
-            new_action_group = target_monitor_client.action_groups.create_or_update(resource_group_name,
-                                                                                    name,
-                                                                                    action_group)
-            MetricAlertAction = cmd.get_models('MetricAlertAction', operation_group='metric_alerts')
-            new_action = MetricAlertAction(action_group_id=new_action_group.id,
-                                           webhook_properties=action.webhook_properties)
-            alert_rule.actions[index] = new_action
-            action_group_mapping[action.action_group_id] = [new_action_group.id, new_action]
-    return alert_rule
-
-
-def _clone_alert_rule(monitor_client, alert_rule, target_resource):
-    alert_rule.scopes = [target_resource]
-    resource_group_name, name = _parse_id(target_resource).values()
-    name = CLONED_NAME.format(name, _gen_guid())
-    return monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
-                                                         rule_name=name,
-                                                         parameters=alert_rule)
-
-
-def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource, always_clone=False):
-    same_rp, same_sub = _is_resource_type_same_and_sub_same(source_resource, target_resource)
-    if not same_rp:
-        raise CLIError('The target resource should be the same type with the source resource')
-    source_monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(source_resource)['subscription'])
-    target_monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(target_resource)['subscription'])
-    updated_metrics_alert_rules = []
-    action_group_mapping = {}
-    ErrorResponseException = cmd.get_models('ErrorResponseException', operation_group='metric_alerts')
-    for alert_rule in _gen_metrics_alert_rules_clone_list(source_monitor_client, source_resource, target_resource):
-        if always_clone or not same_sub:
-            alert_rule = _clone_and_replace_action_group(source_monitor_client,
-                                                         target_monitor_client,
-                                                         cmd,
-                                                         alert_rule,
-                                                         action_group_mapping,
-                                                         target_resource)
-            alert_rule = _clone_alert_rule(target_monitor_client,
-                                           alert_rule,
-                                           target_resource)
-        else:
-            try:
-                alert_rule = _add_into_existing_scopes(source_monitor_client,
-                                                       alert_rule,
-                                                       target_resource)
-            except ErrorResponseException as ex:  # Create new alert rule
-                if ex.response.status_code == 400:
-                    alert_rule = _clone_alert_rule(target_monitor_client,
-                                                   alert_rule,
-                                                   target_resource)
-                else:
-                    raise ex
-        updated_metrics_alert_rules.append(alert_rule)
-
-    return updated_metrics_alert_rules
-
-
-def _is_resource_type_same_and_sub_same(source_resource, target_resource):
-    source_dict = parse_resource_id(source_resource)
-    target_dict = parse_resource_id(target_resource)
-    same_rp = source_dict['namespace'] == target_dict['namespace'] and source_dict['type'] == target_dict['type']
-    same_sub = source_dict['subscription'] == target_dict['subscription']
-    return same_rp, same_sub

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 from .._client_factory import cf_monitor
-from ..util import _gen_guid
+from ..util import gen_guid
 from azure.cli.core.commands.transform import _parse_id
 from knack.log import get_logger
 from knack.util import CLIError
@@ -40,7 +40,7 @@ def _clone_and_replace_action_group(source_monitor_client, target_monitor_client
         else:
             resource_group_name, name = _parse_id(action.action_group_id).values()
             action_group = source_monitor_client.action_groups.get(resource_group_name, name)
-            name = CLONED_NAME.format(name, _gen_guid())
+            name = CLONED_NAME.format(name, gen_guid())
             resource_group_name, _ = _parse_id(target_resource).values()
             new_action_group = target_monitor_client.action_groups.create_or_update(resource_group_name,
                                                                                     name,
@@ -56,7 +56,7 @@ def _clone_and_replace_action_group(source_monitor_client, target_monitor_client
 def _clone_alert_rule(monitor_client, alert_rule, target_resource):
     alert_rule.scopes = [target_resource]
     resource_group_name, name = _parse_id(target_resource).values()
-    name = CLONED_NAME.format(name, _gen_guid())
+    name = CLONED_NAME.format(name, gen_guid())
     return monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
                                                          rule_name=name,
                                                          parameters=alert_rule)
@@ -100,8 +100,8 @@ def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource, always_
 
 
 def _is_resource_type_same_and_sub_same(source_resource, target_resource):
-    source_dict = parse_resource_id(source_resource)
-    target_dict = parse_resource_id(target_resource)
+    source_dict = parse_resource_id(source_resource.lower())
+    target_dict = parse_resource_id(target_resource.lower())
     same_rp = source_dict['namespace'] == target_dict['namespace'] and source_dict['type'] == target_dict['type']
     same_sub = source_dict['subscription'] == target_dict['subscription']
     return same_rp, same_sub

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
@@ -1,0 +1,105 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+from .._client_factory import cf_monitor
+from ..util import _gen_guid
+from azure.cli.core.commands.transform import _parse_id
+from knack.log import get_logger
+from knack.util import CLIError
+from msrestazure.tools import parse_resource_id
+
+logger = get_logger(__name__)
+CLONED_NAME = "cloned-{}-{}"
+
+def _gen_metrics_alert_rules_clone_list(monitor_client, source_resource, target_resource):
+    alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
+    for alert_rule in alert_rules:
+        if source_resource in alert_rule.scopes:
+            if target_resource not in alert_rule.scopes:
+                yield alert_rule
+            else:
+                logger.warning('The target resource already has alert rule %s. '
+                               'Skip cloning this one.', alert_rule.name)
+
+def _add_into_existing_scopes(monitor_client, alert_rule, target_resource):
+    alert_rule.scopes.append(target_resource)
+    resource_group_name, name = _parse_id(alert_rule.id).values()
+    return monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
+                                                         rule_name=name,
+                                                         parameters=alert_rule)
+
+
+def _clone_and_replace_action_group(source_monitor_client, target_monitor_client,
+                                    cmd, alert_rule, action_group_mapping, target_resource):
+    for index, action in enumerate(alert_rule.actions):
+        if action.action_group_id in action_group_mapping:
+            alert_rule.actions[index] = action_group_mapping[action.action_group_id][1]
+        else:
+            resource_group_name, name = _parse_id(action.action_group_id).values()
+            action_group = source_monitor_client.action_groups.get(resource_group_name, name)
+            name = CLONED_NAME.format(name, _gen_guid())
+            resource_group_name, _ = _parse_id(target_resource).values()
+            new_action_group = target_monitor_client.action_groups.create_or_update(resource_group_name,
+                                                                                    name,
+                                                                                    action_group)
+            MetricAlertAction = cmd.get_models('MetricAlertAction', operation_group='metric_alerts')
+            new_action = MetricAlertAction(action_group_id=new_action_group.id,
+                                           webhook_properties=action.webhook_properties)
+            alert_rule.actions[index] = new_action
+            action_group_mapping[action.action_group_id] = [new_action_group.id, new_action]
+    return alert_rule
+
+
+def _clone_alert_rule(monitor_client, alert_rule, target_resource):
+    alert_rule.scopes = [target_resource]
+    resource_group_name, name = _parse_id(target_resource).values()
+    name = CLONED_NAME.format(name, _gen_guid())
+    return monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
+                                                         rule_name=name,
+                                                         parameters=alert_rule)
+
+
+def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource, always_clone=False):
+    same_rp, same_sub = _is_resource_type_same_and_sub_same(source_resource, target_resource)
+    if not same_rp:
+        raise CLIError('The target resource should be the same type with the source resource')
+    source_monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(source_resource)['subscription'])
+    target_monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(target_resource)['subscription'])
+    updated_metrics_alert_rules = []
+    action_group_mapping = {}
+    ErrorResponseException = cmd.get_models('ErrorResponseException', operation_group='metric_alerts')
+    for alert_rule in _gen_metrics_alert_rules_clone_list(source_monitor_client, source_resource, target_resource):
+        if always_clone or not same_sub:
+            alert_rule = _clone_and_replace_action_group(source_monitor_client,
+                                                         target_monitor_client,
+                                                         cmd,
+                                                         alert_rule,
+                                                         action_group_mapping,
+                                                         target_resource)
+            alert_rule = _clone_alert_rule(target_monitor_client,
+                                           alert_rule,
+                                           target_resource)
+        else:
+            try:
+                alert_rule = _add_into_existing_scopes(source_monitor_client,
+                                                       alert_rule,
+                                                       target_resource)
+            except ErrorResponseException as ex:  # Create new alert rule
+                if ex.response.status_code == 400:
+                    alert_rule = _clone_alert_rule(target_monitor_client,
+                                                   alert_rule,
+                                                   target_resource)
+                else:
+                    raise ex
+        updated_metrics_alert_rules.append(alert_rule)
+
+    return updated_metrics_alert_rules
+
+
+def _is_resource_type_same_and_sub_same(source_resource, target_resource):
+    source_dict = parse_resource_id(source_resource)
+    target_dict = parse_resource_id(target_resource)
+    same_rp = source_dict['namespace'] == target_dict['namespace'] and source_dict['type'] == target_dict['type']
+    same_sub = source_dict['subscription'] == target_dict['subscription']
+    return same_rp, same_sub

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
@@ -2,8 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from .._client_factory import cf_monitor
-from ..util import _gen_guid
+from azure.cli.command_modules.monitor._client_factory import cf_monitor
+from azure.cli.command_modules.monitor.util import _gen_guid
 from azure.cli.core.commands.transform import _parse_id
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
@@ -23,6 +23,7 @@ def _gen_metrics_alert_rules_clone_list(monitor_client, source_resource, target_
                 logger.warning('The target resource already has alert rule %s. '
                                'Skip cloning this one.', alert_rule.name)
 
+
 def _add_into_existing_scopes(monitor_client, alert_rule, target_resource):
     alert_rule.scopes.append(target_resource)
     resource_group_name, name = _parse_id(alert_rule.id).values()

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/monitor_clone_util.py
@@ -12,3 +12,95 @@ from msrestazure.tools import parse_resource_id
 logger = get_logger(__name__)
 CLONED_NAME = "cloned-{}-{}"
 
+
+def _gen_metrics_alert_rules_clone_list(monitor_client, source_resource, target_resource):
+    alert_rules = list(monitor_client.metric_alerts.list_by_subscription())
+    for alert_rule in alert_rules:
+        if source_resource in alert_rule.scopes:
+            if target_resource not in alert_rule.scopes:
+                yield alert_rule
+            else:
+                logger.warning('The target resource already has alert rule %s. '
+                               'Skip cloning this one.', alert_rule.name)
+
+def _add_into_existing_scopes(monitor_client, alert_rule, target_resource):
+    alert_rule.scopes.append(target_resource)
+    resource_group_name, name = _parse_id(alert_rule.id).values()
+    return monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
+                                                         rule_name=name,
+                                                         parameters=alert_rule)
+
+
+def _clone_and_replace_action_group(source_monitor_client, target_monitor_client,
+                                    cmd, alert_rule, action_group_mapping, target_resource):
+    for index, action in enumerate(alert_rule.actions):
+        if action.action_group_id in action_group_mapping:
+            alert_rule.actions[index] = action_group_mapping[action.action_group_id][1]
+        else:
+            resource_group_name, name = _parse_id(action.action_group_id).values()
+            action_group = source_monitor_client.action_groups.get(resource_group_name, name)
+            name = CLONED_NAME.format(name, _gen_guid())
+            resource_group_name, _ = _parse_id(target_resource).values()
+            new_action_group = target_monitor_client.action_groups.create_or_update(resource_group_name,
+                                                                                    name,
+                                                                                    action_group)
+            MetricAlertAction = cmd.get_models('MetricAlertAction', operation_group='metric_alerts')
+            new_action = MetricAlertAction(action_group_id=new_action_group.id,
+                                           webhook_properties=action.webhook_properties)
+            alert_rule.actions[index] = new_action
+            action_group_mapping[action.action_group_id] = [new_action_group.id, new_action]
+    return alert_rule
+
+
+def _clone_alert_rule(monitor_client, alert_rule, target_resource):
+    alert_rule.scopes = [target_resource]
+    resource_group_name, name = _parse_id(target_resource).values()
+    name = CLONED_NAME.format(name, _gen_guid())
+    return monitor_client.metric_alerts.create_or_update(resource_group_name=resource_group_name,
+                                                         rule_name=name,
+                                                         parameters=alert_rule)
+
+
+def _clone_monitor_metrics_alerts(cmd, source_resource, target_resource, always_clone=False):
+    same_rp, same_sub = _is_resource_type_same_and_sub_same(source_resource, target_resource)
+    if not same_rp:
+        raise CLIError('The target resource should be the same type with the source resource')
+    source_monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(source_resource)['subscription'])
+    target_monitor_client = cf_monitor(cmd.cli_ctx, subscription_id=parse_resource_id(target_resource)['subscription'])
+    updated_metrics_alert_rules = []
+    action_group_mapping = {}
+    ErrorResponseException = cmd.get_models('ErrorResponseException', operation_group='metric_alerts')
+    for alert_rule in _gen_metrics_alert_rules_clone_list(source_monitor_client, source_resource, target_resource):
+        if always_clone or not same_sub:
+            alert_rule = _clone_and_replace_action_group(source_monitor_client,
+                                                         target_monitor_client,
+                                                         cmd,
+                                                         alert_rule,
+                                                         action_group_mapping,
+                                                         target_resource)
+            alert_rule = _clone_alert_rule(target_monitor_client,
+                                           alert_rule,
+                                           target_resource)
+        else:
+            try:
+                alert_rule = _add_into_existing_scopes(source_monitor_client,
+                                                       alert_rule,
+                                                       target_resource)
+            except ErrorResponseException as ex:  # Create new alert rule
+                if ex.response.status_code == 400:
+                    alert_rule = _clone_alert_rule(target_monitor_client,
+                                                   alert_rule,
+                                                   target_resource)
+                else:
+                    raise ex
+        updated_metrics_alert_rules.append(alert_rule)
+
+    return updated_metrics_alert_rules
+
+
+def _is_resource_type_same_and_sub_same(source_resource, target_resource):
+    source_dict = parse_resource_id(source_resource)
+    target_dict = parse_resource_id(target_resource)
+    same_rp = source_dict['namespace'] == target_dict['namespace'] and source_dict['type'] == target_dict['type']
+    same_sub = source_dict['subscription'] == target_dict['subscription']
+    return same_rp, same_sub

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_always_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_always_scenario.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_metric_alert_clone000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T03:55:42Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:15:15Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:55:49 GMT
+      - Mon, 02 Mar 2020 05:15:25 GMT
       expires:
       - '-1'
       pragma:
@@ -72,9 +72,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
-        \ \"etag\": \"W/\\\"5cddb043-3f44-4e78-8737-d7202d310a26\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"e9abf961-fc27-485e-9784-ccbc0fafed28\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"f9b15e3b-a5a9-4d22-a388-647f7b779d3c\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"ac5143f8-410b-44f9-8fdd-4883f33b0d7f\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -82,7 +82,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/286d34df-406a-4e1a-9ea1-b61b8a520c06?api-version=2019-11-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c4ac14d5-fe6d-4912-84db-adf7aff60fd1?api-version=2019-11-01
       cache-control:
       - no-cache
       content-length:
@@ -90,7 +90,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:55:55 GMT
+      - Mon, 02 Mar 2020 05:15:33 GMT
       expires:
       - '-1'
       pragma:
@@ -103,9 +103,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 257d8449-9be2-476f-b64b-e0afde31a503
+      - 2ca83511-94e0-4e7d-9c54-bde1c83c684d
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -126,7 +126,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/286d34df-406a-4e1a-9ea1-b61b8a520c06?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c4ac14d5-fe6d-4912-84db-adf7aff60fd1?api-version=2019-11-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -138,7 +138,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:55:58 GMT
+      - Mon, 02 Mar 2020 05:15:35 GMT
       expires:
       - '-1'
       pragma:
@@ -155,7 +155,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 131e69c9-9653-4c49-af3c-62dbc432dd33
+      - 17718562-de61-4574-b123-8af76815d55f
     status:
       code: 200
       message: OK
@@ -180,9 +180,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
-        \ \"etag\": \"W/\\\"e8307f64-5ad1-4598-acc6-546252cb2b1f\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"20f95f1e-cd13-4f46-a077-4ca35a4a7855\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f9b15e3b-a5a9-4d22-a388-647f7b779d3c\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"ac5143f8-410b-44f9-8fdd-4883f33b0d7f\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -194,9 +194,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:55:58 GMT
+      - Mon, 02 Mar 2020 05:15:35 GMT
       etag:
-      - W/"e8307f64-5ad1-4598-acc6-546252cb2b1f"
+      - W/"20f95f1e-cd13-4f46-a077-4ca35a4a7855"
       expires:
       - '-1'
       pragma:
@@ -213,7 +213,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 899d5e98-ce37-4642-8ef0-33892a0317f4
+      - e2cda442-5f9b-46e4-b575-10a695686f9b
     status:
       code: 200
       message: OK
@@ -239,7 +239,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_metric_alert_clone000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T03:55:42Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:15:15Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -248,7 +248,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:55:59 GMT
+      - Mon, 02 Mar 2020 05:15:36 GMT
       expires:
       - '-1'
       pragma:
@@ -290,9 +290,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n
-        \ \"etag\": \"W/\\\"40cdec13-f4ca-4d52-ae1a-b6a43e89bd38\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"7348c6b8-ffe7-4f76-a508-21be6929fc6d\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"0d60ae2e-69f3-4c9d-87b5-8172438b0f6b\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"6cadf2ea-0b05-4845-80d9-909e269e2dc6\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -300,7 +300,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/cf23fe1c-a11b-4c3d-a977-4150383cfdd1?api-version=2019-11-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b2617f53-7515-4c5a-aad2-ca105e7dce5d?api-version=2019-11-01
       cache-control:
       - no-cache
       content-length:
@@ -308,7 +308,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:06 GMT
+      - Mon, 02 Mar 2020 05:15:43 GMT
       expires:
       - '-1'
       pragma:
@@ -321,9 +321,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 7bcdd15c-70d2-4389-b6dd-94e109f0a7ae
+      - 70be125c-4054-4af8-893b-9caf0500acbe
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1197'
     status:
       code: 201
       message: Created
@@ -344,7 +344,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/cf23fe1c-a11b-4c3d-a977-4150383cfdd1?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b2617f53-7515-4c5a-aad2-ca105e7dce5d?api-version=2019-11-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -356,7 +356,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:09 GMT
+      - Mon, 02 Mar 2020 05:15:46 GMT
       expires:
       - '-1'
       pragma:
@@ -373,7 +373,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - a48c18fc-967c-40a4-b071-a308c5317266
+      - 4158b9fc-6ac5-47d7-9399-395812c0be50
     status:
       code: 200
       message: OK
@@ -398,9 +398,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n
-        \ \"etag\": \"W/\\\"25356945-f2b3-4339-abfe-4d8c3edf489b\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"640d913c-8aaf-495a-82f4-d506a9148964\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"0d60ae2e-69f3-4c9d-87b5-8172438b0f6b\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"6cadf2ea-0b05-4845-80d9-909e269e2dc6\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -412,9 +412,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:09 GMT
+      - Mon, 02 Mar 2020 05:15:46 GMT
       etag:
-      - W/"25356945-f2b3-4339-abfe-4d8c3edf489b"
+      - W/"640d913c-8aaf-495a-82f4-d506a9148964"
       expires:
       - '-1'
       pragma:
@@ -431,7 +431,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 42bf7935-bad9-401f-a79b-d2a9b345e672
+      - ef6bea5f-147f-4d20-ab2d-0cdce7563fb6
     status:
       code: 200
       message: OK
@@ -474,7 +474,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:17 GMT
+      - Mon, 02 Mar 2020 05:15:51 GMT
       expires:
       - '-1'
       pragma:
@@ -486,7 +486,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -547,7 +547,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:41 GMT
+      - Mon, 02 Mar 2020 05:16:36 GMT
       expires:
       - '-1'
       pragma:
@@ -565,7 +565,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
       x-powered-by:
       - ASP.NET
     status:
@@ -628,7 +628,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:58 GMT
+      - Mon, 02 Mar 2020 05:16:57 GMT
       expires:
       - '-1'
       pragma:
@@ -676,175 +676,7 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"location\": \"global\",\r\n
         \     \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\": \"alert1\",\r\n
-        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/Microsoft.Storage/storageAccounts/saqjlb7ody5b2b7por3lyn2p\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/Microsoft.Storage/storageAccounts/saiajpo37gmzguxthqp3ibgd\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/Microsoft.Storage/storageAccounts/sazexifbqdd4hmpyekut563n\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/Microsoft.Storage/storageAccounts/saiuw6p6ntxwcqkk63653fvu\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/Microsoft.Storage/storageAccounts/sanpq4kcjkahn5xjht34x5nq\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/Microsoft.Storage/storageAccounts/sa7mqrgvdnopua6c65y6rfak\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
         \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
         2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
         \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
@@ -879,11 +711,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '18873'
+      - '3399'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:01 GMT
+      - Mon, 02 Mar 2020 05:16:59 GMT
       expires:
       - '-1'
       pragma:
@@ -951,7 +783,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:02 GMT
+      - Mon, 02 Mar 2020 05:16:59 GMT
       expires:
       - '-1'
       pragma:
@@ -965,7 +797,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
       x-powered-by:
       - ASP.NET
     status:
@@ -1030,7 +862,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:18 GMT
+      - Mon, 02 Mar 2020 05:17:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1048,7 +880,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
       x-powered-by:
       - ASP.NET
     status:
@@ -1100,7 +932,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:19 GMT
+      - Mon, 02 Mar 2020 05:17:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1114,7 +946,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:
@@ -1179,7 +1011,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:32 GMT
+      - Mon, 02 Mar 2020 05:18:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1197,7 +1029,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_always_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_always_scenario.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_metric_alert_clone000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:15:15Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:51:24Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:15:25 GMT
+      - Mon, 02 Mar 2020 05:51:32 GMT
       expires:
       - '-1'
       pragma:
@@ -72,9 +72,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
-        \ \"etag\": \"W/\\\"e9abf961-fc27-485e-9784-ccbc0fafed28\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"2cbd2d9a-752d-4d6b-ad93-59941230b679\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"ac5143f8-410b-44f9-8fdd-4883f33b0d7f\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"01e0c789-3a2a-4b1c-a4a3-c0768634c483\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -82,7 +82,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c4ac14d5-fe6d-4912-84db-adf7aff60fd1?api-version=2019-11-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c78ddfa7-0d1b-48a1-a16a-14714c451c09?api-version=2019-11-01
       cache-control:
       - no-cache
       content-length:
@@ -90,7 +90,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:15:33 GMT
+      - Mon, 02 Mar 2020 05:51:37 GMT
       expires:
       - '-1'
       pragma:
@@ -103,9 +103,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 2ca83511-94e0-4e7d-9c54-bde1c83c684d
+      - 5d5d4fef-4e15-48dd-a0a0-3350ba627c3e
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1197'
     status:
       code: 201
       message: Created
@@ -126,7 +126,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c4ac14d5-fe6d-4912-84db-adf7aff60fd1?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c78ddfa7-0d1b-48a1-a16a-14714c451c09?api-version=2019-11-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -138,7 +138,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:15:35 GMT
+      - Mon, 02 Mar 2020 05:51:43 GMT
       expires:
       - '-1'
       pragma:
@@ -155,7 +155,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 17718562-de61-4574-b123-8af76815d55f
+      - 3c91beea-6e4b-4a26-9eb6-e4474736dd55
     status:
       code: 200
       message: OK
@@ -180,9 +180,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
-        \ \"etag\": \"W/\\\"20f95f1e-cd13-4f46-a077-4ca35a4a7855\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"72165d27-5334-468b-afdc-703c7a300da6\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"ac5143f8-410b-44f9-8fdd-4883f33b0d7f\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"01e0c789-3a2a-4b1c-a4a3-c0768634c483\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -194,9 +194,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:15:35 GMT
+      - Mon, 02 Mar 2020 05:51:43 GMT
       etag:
-      - W/"20f95f1e-cd13-4f46-a077-4ca35a4a7855"
+      - W/"72165d27-5334-468b-afdc-703c7a300da6"
       expires:
       - '-1'
       pragma:
@@ -213,7 +213,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e2cda442-5f9b-46e4-b575-10a695686f9b
+      - 0ec083bd-1a21-42f9-b2fb-eada02237573
     status:
       code: 200
       message: OK
@@ -239,7 +239,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_metric_alert_clone000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:15:15Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:51:24Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -248,7 +248,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:15:36 GMT
+      - Mon, 02 Mar 2020 05:51:44 GMT
       expires:
       - '-1'
       pragma:
@@ -290,9 +290,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n
-        \ \"etag\": \"W/\\\"7348c6b8-ffe7-4f76-a508-21be6929fc6d\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"fddb57e6-f063-4588-8a9b-8ef81a504d24\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"6cadf2ea-0b05-4845-80d9-909e269e2dc6\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"cc97c18f-fdbd-4f95-bbe2-c06b7c030a67\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -300,7 +300,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b2617f53-7515-4c5a-aad2-ca105e7dce5d?api-version=2019-11-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b9bbc86d-2705-4894-87a1-b3ee019514a8?api-version=2019-11-01
       cache-control:
       - no-cache
       content-length:
@@ -308,7 +308,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:15:43 GMT
+      - Mon, 02 Mar 2020 05:51:47 GMT
       expires:
       - '-1'
       pragma:
@@ -321,9 +321,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 70be125c-4054-4af8-893b-9caf0500acbe
+      - 4bad7757-7a85-4532-98b0-74e4d7202d54
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1196'
     status:
       code: 201
       message: Created
@@ -344,7 +344,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b2617f53-7515-4c5a-aad2-ca105e7dce5d?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b9bbc86d-2705-4894-87a1-b3ee019514a8?api-version=2019-11-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -356,7 +356,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:15:46 GMT
+      - Mon, 02 Mar 2020 05:51:52 GMT
       expires:
       - '-1'
       pragma:
@@ -373,7 +373,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 4158b9fc-6ac5-47d7-9399-395812c0be50
+      - 28742b16-d30a-48cf-8125-951bb41c81eb
     status:
       code: 200
       message: OK
@@ -398,9 +398,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n
-        \ \"etag\": \"W/\\\"640d913c-8aaf-495a-82f4-d506a9148964\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"1f2b0e32-ec00-461c-bd3e-afcfde6c0180\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"6cadf2ea-0b05-4845-80d9-909e269e2dc6\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"cc97c18f-fdbd-4f95-bbe2-c06b7c030a67\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -412,9 +412,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:15:46 GMT
+      - Mon, 02 Mar 2020 05:51:52 GMT
       etag:
-      - W/"640d913c-8aaf-495a-82f4-d506a9148964"
+      - W/"1f2b0e32-ec00-461c-bd3e-afcfde6c0180"
       expires:
       - '-1'
       pragma:
@@ -431,7 +431,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - ef6bea5f-147f-4d20-ab2d-0cdce7563fb6
+      - a3311690-4802-4a5f-9c54-28b4bad42f70
     status:
       code: 200
       message: OK
@@ -474,7 +474,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:15:51 GMT
+      - Mon, 02 Mar 2020 05:51:57 GMT
       expires:
       - '-1'
       pragma:
@@ -486,7 +486,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1195'
     status:
       code: 201
       message: Created
@@ -547,7 +547,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:16:36 GMT
+      - Mon, 02 Mar 2020 05:52:42 GMT
       expires:
       - '-1'
       pragma:
@@ -565,7 +565,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:
@@ -628,7 +628,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:16:57 GMT
+      - Mon, 02 Mar 2020 05:53:03 GMT
       expires:
       - '-1'
       pragma:
@@ -676,7 +676,50 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"location\": \"global\",\r\n
         \     \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\": \"alert1\",\r\n
-        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonese6crel6lm5cjlrulzyd3hfzedfekrsdrpaj3tnlf6h4iswe/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonese6crel6lm5cjlrulzyd3hfzedfekrsdrpaj3tnlf6h4iswe/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
+        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Total\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonese6crel6lm5cjlrulzyd3hfzedfekrsdrpaj3tnlf6h4iswe/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Storage/storageAccounts/clitestblokyugzdbj5g3zbd\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
         \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
         2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
         \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
@@ -689,6 +732,35 @@ interactions:
         \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
         \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
         \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"cloned-clitestnxehy7risgfpgwtus-178ab7fb-9bdf-4504-a8d9-f7af4c3853ea\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Insights/metricAlerts/cloned-clitestnxehy7risgfpgwtus-178ab7fb-9bdf-4504-a8d9-f7af4c3853ea\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Storage/storageAccounts/clitestnxehy7risgfpgwtus\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/microsoft.insights/actionGroups/ag1\"\r\n
         \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
         \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
         \"alert2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert2\",\r\n
@@ -704,6 +776,21 @@ interactions:
         \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
         \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
         \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonese6crel6lm5cjlrulzyd3hfzedfekrsdrpaj3tnlf6h4iswe/providers/Microsoft.Insights/metricAlerts/alert2\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test2\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonese6crel6lm5cjlrulzyd3hfzedfekrsdrpaj3tnlf6h4iswe/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
+        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Maximum\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonese6crel6lm5cjlrulzyd3hfzedfekrsdrpaj3tnlf6h4iswe/providers/microsoft.insights/actionGroups/ag1\"\r\n
         \         }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
     headers:
       api-supported-versions:
@@ -711,11 +798,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '3399'
+      - '12364'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:16:59 GMT
+      - Mon, 02 Mar 2020 05:53:05 GMT
       expires:
       - '-1'
       pragma:
@@ -783,7 +870,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:16:59 GMT
+      - Mon, 02 Mar 2020 05:53:05 GMT
       expires:
       - '-1'
       pragma:
@@ -797,7 +884,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:
@@ -833,12 +920,12 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000001?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-67bd7714-0385-4119-8c4b-2814c797e884?api-version=2018-03-01
   response:
     body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"cloned-ip2-88888888-0000-0000-0000-000000000001\",\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000001\",\r\n
+        \ \"name\": \"cloned-ip2-67bd7714-0385-4119-8c4b-2814c797e884\",\r\n  \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-67bd7714-0385-4119-8c4b-2814c797e884\",\r\n
         \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
         2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
@@ -862,7 +949,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:17:38 GMT
+      - Mon, 02 Mar 2020 05:53:44 GMT
       expires:
       - '-1'
       pragma:
@@ -932,7 +1019,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:17:39 GMT
+      - Mon, 02 Mar 2020 05:53:44 GMT
       expires:
       - '-1'
       pragma:
@@ -946,7 +1033,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '295'
       x-powered-by:
       - ASP.NET
     status:
@@ -982,12 +1069,12 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000002?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-ef686749-24fe-4f44-87cc-a19a10098594?api-version=2018-03-01
   response:
     body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"cloned-ip2-88888888-0000-0000-0000-000000000002\",\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000002\",\r\n
+        \ \"name\": \"cloned-ip2-ef686749-24fe-4f44-87cc-a19a10098594\",\r\n  \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-ef686749-24fe-4f44-87cc-a19a10098594\",\r\n
         \ \"properties\": {\r\n    \"description\": \"Test2\",\r\n    \"severity\":
         2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
@@ -1011,7 +1098,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:18:04 GMT
+      - Mon, 02 Mar 2020 05:54:06 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_scenario.yaml
@@ -1,0 +1,1036 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_metric_alert_clone000001?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T05:56:35Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:56:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus", "properties": {"publicIPAllocationMethod": "Dynamic",
+      "publicIPAddressVersion": "IPv4", "idleTimeoutInMinutes": 4}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2019-11-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
+        \ \"etag\": \"W/\\\"dcdeda3f-1c31-4a09-be4d-b48ed5b32bec\\\"\",\r\n  \"location\":
+        \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"ece22016-9a27-443e-bda1-416190ac34ff\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ef4d8371-c6c0-450d-8d26-4c11a8562664?api-version=2019-11-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '654'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:56:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - d14fcd30-618c-49d6-9e7b-8aa2cb7ae99f
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ef4d8371-c6c0-450d-8d26-4c11a8562664?api-version=2019-11-01
+  response:
+    body:
+      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '29'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:56:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 9f04db34-30fa-4782-9e11-b09d4ebb2714
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1?api-version=2019-11-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
+        \ \"etag\": \"W/\\\"aa05e2ac-04d8-4361-8c29-714d1b4c39d3\\\"\",\r\n  \"location\":
+        \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"ece22016-9a27-443e-bda1-416190ac34ff\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '655'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:56:49 GMT
+      etag:
+      - W/"aa05e2ac-04d8-4361-8c29-714d1b4c39d3"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 3a67665e-8fc5-4342-8787-36bb7b3e348f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_metric_alert_clone000001?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T05:56:35Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:56:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus", "properties": {"publicIPAllocationMethod": "Dynamic",
+      "publicIPAddressVersion": "IPv4", "idleTimeoutInMinutes": 4}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2?api-version=2019-11-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n
+        \ \"etag\": \"W/\\\"8ce1620f-3fc9-4d7e-9be6-9689e979e315\\\"\",\r\n  \"location\":
+        \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"93bea6a3-2acf-4a1d-af66-d1c6be8abb9a\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/77c696ea-d957-4b99-8f29-4a95a2fa15de?api-version=2019-11-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '654'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:56:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 0ac36331-dc66-4ba9-9b1a-8bdd22113322
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/77c696ea-d957-4b99-8f29-4a95a2fa15de?api-version=2019-11-01
+  response:
+    body:
+      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '29'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:56:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 81a25b4e-807d-4f7f-b51b-acb9f13e7629
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network public-ip create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2?api-version=2019-11-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n
+        \ \"etag\": \"W/\\\"f05c75ea-ba08-4c0a-8a18-8d1c5e4ee03a\\\"\",\r\n  \"location\":
+        \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"93bea6a3-2acf-4a1d-af66-d1c6be8abb9a\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '655'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:56:57 GMT
+      etag:
+      - W/"f05c75ea-ba08-4c0a-8a18-8d1c5e4ee03a"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 0ce0fb99-0ee5-4198-9149-735b0db16d28
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global", "properties": {"groupShortName": "ag1", "enabled":
+      true, "emailReceivers": [], "smsReceivers": [], "webhookReceivers": [], "itsmReceivers":
+      [], "azureAppPushReceivers": [], "automationRunbookReceivers": [], "voiceReceivers":
+      [], "logicAppReceivers": [], "azureFunctionReceivers": [], "armRoleReceivers":
+      []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor action-group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '331'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1","type":"Microsoft.Insights/ActionGroups","name":"ag1","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"ag1","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[],"automationRunbookReceivers":[],"voiceReceivers":[],"logicAppReceivers":[],"azureFunctionReceivers":[],"armRoleReceivers":[]},"identity":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '595'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:57:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: 'b''{"location": "global", "properties": {"description": "Test", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "criteria": {"odata.type":
+      "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria", "allOf": [{"name":
+      "cond0", "metricName": "TCPBytesForwardedDDoS", "timeAggregation": "Total",
+      "dimensions": [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
+      "threshold": 5.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor metrics alert create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '875'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --scopes --action --description --condition
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
+        \ \"name\": \"alert1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
+        \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
+        \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
+        \       {\r\n          \"threshold\": 5.0,\r\n          \"name\": \"cond0\",\r\n
+        \         \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \         \"metricName\": \"TCPBytesForwardedDDoS\",\r\n          \"dimensions\":
+        [],\r\n          \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
+        \"Total\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \       }\r\n      ],\r\n      \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \   },\r\n    \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \   \"actions\": [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1532'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:57:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"location": "global", "properties": {"description": "Test2", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "criteria": {"odata.type":
+      "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria", "allOf": [{"name":
+      "cond0", "metricName": "TCPBytesForwardedDDoS", "timeAggregation": "Maximum",
+      "dimensions": [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
+      "threshold": 5.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor metrics alert create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '878'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --scopes --action --description --condition
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert2?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
+        \ \"name\": \"alert2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert2\",\r\n
+        \ \"properties\": {\r\n    \"description\": \"Test2\",\r\n    \"severity\":
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
+        \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
+        \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
+        \       {\r\n          \"threshold\": 5.0,\r\n          \"name\": \"cond0\",\r\n
+        \         \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \         \"metricName\": \"TCPBytesForwardedDDoS\",\r\n          \"dimensions\":
+        [],\r\n          \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
+        \"Maximum\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \       }\r\n      ],\r\n      \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \   },\r\n    \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \   \"actions\": [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1535'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:57:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Insights/metricAlerts?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"location\": \"global\",\r\n
+        \     \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\": \"alert1\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
+        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Total\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert2\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test2\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
+        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Maximum\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '3399'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:57:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"location": "global", "properties": {"description": "Test", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.network/publicipaddresses",
+      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+      "allOf": [{"name": "cond0", "metricName": "TCPBytesForwardedDDoS", "metricNamespace":
+      "microsoft.network/publicipaddresses", "timeAggregation": "Total", "dimensions":
+      [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
+      "threshold": 5.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1190'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1?api-version=2018-03-01
+  response:
+    body:
+      string: '{"Code":"BadRequest","Message":"Scopes property is invalid. Only single
+        resource is allowed for criteria type SingleResourceMultipleMetricCriteria.
+        If you want to create an alert on multiple resources, use MultipleResourceMultipleMetricCriteria
+        odata.type."}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '258'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:57:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 400
+      message: BadRequest
+- request:
+    body: 'b''{"location": "global", "properties": {"description": "Test", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.network/publicipaddresses",
+      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+      "allOf": [{"name": "cond0", "metricName": "TCPBytesForwardedDDoS", "metricNamespace":
+      "microsoft.network/publicipaddresses", "timeAggregation": "Total", "dimensions":
+      [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
+      "threshold": 5.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '994'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/ip2-88888888-0000-0000-0000-000000000001?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
+        \ \"name\": \"ip2-88888888-0000-0000-0000-000000000001\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/ip2-88888888-0000-0000-0000-000000000001\",\r\n
+        \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\"\r\n
+        \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
+        \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
+        \       {\r\n          \"threshold\": 5.0,\r\n          \"name\": \"cond0\",\r\n
+        \         \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \         \"metricName\": \"TCPBytesForwardedDDoS\",\r\n          \"dimensions\":
+        [],\r\n          \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
+        \"Total\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \       }\r\n      ],\r\n      \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \   },\r\n    \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \   \"actions\": [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1600'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:58:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"location": "global", "properties": {"description": "Test2", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.network/publicipaddresses",
+      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+      "allOf": [{"name": "cond0", "metricName": "TCPBytesForwardedDDoS", "metricNamespace":
+      "microsoft.network/publicipaddresses", "timeAggregation": "Maximum", "dimensions":
+      [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
+      "threshold": 5.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1193'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert2?api-version=2018-03-01
+  response:
+    body:
+      string: '{"Code":"BadRequest","Message":"Scopes property is invalid. Only single
+        resource is allowed for criteria type SingleResourceMultipleMetricCriteria.
+        If you want to create an alert on multiple resources, use MultipleResourceMultipleMetricCriteria
+        odata.type."}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '258'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:58:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '297'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 400
+      message: BadRequest
+- request:
+    body: 'b''{"location": "global", "properties": {"description": "Test2", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.network/publicipaddresses",
+      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+      "allOf": [{"name": "cond0", "metricName": "TCPBytesForwardedDDoS", "metricNamespace":
+      "microsoft.network/publicipaddresses", "timeAggregation": "Maximum", "dimensions":
+      [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
+      "threshold": 5.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '997'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/ip2-88888888-0000-0000-0000-000000000002?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
+        \ \"name\": \"ip2-88888888-0000-0000-0000-000000000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/ip2-88888888-0000-0000-0000-000000000002\",\r\n
+        \ \"properties\": {\r\n    \"description\": \"Test2\",\r\n    \"severity\":
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\"\r\n
+        \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
+        \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
+        \       {\r\n          \"threshold\": 5.0,\r\n          \"name\": \"cond0\",\r\n
+        \         \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \         \"metricName\": \"TCPBytesForwardedDDoS\",\r\n          \"dimensions\":
+        [],\r\n          \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
+        \"Maximum\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \       }\r\n      ],\r\n      \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \   },\r\n    \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \   \"actions\": [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1603'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:58:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '296'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_scenario.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_metric_alert_clone000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T03:55:42Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:51:24Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:55:49 GMT
+      - Mon, 02 Mar 2020 05:51:32 GMT
       expires:
       - '-1'
       pragma:
@@ -72,9 +72,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
-        \ \"etag\": \"W/\\\"5cddb043-3f44-4e78-8737-d7202d310a26\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"0abf3ac7-45f6-4caa-82c6-cfe1aefc1248\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"f9b15e3b-a5a9-4d22-a388-647f7b779d3c\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"c0c92792-7b99-4805-9477-67eb064aad63\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -82,7 +82,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/286d34df-406a-4e1a-9ea1-b61b8a520c06?api-version=2019-11-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1d22dc82-8c89-4f65-8aac-9cf2d35250dc?api-version=2019-11-01
       cache-control:
       - no-cache
       content-length:
@@ -90,7 +90,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:55:55 GMT
+      - Mon, 02 Mar 2020 05:51:39 GMT
       expires:
       - '-1'
       pragma:
@@ -103,7 +103,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 257d8449-9be2-476f-b64b-e0afde31a503
+      - 565bd83a-6974-4292-b50c-c5297b5306c1
       x-ms-ratelimit-remaining-subscription-writes:
       - '1197'
     status:
@@ -126,7 +126,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/286d34df-406a-4e1a-9ea1-b61b8a520c06?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1d22dc82-8c89-4f65-8aac-9cf2d35250dc?api-version=2019-11-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -138,7 +138,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:55:58 GMT
+      - Mon, 02 Mar 2020 05:51:44 GMT
       expires:
       - '-1'
       pragma:
@@ -155,7 +155,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 131e69c9-9653-4c49-af3c-62dbc432dd33
+      - 15cfabfb-8f74-48d5-a908-85ec46a59854
     status:
       code: 200
       message: OK
@@ -180,9 +180,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
-        \ \"etag\": \"W/\\\"e8307f64-5ad1-4598-acc6-546252cb2b1f\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"2088e6bd-7b6b-4d38-bcb5-a6bded830c4b\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f9b15e3b-a5a9-4d22-a388-647f7b779d3c\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"c0c92792-7b99-4805-9477-67eb064aad63\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -194,9 +194,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:55:58 GMT
+      - Mon, 02 Mar 2020 05:51:44 GMT
       etag:
-      - W/"e8307f64-5ad1-4598-acc6-546252cb2b1f"
+      - W/"2088e6bd-7b6b-4d38-bcb5-a6bded830c4b"
       expires:
       - '-1'
       pragma:
@@ -213,7 +213,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 899d5e98-ce37-4642-8ef0-33892a0317f4
+      - ccf88ea0-156d-4421-9c0f-6ad6e5b81dc3
     status:
       code: 200
       message: OK
@@ -239,7 +239,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_metric_alert_clone000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T03:55:42Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:51:24Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -248,7 +248,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:55:59 GMT
+      - Mon, 02 Mar 2020 05:51:45 GMT
       expires:
       - '-1'
       pragma:
@@ -290,9 +290,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n
-        \ \"etag\": \"W/\\\"40cdec13-f4ca-4d52-ae1a-b6a43e89bd38\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"3781d3da-db27-4060-8273-1e14aa879136\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"0d60ae2e-69f3-4c9d-87b5-8172438b0f6b\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"a793cdd6-ce5e-4ed6-8aad-c99f74867072\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -300,7 +300,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/cf23fe1c-a11b-4c3d-a977-4150383cfdd1?api-version=2019-11-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6e1487a4-1e63-4759-a1ed-74b81bf1f74c?api-version=2019-11-01
       cache-control:
       - no-cache
       content-length:
@@ -308,7 +308,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:06 GMT
+      - Mon, 02 Mar 2020 05:51:52 GMT
       expires:
       - '-1'
       pragma:
@@ -321,9 +321,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 7bcdd15c-70d2-4389-b6dd-94e109f0a7ae
+      - 7fa2a468-eae6-4106-884d-e5a04b47e200
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1196'
     status:
       code: 201
       message: Created
@@ -344,7 +344,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/cf23fe1c-a11b-4c3d-a977-4150383cfdd1?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6e1487a4-1e63-4759-a1ed-74b81bf1f74c?api-version=2019-11-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -356,7 +356,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:09 GMT
+      - Mon, 02 Mar 2020 05:51:54 GMT
       expires:
       - '-1'
       pragma:
@@ -373,7 +373,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - a48c18fc-967c-40a4-b071-a308c5317266
+      - 5a4fd195-8e08-426f-a012-5083a4446e8c
     status:
       code: 200
       message: OK
@@ -398,9 +398,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n
-        \ \"etag\": \"W/\\\"25356945-f2b3-4339-abfe-4d8c3edf489b\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"461493c0-ca59-4a68-aafe-911e6d684d03\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"0d60ae2e-69f3-4c9d-87b5-8172438b0f6b\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"a793cdd6-ce5e-4ed6-8aad-c99f74867072\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -412,9 +412,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:09 GMT
+      - Mon, 02 Mar 2020 05:51:54 GMT
       etag:
-      - W/"25356945-f2b3-4339-abfe-4d8c3edf489b"
+      - W/"461493c0-ca59-4a68-aafe-911e6d684d03"
       expires:
       - '-1'
       pragma:
@@ -431,7 +431,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 42bf7935-bad9-401f-a79b-d2a9b345e672
+      - f9e3a389-dea7-4d7f-a491-04906d1581bc
     status:
       code: 200
       message: OK
@@ -474,7 +474,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:17 GMT
+      - Mon, 02 Mar 2020 05:52:02 GMT
       expires:
       - '-1'
       pragma:
@@ -486,7 +486,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -547,7 +547,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:41 GMT
+      - Mon, 02 Mar 2020 05:52:38 GMT
       expires:
       - '-1'
       pragma:
@@ -565,7 +565,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
       x-powered-by:
       - ASP.NET
     status:
@@ -628,7 +628,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:58 GMT
+      - Mon, 02 Mar 2020 05:53:04 GMT
       expires:
       - '-1'
       pragma:
@@ -676,175 +676,7 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"location\": \"global\",\r\n
         \     \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\": \"alert1\",\r\n
-        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/Microsoft.Storage/storageAccounts/saqjlb7ody5b2b7por3lyn2p\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/Microsoft.Storage/storageAccounts/saiajpo37gmzguxthqp3ibgd\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/Microsoft.Storage/storageAccounts/sazexifbqdd4hmpyekut563n\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/Microsoft.Storage/storageAccounts/saiuw6p6ntxwcqkk63653fvu\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/Microsoft.Storage/storageAccounts/sanpq4kcjkahn5xjht34x5nq\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/Microsoft.Storage/storageAccounts/sa7mqrgvdnopua6c65y6rfak\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
         \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
         2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
         \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
@@ -857,6 +689,93 @@ interactions:
         \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
         \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
         \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Storage/storageAccounts/clitestblokyugzdbj5g3zbd\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
+        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Total\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"cloned-clitestnxehy7risgfpgwtus-178ab7fb-9bdf-4504-a8d9-f7af4c3853ea\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Insights/metricAlerts/cloned-clitestnxehy7risgfpgwtus-178ab7fb-9bdf-4504-a8d9-f7af4c3853ea\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Storage/storageAccounts/clitestnxehy7risgfpgwtus\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/Microsoft.Insights/metricAlerts/alert2\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test2\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
+        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Maximum\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/microsoft.insights/actionGroups/ag1\"\r\n
         \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
         \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
         \"alert2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert2\",\r\n
@@ -879,11 +798,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '18873'
+      - '12364'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:01 GMT
+      - Mon, 02 Mar 2020 05:53:05 GMT
       expires:
       - '-1'
       pragma:
@@ -951,7 +870,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:02 GMT
+      - Mon, 02 Mar 2020 05:53:06 GMT
       expires:
       - '-1'
       pragma:
@@ -965,7 +884,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '297'
       x-powered-by:
       - ASP.NET
     status:
@@ -1001,12 +920,12 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000001?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-635a2da6-d651-4823-9f48-77976bcb1815?api-version=2018-03-01
   response:
     body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"cloned-ip2-88888888-0000-0000-0000-000000000001\",\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000001\",\r\n
+        \ \"name\": \"cloned-ip2-635a2da6-d651-4823-9f48-77976bcb1815\",\r\n  \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-635a2da6-d651-4823-9f48-77976bcb1815\",\r\n
         \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
         2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
@@ -1030,7 +949,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:18 GMT
+      - Mon, 02 Mar 2020 05:53:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1048,7 +967,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '297'
       x-powered-by:
       - ASP.NET
     status:
@@ -1100,7 +1019,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:19 GMT
+      - Mon, 02 Mar 2020 05:53:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1114,7 +1033,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '296'
       x-powered-by:
       - ASP.NET
     status:
@@ -1150,12 +1069,12 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000002?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-9fed509b-c699-472d-9fca-f71d9196bb86?api-version=2018-03-01
   response:
     body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"cloned-ip2-88888888-0000-0000-0000-000000000002\",\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000002\",\r\n
+        \ \"name\": \"cloned-ip2-9fed509b-c699-472d-9fca-f71d9196bb86\",\r\n  \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-9fed509b-c699-472d-9fca-f71d9196bb86\",\r\n
         \ \"properties\": {\r\n    \"description\": \"Test2\",\r\n    \"severity\":
         2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
@@ -1179,7 +1098,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:32 GMT
+      - Mon, 02 Mar 2020 05:53:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1197,7 +1116,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '296'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_public_ip_metric_alerts_scenario.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_metric_alert_clone000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:51:24Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T06:54:11Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:51:32 GMT
+      - Mon, 02 Mar 2020 06:54:19 GMT
       expires:
       - '-1'
       pragma:
@@ -72,9 +72,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
-        \ \"etag\": \"W/\\\"0abf3ac7-45f6-4caa-82c6-cfe1aefc1248\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"5d2f630c-c459-4993-b39e-e1613145bc31\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"c0c92792-7b99-4805-9477-67eb064aad63\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"7c71589f-b37c-4da0-a008-8847b6f2602a\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -82,7 +82,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1d22dc82-8c89-4f65-8aac-9cf2d35250dc?api-version=2019-11-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/35731d8a-fce9-442e-a109-6928aba1f291?api-version=2019-11-01
       cache-control:
       - no-cache
       content-length:
@@ -90,7 +90,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:51:39 GMT
+      - Mon, 02 Mar 2020 06:54:24 GMT
       expires:
       - '-1'
       pragma:
@@ -103,7 +103,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 565bd83a-6974-4292-b50c-c5297b5306c1
+      - 97816112-6e8b-408b-9c86-b099b4668665
       x-ms-ratelimit-remaining-subscription-writes:
       - '1197'
     status:
@@ -126,7 +126,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1d22dc82-8c89-4f65-8aac-9cf2d35250dc?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/35731d8a-fce9-442e-a109-6928aba1f291?api-version=2019-11-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -138,7 +138,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:51:44 GMT
+      - Mon, 02 Mar 2020 06:54:27 GMT
       expires:
       - '-1'
       pragma:
@@ -155,7 +155,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 15cfabfb-8f74-48d5-a908-85ec46a59854
+      - 2cf97dec-6d50-44cd-937a-054864159b67
     status:
       code: 200
       message: OK
@@ -180,9 +180,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\",\r\n
-        \ \"etag\": \"W/\\\"2088e6bd-7b6b-4d38-bcb5-a6bded830c4b\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"3db0d941-a331-4675-b38c-b9864062d3aa\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"c0c92792-7b99-4805-9477-67eb064aad63\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"7c71589f-b37c-4da0-a008-8847b6f2602a\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -194,9 +194,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:51:44 GMT
+      - Mon, 02 Mar 2020 06:54:27 GMT
       etag:
-      - W/"2088e6bd-7b6b-4d38-bcb5-a6bded830c4b"
+      - W/"3db0d941-a331-4675-b38c-b9864062d3aa"
       expires:
       - '-1'
       pragma:
@@ -213,7 +213,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - ccf88ea0-156d-4421-9c0f-6ad6e5b81dc3
+      - 99233657-525e-4317-ab0b-c401f603c91a
     status:
       code: 200
       message: OK
@@ -239,7 +239,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_metric_alert_clone000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:51:24Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001","name":"cli_test_metric_alert_clone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T06:54:11Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -248,7 +248,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:51:45 GMT
+      - Mon, 02 Mar 2020 06:54:28 GMT
       expires:
       - '-1'
       pragma:
@@ -290,9 +290,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n
-        \ \"etag\": \"W/\\\"3781d3da-db27-4060-8273-1e14aa879136\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"f522b9af-8c43-4d9b-adb1-9dc6ed7e46dc\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"a793cdd6-ce5e-4ed6-8aad-c99f74867072\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"6a3ff53d-f4ba-428a-a9be-c17431fcf317\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -300,7 +300,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6e1487a4-1e63-4759-a1ed-74b81bf1f74c?api-version=2019-11-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/60325801-4ac6-4de6-85d9-6af6ac50bfcb?api-version=2019-11-01
       cache-control:
       - no-cache
       content-length:
@@ -308,7 +308,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:51:52 GMT
+      - Mon, 02 Mar 2020 06:54:34 GMT
       expires:
       - '-1'
       pragma:
@@ -321,9 +321,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 7fa2a468-eae6-4106-884d-e5a04b47e200
+      - 0e11736e-3b44-4cfe-a30e-89379ed08635
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -344,7 +344,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6e1487a4-1e63-4759-a1ed-74b81bf1f74c?api-version=2019-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/60325801-4ac6-4de6-85d9-6af6ac50bfcb?api-version=2019-11-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -356,7 +356,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:51:54 GMT
+      - Mon, 02 Mar 2020 06:54:36 GMT
       expires:
       - '-1'
       pragma:
@@ -373,7 +373,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 5a4fd195-8e08-426f-a012-5083a4446e8c
+      - a9e97663-37be-48cb-b973-1a6093464649
     status:
       code: 200
       message: OK
@@ -398,9 +398,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"ip2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\",\r\n
-        \ \"etag\": \"W/\\\"461493c0-ca59-4a68-aafe-911e6d684d03\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"cd89e605-8dad-458f-a5a7-3da93beba632\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"a793cdd6-ce5e-4ed6-8aad-c99f74867072\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"6a3ff53d-f4ba-428a-a9be-c17431fcf317\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": []\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -412,9 +412,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:51:54 GMT
+      - Mon, 02 Mar 2020 06:54:36 GMT
       etag:
-      - W/"461493c0-ca59-4a68-aafe-911e6d684d03"
+      - W/"cd89e605-8dad-458f-a5a7-3da93beba632"
       expires:
       - '-1'
       pragma:
@@ -431,7 +431,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - f9e3a389-dea7-4d7f-a491-04906d1581bc
+      - d52962fa-8f42-4c32-9260-c1f4e2577fe9
     status:
       code: 200
       message: OK
@@ -474,7 +474,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:52:02 GMT
+      - Mon, 02 Mar 2020 06:54:45 GMT
       expires:
       - '-1'
       pragma:
@@ -547,7 +547,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:52:38 GMT
+      - Mon, 02 Mar 2020 06:55:03 GMT
       expires:
       - '-1'
       pragma:
@@ -628,7 +628,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:53:04 GMT
+      - Mon, 02 Mar 2020 06:55:32 GMT
       expires:
       - '-1'
       pragma:
@@ -646,7 +646,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:
@@ -691,93 +691,6 @@ interactions:
         \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
         \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
         \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Storage/storageAccounts/clitestblokyugzdbj5g3zbd\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
-        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
-        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Total\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"cloned-clitestnxehy7risgfpgwtus-178ab7fb-9bdf-4504-a8d9-f7af4c3853ea\",\r\n
-        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Insights/metricAlerts/cloned-clitestnxehy7risgfpgwtus-178ab7fb-9bdf-4504-a8d9-f7af4c3853ea\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/Microsoft.Storage/storageAccounts/clitestnxehy7risgfpgwtus\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone2y5p5lrbfqyfwpsdwwgd6um6qnkqdswh57dpq43oix4kjtrt/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/Microsoft.Insights/metricAlerts/alert2\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test2\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
-        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
-        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Maximum\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonei73mg4b5yafrm4gjmt3mro5ldqpu4zbecov7zwnrod2eoujz/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
         \"alert2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert2\",\r\n
         \     \"properties\": {\r\n        \"description\": \"Test2\",\r\n        \"severity\":
         2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
@@ -791,6 +704,34 @@ interactions:
         \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
         \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
         \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_cloneksezcg4wolx2lfbravqwp2zjzzdorvtrckp7pm3z6p5xcazf/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_cloneksezcg4wolx2lfbravqwp2zjzzdorvtrckp7pm3z6p5xcazf/providers/Microsoft.Storage/storageAccounts/clitestb55kxwm55zf6xlfv5\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_cloneksezcg4wolx2lfbravqwp2zjzzdorvtrckp7pm3z6p5xcazf/providers/microsoft.insights/actionGroups/ag1\"\r\n
         \         }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
     headers:
       api-supported-versions:
@@ -798,11 +739,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '12364'
+      - '6131'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:53:05 GMT
+      - Mon, 02 Mar 2020 06:55:34 GMT
       expires:
       - '-1'
       pragma:
@@ -870,7 +811,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:53:06 GMT
+      - Mon, 02 Mar 2020 06:55:35 GMT
       expires:
       - '-1'
       pragma:
@@ -884,7 +825,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '299'
       x-powered-by:
       - ASP.NET
     status:
@@ -920,12 +861,12 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-635a2da6-d651-4823-9f48-77976bcb1815?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000001?api-version=2018-03-01
   response:
     body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"cloned-ip2-635a2da6-d651-4823-9f48-77976bcb1815\",\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-635a2da6-d651-4823-9f48-77976bcb1815\",\r\n
+        \ \"name\": \"cloned-ip2-88888888-0000-0000-0000-000000000001\",\r\n  \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000001\",\r\n
         \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
         2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
@@ -949,7 +890,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:53:31 GMT
+      - Mon, 02 Mar 2020 06:55:48 GMT
       expires:
       - '-1'
       pragma:
@@ -967,7 +908,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '299'
       x-powered-by:
       - ASP.NET
     status:
@@ -1019,7 +960,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:53:31 GMT
+      - Mon, 02 Mar 2020 06:55:50 GMT
       expires:
       - '-1'
       pragma:
@@ -1033,7 +974,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:
@@ -1069,12 +1010,12 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-9fed509b-c699-472d-9fca-f71d9196bb86?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000002?api-version=2018-03-01
   response:
     body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"cloned-ip2-9fed509b-c699-472d-9fca-f71d9196bb86\",\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-9fed509b-c699-472d-9fca-f71d9196bb86\",\r\n
+        \ \"name\": \"cloned-ip2-88888888-0000-0000-0000-000000000002\",\r\n  \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-ip2-88888888-0000-0000-0000-000000000002\",\r\n
         \ \"properties\": {\r\n    \"description\": \"Test2\",\r\n    \"severity\":
         2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Network/publicIPAddresses/ip2\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
@@ -1098,7 +1039,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 05:53:53 GMT
+      - Mon, 02 Mar 2020 06:56:05 GMT
       expires:
       - '-1'
       pragma:
@@ -1116,7 +1057,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '296'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_across_subs_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_across_subs_scenario.yaml
@@ -34,7 +34,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 04:19:25 GMT
+      - Mon, 02 Mar 2020 05:51:38 GMT
       expires:
       - '-1'
       pragma:
@@ -83,11 +83,11 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 04:19:32 GMT
+      - Mon, 02 Mar 2020 05:51:50 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/5b74d2ad-3483-4ef0-83dc-31005307771e?monitor=true&api-version=2019-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/8008661a-304e-4980-8ed5-009699d754fa?monitor=true&api-version=2019-06-01
       pragma:
       - no-cache
       server:
@@ -97,7 +97,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -118,10 +118,55 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-storage/7.1.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/5b74d2ad-3483-4ef0-83dc-31005307771e?monitor=true&api-version=2019-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/8008661a-304e-4980-8ed5-009699d754fa?monitor=true&api-version=2019-06-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Storage/storageAccounts/sa000002","name":"sa000002","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T04:19:32.6103513Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T04:19:32.6103513Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-03-02T04:19:32.4853759Z","primaryEndpoints":{"blob":"https://sa000002.blob.core.windows.net/","queue":"https://sa000002.queue.core.windows.net/","table":"https://sa000002.table.core.windows.net/","file":"https://sa000002.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      content-type:
+      - text/plain; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 05:52:08 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/8008661a-304e-4980-8ed5-009699d754fa?monitor=true&api-version=2019-06-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -l --sku --kind --subscription
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-storage/7.1.0 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/8008661a-304e-4980-8ed5-009699d754fa?monitor=true&api-version=2019-06-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Storage/storageAccounts/sa000002","name":"sa000002","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T05:51:50.0240502Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T05:51:50.0240502Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-03-02T05:51:49.8833907Z","primaryEndpoints":{"blob":"https://sa000002.blob.core.windows.net/","queue":"https://sa000002.queue.core.windows.net/","table":"https://sa000002.table.core.windows.net/","file":"https://sa000002.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -130,7 +175,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 02 Mar 2020 04:19:52 GMT
+      - Mon, 02 Mar 2020 05:52:11 GMT
       expires:
       - '-1'
       pragma:
@@ -183,11 +228,11 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 04:20:02 GMT
+      - Mon, 02 Mar 2020 05:52:17 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/7bc97773-70fa-40b2-9c4b-1dade077c9b7?monitor=true&api-version=2019-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/142f6a5b-7eed-4cf9-b443-84c2ad7e0dc6?monitor=true&api-version=2019-06-01
       pragma:
       - no-cache
       server:
@@ -197,7 +242,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 202
       message: Accepted
@@ -218,10 +263,10 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-storage/7.1.0 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/7bc97773-70fa-40b2-9c4b-1dade077c9b7?monitor=true&api-version=2019-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/142f6a5b-7eed-4cf9-b443-84c2ad7e0dc6?monitor=true&api-version=2019-06-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/sa000003","name":"sa000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T04:20:02.9561791Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T04:20:02.9561791Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-03-02T04:20:02.8624673Z","primaryEndpoints":{"blob":"https://sa000003.blob.core.windows.net/","queue":"https://sa000003.queue.core.windows.net/","table":"https://sa000003.table.core.windows.net/","file":"https://sa000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/sa000003","name":"sa000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T05:52:18.0242140Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T05:52:18.0242140Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-03-02T05:52:17.9460586Z","primaryEndpoints":{"blob":"https://sa000003.blob.core.windows.net/","queue":"https://sa000003.queue.core.windows.net/","table":"https://sa000003.table.core.windows.net/","file":"https://sa000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -230,7 +275,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 02 Mar 2020 04:20:21 GMT
+      - Mon, 02 Mar 2020 05:52:36 GMT
       expires:
       - '-1'
       pragma:
@@ -287,7 +332,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 04:20:33 GMT
+      - Mon, 02 Mar 2020 05:52:47 GMT
       expires:
       - '-1'
       pragma:
@@ -378,7 +423,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 04:20:54 GMT
+      - Mon, 02 Mar 2020 05:53:03 GMT
       expires:
       - '-1'
       pragma:
@@ -482,6 +527,34 @@ interactions:
         \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgzkq7ca4pmgnalsxan/providers/microsoft.insights/actionGroups/ag1\"\r\n
         \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
         \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg6w72yckgbyuwi6kem/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg6w72yckgbyuwi6kem/providers/Microsoft.Storage/storageAccounts/sazlonifxyejwxtwfwxgbl6a\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg6w72yckgbyuwi6kem/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
         \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
         \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
         2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Storage/storageAccounts/sa000002\"\r\n
@@ -515,11 +588,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '7759'
+      - '10338'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 04:21:15 GMT
+      - Mon, 02 Mar 2020 05:53:06 GMT
       expires:
       - '-1'
       pragma:
@@ -572,7 +645,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 04:21:16 GMT
+      - Mon, 02 Mar 2020 05:53:06 GMT
       expires:
       - '-1'
       pragma:
@@ -617,10 +690,10 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001?api-version=2019-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-4f8f8eb5-91f8-4082-ae0d-7aa8f5ecd3b8?api-version=2019-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001","type":"Microsoft.Insights/ActionGroups","name":"cloned-ag1-88888888-0000-0000-0000-000000000001","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"ag1","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[],"automationRunbookReceivers":[],"voiceReceivers":[],"logicAppReceivers":[],"azureFunctionReceivers":[],"armRoleReceivers":[]},"identity":null}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-4f8f8eb5-91f8-4082-ae0d-7aa8f5ecd3b8","type":"Microsoft.Insights/ActionGroups","name":"cloned-ag1-4f8f8eb5-91f8-4082-ae0d-7aa8f5ecd3b8","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"ag1","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[],"automationRunbookReceivers":[],"voiceReceivers":[],"logicAppReceivers":[],"azureFunctionReceivers":[],"armRoleReceivers":[]},"identity":null}'
     headers:
       cache-control:
       - no-cache
@@ -629,7 +702,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 04:21:25 GMT
+      - Mon, 02 Mar 2020 05:53:12 GMT
       expires:
       - '-1'
       pragma:
@@ -641,7 +714,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1196'
     status:
       code: 201
       message: Created
@@ -659,7 +732,7 @@ interactions:
       "timeAggregation": "Average", "dimensions": [{"name": "ApiName", "operator":
       "Include", "values": ["GetBlob"]}], "criterionType": "StaticThresholdCriterion",
       "operator": "GreaterThan", "threshold": 250.0}]}, "actions": [{"actionGroupId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001"}]}}'''
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-4f8f8eb5-91f8-4082-ae0d-7aa8f5ecd3b8"}]}}'''
     headers:
       Accept:
       - application/json
@@ -681,12 +754,12 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-sa000003-88888888-0000-0000-0000-000000000002?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-sa000003-26f64dba-64ba-4fbb-b69d-ddb855c5c89b?api-version=2018-03-01
   response:
     body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"cloned-sa000003-88888888-0000-0000-0000-000000000002\",\r\n
-        \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-sa000003-88888888-0000-0000-0000-000000000002\",\r\n
+        \ \"name\": \"cloned-sa000003-26f64dba-64ba-4fbb-b69d-ddb855c5c89b\",\r\n
+        \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-sa000003-26f64dba-64ba-4fbb-b69d-ddb855c5c89b\",\r\n
         \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
         2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/sa000003\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
@@ -711,7 +784,7 @@ interactions:
         \"StaticThresholdCriterion\"\r\n        }\r\n      ],\r\n      \"odata.type\":
         \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n    },\r\n
         \   \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n    \"actions\":
-        [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001\"\r\n
+        [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-4f8f8eb5-91f8-4082-ae0d-7aa8f5ecd3b8\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     headers:
       api-supported-versions:
@@ -723,7 +796,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 04:21:34 GMT
+      - Mon, 02 Mar 2020 05:53:19 GMT
       expires:
       - '-1'
       pragma:
@@ -741,7 +814,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_across_subs_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_across_subs_scenario.yaml
@@ -1,0 +1,750 @@
+interactions:
+- request:
+    body: '{"location": "eastus"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -l -n --subscription
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test_rg000004?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004","name":"test_rg000004","type":"Microsoft.Resources/resourceGroups","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '245'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 04:19:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"sku": {"name": "Standard_LRS"}, "kind": "Storage", "location": "eastus"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g -l --sku --kind --subscription
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-storage/7.1.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Storage/storageAccounts/sa000002?api-version=2019-06-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      content-type:
+      - text/plain; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 04:19:32 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/5b74d2ad-3483-4ef0-83dc-31005307771e?monitor=true&api-version=2019-06-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -l --sku --kind --subscription
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-storage/7.1.0 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/5b74d2ad-3483-4ef0-83dc-31005307771e?monitor=true&api-version=2019-06-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Storage/storageAccounts/sa000002","name":"sa000002","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T04:19:32.6103513Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T04:19:32.6103513Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-03-02T04:19:32.4853759Z","primaryEndpoints":{"blob":"https://sa000002.blob.core.windows.net/","queue":"https://sa000002.queue.core.windows.net/","table":"https://sa000002.table.core.windows.net/","file":"https://sa000002.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1189'
+      content-type:
+      - application/json
+      date:
+      - Mon, 02 Mar 2020 04:19:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"sku": {"name": "Standard_LRS"}, "kind": "Storage", "location": "eastus"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g -l --sku --kind
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-storage/7.1.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/sa000003?api-version=2019-06-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      content-type:
+      - text/plain; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 04:20:02 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/7bc97773-70fa-40b2-9c4b-1dade077c9b7?monitor=true&api-version=2019-06-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -l --sku --kind
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-storage/7.1.0 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/7bc97773-70fa-40b2-9c4b-1dade077c9b7?monitor=true&api-version=2019-06-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/sa000003","name":"sa000003","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T04:20:02.9561791Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-03-02T04:20:02.9561791Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-03-02T04:20:02.8624673Z","primaryEndpoints":{"blob":"https://sa000003.blob.core.windows.net/","queue":"https://sa000003.queue.core.windows.net/","table":"https://sa000003.table.core.windows.net/","file":"https://sa000003.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1240'
+      content-type:
+      - application/json
+      date:
+      - Mon, 02 Mar 2020 04:20:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global", "properties": {"groupShortName": "ag1", "enabled":
+      true, "emailReceivers": [], "smsReceivers": [], "webhookReceivers": [], "itsmReceivers":
+      [], "azureAppPushReceivers": [], "automationRunbookReceivers": [], "voiceReceivers":
+      [], "logicAppReceivers": [], "azureFunctionReceivers": [], "armRoleReceivers":
+      []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor action-group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '331'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --subscription
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/microsoft.insights/actionGroups/ag1?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/microsoft.insights/actionGroups/ag1","type":"Microsoft.Insights/ActionGroups","name":"ag1","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"ag1","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[],"automationRunbookReceivers":[],"voiceReceivers":[],"logicAppReceivers":[],"azureFunctionReceivers":[],"armRoleReceivers":[]},"identity":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '544'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 04:20:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"location": "global", "properties": {"description": "Test", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Storage/storageAccounts/sa000002"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "criteria": {"odata.type":
+      "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria", "allOf": [{"name":
+      "cond0", "metricName": "transactions", "timeAggregation": "Total", "dimensions":
+      [{"name": "ResponseType", "operator": "Include", "values": ["Success"]}, {"name":
+      "ApiName", "operator": "Include", "values": ["GetBlob"]}], "criterionType":
+      "StaticThresholdCriterion", "operator": "GreaterThan", "threshold": 5.0}, {"name":
+      "cond1", "metricName": "SuccessE2ELatency", "timeAggregation": "Average", "dimensions":
+      [{"name": "ApiName", "operator": "Include", "values": ["GetBlob"]}], "criterionType":
+      "StaticThresholdCriterion", "operator": "GreaterThan", "threshold": 250.0}]},
+      "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/microsoft.insights/actionGroups/ag1"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor metrics alert create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1179'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g --subscription -n --scopes --action --description --condition --condition
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Insights/metricAlerts/alert1?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
+        \ \"name\": \"alert1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Storage/storageAccounts/sa000002\"\r\n
+        \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
+        \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
+        \       {\r\n          \"threshold\": 5.0,\r\n          \"name\": \"cond0\",\r\n
+        \         \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \         \"metricName\": \"transactions\",\r\n          \"dimensions\": [\r\n
+        \           {\r\n              \"name\": \"ResponseType\",\r\n              \"operator\":
+        \"Include\",\r\n              \"values\": [\r\n                \"Success\"\r\n
+        \             ]\r\n            },\r\n            {\r\n              \"name\":
+        \"ApiName\",\r\n              \"operator\": \"Include\",\r\n              \"values\":
+        [\r\n                \"GetBlob\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
+        \"Total\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \       },\r\n        {\r\n          \"threshold\": 250.0,\r\n          \"name\":
+        \"cond1\",\r\n          \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \         \"metricName\": \"SuccessE2ELatency\",\r\n          \"dimensions\":
+        [\r\n            {\r\n              \"name\": \"ApiName\",\r\n              \"operator\":
+        \"Include\",\r\n              \"values\": [\r\n                \"GetBlob\"\r\n
+        \             ]\r\n            }\r\n          ],\r\n          \"operator\":
+        \"GreaterThan\",\r\n          \"timeAggregation\": \"Average\",\r\n          \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n        }\r\n      ],\r\n      \"odata.type\":
+        \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n    },\r\n
+        \   \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n    \"actions\":
+        [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2292'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 04:20:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Insights/metricAlerts?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"location\": \"global\",\r\n
+        \     \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\": \"alert1\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgied6663ext3va6qgu/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgied6663ext3va6qgu/providers/Microsoft.Storage/storageAccounts/sagg74njp4hlkuznd5nemojg\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgied6663ext3va6qgu/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgzkq7ca4pmgnalsxan/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgzkq7ca4pmgnalsxan/providers/Microsoft.Storage/storageAccounts/sar3wcsedwatnbwsxasn6qmo\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgzkq7ca4pmgnalsxan/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/Microsoft.Storage/storageAccounts/sa000002\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '7759'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 04:21:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/microsoft.insights/actionGroups/ag1?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rg000004/providers/microsoft.insights/actionGroups/ag1","type":"Microsoft.Insights/ActionGroups","name":"ag1","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"ag1","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[],"automationRunbookReceivers":[],"voiceReceivers":[],"logicAppReceivers":[],"azureFunctionReceivers":[],"armRoleReceivers":[]},"identity":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '544'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 04:21:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "Global", "properties": {"groupShortName": "ag1", "enabled":
+      true, "emailReceivers": [], "smsReceivers": [], "webhookReceivers": [], "itsmReceivers":
+      [], "azureAppPushReceivers": [], "automationRunbookReceivers": [], "voiceReceivers":
+      [], "logicAppReceivers": [], "azureFunctionReceivers": [], "armRoleReceivers":
+      []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '331'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001","type":"Microsoft.Insights/ActionGroups","name":"cloned-ag1-88888888-0000-0000-0000-000000000001","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"ag1","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[],"automationRunbookReceivers":[],"voiceReceivers":[],"logicAppReceivers":[],"azureFunctionReceivers":[],"armRoleReceivers":[]},"identity":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '683'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 04:21:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: 'b''{"location": "global", "properties": {"description": "Test", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/sa000003"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.storage/storageaccounts",
+      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+      "allOf": [{"name": "cond0", "metricName": "transactions", "metricNamespace":
+      "microsoft.storage/storageaccounts", "timeAggregation": "Total", "dimensions":
+      [{"name": "ResponseType", "operator": "Include", "values": ["Success"]}, {"name":
+      "ApiName", "operator": "Include", "values": ["GetBlob"]}], "criterionType":
+      "StaticThresholdCriterion", "operator": "GreaterThan", "threshold": 5.0}, {"name":
+      "cond1", "metricName": "SuccessE2ELatency", "metricNamespace": "microsoft.storage/storageaccounts",
+      "timeAggregation": "Average", "dimensions": [{"name": "ApiName", "operator":
+      "Include", "values": ["GetBlob"]}], "criterionType": "StaticThresholdCriterion",
+      "operator": "GreaterThan", "threshold": 250.0}]}, "actions": [{"actionGroupId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001"}]}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1496'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-sa000003-88888888-0000-0000-0000-000000000002?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
+        \ \"name\": \"cloned-sa000003-88888888-0000-0000-0000-000000000002\",\r\n
+        \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-sa000003-88888888-0000-0000-0000-000000000002\",\r\n
+        \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/sa000003\"\r\n
+        \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
+        \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
+        \       {\r\n          \"threshold\": 5.0,\r\n          \"name\": \"cond0\",\r\n
+        \         \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \         \"metricName\": \"transactions\",\r\n          \"dimensions\": [\r\n
+        \           {\r\n              \"name\": \"ResponseType\",\r\n              \"operator\":
+        \"Include\",\r\n              \"values\": [\r\n                \"Success\"\r\n
+        \             ]\r\n            },\r\n            {\r\n              \"name\":
+        \"ApiName\",\r\n              \"operator\": \"Include\",\r\n              \"values\":
+        [\r\n                \"GetBlob\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
+        \"Total\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \       },\r\n        {\r\n          \"threshold\": 250.0,\r\n          \"name\":
+        \"cond1\",\r\n          \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \         \"metricName\": \"SuccessE2ELatency\",\r\n          \"dimensions\":
+        [\r\n            {\r\n              \"name\": \"ApiName\",\r\n              \"operator\":
+        \"Include\",\r\n              \"values\": [\r\n                \"GetBlob\"\r\n
+        \             ]\r\n            }\r\n          ],\r\n          \"operator\":
+        \"GreaterThan\",\r\n          \"timeAggregation\": \"Average\",\r\n          \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n        }\r\n      ],\r\n      \"odata.type\":
+        \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n    },\r\n
+        \   \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n    \"actions\":
+        [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 04:21:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_always_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_always_scenario.yaml
@@ -38,7 +38,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 06:55:18 GMT
+      - Mon, 02 Mar 2020 06:58:06 GMT
       expires:
       - '-1'
       pragma:
@@ -50,7 +50,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -129,7 +129,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 06:55:33 GMT
+      - Mon, 02 Mar 2020 06:58:18 GMT
       expires:
       - '-1'
       pragma:
@@ -147,7 +147,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
       x-powered-by:
       - ASP.NET
     status:
@@ -165,7 +165,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --source-resource --target-resource
+      - --source-resource --target-resource --always-clone
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
@@ -177,37 +177,7 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"location\": \"global\",\r\n
         \     \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\": \"alert1\",\r\n
-        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonezlrlqmdsjz5if5flwhj4nu43oqdaqhy5ko6t3jauvqtw5dsm/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonezlrlqmdsjz5if5flwhj4nu43oqdaqhy5ko6t3jauvqtw5dsm/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
-        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
-        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Total\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonezlrlqmdsjz5if5flwhj4nu43oqdaqhy5ko6t3jauvqtw5dsm/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonezlrlqmdsjz5if5flwhj4nu43oqdaqhy5ko6t3jauvqtw5dsm/providers/Microsoft.Insights/metricAlerts/alert2\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test2\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonezlrlqmdsjz5if5flwhj4nu43oqdaqhy5ko6t3jauvqtw5dsm/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
-        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
-        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Maximum\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonezlrlqmdsjz5if5flwhj4nu43oqdaqhy5ko6t3jauvqtw5dsm/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
         \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
         2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000002\"\r\n
         \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
@@ -240,11 +210,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '6131'
+      - '2754'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 06:55:35 GMT
+      - Mon, 02 Mar 2020 06:58:19 GMT
       expires:
       - '-1'
       pragma:
@@ -267,21 +237,60 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: 'b''b\''b\\\''{"location": "global", "properties": {"description": "Test",
-      "severity": 2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000002",
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000003"],
-      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.storage/storageaccounts",
-      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
-      "allOf": [{"name": "cond0", "metricName": "transactions", "metricNamespace":
-      "microsoft.storage/storageaccounts", "timeAggregation": "Total", "dimensions":
-      [{"name": "ResponseType", "operator": "Include", "values": ["Success"]}, {"name":
-      "ApiName", "operator": "Include", "values": ["GetBlob"]}], "criterionType":
-      "StaticThresholdCriterion", "operator": "GreaterThan", "threshold": 5.0}, {"name":
-      "cond1", "metricName": "SuccessE2ELatency", "metricNamespace": "microsoft.storage/storageaccounts",
-      "timeAggregation": "Average", "dimensions": [{"name": "ApiName", "operator":
-      "Include", "values": ["GetBlob"]}], "criterionType": "StaticThresholdCriterion",
-      "operator": "GreaterThan", "threshold": 250.0}]}, "actions": [{"actionGroupId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1"}]}}\\\''\'''''
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource --target-resource --always-clone
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1","type":"Microsoft.Insights/ActionGroups","name":"ag1","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"ag1","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[],"automationRunbookReceivers":[],"voiceReceivers":[],"logicAppReceivers":[],"azureFunctionReceivers":[],"armRoleReceivers":[]},"identity":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '595'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 06:58:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "Global", "properties": {"groupShortName": "ag1", "enabled":
+      true, "emailReceivers": [], "smsReceivers": [], "webhookReceivers": [], "itsmReceivers":
+      [], "azureAppPushReceivers": [], "automationRunbookReceivers": [], "voiceReceivers":
+      [], "logicAppReceivers": [], "azureFunctionReceivers": [], "armRoleReceivers":
+      []}}'
     headers:
       Accept:
       - application/json
@@ -292,33 +301,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1667'
+      - '331'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - --source-resource --target-resource
+      - --source-resource --target-resource --always-clone
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001?api-version=2019-06-01
   response:
     body:
-      string: '{"Code":"BadRequest","Message":"Scopes property is invalid. Only single
-        resource is allowed for criteria type SingleResourceMultipleMetricCriteria.
-        If you want to create an alert on multiple resources, use MultipleResourceMultipleMetricCriteria
-        odata.type."}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001","type":"Microsoft.Insights/ActionGroups","name":"cloned-ag1-88888888-0000-0000-0000-000000000001","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"ag1","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[],"automationRunbookReceivers":[],"voiceReceivers":[],"logicAppReceivers":[],"azureFunctionReceivers":[],"armRoleReceivers":[]},"identity":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '258'
+      - '683'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 06:55:36 GMT
+      - Mon, 02 Mar 2020 06:58:23 GMT
       expires:
       - '-1'
       pragma:
@@ -327,17 +333,13 @@ interactions:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
       x-content-type-options:
       - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
-      x-powered-by:
-      - ASP.NET
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1197'
     status:
-      code: 400
-      message: BadRequest
+      code: 201
+      message: Created
 - request:
     body: 'b''b\''{"location": "global", "properties": {"description": "Test", "severity":
       2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000003"],
@@ -352,7 +354,7 @@ interactions:
       "timeAggregation": "Average", "dimensions": [{"name": "ApiName", "operator":
       "Include", "values": ["GetBlob"]}], "criterionType": "StaticThresholdCriterion",
       "operator": "GreaterThan", "threshold": 250.0}]}, "actions": [{"actionGroupId":
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1"}]}}\'''''
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001"}]}}\'''''
     headers:
       Accept:
       - application/json
@@ -363,23 +365,23 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1452'
+      - '1496'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - --source-resource --target-resource
+      - --source-resource --target-resource --always-clone
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-clitest000003-88888888-0000-0000-0000-000000000001?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-clitest000003-88888888-0000-0000-0000-000000000002?api-version=2018-03-01
   response:
     body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"cloned-clitest000003-88888888-0000-0000-0000-000000000001\",\r\n
-        \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-clitest000003-88888888-0000-0000-0000-000000000001\",\r\n
+        \ \"name\": \"cloned-clitest000003-88888888-0000-0000-0000-000000000002\",\r\n
+        \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-clitest000003-88888888-0000-0000-0000-000000000002\",\r\n
         \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
         2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000003\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
@@ -404,7 +406,7 @@ interactions:
         \"StaticThresholdCriterion\"\r\n        }\r\n      ],\r\n      \"odata.type\":
         \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n    },\r\n
         \   \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n    \"actions\":
-        [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/cloned-ag1-88888888-0000-0000-0000-000000000001\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     headers:
       api-supported-versions:
@@ -412,11 +414,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2569'
+      - '2613'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 06:55:49 GMT
+      - Mon, 02 Mar 2020 06:58:31 GMT
       expires:
       - '-1'
       pragma:
@@ -434,7 +436,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_scenario.yaml
@@ -1,0 +1,413 @@
+interactions:
+- request:
+    body: '{"location": "global", "properties": {"groupShortName": "ag1", "enabled":
+      true, "emailReceivers": [], "smsReceivers": [], "webhookReceivers": [], "itsmReceivers":
+      [], "azureAppPushReceivers": [], "automationRunbookReceivers": [], "voiceReceivers":
+      [], "logicAppReceivers": [], "azureFunctionReceivers": [], "armRoleReceivers":
+      []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor action-group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '331'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1","type":"Microsoft.Insights/ActionGroups","name":"ag1","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"ag1","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[],"automationRunbookReceivers":[],"voiceReceivers":[],"logicAppReceivers":[],"azureFunctionReceivers":[],"armRoleReceivers":[]},"identity":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '595'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:11:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1196'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: 'b''b\''{"location": "global", "properties": {"description": "Test", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000002"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "criteria": {"odata.type":
+      "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria", "allOf": [{"name":
+      "cond0", "metricName": "transactions", "timeAggregation": "Total", "dimensions":
+      [{"name": "ResponseType", "operator": "Include", "values": ["Success"]}, {"name":
+      "ApiName", "operator": "Include", "values": ["GetBlob"]}], "criterionType":
+      "StaticThresholdCriterion", "operator": "GreaterThan", "threshold": 5.0}, {"name":
+      "cond1", "metricName": "SuccessE2ELatency", "timeAggregation": "Average", "dimensions":
+      [{"name": "ApiName", "operator": "Include", "values": ["GetBlob"]}], "criterionType":
+      "StaticThresholdCriterion", "operator": "GreaterThan", "threshold": 250.0}]},
+      "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1"}]}}\'''''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor metrics alert create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1281'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --scopes --action --description --condition --condition
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
+        \ \"name\": \"alert1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000002\"\r\n
+        \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
+        \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
+        \       {\r\n          \"threshold\": 5.0,\r\n          \"name\": \"cond0\",\r\n
+        \         \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \         \"metricName\": \"transactions\",\r\n          \"dimensions\": [\r\n
+        \           {\r\n              \"name\": \"ResponseType\",\r\n              \"operator\":
+        \"Include\",\r\n              \"values\": [\r\n                \"Success\"\r\n
+        \             ]\r\n            },\r\n            {\r\n              \"name\":
+        \"ApiName\",\r\n              \"operator\": \"Include\",\r\n              \"values\":
+        [\r\n                \"GetBlob\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
+        \"Total\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \       },\r\n        {\r\n          \"threshold\": 250.0,\r\n          \"name\":
+        \"cond1\",\r\n          \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \         \"metricName\": \"SuccessE2ELatency\",\r\n          \"dimensions\":
+        [\r\n            {\r\n              \"name\": \"ApiName\",\r\n              \"operator\":
+        \"Include\",\r\n              \"values\": [\r\n                \"GetBlob\"\r\n
+        \             ]\r\n            }\r\n          ],\r\n          \"operator\":
+        \"GreaterThan\",\r\n          \"timeAggregation\": \"Average\",\r\n          \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n        }\r\n      ],\r\n      \"odata.type\":
+        \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n    },\r\n
+        \   \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n    \"actions\":
+        [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2445'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:11:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Insights/metricAlerts?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"location\": \"global\",\r\n
+        \     \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\": \"alert1\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000002\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2754'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:11:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''b\''b\\\''{"location": "global", "properties": {"description": "Test",
+      "severity": 2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000002",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000003"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.storage/storageaccounts",
+      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+      "allOf": [{"name": "cond0", "metricName": "transactions", "metricNamespace":
+      "microsoft.storage/storageaccounts", "timeAggregation": "Total", "dimensions":
+      [{"name": "ResponseType", "operator": "Include", "values": ["Success"]}, {"name":
+      "ApiName", "operator": "Include", "values": ["GetBlob"]}], "criterionType":
+      "StaticThresholdCriterion", "operator": "GreaterThan", "threshold": 5.0}, {"name":
+      "cond1", "metricName": "SuccessE2ELatency", "metricNamespace": "microsoft.storage/storageaccounts",
+      "timeAggregation": "Average", "dimensions": [{"name": "ApiName", "operator":
+      "Include", "values": ["GetBlob"]}], "criterionType": "StaticThresholdCriterion",
+      "operator": "GreaterThan", "threshold": 250.0}]}, "actions": [{"actionGroupId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1"}]}}\\\''\'''''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1667'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1?api-version=2018-03-01
+  response:
+    body:
+      string: '{"Code":"BadRequest","Message":"Scopes property is invalid. Only single
+        resource is allowed for criteria type SingleResourceMultipleMetricCriteria.
+        If you want to create an alert on multiple resources, use MultipleResourceMultipleMetricCriteria
+        odata.type."}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '258'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:11:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 400
+      message: BadRequest
+- request:
+    body: 'b''b\''{"location": "global", "properties": {"description": "Test", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000003"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.storage/storageaccounts",
+      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+      "allOf": [{"name": "cond0", "metricName": "transactions", "metricNamespace":
+      "microsoft.storage/storageaccounts", "timeAggregation": "Total", "dimensions":
+      [{"name": "ResponseType", "operator": "Include", "values": ["Success"]}, {"name":
+      "ApiName", "operator": "Include", "values": ["GetBlob"]}], "criterionType":
+      "StaticThresholdCriterion", "operator": "GreaterThan", "threshold": 5.0}, {"name":
+      "cond1", "metricName": "SuccessE2ELatency", "metricNamespace": "microsoft.storage/storageaccounts",
+      "timeAggregation": "Average", "dimensions": [{"name": "ApiName", "operator":
+      "Include", "values": ["GetBlob"]}], "criterionType": "StaticThresholdCriterion",
+      "operator": "GreaterThan", "threshold": 250.0}]}, "actions": [{"actionGroupId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1"}]}}\'''''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1452'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/clitest000003-88888888-0000-0000-0000-000000000001?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
+        \ \"name\": \"clitest000003-88888888-0000-0000-0000-000000000001\",\r\n  \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/clitest000003-88888888-0000-0000-0000-000000000001\",\r\n
+        \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000003\"\r\n
+        \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
+        \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
+        \       {\r\n          \"threshold\": 5.0,\r\n          \"name\": \"cond0\",\r\n
+        \         \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \         \"metricName\": \"transactions\",\r\n          \"dimensions\": [\r\n
+        \           {\r\n              \"name\": \"ResponseType\",\r\n              \"operator\":
+        \"Include\",\r\n              \"values\": [\r\n                \"Success\"\r\n
+        \             ]\r\n            },\r\n            {\r\n              \"name\":
+        \"ApiName\",\r\n              \"operator\": \"Include\",\r\n              \"values\":
+        [\r\n                \"GetBlob\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
+        \"Total\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \       },\r\n        {\r\n          \"threshold\": 250.0,\r\n          \"name\":
+        \"cond1\",\r\n          \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \         \"metricName\": \"SuccessE2ELatency\",\r\n          \"dimensions\":
+        [\r\n            {\r\n              \"name\": \"ApiName\",\r\n              \"operator\":
+        \"Include\",\r\n              \"values\": [\r\n                \"GetBlob\"\r\n
+        \             ]\r\n            }\r\n          ],\r\n          \"operator\":
+        \"GreaterThan\",\r\n          \"timeAggregation\": \"Average\",\r\n          \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n        }\r\n      ],\r\n      \"odata.type\":
+        \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n    },\r\n
+        \   \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n    \"actions\":
+        [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2555'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 05:11:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_scenario.yaml
@@ -38,7 +38,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:56:50 GMT
+      - Mon, 02 Mar 2020 06:06:00 GMT
       expires:
       - '-1'
       pragma:
@@ -50,7 +50,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -129,7 +129,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:04 GMT
+      - Mon, 02 Mar 2020 06:06:14 GMT
       expires:
       - '-1'
       pragma:
@@ -147,7 +147,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
       x-powered-by:
       - ASP.NET
     status:
@@ -177,205 +177,7 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"location\": \"global\",\r\n
         \     \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\": \"alert1\",\r\n
-        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/Microsoft.Storage/storageAccounts/saqjlb7ody5b2b7por3lyn2p\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/Microsoft.Storage/storageAccounts/saiajpo37gmzguxthqp3ibgd\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/Microsoft.Storage/storageAccounts/sazexifbqdd4hmpyekut563n\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/Microsoft.Storage/storageAccounts/saiuw6p6ntxwcqkk63653fvu\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/Microsoft.Storage/storageAccounts/sanpq4kcjkahn5xjht34x5nq\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/Microsoft.Storage/storageAccounts/sa7mqrgvdnopua6c65y6rfak\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
-        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
-        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
-        \                 \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
-        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
-        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
-        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
-        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
-        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
-        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
-        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
-        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
-        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
-        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
-        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
-        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
-        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Total\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/Microsoft.Insights/metricAlerts/alert2\",\r\n
-        \     \"properties\": {\r\n        \"description\": \"Test2\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
-        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
-        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
-        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
-        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
-        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
-        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
-        \"Maximum\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/microsoft.insights/actionGroups/ag1\"\r\n
-        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
-        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
-        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
         \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
         2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000002\"\r\n
         \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
@@ -408,11 +210,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '21605'
+      - '2754'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:05 GMT
+      - Mon, 02 Mar 2020 06:06:16 GMT
       expires:
       - '-1'
       pragma:
@@ -486,7 +288,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:06 GMT
+      - Mon, 02 Mar 2020 06:06:17 GMT
       expires:
       - '-1'
       pragma:
@@ -500,7 +302,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '295'
       x-powered-by:
       - ASP.NET
     status:
@@ -542,12 +344,12 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-clitest000003-88888888-0000-0000-0000-000000000001?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-clitest000003-49d49ef0-0350-4d7c-9464-2270ee4ebb60?api-version=2018-03-01
   response:
     body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"cloned-clitest000003-88888888-0000-0000-0000-000000000001\",\r\n
-        \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-clitest000003-88888888-0000-0000-0000-000000000001\",\r\n
+        \ \"name\": \"cloned-clitest000003-49d49ef0-0350-4d7c-9464-2270ee4ebb60\",\r\n
+        \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-clitest000003-49d49ef0-0350-4d7c-9464-2270ee4ebb60\",\r\n
         \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
         2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000003\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
@@ -584,7 +386,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 02 Mar 2020 03:57:19 GMT
+      - Mon, 02 Mar 2020 06:06:31 GMT
       expires:
       - '-1'
       pragma:
@@ -602,7 +404,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '297'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_scenario.yaml
@@ -38,7 +38,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 24 Feb 2020 06:14:41 GMT
+      - Mon, 02 Mar 2020 03:56:50 GMT
       expires:
       - '-1'
       pragma:
@@ -50,7 +50,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -129,7 +129,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 24 Feb 2020 06:14:57 GMT
+      - Mon, 02 Mar 2020 03:57:04 GMT
       expires:
       - '-1'
       pragma:
@@ -147,7 +147,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:
@@ -177,7 +177,205 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"location\": \"global\",\r\n
         \     \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\": \"alert1\",\r\n
-        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/Microsoft.Storage/storageAccounts/saqjlb7ody5b2b7por3lyn2p\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgqphuqtir26nd7qhp6/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/Microsoft.Storage/storageAccounts/saiajpo37gmzguxthqp3ibgd\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg35lqq3j3tsfnzd7p/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/Microsoft.Storage/storageAccounts/sazexifbqdd4hmpyekut563n\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgwwmlupv65chlu2q4i/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/Microsoft.Storage/storageAccounts/saiuw6p6ntxwcqkk63653fvu\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgmpspzzvqw5djtn2uc/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/Microsoft.Storage/storageAccounts/sanpq4kcjkahn5xjht34x5nq\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgf7prmsyvbamotobvj/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/Microsoft.Storage/storageAccounts/sa7mqrgvdnopua6c65y6rfak\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.storage/storageaccounts\",\r\n
+        \             \"metricName\": \"transactions\",\r\n              \"dimensions\":
+        [\r\n                {\r\n                  \"name\": \"ResponseType\",\r\n
+        \                 \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"Success\"\r\n                  ]\r\n                },\r\n
+        \               {\r\n                  \"name\": \"ApiName\",\r\n                  \"operator\":
+        \"Include\",\r\n                  \"values\": [\r\n                    \"GetBlob\"\r\n
+        \                 ]\r\n                }\r\n              ],\r\n              \"operator\":
+        \"GreaterThan\",\r\n              \"timeAggregation\": \"Total\",\r\n              \"criterionType\":
+        \"StaticThresholdCriterion\"\r\n            },\r\n            {\r\n              \"threshold\":
+        250.0,\r\n              \"name\": \"cond1\",\r\n              \"metricNamespace\":
+        \"microsoft.storage/storageaccounts\",\r\n              \"metricName\": \"SuccessE2ELatency\",\r\n
+        \             \"dimensions\": [\r\n                {\r\n                  \"name\":
+        \"ApiName\",\r\n                  \"operator\": \"Include\",\r\n                  \"values\":
+        [\r\n                    \"GetBlob\"\r\n                  ]\r\n                }\r\n
+        \             ],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.storage/storageaccounts\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_rgg4m4vxguo3uwbri5e/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
+        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Total\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert2\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/Microsoft.Insights/metricAlerts/alert2\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"Test2\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/Microsoft.Network/publicIPAddresses/ip1\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 5.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.network/publicipaddresses\",\r\n
+        \             \"metricName\": \"TCPBytesForwardedDDoS\",\r\n              \"dimensions\":
+        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Maximum\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.network/publicipaddresses\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clonedks5gerkjbk3jl2iua3vxzz4qqg5fffbtbcpl33dif7t3r7h/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    },\r\n    {\r\n      \"location\":
+        \"global\",\r\n      \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\":
+        \"alert1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
         \     \"properties\": {\r\n        \"description\": \"Test\",\r\n        \"severity\":
         2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000002\"\r\n
         \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
@@ -210,11 +408,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2754'
+      - '21605'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 24 Feb 2020 06:15:00 GMT
+      - Mon, 02 Mar 2020 03:57:05 GMT
       expires:
       - '-1'
       pragma:
@@ -288,7 +486,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 24 Feb 2020 06:15:01 GMT
+      - Mon, 02 Mar 2020 03:57:06 GMT
       expires:
       - '-1'
       pragma:
@@ -302,7 +500,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '297'
       x-powered-by:
       - ASP.NET
     status:
@@ -344,12 +542,12 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/clitest000003-88888888-0000-0000-0000-000000000001?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-clitest000003-88888888-0000-0000-0000-000000000001?api-version=2018-03-01
   response:
     body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"clitest000003-88888888-0000-0000-0000-000000000001\",\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/clitest000003-88888888-0000-0000-0000-000000000001\",\r\n
+        \ \"name\": \"cloned-clitest000003-88888888-0000-0000-0000-000000000001\",\r\n
+        \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Insights/metricAlerts/cloned-clitest000003-88888888-0000-0000-0000-000000000001\",\r\n
         \ \"properties\": {\r\n    \"description\": \"Test\",\r\n    \"severity\":
         2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_metric_alert_clone000001/providers/Microsoft.Storage/storageAccounts/clitest000003\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
@@ -382,11 +580,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2555'
+      - '2569'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 24 Feb 2020 06:15:12 GMT
+      - Mon, 02 Mar 2020 03:57:19 GMT
       expires:
       - '-1'
       pragma:
@@ -404,7 +602,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '297'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_scenario.yaml
@@ -38,7 +38,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 05:11:23 GMT
+      - Mon, 17 Feb 2020 09:07:47 GMT
       expires:
       - '-1'
       pragma:
@@ -50,7 +50,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -129,7 +129,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 05:11:35 GMT
+      - Mon, 17 Feb 2020 09:07:58 GMT
       expires:
       - '-1'
       pragma:
@@ -214,7 +214,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 05:11:40 GMT
+      - Mon, 17 Feb 2020 09:08:01 GMT
       expires:
       - '-1'
       pragma:
@@ -288,7 +288,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 05:11:40 GMT
+      - Mon, 17 Feb 2020 09:08:02 GMT
       expires:
       - '-1'
       pragma:
@@ -386,7 +386,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 05:11:49 GMT
+      - Mon, 17 Feb 2020 09:08:14 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_storage_metric_alerts_scenario.yaml
@@ -38,7 +38,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 09:07:47 GMT
+      - Mon, 24 Feb 2020 06:14:41 GMT
       expires:
       - '-1'
       pragma:
@@ -129,7 +129,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 09:07:58 GMT
+      - Mon, 24 Feb 2020 06:14:57 GMT
       expires:
       - '-1'
       pragma:
@@ -214,7 +214,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 09:08:01 GMT
+      - Mon, 24 Feb 2020 06:15:00 GMT
       expires:
       - '-1'
       pragma:
@@ -288,7 +288,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 09:08:02 GMT
+      - Mon, 24 Feb 2020 06:15:01 GMT
       expires:
       - '-1'
       pragma:
@@ -386,7 +386,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 09:08:14 GMT
+      - Mon, 24 Feb 2020 06:15:12 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_vm_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_vm_metric_alerts_scenario.yaml
@@ -14,14 +14,14 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-11T09:05:52Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T03:53:23Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:06:13 GMT
+      - Mon, 17 Feb 2020 03:53:33 GMT
       expires:
       - '-1'
       pragma:
@@ -41,6 +41,108 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
+  response:
+    body:
+      string: "{\n  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n
+        \ \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {},\n  \"variables\":
+        {},\n  \"resources\": [],\n  \"outputs\": {\n    \"aliases\": {\n      \"type\":
+        \"object\",\n      \"value\": {\n        \"Linux\": {\n          \"CentOS\":
+        {\n            \"publisher\": \"OpenLogic\",\n            \"offer\": \"CentOS\",\n
+        \           \"sku\": \"7.5\",\n            \"version\": \"latest\"\n          },\n
+        \         \"CoreOS\": {\n            \"publisher\": \"CoreOS\",\n            \"offer\":
+        \"CoreOS\",\n            \"sku\": \"Stable\",\n            \"version\": \"latest\"\n
+        \         },\n          \"Debian\": {\n            \"publisher\": \"Debian\",\n
+        \           \"offer\": \"debian-10\",\n            \"sku\": \"10\",\n            \"version\":
+        \"latest\"\n          },\n          \"openSUSE-Leap\": {\n            \"publisher\":
+        \"SUSE\",\n            \"offer\": \"openSUSE-Leap\",\n            \"sku\":
+        \"42.3\",\n            \"version\": \"latest\"\n          },\n          \"RHEL\":
+        {\n            \"publisher\": \"RedHat\",\n            \"offer\": \"RHEL\",\n
+        \           \"sku\": \"7-LVM\",\n            \"version\": \"latest\"\n          },\n
+        \         \"SLES\": {\n            \"publisher\": \"SUSE\",\n            \"offer\":
+        \"SLES\",\n            \"sku\": \"15\",\n            \"version\": \"latest\"\n
+        \         },\n          \"UbuntuLTS\": {\n            \"publisher\": \"Canonical\",\n
+        \           \"offer\": \"UbuntuServer\",\n            \"sku\": \"18.04-LTS\",\n
+        \           \"version\": \"latest\"\n          }\n        },\n        \"Windows\":
+        {\n          \"Win2019Datacenter\": {\n            \"publisher\": \"MicrosoftWindowsServer\",\n
+        \           \"offer\": \"WindowsServer\",\n            \"sku\": \"2019-Datacenter\",\n
+        \           \"version\": \"latest\"\n          },\n          \"Win2016Datacenter\":
+        {\n            \"publisher\": \"MicrosoftWindowsServer\",\n            \"offer\":
+        \"WindowsServer\",\n            \"sku\": \"2016-Datacenter\",\n            \"version\":
+        \"latest\"\n          },\n          \"Win2012R2Datacenter\": {\n            \"publisher\":
+        \"MicrosoftWindowsServer\",\n            \"offer\": \"WindowsServer\",\n            \"sku\":
+        \"2012-R2-Datacenter\",\n            \"version\": \"latest\"\n          },\n
+        \         \"Win2012Datacenter\": {\n            \"publisher\": \"MicrosoftWindowsServer\",\n
+        \           \"offer\": \"WindowsServer\",\n            \"sku\": \"2012-Datacenter\",\n
+        \           \"version\": \"latest\"\n          },\n          \"Win2008R2SP1\":
+        {\n            \"publisher\": \"MicrosoftWindowsServer\",\n            \"offer\":
+        \"WindowsServer\",\n            \"sku\": \"2008-R2-SP1\",\n            \"version\":
+        \"latest\"\n          }\n        }\n      }\n    }\n  }\n}\n"
+    headers:
+      accept-ranges:
+      - bytes
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=300
+      connection:
+      - keep-alive
+      content-length:
+      - '2501'
+      content-security-policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      content-type:
+      - text/plain; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 03:53:34 GMT
+      etag:
+      - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
+      expires:
+      - Mon, 17 Feb 2020 03:58:34 GMT
+      source-age:
+      - '259'
+      strict-transport-security:
+      - max-age=31536000
+      vary:
+      - Authorization,Accept-Encoding
+      via:
+      - 1.1 varnish (Varnish/6.0)
+      - 1.1 varnish
+      x-cache:
+      - HIT, HIT
+      x-cache-hits:
+      - 3, 1
+      x-content-type-options:
+      - nosniff
+      x-fastly-request-id:
+      - aec3d22f87ec1bcf9a08f16cb427e5d1beedbf49
+      x-frame-options:
+      - deny
+      x-geo-block-list:
+      - ''
+      x-github-request-id:
+      - 3C4C:0DF0:183AA9:1A2D94:5E49C518
+      x-served-by:
+      - cache-sin18032-SIN
+      x-timer:
+      - S1581911615.889066,VS0,VE0
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -59,7 +161,7 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: GET
@@ -75,7 +177,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:06:24 GMT
+      - Mon, 17 Feb 2020 03:53:36 GMT
       expires:
       - '-1'
       pragma:
@@ -138,17 +240,17 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_hqm5Mkep1dz5ywN9voS2lroXKH8aJjjU","name":"vm_deploy_hqm5Mkep1dz5ywN9voS2lroXKH8aJjjU","type":"Microsoft.Resources/deployments","properties":{"templateHash":"15091726830086748000","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-11T09:06:29.9239888Z","duration":"PT2.8854828S","correlationId":"1a5f23da-a3b3-488c-932f-8dd363ffbffc","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_68PRwLpSYvYK7FosxOojV3ndLeXB1pLP","name":"vm_deploy_68PRwLpSYvYK7FosxOojV3ndLeXB1pLP","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14801277511473264404","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-17T03:53:42.8922982Z","duration":"PT3.2351582S","correlationId":"865b2ddd-81be-4e40-83b2-e5ccf96d2b89","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_hqm5Mkep1dz5ywN9voS2lroXKH8aJjjU/operationStatuses/08586201948984391154?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_68PRwLpSYvYK7FosxOojV3ndLeXB1pLP/operationStatuses/08586196952658204920?api-version=2019-07-01
       cache-control:
       - no-cache
       content-length:
@@ -156,7 +258,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:06:31 GMT
+      - Mon, 17 Feb 2020 03:53:43 GMT
       expires:
       - '-1'
       pragma:
@@ -166,7 +268,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -185,9 +287,9 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196952658204920?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -199,7 +301,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:07:03 GMT
+      - Mon, 17 Feb 2020 03:54:15 GMT
       expires:
       - '-1'
       pragma:
@@ -228,9 +330,9 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196952658204920?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -242,7 +344,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:07:34 GMT
+      - Mon, 17 Feb 2020 03:54:59 GMT
       expires:
       - '-1'
       pragma:
@@ -271,9 +373,9 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196952658204920?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -285,7 +387,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:08:03 GMT
+      - Mon, 17 Feb 2020 03:55:29 GMT
       expires:
       - '-1'
       pragma:
@@ -314,138 +416,9 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 11 Feb 2020 09:08:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --admin-password --admin-username --authentication-type
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 11 Feb 2020 09:09:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --admin-password --admin-username --authentication-type
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 11 Feb 2020 09:09:36 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --admin-password --admin-username --authentication-type
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196952658204920?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -457,7 +430,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:10:07 GMT
+      - Mon, 17 Feb 2020 03:56:01 GMT
       expires:
       - '-1'
       pragma:
@@ -486,12 +459,12 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_hqm5Mkep1dz5ywN9voS2lroXKH8aJjjU","name":"vm_deploy_hqm5Mkep1dz5ywN9voS2lroXKH8aJjjU","type":"Microsoft.Resources/deployments","properties":{"templateHash":"15091726830086748000","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-11T09:09:49.7361659Z","duration":"PT3M22.6976599S","correlationId":"1a5f23da-a3b3-488c-932f-8dd363ffbffc","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_68PRwLpSYvYK7FosxOojV3ndLeXB1pLP","name":"vm_deploy_68PRwLpSYvYK7FosxOojV3ndLeXB1pLP","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14801277511473264404","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-17T03:55:31.9017657Z","duration":"PT1M52.2446257S","correlationId":"865b2ddd-81be-4e40-83b2-e5ccf96d2b89","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'
     headers:
       cache-control:
       - no-cache
@@ -500,7 +473,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:10:08 GMT
+      - Mon, 17 Feb 2020 03:56:03 GMT
       expires:
       - '-1'
       pragma:
@@ -529,7 +502,7 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-compute/10.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-compute/10.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: GET
@@ -538,16 +511,16 @@ interactions:
     body:
       string: "{\r\n  \"name\": \"vm1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"c10c5b8d-11d1-44dc-9bd9-4bf646e87180\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"5ec3f641-79d1-4bad-8834-e89ab88f2298\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"18.04.202002080\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"vm1_disk1_83eef59a2c5a44caa6a599101fe6f9d7\",\r\n
+        \"Linux\",\r\n        \"name\": \"vm1_disk1_1d906857dcc34182a36474d1404df507\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGX3UN77LHOUPP64AZCOBUAFO3KMGSQFYS7ZT4C4WCDI4DHIKM2R4OHJWO3A4IUIPWT/providers/Microsoft.Compute/disks/vm1_disk1_83eef59a2c5a44caa6a599101fe6f9d7\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGT6GEVSV42PXNN6XYK3LHMSGYXKAEY52APLFZVNUQNCJ52FUVNLIAC5RQPWSH5X2SV/providers/Microsoft.Compute/disks/vm1_disk1_1d906857dcc34182a36474d1404df507\"\r\n
         \       },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n
         \     \"adminUsername\": \"testadmin\",\r\n      \"linuxConfiguration\": {\r\n
@@ -561,15 +534,15 @@ interactions:
         [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
         \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
         \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2020-02-11T09:10:10+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_disk1_83eef59a2c5a44caa6a599101fe6f9d7\",\r\n
+        \"2020-02-17T03:56:07+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_disk1_1d906857dcc34182a36474d1404df507\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-02-11T09:09:30.3161819+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-02-17T03:55:10.9773594+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2020-02-11T09:09:44.8474797+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2020-02-17T03:55:26.6024644+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -581,7 +554,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:10:10 GMT
+      - Mon, 17 Feb 2020 03:56:09 GMT
       expires:
       - '-1'
       pragma:
@@ -598,7 +571,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31997
+      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31985
     status:
       code: 200
       message: OK
@@ -617,7 +590,7 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: GET
@@ -625,12 +598,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\",\r\n
-        \ \"etag\": \"W/\\\"f3fc60a0-222a-4b29-81d8-f8fbefd02cad\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"5e1336c7-17ce-4be1-8a07-f15ec1473dd8\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"8eafbab4-a988-4c9e-8d6c-85114d725288\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"cad701bc-6307-4594-8732-547b9c95266a\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\",\r\n
-        \       \"etag\": \"W/\\\"f3fc60a0-222a-4b29-81d8-f8fbefd02cad\\\"\",\r\n
+        \       \"etag\": \"W/\\\"5e1336c7-17ce-4be1-8a07-f15ec1473dd8\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
@@ -639,8 +612,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"coeq0y4kdbdetmp04qlzm4folf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-8B-99-0B\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"ul0wfecdzrve5fqqpwxyzb4vpe.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-8C-A6-E8\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -654,9 +627,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:10:14 GMT
+      - Mon, 17 Feb 2020 03:56:30 GMT
       etag:
-      - W/"f3fc60a0-222a-4b29-81d8-f8fbefd02cad"
+      - W/"5e1336c7-17ce-4be1-8a07-f15ec1473dd8"
       expires:
       - '-1'
       pragma:
@@ -673,7 +646,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 60b3a4e1-a42e-4b62-8da2-b067125edab3
+      - 7660c1bb-6d7b-4afe-a21d-3daf1933d443
     status:
       code: 200
       message: OK
@@ -692,7 +665,7 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: GET
@@ -700,11 +673,11 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"c24289b6-9474-4d6b-81ce-eb197097667f\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"08381301-dc9c-41b6-be8c-e5e704a47d0c\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"34865fb7-960a-4253-83d7-807a9176666d\",\r\n
-        \   \"ipAddress\": \"13.82.5.234\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
-        \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"72f37a62-b0c7-4bb8-8ca7-70677a3de3c5\",\r\n
+        \   \"ipAddress\": \"52.170.118.147\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -712,13 +685,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '995'
+      - '998'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:10:15 GMT
+      - Mon, 17 Feb 2020 03:56:42 GMT
       etag:
-      - W/"c24289b6-9474-4d6b-81ce-eb197097667f"
+      - W/"08381301-dc9c-41b6-be8c-e5e704a47d0c"
       expires:
       - '-1'
       pragma:
@@ -735,7 +708,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 5f8907a8-1c82-4df6-91be-e77102228511
+      - 39b9a575-2459-40a4-a3b0-0111609f20d2
     status:
       code: 200
       message: OK
@@ -754,14 +727,14 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-11T09:05:52Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T03:53:23Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -770,7 +743,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:10:18 GMT
+      - Mon, 17 Feb 2020 03:56:46 GMT
       expires:
       - '-1'
       pragma:
@@ -781,6 +754,108 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
+  response:
+    body:
+      string: "{\n  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n
+        \ \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {},\n  \"variables\":
+        {},\n  \"resources\": [],\n  \"outputs\": {\n    \"aliases\": {\n      \"type\":
+        \"object\",\n      \"value\": {\n        \"Linux\": {\n          \"CentOS\":
+        {\n            \"publisher\": \"OpenLogic\",\n            \"offer\": \"CentOS\",\n
+        \           \"sku\": \"7.5\",\n            \"version\": \"latest\"\n          },\n
+        \         \"CoreOS\": {\n            \"publisher\": \"CoreOS\",\n            \"offer\":
+        \"CoreOS\",\n            \"sku\": \"Stable\",\n            \"version\": \"latest\"\n
+        \         },\n          \"Debian\": {\n            \"publisher\": \"Debian\",\n
+        \           \"offer\": \"debian-10\",\n            \"sku\": \"10\",\n            \"version\":
+        \"latest\"\n          },\n          \"openSUSE-Leap\": {\n            \"publisher\":
+        \"SUSE\",\n            \"offer\": \"openSUSE-Leap\",\n            \"sku\":
+        \"42.3\",\n            \"version\": \"latest\"\n          },\n          \"RHEL\":
+        {\n            \"publisher\": \"RedHat\",\n            \"offer\": \"RHEL\",\n
+        \           \"sku\": \"7-LVM\",\n            \"version\": \"latest\"\n          },\n
+        \         \"SLES\": {\n            \"publisher\": \"SUSE\",\n            \"offer\":
+        \"SLES\",\n            \"sku\": \"15\",\n            \"version\": \"latest\"\n
+        \         },\n          \"UbuntuLTS\": {\n            \"publisher\": \"Canonical\",\n
+        \           \"offer\": \"UbuntuServer\",\n            \"sku\": \"18.04-LTS\",\n
+        \           \"version\": \"latest\"\n          }\n        },\n        \"Windows\":
+        {\n          \"Win2019Datacenter\": {\n            \"publisher\": \"MicrosoftWindowsServer\",\n
+        \           \"offer\": \"WindowsServer\",\n            \"sku\": \"2019-Datacenter\",\n
+        \           \"version\": \"latest\"\n          },\n          \"Win2016Datacenter\":
+        {\n            \"publisher\": \"MicrosoftWindowsServer\",\n            \"offer\":
+        \"WindowsServer\",\n            \"sku\": \"2016-Datacenter\",\n            \"version\":
+        \"latest\"\n          },\n          \"Win2012R2Datacenter\": {\n            \"publisher\":
+        \"MicrosoftWindowsServer\",\n            \"offer\": \"WindowsServer\",\n            \"sku\":
+        \"2012-R2-Datacenter\",\n            \"version\": \"latest\"\n          },\n
+        \         \"Win2012Datacenter\": {\n            \"publisher\": \"MicrosoftWindowsServer\",\n
+        \           \"offer\": \"WindowsServer\",\n            \"sku\": \"2012-Datacenter\",\n
+        \           \"version\": \"latest\"\n          },\n          \"Win2008R2SP1\":
+        {\n            \"publisher\": \"MicrosoftWindowsServer\",\n            \"offer\":
+        \"WindowsServer\",\n            \"sku\": \"2008-R2-SP1\",\n            \"version\":
+        \"latest\"\n          }\n        }\n      }\n    }\n  }\n}\n"
+    headers:
+      accept-ranges:
+      - bytes
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=300
+      connection:
+      - keep-alive
+      content-length:
+      - '2501'
+      content-security-policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      content-type:
+      - text/plain; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 03:56:51 GMT
+      etag:
+      - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
+      expires:
+      - Mon, 17 Feb 2020 04:01:51 GMT
+      source-age:
+      - '137'
+      strict-transport-security:
+      - max-age=31536000
+      vary:
+      - Authorization,Accept-Encoding
+      via:
+      - 1.1 varnish (Varnish/6.0)
+      - 1.1 varnish
+      x-cache:
+      - HIT, HIT
+      x-cache-hits:
+      - 3, 1
+      x-content-type-options:
+      - nosniff
+      x-fastly-request-id:
+      - d3e251d2934d38fc5c98317bd80d814b073a4832
+      x-frame-options:
+      - deny
+      x-geo-block-list:
+      - ''
+      x-github-request-id:
+      - 3C4C:0DF0:183AA9:1A2D94:5E49C518
+      x-served-by:
+      - cache-sin18029-SIN
+      x-timer:
+      - S1581911811.069639,VS0,VE1
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
@@ -799,7 +874,7 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: GET
@@ -808,14 +883,14 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\n      \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\",\r\n
-        \     \"etag\": \"W/\\\"93d1cb69-2e12-4613-a714-b888155b6332\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"aab8195f-8773-4d81-ad72-b7d56509cca8\\\"\",\r\n      \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
         \     \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
-        \"Succeeded\",\r\n        \"resourceGuid\": \"630d8913-18ca-4946-b1fa-f4179678ae5d\",\r\n
+        \"Succeeded\",\r\n        \"resourceGuid\": \"9062f5a2-cc43-4f6a-9610-7daf8c87d57c\",\r\n
         \       \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n
         \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
         \"vm1Subnet\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\",\r\n
-        \           \"etag\": \"W/\\\"93d1cb69-2e12-4613-a714-b888155b6332\\\"\",\r\n
+        \           \"etag\": \"W/\\\"aab8195f-8773-4d81-ad72-b7d56509cca8\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"ipConfigurations\":
         [\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
@@ -831,7 +906,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:10:39 GMT
+      - Mon, 17 Feb 2020 03:56:55 GMT
       expires:
       - '-1'
       pragma:
@@ -848,7 +923,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 39ebe7da-cdd4-4333-8982-a9fc71d2e254
+      - 733a2df3-e4d6-46e2-a00a-aa24a45be30e
     status:
       code: 200
       message: OK
@@ -897,25 +972,25 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_uBS0QHBVpfQInaqBt5f17rs0UI5nfViP","name":"vm_deploy_uBS0QHBVpfQInaqBt5f17rs0UI5nfViP","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6581767281778689687","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-11T09:10:51.0842462Z","duration":"PT3.3957124S","correlationId":"748c3a39-fd13-42bb-9cab-0fe5d590592d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_RQXP1GLYzcoCDnXAxOIKLtjNvxpQ7a2t","name":"vm_deploy_RQXP1GLYzcoCDnXAxOIKLtjNvxpQ7a2t","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13203869083500053381","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-17T03:57:03.3118049Z","duration":"PT3.3340276S","correlationId":"655dc7e8-d0f6-4e4b-856d-eb6bf1d7fc09","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_uBS0QHBVpfQInaqBt5f17rs0UI5nfViP/operationStatuses/08586201946377891177?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_RQXP1GLYzcoCDnXAxOIKLtjNvxpQ7a2t/operationStatuses/08586196950654998466?api-version=2019-07-01
       cache-control:
       - no-cache
       content-length:
-      - '2443'
+      - '2444'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:10:51 GMT
+      - Mon, 17 Feb 2020 03:57:05 GMT
       expires:
       - '-1'
       pragma:
@@ -925,7 +1000,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -944,9 +1019,9 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196950654998466?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -958,7 +1033,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:11:23 GMT
+      - Mon, 17 Feb 2020 03:57:59 GMT
       expires:
       - '-1'
       pragma:
@@ -987,9 +1062,9 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196950654998466?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1001,7 +1076,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:11:54 GMT
+      - Mon, 17 Feb 2020 03:58:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1030,9 +1105,9 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196950654998466?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1044,7 +1119,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:12:25 GMT
+      - Mon, 17 Feb 2020 03:59:11 GMT
       expires:
       - '-1'
       pragma:
@@ -1073,9 +1148,9 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196950654998466?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1087,7 +1162,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:13:16 GMT
+      - Mon, 17 Feb 2020 03:59:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1116,95 +1191,9 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 11 Feb 2020 09:13:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --admin-password --admin-username --authentication-type
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 11 Feb 2020 09:14:17 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --admin-password --admin-username --authentication-type
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196950654998466?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1216,7 +1205,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:14:47 GMT
+      - Mon, 17 Feb 2020 04:00:16 GMT
       expires:
       - '-1'
       pragma:
@@ -1245,21 +1234,21 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_uBS0QHBVpfQInaqBt5f17rs0UI5nfViP","name":"vm_deploy_uBS0QHBVpfQInaqBt5f17rs0UI5nfViP","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6581767281778689687","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-11T09:14:43.5703629Z","duration":"PT3M55.8818291S","correlationId":"748c3a39-fd13-42bb-9cab-0fe5d590592d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_RQXP1GLYzcoCDnXAxOIKLtjNvxpQ7a2t","name":"vm_deploy_RQXP1GLYzcoCDnXAxOIKLtjNvxpQ7a2t","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13203869083500053381","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-17T04:00:04.8329563Z","duration":"PT3M4.855179S","correlationId":"655dc7e8-d0f6-4e4b-856d-eb6bf1d7fc09","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3306'
+      - '3305'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:14:48 GMT
+      - Mon, 17 Feb 2020 04:00:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1288,7 +1277,7 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-compute/10.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-compute/10.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: GET
@@ -1297,16 +1286,16 @@ interactions:
     body:
       string: "{\r\n  \"name\": \"vm2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"76e5a75e-6362-45dc-a232-cc4c4eef07d8\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"b2526d39-4044-4bcc-b7f5-cca2c96d86a0\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"18.04.202002080\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"vm2_disk1_2c874c92924245989b8f37a9719bc7d8\",\r\n
+        \"Linux\",\r\n        \"name\": \"vm2_disk1_de3036d940a54a37b23f369edf3fe572\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGX3UN77LHOUPP64AZCOBUAFO3KMGSQFYS7ZT4C4WCDI4DHIKM2R4OHJWO3A4IUIPWT/providers/Microsoft.Compute/disks/vm2_disk1_2c874c92924245989b8f37a9719bc7d8\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGT6GEVSV42PXNN6XYK3LHMSGYXKAEY52APLFZVNUQNCJ52FUVNLIAC5RQPWSH5X2SV/providers/Microsoft.Compute/disks/vm2_disk1_de3036d940a54a37b23f369edf3fe572\"\r\n
         \       },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\",\r\n
         \     \"adminUsername\": \"testadmin\",\r\n      \"linuxConfiguration\": {\r\n
@@ -1314,21 +1303,25 @@ interactions:
         true\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
         true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
         {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\"}]},\r\n
-        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
-        {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n        \"statuses\": [\r\n
-        \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
-        \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
-        Ready\",\r\n            \"message\": \"VM status blob is found but not yet
-        populated.\",\r\n            \"time\": \"2020-02-11T09:14:54+00:00\"\r\n          }\r\n
-        \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
-        \"vm2_disk1_2c874c92924245989b8f37a9719bc7d8\",\r\n          \"statuses\":
-        [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"computerName\":
+        \"vm2\",\r\n      \"osName\": \"ubuntu\",\r\n      \"osVersion\": \"18.04\",\r\n
+        \     \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.46\",\r\n        \"statuses\":
+        [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
+        \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
+        \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
+        \"2020-02-17T04:00:28+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"maintenanceRedeployStatus\": {\r\n        \"isCustomerInitiatedMaintenanceAllowed\":
+        false,\r\n        \"lastOperationResultCode\": \"MaintenanceCompleted\",\r\n
+        \       \"lastOperationMessage\": \"Maintenance Redeploy operation on the
+        Virtual Machine was successfully completed.\"\r\n      },\r\n      \"disks\":
+        [\r\n        {\r\n          \"name\": \"vm2_disk1_de3036d940a54a37b23f369edf3fe572\",\r\n
+        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-02-11T09:14:01.4738997+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-02-17T03:59:21.3684479+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2020-02-11T09:14:39.0053558+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2020-02-17T04:00:00.1341237+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -1336,11 +1329,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '3086'
+      - '3454'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:14:53 GMT
+      - Mon, 17 Feb 2020 04:00:30 GMT
       expires:
       - '-1'
       pragma:
@@ -1357,7 +1350,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31994
+      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31982
     status:
       code: 200
       message: OK
@@ -1376,7 +1369,7 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: GET
@@ -1384,12 +1377,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm2VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\",\r\n
-        \ \"etag\": \"W/\\\"ba8fb9f8-21ac-4d59-88bf-31e6e7d568ff\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"be347e31-8aa4-45a6-994c-59fb31b897cb\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"ce7fb3ab-c468-4011-a74b-f95877f8e133\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"d98001af-e947-4747-8da1-f2153f878819\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm2\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\",\r\n
-        \       \"etag\": \"W/\\\"ba8fb9f8-21ac-4d59-88bf-31e6e7d568ff\\\"\",\r\n
+        \       \"etag\": \"W/\\\"be347e31-8aa4-45a6-994c-59fb31b897cb\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
@@ -1398,8 +1391,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"coeq0y4kdbdetmp04qlzm4folf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-11-FA-1E\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"ul0wfecdzrve5fqqpwxyzb4vpe.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-4D-72-C8\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -1413,9 +1406,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:14:58 GMT
+      - Mon, 17 Feb 2020 04:00:33 GMT
       etag:
-      - W/"ba8fb9f8-21ac-4d59-88bf-31e6e7d568ff"
+      - W/"be347e31-8aa4-45a6-994c-59fb31b897cb"
       expires:
       - '-1'
       pragma:
@@ -1432,7 +1425,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 46d582fe-d333-4bd1-9950-84bce33b44ce
+      - f89ffbd3-e5ee-43d0-803b-8350a2ff466c
     status:
       code: 200
       message: OK
@@ -1451,7 +1444,7 @@ interactions:
       - -g -n --image --admin-password --admin-username --authentication-type
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: GET
@@ -1459,10 +1452,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm2PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"79ca70a7-32c3-4c2f-a34a-181f2f9b7b4b\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"b40c7349-2081-495c-93c7-b1887895caae\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"9d69c976-e124-43ab-8431-055c876455f8\",\r\n
-        \   \"ipAddress\": \"40.71.207.53\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"b4a06561-722b-4426-b4b0-e82efdbf8b2f\",\r\n
+        \   \"ipAddress\": \"40.87.80.189\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
         \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
@@ -1475,9 +1468,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:14:58 GMT
+      - Mon, 17 Feb 2020 04:00:34 GMT
       etag:
-      - W/"79ca70a7-32c3-4c2f-a34a-181f2f9b7b4b"
+      - W/"b40c7349-2081-495c-93c7-b1887895caae"
       expires:
       - '-1'
       pragma:
@@ -1494,7 +1487,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - b687ddd5-0ef8-4808-bb5f-92c0a6edc1e4
+      - fa2d0ec8-ad2e-42bb-bf10-f0d97dfca2e2
     status:
       code: 200
       message: OK
@@ -1521,7 +1514,7 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: PUT
@@ -1537,7 +1530,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:15:12 GMT
+      - Mon, 17 Feb 2020 04:00:50 GMT
       expires:
       - '-1'
       pragma:
@@ -1549,7 +1542,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1197'
     status:
       code: 201
       message: Created
@@ -1578,7 +1571,7 @@ interactions:
       - -g -n --scopes --action --condition --description
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: PUT
@@ -1610,7 +1603,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:15:34 GMT
+      - Mon, 17 Feb 2020 04:02:57 GMT
       expires:
       - '-1'
       pragma:
@@ -1649,7 +1642,7 @@ interactions:
       - --source-resource --target-resource
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: GET
@@ -1682,7 +1675,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:15:36 GMT
+      - Mon, 17 Feb 2020 04:03:00 GMT
       expires:
       - '-1'
       pragma:
@@ -1731,7 +1724,7 @@ interactions:
       - --source-resource --target-resource
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: PUT
@@ -1750,7 +1743,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:15:37 GMT
+      - Mon, 17 Feb 2020 04:03:01 GMT
       expires:
       - '-1'
       pragma:
@@ -1796,15 +1789,15 @@ interactions:
       - --source-resource --target-resource
       User-Agent:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.0.79
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/vm2-7df9adee-04de-41ef-b315-eafd7abd3dc5?api-version=2018-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/vm2-88888888-0000-0000-0000-000000000001?api-version=2018-03-01
   response:
     body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"vm2-7df9adee-04de-41ef-b315-eafd7abd3dc5\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/vm2-7df9adee-04de-41ef-b315-eafd7abd3dc5\",\r\n
+        \ \"name\": \"vm2-88888888-0000-0000-0000-000000000001\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/vm2-88888888-0000-0000-0000-000000000001\",\r\n
         \ \"properties\": {\r\n    \"description\": \"High CPU\",\r\n    \"severity\":
         2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
@@ -1828,7 +1821,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 11 Feb 2020 09:15:55 GMT
+      - Mon, 17 Feb 2020 04:03:16 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_vm_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_vm_metric_alerts_scenario.yaml
@@ -1,0 +1,1855 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-11T09:05:52Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:06:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-01-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:06:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"adminPassword": {"type": "securestring",
+      "metadata": {"description": "Secure adminPassword"}}}, "variables": {}, "resources":
+      [{"name": "vm1VNET", "type": "Microsoft.Network/virtualNetworks", "location":
+      "eastus", "apiVersion": "2015-06-15", "dependsOn": [], "tags": {}, "properties":
+      {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]}, "subnets": [{"name":
+      "vm1Subnet", "properties": {"addressPrefix": "10.0.0.0/24"}}]}}, {"type": "Microsoft.Network/networkSecurityGroups",
+      "name": "vm1NSG", "apiVersion": "2015-06-15", "location": "eastus", "tags":
+      {}, "dependsOn": [], "properties": {"securityRules": [{"name": "default-allow-ssh",
+      "properties": {"protocol": "Tcp", "sourcePortRange": "*", "destinationPortRange":
+      "22", "sourceAddressPrefix": "*", "destinationAddressPrefix": "*", "access":
+      "Allow", "priority": 1000, "direction": "Inbound"}}]}}, {"apiVersion": "2018-01-01",
+      "type": "Microsoft.Network/publicIPAddresses", "name": "vm1PublicIP", "location":
+      "eastus", "tags": {}, "dependsOn": [], "properties": {"publicIPAllocationMethod":
+      null}}, {"apiVersion": "2015-06-15", "type": "Microsoft.Network/networkInterfaces",
+      "name": "vm1VMNic", "location": "eastus", "tags": {}, "dependsOn": ["Microsoft.Network/virtualNetworks/vm1VNET",
+      "Microsoft.Network/networkSecurityGroups/vm1NSG", "Microsoft.Network/publicIpAddresses/vm1PublicIP"],
+      "properties": {"ipConfigurations": [{"name": "ipconfigvm1", "properties": {"privateIPAllocationMethod":
+      "Dynamic", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"}}}],
+      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"}}},
+      {"apiVersion": "2019-07-01", "type": "Microsoft.Compute/virtualMachines", "name":
+      "vm1", "location": "eastus", "tags": {}, "dependsOn": ["Microsoft.Network/networkInterfaces/vm1VMNic"],
+      "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"}]},
+      "storageProfile": {"osDisk": {"createOption": "fromImage", "name": null, "caching":
+      "ReadWrite", "managedDisk": {"storageAccountType": null}}, "imageReference":
+      {"publisher": "Canonical", "offer": "UbuntuServer", "sku": "18.04-LTS", "version":
+      "latest"}}, "osProfile": {"computerName": "vm1", "adminUsername": "testadmin",
+      "adminPassword": "[parameters(\''adminPassword\'')]"}}}], "outputs": {}}, "parameters":
+      {"adminPassword": {"value": "TestPassword11!!"}}, "mode": "Incremental"}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3316'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_hqm5Mkep1dz5ywN9voS2lroXKH8aJjjU","name":"vm_deploy_hqm5Mkep1dz5ywN9voS2lroXKH8aJjjU","type":"Microsoft.Resources/deployments","properties":{"templateHash":"15091726830086748000","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-11T09:06:29.9239888Z","duration":"PT2.8854828S","correlationId":"1a5f23da-a3b3-488c-932f-8dd363ffbffc","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_hqm5Mkep1dz5ywN9voS2lroXKH8aJjjU/operationStatuses/08586201948984391154?api-version=2019-07-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2782'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:06:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:07:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:07:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:08:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:08:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:09:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:09:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201948984391154?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:10:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_hqm5Mkep1dz5ywN9voS2lroXKH8aJjjU","name":"vm_deploy_hqm5Mkep1dz5ywN9voS2lroXKH8aJjjU","type":"Microsoft.Resources/deployments","properties":{"templateHash":"15091726830086748000","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-11T09:09:49.7361659Z","duration":"PT3M22.6976599S","correlationId":"1a5f23da-a3b3-488c-932f-8dd363ffbffc","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3849'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:10:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-compute/10.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1?$expand=instanceView&api-version=2019-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"vm1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\",\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"c10c5b8d-11d1-44dc-9bd9-4bf646e87180\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
+        \"18.04.202002080\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"vm1_disk1_83eef59a2c5a44caa6a599101fe6f9d7\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGX3UN77LHOUPP64AZCOBUAFO3KMGSQFYS7ZT4C4WCDI4DHIKM2R4OHJWO3A4IUIPWT/providers/Microsoft.Compute/disks/vm1_disk1_83eef59a2c5a44caa6a599101fe6f9d7\"\r\n
+        \       },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n
+        \     \"adminUsername\": \"testadmin\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false,\r\n        \"provisionVMAgent\":
+        true\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
+        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"computerName\":
+        \"vm1\",\r\n      \"osName\": \"ubuntu\",\r\n      \"osVersion\": \"18.04\",\r\n
+        \     \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.46\",\r\n        \"statuses\":
+        [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
+        \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
+        \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
+        \"2020-02-11T09:10:10+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_disk1_83eef59a2c5a44caa6a599101fe6f9d7\",\r\n
+        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
+        succeeded\",\r\n              \"time\": \"2020-02-11T09:09:30.3161819+00:00\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
+        \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2020-02-11T09:09:44.8474797+00:00\"\r\n
+        \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3172'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:10:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31997
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2018-01-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\",\r\n
+        \ \"etag\": \"W/\\\"f3fc60a0-222a-4b29-81d8-f8fbefd02cad\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"8eafbab4-a988-4c9e-8d6c-85114d725288\",\r\n
+        \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\",\r\n
+        \       \"etag\": \"W/\\\"f3fc60a0-222a-4b29-81d8-f8fbefd02cad\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"coeq0y4kdbdetmp04qlzm4folf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-8B-99-0B\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2568'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:10:14 GMT
+      etag:
+      - W/"f3fc60a0-222a-4b29-81d8-f8fbefd02cad"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 60b3a4e1-a42e-4b62-8da2-b067125edab3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP?api-version=2018-01-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\",\r\n
+        \ \"etag\": \"W/\\\"c24289b6-9474-4d6b-81ce-eb197097667f\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"34865fb7-960a-4253-83d7-807a9176666d\",\r\n
+        \   \"ipAddress\": \"13.82.5.234\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '995'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:10:15 GMT
+      etag:
+      - W/"c24289b6-9474-4d6b-81ce-eb197097667f"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 5f8907a8-1c82-4df6-91be-e77102228511
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-11T09:05:52Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:10:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-01-01
+  response:
+    body:
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\n      \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\",\r\n
+        \     \"etag\": \"W/\\\"93d1cb69-2e12-4613-a714-b888155b6332\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
+        \"Succeeded\",\r\n        \"resourceGuid\": \"630d8913-18ca-4946-b1fa-f4179678ae5d\",\r\n
+        \       \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n
+        \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
+        \"vm1Subnet\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\",\r\n
+        \           \"etag\": \"W/\\\"93d1cb69-2e12-4613-a714-b888155b6332\\\"\",\r\n
+        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"ipConfigurations\":
+        [\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
+        \               }\r\n              ]\r\n            },\r\n            \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n          }\r\n        ],\r\n
+        \       \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\":
+        false,\r\n        \"enableVmProtection\": false\r\n      }\r\n    }\r\n  ]\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1750'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:10:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 39ebe7da-cdd4-4333-8982-a9fc71d2e254
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"adminPassword": {"type": "securestring",
+      "metadata": {"description": "Secure adminPassword"}}}, "variables": {}, "resources":
+      [{"type": "Microsoft.Network/networkSecurityGroups", "name": "vm2NSG", "apiVersion":
+      "2015-06-15", "location": "eastus", "tags": {}, "dependsOn": [], "properties":
+      {"securityRules": [{"name": "default-allow-ssh", "properties": {"protocol":
+      "Tcp", "sourcePortRange": "*", "destinationPortRange": "22", "sourceAddressPrefix":
+      "*", "destinationAddressPrefix": "*", "access": "Allow", "priority": 1000, "direction":
+      "Inbound"}}]}}, {"apiVersion": "2018-01-01", "type": "Microsoft.Network/publicIPAddresses",
+      "name": "vm2PublicIP", "location": "eastus", "tags": {}, "dependsOn": [], "properties":
+      {"publicIPAllocationMethod": null}}, {"apiVersion": "2015-06-15", "type": "Microsoft.Network/networkInterfaces",
+      "name": "vm2VMNic", "location": "eastus", "tags": {}, "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm2NSG",
+      "Microsoft.Network/publicIpAddresses/vm2PublicIP"], "properties": {"ipConfigurations":
+      [{"name": "ipconfigvm2", "properties": {"privateIPAllocationMethod": "Dynamic",
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}}}],
+      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"}}},
+      {"apiVersion": "2019-07-01", "type": "Microsoft.Compute/virtualMachines", "name":
+      "vm2", "location": "eastus", "tags": {}, "dependsOn": ["Microsoft.Network/networkInterfaces/vm2VMNic"],
+      "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"}]},
+      "storageProfile": {"osDisk": {"createOption": "fromImage", "name": null, "caching":
+      "ReadWrite", "managedDisk": {"storageAccountType": null}}, "imageReference":
+      {"publisher": "Canonical", "offer": "UbuntuServer", "sku": "18.04-LTS", "version":
+      "latest"}}, "osProfile": {"computerName": "vm2", "adminUsername": "testadmin",
+      "adminPassword": "[parameters(\''adminPassword\'')]"}}}], "outputs": {}}, "parameters":
+      {"adminPassword": {"value": "TestPassword11!!"}}, "mode": "Incremental"}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2972'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_uBS0QHBVpfQInaqBt5f17rs0UI5nfViP","name":"vm_deploy_uBS0QHBVpfQInaqBt5f17rs0UI5nfViP","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6581767281778689687","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-11T09:10:51.0842462Z","duration":"PT3.3957124S","correlationId":"748c3a39-fd13-42bb-9cab-0fe5d590592d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_uBS0QHBVpfQInaqBt5f17rs0UI5nfViP/operationStatuses/08586201946377891177?api-version=2019-07-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2443'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:10:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:11:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:11:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:12:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:13:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:13:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:14:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586201946377891177?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:14:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_uBS0QHBVpfQInaqBt5f17rs0UI5nfViP","name":"vm_deploy_uBS0QHBVpfQInaqBt5f17rs0UI5nfViP","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6581767281778689687","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-11T09:14:43.5703629Z","duration":"PT3M55.8818291S","correlationId":"748c3a39-fd13-42bb-9cab-0fe5d590592d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3306'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:14:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-compute/10.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2?$expand=instanceView&api-version=2019-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"vm2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\",\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"76e5a75e-6362-45dc-a232-cc4c4eef07d8\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
+        \"18.04.202002080\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"vm2_disk1_2c874c92924245989b8f37a9719bc7d8\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGX3UN77LHOUPP64AZCOBUAFO3KMGSQFYS7ZT4C4WCDI4DHIKM2R4OHJWO3A4IUIPWT/providers/Microsoft.Compute/disks/vm2_disk1_2c874c92924245989b8f37a9719bc7d8\"\r\n
+        \       },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\",\r\n
+        \     \"adminUsername\": \"testadmin\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false,\r\n        \"provisionVMAgent\":
+        true\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
+        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
+        {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n        \"statuses\": [\r\n
+        \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
+        \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
+        Ready\",\r\n            \"message\": \"VM status blob is found but not yet
+        populated.\",\r\n            \"time\": \"2020-02-11T09:14:54+00:00\"\r\n          }\r\n
+        \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
+        \"vm2_disk1_2c874c92924245989b8f37a9719bc7d8\",\r\n          \"statuses\":
+        [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
+        succeeded\",\r\n              \"time\": \"2020-02-11T09:14:01.4738997+00:00\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
+        \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2020-02-11T09:14:39.0053558+00:00\"\r\n
+        \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3086'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:14:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31994
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic?api-version=2018-01-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"vm2VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\",\r\n
+        \ \"etag\": \"W/\\\"ba8fb9f8-21ac-4d59-88bf-31e6e7d568ff\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"ce7fb3ab-c468-4011-a74b-f95877f8e133\",\r\n
+        \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm2\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\",\r\n
+        \       \"etag\": \"W/\\\"ba8fb9f8-21ac-4d59-88bf-31e6e7d568ff\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"coeq0y4kdbdetmp04qlzm4folf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-11-FA-1E\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2568'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:14:58 GMT
+      etag:
+      - W/"ba8fb9f8-21ac-4d59-88bf-31e6e7d568ff"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 46d582fe-d333-4bd1-9950-84bce33b44ce
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP?api-version=2018-01-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"vm2PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP\",\r\n
+        \ \"etag\": \"W/\\\"79ca70a7-32c3-4c2f-a34a-181f2f9b7b4b\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"9d69c976-e124-43ab-8431-055c876455f8\",\r\n
+        \   \"ipAddress\": \"40.71.207.53\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '996'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:14:58 GMT
+      etag:
+      - W/"79ca70a7-32c3-4c2f-a34a-181f2f9b7b4b"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - b687ddd5-0ef8-4808-bb5f-92c0a6edc1e4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global", "properties": {"groupShortName": "ag1", "enabled":
+      true, "emailReceivers": [], "smsReceivers": [], "webhookReceivers": [], "itsmReceivers":
+      [], "azureAppPushReceivers": [], "automationRunbookReceivers": [], "voiceReceivers":
+      [], "logicAppReceivers": [], "azureFunctionReceivers": [], "armRoleReceivers":
+      []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor action-group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '331'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1","type":"Microsoft.Insights/ActionGroups","name":"ag1","location":"Global","kind":null,"tags":null,"properties":{"groupShortName":"ag1","enabled":true,"emailReceivers":[],"smsReceivers":[],"webhookReceivers":[],"itsmReceivers":[],"azureAppPushReceivers":[],"automationRunbookReceivers":[],"voiceReceivers":[],"logicAppReceivers":[],"azureFunctionReceivers":[],"armRoleReceivers":[]},"identity":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '595'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:15:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: 'b''{"location": "global", "properties": {"description": "High CPU", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "criteria": {"odata.type":
+      "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria", "allOf": [{"name":
+      "cond0", "metricName": "Percentage CPU", "timeAggregation": "Average", "dimensions":
+      [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
+      "threshold": 90.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor metrics alert create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '873'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --scopes --action --condition --description
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/alert1?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
+        \ \"name\": \"alert1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \ \"properties\": {\r\n    \"description\": \"High CPU\",\r\n    \"severity\":
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\r\n
+        \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
+        \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
+        \       {\r\n          \"threshold\": 90.0,\r\n          \"name\": \"cond0\",\r\n
+        \         \"metricNamespace\": \"microsoft.compute/virtualmachines\",\r\n
+        \         \"metricName\": \"Percentage CPU\",\r\n          \"dimensions\":
+        [],\r\n          \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
+        \"Average\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \       }\r\n      ],\r\n      \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \   },\r\n    \"targetResourceType\": \"microsoft.compute/virtualmachines\",\r\n
+        \   \"actions\": [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1526'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:15:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Insights/metricAlerts?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"location\": \"global\",\r\n
+        \     \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\": \"alert1\",\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
+        \     \"properties\": {\r\n        \"description\": \"High CPU\",\r\n        \"severity\":
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\r\n
+        \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
+        \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
+        [\r\n            {\r\n              \"threshold\": 90.0,\r\n              \"name\":
+        \"cond0\",\r\n              \"metricNamespace\": \"microsoft.compute/virtualmachines\",\r\n
+        \             \"metricName\": \"Percentage CPU\",\r\n              \"dimensions\":
+        [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
+        \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"microsoft.compute/virtualmachines\",\r\n
+        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \         }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1703'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:15:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"location": "global", "properties": {"description": "High CPU", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.compute/virtualmachines",
+      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+      "allOf": [{"name": "cond0", "metricName": "Percentage CPU", "metricNamespace":
+      "microsoft.compute/virtualmachines", "timeAggregation": "Average", "dimensions":
+      [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
+      "threshold": 90.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1182'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/alert1?api-version=2018-03-01
+  response:
+    body:
+      string: '{"Code":"BadRequest","Message":"Scopes property is invalid. Only single
+        resource is allowed for criteria type SingleResourceMultipleMetricCriteria.
+        If you want to create an alert on multiple resources, use MultipleResourceMultipleMetricCriteria
+        odata.type."}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '258'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:15:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 400
+      message: BadRequest
+- request:
+    body: 'b''{"location": "global", "properties": {"description": "High CPU", "severity":
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.compute/virtualmachines",
+      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+      "allOf": [{"name": "cond0", "metricName": "Percentage CPU", "metricNamespace":
+      "microsoft.compute/virtualmachines", "timeAggregation": "Average", "dimensions":
+      [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
+      "threshold": 90.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - monitor clone
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '988'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --source-resource --target-resource
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.0.79
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/vm2-7df9adee-04de-41ef-b315-eafd7abd3dc5?api-version=2018-03-01
+  response:
+    body:
+      string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
+        \ \"name\": \"vm2-7df9adee-04de-41ef-b315-eafd7abd3dc5\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/vm2-7df9adee-04de-41ef-b315-eafd7abd3dc5\",\r\n
+        \ \"properties\": {\r\n    \"description\": \"High CPU\",\r\n    \"severity\":
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\"\r\n
+        \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
+        \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
+        \       {\r\n          \"threshold\": 90.0,\r\n          \"name\": \"cond0\",\r\n
+        \         \"metricNamespace\": \"microsoft.compute/virtualmachines\",\r\n
+        \         \"metricName\": \"Percentage CPU\",\r\n          \"dimensions\":
+        [],\r\n          \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
+        \"Average\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
+        \       }\r\n      ],\r\n      \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
+        \   },\r\n    \"targetResourceType\": \"microsoft.compute/virtualmachines\",\r\n
+        \   \"actions\": [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    headers:
+      api-supported-versions:
+      - 2017-09-01-preview, 2018-03-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 11 Feb 2020 09:15:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '298'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_vm_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_vm_metric_alerts_scenario.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T03:53:23Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T06:00:34Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:53:33 GMT
+      - Mon, 17 Feb 2020 06:00:45 GMT
       expires:
       - '-1'
       pragma:
@@ -109,13 +109,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:53:34 GMT
+      - Mon, 17 Feb 2020 06:00:46 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Mon, 17 Feb 2020 03:58:34 GMT
+      - Mon, 17 Feb 2020 06:05:46 GMT
       source-age:
-      - '259'
+      - '84'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -130,17 +130,17 @@ interactions:
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - aec3d22f87ec1bcf9a08f16cb427e5d1beedbf49
+      - 62bb33160ca0a4265cd2410af2d29fe778a965e2
       x-frame-options:
       - deny
       x-geo-block-list:
       - ''
       x-github-request-id:
-      - 3C4C:0DF0:183AA9:1A2D94:5E49C518
+      - 155E:1821:1AEEF3:1D42A5:5E4A0FEA
       x-served-by:
-      - cache-sin18032-SIN
+      - cache-tyo19937-TYO
       x-timer:
-      - S1581911615.889066,VS0,VE0
+      - S1581919247.729939,VS0,VE165
       x-xss-protection:
       - 1; mode=block
     status:
@@ -177,7 +177,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:53:36 GMT
+      - Mon, 17 Feb 2020 06:00:48 GMT
       expires:
       - '-1'
       pragma:
@@ -247,18 +247,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_68PRwLpSYvYK7FosxOojV3ndLeXB1pLP","name":"vm_deploy_68PRwLpSYvYK7FosxOojV3ndLeXB1pLP","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14801277511473264404","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-17T03:53:42.8922982Z","duration":"PT3.2351582S","correlationId":"865b2ddd-81be-4e40-83b2-e5ccf96d2b89","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_mOmr6nSDGMuHRZKBmcyMmRPnlkOqx7gh","name":"vm_deploy_mOmr6nSDGMuHRZKBmcyMmRPnlkOqx7gh","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12328411686541392177","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-17T06:00:56.682182Z","duration":"PT3.4993507S","correlationId":"165fbb0d-dfa6-430a-9d94-69485e1d969f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_68PRwLpSYvYK7FosxOojV3ndLeXB1pLP/operationStatuses/08586196952658204920?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_mOmr6nSDGMuHRZKBmcyMmRPnlkOqx7gh/operationStatuses/08586196876322947994?api-version=2019-07-01
       cache-control:
       - no-cache
       content-length:
-      - '2782'
+      - '2781'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:53:43 GMT
+      - Mon, 17 Feb 2020 06:00:57 GMT
       expires:
       - '-1'
       pragma:
@@ -268,7 +268,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -289,7 +289,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196952658204920?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -301,7 +301,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:54:15 GMT
+      - Mon, 17 Feb 2020 06:01:29 GMT
       expires:
       - '-1'
       pragma:
@@ -332,7 +332,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196952658204920?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -344,7 +344,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:54:59 GMT
+      - Mon, 17 Feb 2020 06:02:00 GMT
       expires:
       - '-1'
       pragma:
@@ -375,7 +375,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196952658204920?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -387,7 +387,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:55:29 GMT
+      - Mon, 17 Feb 2020 06:02:30 GMT
       expires:
       - '-1'
       pragma:
@@ -418,7 +418,136 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196952658204920?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:03:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:03:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:04:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -430,7 +559,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:56:01 GMT
+      - Mon, 17 Feb 2020 06:04:32 GMT
       expires:
       - '-1'
       pragma:
@@ -464,16 +593,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_68PRwLpSYvYK7FosxOojV3ndLeXB1pLP","name":"vm_deploy_68PRwLpSYvYK7FosxOojV3ndLeXB1pLP","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14801277511473264404","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-17T03:55:31.9017657Z","duration":"PT1M52.2446257S","correlationId":"865b2ddd-81be-4e40-83b2-e5ccf96d2b89","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_mOmr6nSDGMuHRZKBmcyMmRPnlkOqx7gh","name":"vm_deploy_mOmr6nSDGMuHRZKBmcyMmRPnlkOqx7gh","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12328411686541392177","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-17T06:04:02.6861895Z","duration":"PT3M9.5033582S","correlationId":"165fbb0d-dfa6-430a-9d94-69485e1d969f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3849'
+      - '3848'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:56:03 GMT
+      - Mon, 17 Feb 2020 06:04:32 GMT
       expires:
       - '-1'
       pragma:
@@ -511,16 +640,16 @@ interactions:
     body:
       string: "{\r\n  \"name\": \"vm1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"5ec3f641-79d1-4bad-8834-e89ab88f2298\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"cd6d1718-3adc-4529-9fea-565c605a877d\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"18.04.202002080\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"vm1_disk1_1d906857dcc34182a36474d1404df507\",\r\n
+        \"Linux\",\r\n        \"name\": \"vm1_disk1_b872e05ac914429eae6f760f14d28f9e\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGT6GEVSV42PXNN6XYK3LHMSGYXKAEY52APLFZVNUQNCJ52FUVNLIAC5RQPWSH5X2SV/providers/Microsoft.Compute/disks/vm1_disk1_1d906857dcc34182a36474d1404df507\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGG657KKXIHXHG4R6XVNKK5DGVMZKS7B2ISMHN7I33DSJBI7WON42CWKBMGFF7LWCSK/providers/Microsoft.Compute/disks/vm1_disk1_b872e05ac914429eae6f760f14d28f9e\"\r\n
         \       },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n
         \     \"adminUsername\": \"testadmin\",\r\n      \"linuxConfiguration\": {\r\n
@@ -534,15 +663,15 @@ interactions:
         [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
         \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
         \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2020-02-17T03:56:07+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_disk1_1d906857dcc34182a36474d1404df507\",\r\n
+        \"2020-02-17T06:04:33+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_disk1_b872e05ac914429eae6f760f14d28f9e\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-02-17T03:55:10.9773594+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-02-17T06:03:24.7183177+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2020-02-17T03:55:26.6024644+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2020-02-17T06:03:56.9216067+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -554,7 +683,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:56:09 GMT
+      - Mon, 17 Feb 2020 06:04:35 GMT
       expires:
       - '-1'
       pragma:
@@ -571,7 +700,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31985
+      - Microsoft.Compute/LowCostGet3Min;3996,Microsoft.Compute/LowCostGet30Min;31971
     status:
       code: 200
       message: OK
@@ -598,12 +727,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\",\r\n
-        \ \"etag\": \"W/\\\"5e1336c7-17ce-4be1-8a07-f15ec1473dd8\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"b528eb76-be35-44e3-b38c-ce9f0e36e1e5\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"cad701bc-6307-4594-8732-547b9c95266a\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"c5e570dd-eb41-40ef-91f1-7db4ad1c9caf\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\",\r\n
-        \       \"etag\": \"W/\\\"5e1336c7-17ce-4be1-8a07-f15ec1473dd8\\\"\",\r\n
+        \       \"etag\": \"W/\\\"b528eb76-be35-44e3-b38c-ce9f0e36e1e5\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
@@ -612,8 +741,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"ul0wfecdzrve5fqqpwxyzb4vpe.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-8C-A6-E8\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"vzvt5deiff2udcaatyypnl4kqb.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-1D-B2-36\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -627,9 +756,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:56:30 GMT
+      - Mon, 17 Feb 2020 06:04:36 GMT
       etag:
-      - W/"5e1336c7-17ce-4be1-8a07-f15ec1473dd8"
+      - W/"b528eb76-be35-44e3-b38c-ce9f0e36e1e5"
       expires:
       - '-1'
       pragma:
@@ -646,7 +775,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 7660c1bb-6d7b-4afe-a21d-3daf1933d443
+      - d27b8d49-e4da-450b-940a-308b8b58c04c
     status:
       code: 200
       message: OK
@@ -673,11 +802,11 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"08381301-dc9c-41b6-be8c-e5e704a47d0c\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"8162e4e0-5f2e-4e1a-b7ce-ec4433497438\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"72f37a62-b0c7-4bb8-8ca7-70677a3de3c5\",\r\n
-        \   \"ipAddress\": \"52.170.118.147\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"d4dbc0be-65f3-43e6-a952-e6ef8af39d24\",\r\n
+        \   \"ipAddress\": \"40.121.11.154\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -685,13 +814,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '998'
+      - '997'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:56:42 GMT
+      - Mon, 17 Feb 2020 06:04:36 GMT
       etag:
-      - W/"08381301-dc9c-41b6-be8c-e5e704a47d0c"
+      - W/"8162e4e0-5f2e-4e1a-b7ce-ec4433497438"
       expires:
       - '-1'
       pragma:
@@ -708,7 +837,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 39b9a575-2459-40a4-a3b0-0111609f20d2
+      - 164a6431-63ef-4b60-8fe6-0d9af82a0ac0
     status:
       code: 200
       message: OK
@@ -734,7 +863,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T03:53:23Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T06:00:34Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -743,7 +872,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:56:46 GMT
+      - Mon, 17 Feb 2020 06:04:38 GMT
       expires:
       - '-1'
       pragma:
@@ -822,13 +951,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:56:51 GMT
+      - Mon, 17 Feb 2020 06:04:39 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Mon, 17 Feb 2020 04:01:51 GMT
+      - Mon, 17 Feb 2020 06:09:39 GMT
       source-age:
-      - '137'
+      - '0'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -843,17 +972,17 @@ interactions:
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - d3e251d2934d38fc5c98317bd80d814b073a4832
+      - 481932013d6fcd0fd098b8a16cf23dcf2789da77
       x-frame-options:
       - deny
       x-geo-block-list:
       - ''
       x-github-request-id:
-      - 3C4C:0DF0:183AA9:1A2D94:5E49C518
+      - 155E:1821:1AEEF3:1D42A5:5E4A0FEA
       x-served-by:
-      - cache-sin18029-SIN
+      - cache-tyo19946-TYO
       x-timer:
-      - S1581911811.069639,VS0,VE1
+      - S1581919479.411123,VS0,VE265
       x-xss-protection:
       - 1; mode=block
     status:
@@ -883,14 +1012,14 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\n      \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\",\r\n
-        \     \"etag\": \"W/\\\"aab8195f-8773-4d81-ad72-b7d56509cca8\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"95b7d44f-dbfe-42a7-9338-47945f160eff\\\"\",\r\n      \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
         \     \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
-        \"Succeeded\",\r\n        \"resourceGuid\": \"9062f5a2-cc43-4f6a-9610-7daf8c87d57c\",\r\n
+        \"Succeeded\",\r\n        \"resourceGuid\": \"8c3f6bae-2988-4179-8800-9e30f6afca81\",\r\n
         \       \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n
         \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
         \"vm1Subnet\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\",\r\n
-        \           \"etag\": \"W/\\\"aab8195f-8773-4d81-ad72-b7d56509cca8\\\"\",\r\n
+        \           \"etag\": \"W/\\\"95b7d44f-dbfe-42a7-9338-47945f160eff\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"ipConfigurations\":
         [\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
@@ -906,7 +1035,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:56:55 GMT
+      - Mon, 17 Feb 2020 06:04:40 GMT
       expires:
       - '-1'
       pragma:
@@ -923,7 +1052,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 733a2df3-e4d6-46e2-a00a-aa24a45be30e
+      - ba04d5d0-d325-4069-85cf-05a1e299fae2
     status:
       code: 200
       message: OK
@@ -979,18 +1108,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_RQXP1GLYzcoCDnXAxOIKLtjNvxpQ7a2t","name":"vm_deploy_RQXP1GLYzcoCDnXAxOIKLtjNvxpQ7a2t","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13203869083500053381","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-17T03:57:03.3118049Z","duration":"PT3.3340276S","correlationId":"655dc7e8-d0f6-4e4b-856d-eb6bf1d7fc09","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_1ffekicXUohnUlIVC6snMsDEZCDjwXu2","name":"vm_deploy_1ffekicXUohnUlIVC6snMsDEZCDjwXu2","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5137379213259568291","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-17T06:04:46.246396Z","duration":"PT2.6765175S","correlationId":"cdd4da59-d7fb-4445-98a5-5bf7615f48b3","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_RQXP1GLYzcoCDnXAxOIKLtjNvxpQ7a2t/operationStatuses/08586196950654998466?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_1ffekicXUohnUlIVC6snMsDEZCDjwXu2/operationStatuses/08586196874019077504?api-version=2019-07-01
       cache-control:
       - no-cache
       content-length:
-      - '2444'
+      - '2442'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:57:05 GMT
+      - Mon, 17 Feb 2020 06:04:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1000,7 +1129,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1197'
     status:
       code: 201
       message: Created
@@ -1021,7 +1150,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196950654998466?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196874019077504?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1033,7 +1162,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:57:59 GMT
+      - Mon, 17 Feb 2020 06:05:18 GMT
       expires:
       - '-1'
       pragma:
@@ -1064,7 +1193,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196950654998466?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196874019077504?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1076,7 +1205,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:58:31 GMT
+      - Mon, 17 Feb 2020 06:05:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1107,7 +1236,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196950654998466?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196874019077504?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1119,7 +1248,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 03:59:11 GMT
+      - Mon, 17 Feb 2020 06:06:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1150,50 +1279,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196950654998466?api-version=2019-07-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 17 Feb 2020 03:59:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --admin-password --admin-username --authentication-type
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196950654998466?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196874019077504?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1205,7 +1291,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 04:00:16 GMT
+      - Mon, 17 Feb 2020 06:06:50 GMT
       expires:
       - '-1'
       pragma:
@@ -1239,7 +1325,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_RQXP1GLYzcoCDnXAxOIKLtjNvxpQ7a2t","name":"vm_deploy_RQXP1GLYzcoCDnXAxOIKLtjNvxpQ7a2t","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13203869083500053381","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-17T04:00:04.8329563Z","duration":"PT3M4.855179S","correlationId":"655dc7e8-d0f6-4e4b-856d-eb6bf1d7fc09","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_1ffekicXUohnUlIVC6snMsDEZCDjwXu2","name":"vm_deploy_1ffekicXUohnUlIVC6snMsDEZCDjwXu2","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5137379213259568291","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-17T06:06:50.2879103Z","duration":"PT2M6.7180318S","correlationId":"cdd4da59-d7fb-4445-98a5-5bf7615f48b3","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'
     headers:
       cache-control:
       - no-cache
@@ -1248,7 +1334,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 04:00:23 GMT
+      - Mon, 17 Feb 2020 06:06:51 GMT
       expires:
       - '-1'
       pragma:
@@ -1286,16 +1372,16 @@ interactions:
     body:
       string: "{\r\n  \"name\": \"vm2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"b2526d39-4044-4bcc-b7f5-cca2c96d86a0\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"cb1b7ba2-13ee-479c-ab4d-628f8495c908\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"18.04.202002080\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"vm2_disk1_de3036d940a54a37b23f369edf3fe572\",\r\n
+        \"Linux\",\r\n        \"name\": \"vm2_disk1_75f20397afea4cde96007ce89faf6b3a\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGT6GEVSV42PXNN6XYK3LHMSGYXKAEY52APLFZVNUQNCJ52FUVNLIAC5RQPWSH5X2SV/providers/Microsoft.Compute/disks/vm2_disk1_de3036d940a54a37b23f369edf3fe572\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGG657KKXIHXHG4R6XVNKK5DGVMZKS7B2ISMHN7I33DSJBI7WON42CWKBMGFF7LWCSK/providers/Microsoft.Compute/disks/vm2_disk1_75f20397afea4cde96007ce89faf6b3a\"\r\n
         \       },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\",\r\n
         \     \"adminUsername\": \"testadmin\",\r\n      \"linuxConfiguration\": {\r\n
@@ -1303,25 +1389,21 @@ interactions:
         true\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
         true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
         {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\"}]},\r\n
-        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"computerName\":
-        \"vm2\",\r\n      \"osName\": \"ubuntu\",\r\n      \"osVersion\": \"18.04\",\r\n
-        \     \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.46\",\r\n        \"statuses\":
-        [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
-        \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
-        \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2020-02-17T04:00:28+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"maintenanceRedeployStatus\": {\r\n        \"isCustomerInitiatedMaintenanceAllowed\":
-        false,\r\n        \"lastOperationResultCode\": \"MaintenanceCompleted\",\r\n
-        \       \"lastOperationMessage\": \"Maintenance Redeploy operation on the
-        Virtual Machine was successfully completed.\"\r\n      },\r\n      \"disks\":
-        [\r\n        {\r\n          \"name\": \"vm2_disk1_de3036d940a54a37b23f369edf3fe572\",\r\n
-        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
+        {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n        \"statuses\": [\r\n
+        \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
+        \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
+        Ready\",\r\n            \"message\": \"VM status blob is found but not yet
+        populated.\",\r\n            \"time\": \"2020-02-17T06:06:53+00:00\"\r\n          }\r\n
+        \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
+        \"vm2_disk1_75f20397afea4cde96007ce89faf6b3a\",\r\n          \"statuses\":
+        [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-02-17T03:59:21.3684479+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-02-17T06:06:25.0474392+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2020-02-17T04:00:00.1341237+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2020-02-17T06:06:44.5006919+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -1329,11 +1411,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '3454'
+      - '3086'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 04:00:30 GMT
+      - Mon, 17 Feb 2020 06:06:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1350,7 +1432,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31982
+      - Microsoft.Compute/LowCostGet3Min;3990,Microsoft.Compute/LowCostGet30Min;31969
     status:
       code: 200
       message: OK
@@ -1377,12 +1459,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm2VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\",\r\n
-        \ \"etag\": \"W/\\\"be347e31-8aa4-45a6-994c-59fb31b897cb\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"42b659e6-33d2-40aa-b552-37854d9685be\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"d98001af-e947-4747-8da1-f2153f878819\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"918c06a0-6665-46ce-8747-eb809275e88f\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm2\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\",\r\n
-        \       \"etag\": \"W/\\\"be347e31-8aa4-45a6-994c-59fb31b897cb\\\"\",\r\n
+        \       \"etag\": \"W/\\\"42b659e6-33d2-40aa-b552-37854d9685be\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
@@ -1391,8 +1473,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"ul0wfecdzrve5fqqpwxyzb4vpe.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-4D-72-C8\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"vzvt5deiff2udcaatyypnl4kqb.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-8D-0E-6D\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -1406,9 +1488,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 04:00:33 GMT
+      - Mon, 17 Feb 2020 06:06:54 GMT
       etag:
-      - W/"be347e31-8aa4-45a6-994c-59fb31b897cb"
+      - W/"42b659e6-33d2-40aa-b552-37854d9685be"
       expires:
       - '-1'
       pragma:
@@ -1425,7 +1507,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - f89ffbd3-e5ee-43d0-803b-8350a2ff466c
+      - 498c1dcf-5b9d-41b5-9a98-b5a0d067b50e
     status:
       code: 200
       message: OK
@@ -1452,11 +1534,11 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm2PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"b40c7349-2081-495c-93c7-b1887895caae\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"3e85be94-e727-44ab-96e0-aebf7b3205c9\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"b4a06561-722b-4426-b4b0-e82efdbf8b2f\",\r\n
-        \   \"ipAddress\": \"40.87.80.189\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
-        \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"1a20e11a-7d65-4abf-9fc5-3177c6207f0d\",\r\n
+        \   \"ipAddress\": \"52.224.219.244\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -1464,13 +1546,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '996'
+      - '998'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 04:00:34 GMT
+      - Mon, 17 Feb 2020 06:06:55 GMT
       etag:
-      - W/"b40c7349-2081-495c-93c7-b1887895caae"
+      - W/"3e85be94-e727-44ab-96e0-aebf7b3205c9"
       expires:
       - '-1'
       pragma:
@@ -1487,7 +1569,826 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - fa2d0ec8-ad2e-42bb-bf10-f0d97dfca2e2
+      - e4f98e8d-527b-49ac-a44e-a6a953f9fde1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T06:00:34Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:06:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
+  response:
+    body:
+      string: "{\n  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n
+        \ \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {},\n  \"variables\":
+        {},\n  \"resources\": [],\n  \"outputs\": {\n    \"aliases\": {\n      \"type\":
+        \"object\",\n      \"value\": {\n        \"Linux\": {\n          \"CentOS\":
+        {\n            \"publisher\": \"OpenLogic\",\n            \"offer\": \"CentOS\",\n
+        \           \"sku\": \"7.5\",\n            \"version\": \"latest\"\n          },\n
+        \         \"CoreOS\": {\n            \"publisher\": \"CoreOS\",\n            \"offer\":
+        \"CoreOS\",\n            \"sku\": \"Stable\",\n            \"version\": \"latest\"\n
+        \         },\n          \"Debian\": {\n            \"publisher\": \"Debian\",\n
+        \           \"offer\": \"debian-10\",\n            \"sku\": \"10\",\n            \"version\":
+        \"latest\"\n          },\n          \"openSUSE-Leap\": {\n            \"publisher\":
+        \"SUSE\",\n            \"offer\": \"openSUSE-Leap\",\n            \"sku\":
+        \"42.3\",\n            \"version\": \"latest\"\n          },\n          \"RHEL\":
+        {\n            \"publisher\": \"RedHat\",\n            \"offer\": \"RHEL\",\n
+        \           \"sku\": \"7-LVM\",\n            \"version\": \"latest\"\n          },\n
+        \         \"SLES\": {\n            \"publisher\": \"SUSE\",\n            \"offer\":
+        \"SLES\",\n            \"sku\": \"15\",\n            \"version\": \"latest\"\n
+        \         },\n          \"UbuntuLTS\": {\n            \"publisher\": \"Canonical\",\n
+        \           \"offer\": \"UbuntuServer\",\n            \"sku\": \"18.04-LTS\",\n
+        \           \"version\": \"latest\"\n          }\n        },\n        \"Windows\":
+        {\n          \"Win2019Datacenter\": {\n            \"publisher\": \"MicrosoftWindowsServer\",\n
+        \           \"offer\": \"WindowsServer\",\n            \"sku\": \"2019-Datacenter\",\n
+        \           \"version\": \"latest\"\n          },\n          \"Win2016Datacenter\":
+        {\n            \"publisher\": \"MicrosoftWindowsServer\",\n            \"offer\":
+        \"WindowsServer\",\n            \"sku\": \"2016-Datacenter\",\n            \"version\":
+        \"latest\"\n          },\n          \"Win2012R2Datacenter\": {\n            \"publisher\":
+        \"MicrosoftWindowsServer\",\n            \"offer\": \"WindowsServer\",\n            \"sku\":
+        \"2012-R2-Datacenter\",\n            \"version\": \"latest\"\n          },\n
+        \         \"Win2012Datacenter\": {\n            \"publisher\": \"MicrosoftWindowsServer\",\n
+        \           \"offer\": \"WindowsServer\",\n            \"sku\": \"2012-Datacenter\",\n
+        \           \"version\": \"latest\"\n          },\n          \"Win2008R2SP1\":
+        {\n            \"publisher\": \"MicrosoftWindowsServer\",\n            \"offer\":
+        \"WindowsServer\",\n            \"sku\": \"2008-R2-SP1\",\n            \"version\":
+        \"latest\"\n          }\n        }\n      }\n    }\n  }\n}\n"
+    headers:
+      accept-ranges:
+      - bytes
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=300
+      connection:
+      - keep-alive
+      content-length:
+      - '2501'
+      content-security-policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      content-type:
+      - text/plain; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:06:58 GMT
+      etag:
+      - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
+      expires:
+      - Mon, 17 Feb 2020 06:11:58 GMT
+      source-age:
+      - '139'
+      strict-transport-security:
+      - max-age=31536000
+      vary:
+      - Authorization,Accept-Encoding
+      via:
+      - 1.1 varnish (Varnish/6.0)
+      - 1.1 varnish
+      x-cache:
+      - HIT, HIT
+      x-cache-hits:
+      - 3, 2
+      x-content-type-options:
+      - nosniff
+      x-fastly-request-id:
+      - a7588ce7b1bce1ef79c4c1948a6960c6e98e3eae
+      x-frame-options:
+      - deny
+      x-geo-block-list:
+      - ''
+      x-github-request-id:
+      - 155E:1821:1AEEF3:1D42A5:5E4A0FEA
+      x-served-by:
+      - cache-tyo19946-TYO
+      x-timer:
+      - S1581919618.209163,VS0,VE0
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-01-01
+  response:
+    body:
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\n      \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\",\r\n
+        \     \"etag\": \"W/\\\"56f2720b-88c1-4595-b69e-26dbf201af20\\\"\",\r\n      \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
+        \"Succeeded\",\r\n        \"resourceGuid\": \"8c3f6bae-2988-4179-8800-9e30f6afca81\",\r\n
+        \       \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n
+        \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
+        \"vm1Subnet\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\",\r\n
+        \           \"etag\": \"W/\\\"56f2720b-88c1-4595-b69e-26dbf201af20\\\"\",\r\n
+        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"ipConfigurations\":
+        [\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
+        \               },\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\r\n
+        \               }\r\n              ]\r\n            },\r\n            \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n          }\r\n        ],\r\n
+        \       \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\":
+        false,\r\n        \"enableVmProtection\": false\r\n      }\r\n    }\r\n  ]\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2043'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:06:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 7acd28db-e618-478f-8b32-dc56a8e2de30
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"adminPassword": {"type": "securestring",
+      "metadata": {"description": "Secure adminPassword"}}}, "variables": {}, "resources":
+      [{"type": "Microsoft.Network/networkSecurityGroups", "name": "vm3NSG", "apiVersion":
+      "2015-06-15", "location": "eastus", "tags": {}, "dependsOn": [], "properties":
+      {"securityRules": [{"name": "default-allow-ssh", "properties": {"protocol":
+      "Tcp", "sourcePortRange": "*", "destinationPortRange": "22", "sourceAddressPrefix":
+      "*", "destinationAddressPrefix": "*", "access": "Allow", "priority": 1000, "direction":
+      "Inbound"}}]}}, {"apiVersion": "2018-01-01", "type": "Microsoft.Network/publicIPAddresses",
+      "name": "vm3PublicIP", "location": "eastus", "tags": {}, "dependsOn": [], "properties":
+      {"publicIPAllocationMethod": null}}, {"apiVersion": "2015-06-15", "type": "Microsoft.Network/networkInterfaces",
+      "name": "vm3VMNic", "location": "eastus", "tags": {}, "dependsOn": ["Microsoft.Network/networkSecurityGroups/vm3NSG",
+      "Microsoft.Network/publicIpAddresses/vm3PublicIP"], "properties": {"ipConfigurations":
+      [{"name": "ipconfigvm3", "properties": {"privateIPAllocationMethod": "Dynamic",
+      "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet"},
+      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP"}}}],
+      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"}}},
+      {"apiVersion": "2019-07-01", "type": "Microsoft.Compute/virtualMachines", "name":
+      "vm3", "location": "eastus", "tags": {}, "dependsOn": ["Microsoft.Network/networkInterfaces/vm3VMNic"],
+      "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"}]},
+      "storageProfile": {"osDisk": {"createOption": "fromImage", "name": null, "caching":
+      "ReadWrite", "managedDisk": {"storageAccountType": null}}, "imageReference":
+      {"publisher": "Canonical", "offer": "UbuntuServer", "sku": "18.04-LTS", "version":
+      "latest"}}, "osProfile": {"computerName": "vm3", "adminUsername": "testadmin",
+      "adminPassword": "[parameters(\''adminPassword\'')]"}}}], "outputs": {}}, "parameters":
+      {"adminPassword": {"value": "TestPassword11!!"}}, "mode": "Incremental"}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2972'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_ehW0iKMe2yAEqpvQmWNMOkPt6sLvp7Xw","name":"vm_deploy_ehW0iKMe2yAEqpvQmWNMOkPt6sLvp7Xw","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13073710376040538704","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-17T06:07:08.4473889Z","duration":"PT4.5452992S","correlationId":"c3cb2471-ee8f-45f0-b10f-fdb10f7542b9","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}]}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_ehW0iKMe2yAEqpvQmWNMOkPt6sLvp7Xw/operationStatuses/08586196872615755319?api-version=2019-07-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2444'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:07:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:07:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:08:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:08:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:09:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:09:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:10:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_ehW0iKMe2yAEqpvQmWNMOkPt6sLvp7Xw","name":"vm_deploy_ehW0iKMe2yAEqpvQmWNMOkPt6sLvp7Xw","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13073710376040538704","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-17T06:10:05.2327952Z","duration":"PT3M1.3307055S","correlationId":"c3cb2471-ee8f-45f0-b10f-fdb10f7542b9","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP"}]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3306'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:10:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-compute/10.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3?$expand=instanceView&api-version=2019-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"vm3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3\",\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"1e27caaa-79b5-4855-892d-11ddccc9133f\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
+        \"18.04.202002080\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"vm3_disk1_b44d271eeb2449ea9daa6686ffe56a6a\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGG657KKXIHXHG4R6XVNKK5DGVMZKS7B2ISMHN7I33DSJBI7WON42CWKBMGFF7LWCSK/providers/Microsoft.Compute/disks/vm3_disk1_b44d271eeb2449ea9daa6686ffe56a6a\"\r\n
+        \       },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\",\r\n
+        \     \"adminUsername\": \"testadmin\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false,\r\n        \"provisionVMAgent\":
+        true\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
+        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
+        {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n        \"statuses\": [\r\n
+        \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
+        \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
+        Ready\",\r\n            \"message\": \"VM status blob is found but not yet
+        populated.\",\r\n            \"time\": \"2020-02-17T06:10:18+00:00\"\r\n          }\r\n
+        \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
+        \"vm3_disk1_b44d271eeb2449ea9daa6686ffe56a6a\",\r\n          \"statuses\":
+        [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
+        succeeded\",\r\n              \"time\": \"2020-02-17T06:09:18.2046308+00:00\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
+        \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2020-02-17T06:10:00.6424017+00:00\"\r\n
+        \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3086'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:10:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/LowCostGet3Min;3993,Microsoft.Compute/LowCostGet30Min;31964
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic?api-version=2018-01-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"vm3VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic\",\r\n
+        \ \"etag\": \"W/\\\"aa02b95b-4575-4df1-8021-4b85d2c47829\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"7378e5be-1872-4a9b-8882-3cbf65bfb108\",\r\n
+        \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm3\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic/ipConfigurations/ipconfigvm3\",\r\n
+        \       \"etag\": \"W/\\\"aa02b95b-4575-4df1-8021-4b85d2c47829\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.6\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"vzvt5deiff2udcaatyypnl4kqb.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-18-D7-AD\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2568'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:10:18 GMT
+      etag:
+      - W/"aa02b95b-4575-4df1-8021-4b85d2c47829"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 478efa92-86c4-4090-b38b-e1bc300780b3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-network/9.0.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP?api-version=2018-01-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"vm3PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP\",\r\n
+        \ \"etag\": \"W/\\\"bf2aee70-caee-43cc-9bb2-04302c5c4cd9\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"236aeb87-8d6e-435a-aa0f-6107af486f00\",\r\n
+        \   \"ipAddress\": \"13.90.18.169\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic/ipConfigurations/ipconfigvm3\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '996'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 17 Feb 2020 06:10:19 GMT
+      etag:
+      - W/"bf2aee70-caee-43cc-9bb2-04302c5c4cd9"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 877cffa6-f961-42d2-a306-5799b69f46fe
     status:
       code: 200
       message: OK
@@ -1530,7 +2431,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 04:00:50 GMT
+      - Mon, 17 Feb 2020 06:10:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1542,18 +2443,19 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1198'
     status:
       code: 201
       message: Created
 - request:
     body: 'b''{"location": "global", "properties": {"description": "High CPU", "severity":
-      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"],
-      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "criteria": {"odata.type":
-      "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria", "allOf": [{"name":
-      "cond0", "metricName": "Percentage CPU", "timeAggregation": "Average", "dimensions":
-      [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
-      "threshold": 90.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
+      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "Microsoft.Compute/virtualMachines",
+      "targetResourceRegion": "global", "criteria": {"odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
+      "allOf": [{"name": "cond0", "metricName": "Percentage CPU", "timeAggregation":
+      "Average", "dimensions": [], "criterionType": "StaticThresholdCriterion", "operator":
+      "GreaterThan", "threshold": 90.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
     headers:
       Accept:
       - application/json
@@ -1564,7 +2466,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '873'
+      - '1162'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -1581,7 +2483,8 @@ interactions:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
         \ \"name\": \"alert1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
         \ \"properties\": {\r\n    \"description\": \"High CPU\",\r\n    \"severity\":
-        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\r\n
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\",\r\n
+        \     \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
         \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
         \       {\r\n          \"threshold\": 90.0,\r\n          \"name\": \"cond0\",\r\n
@@ -1589,9 +2492,10 @@ interactions:
         \         \"metricName\": \"Percentage CPU\",\r\n          \"dimensions\":
         [],\r\n          \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
         \"Average\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \       }\r\n      ],\r\n      \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \   },\r\n    \"targetResourceType\": \"microsoft.compute/virtualmachines\",\r\n
-        \   \"actions\": [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \       }\r\n      ],\r\n      \"odata.type\": \"Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria\"\r\n
+        \   },\r\n    \"targetResourceType\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \   \"targetResourceRegion\": \"global\",\r\n    \"actions\": [\r\n      {\r\n
+        \       \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     headers:
       api-supported-versions:
@@ -1599,11 +2503,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1526'
+      - '1768'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 04:02:57 GMT
+      - Mon, 17 Feb 2020 06:10:43 GMT
       expires:
       - '-1'
       pragma:
@@ -1653,7 +2557,8 @@ interactions:
         \     \"type\": \"Microsoft.Insights/metricAlerts\",\r\n      \"name\": \"alert1\",\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
         \     \"properties\": {\r\n        \"description\": \"High CPU\",\r\n        \"severity\":
-        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\"\r\n
+        2,\r\n        \"enabled\": true,\r\n        \"scopes\": [\r\n          \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\",\r\n
+        \         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\"\r\n
         \       ],\r\n        \"evaluationFrequency\": \"PT1M\",\r\n        \"windowSize\":
         \"PT5M\",\r\n        \"templateType\": 8,\r\n        \"criteria\": {\r\n          \"allOf\":
         [\r\n            {\r\n              \"threshold\": 90.0,\r\n              \"name\":
@@ -1661,9 +2566,10 @@ interactions:
         \             \"metricName\": \"Percentage CPU\",\r\n              \"dimensions\":
         [],\r\n              \"operator\": \"GreaterThan\",\r\n              \"timeAggregation\":
         \"Average\",\r\n              \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \       },\r\n        \"targetResourceType\": \"microsoft.compute/virtualmachines\",\r\n
-        \       \"actions\": [\r\n          {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \           }\r\n          ],\r\n          \"odata.type\": \"Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria\"\r\n
+        \       },\r\n        \"targetResourceType\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \       \"targetResourceRegion\": \"global\",\r\n        \"actions\": [\r\n
+        \         {\r\n            \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
         \         }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
     headers:
       api-supported-versions:
@@ -1671,11 +2577,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1703'
+      - '1953'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 04:03:00 GMT
+      - Mon, 17 Feb 2020 06:10:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1700,9 +2606,10 @@ interactions:
 - request:
     body: 'b''{"location": "global", "properties": {"description": "High CPU", "severity":
       2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1",
-      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"],
-      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.compute/virtualmachines",
-      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2",
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3"],
+      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "Microsoft.Compute/virtualMachines",
+      "targetResourceRegion": "global", "criteria": {"odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
       "allOf": [{"name": "cond0", "metricName": "Percentage CPU", "metricNamespace":
       "microsoft.compute/virtualmachines", "timeAggregation": "Average", "dimensions":
       [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
@@ -1717,7 +2624,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1182'
+      - '1412'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -1731,75 +2638,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/alert1?api-version=2018-03-01
   response:
     body:
-      string: '{"Code":"BadRequest","Message":"Scopes property is invalid. Only single
-        resource is allowed for criteria type SingleResourceMultipleMetricCriteria.
-        If you want to create an alert on multiple resources, use MultipleResourceMultipleMetricCriteria
-        odata.type."}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '258'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 17 Feb 2020 04:03:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 400
-      message: BadRequest
-- request:
-    body: 'b''{"location": "global", "properties": {"description": "High CPU", "severity":
-      2, "enabled": true, "scopes": ["/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"],
-      "evaluationFrequency": "PT1M", "windowSize": "PT5M", "targetResourceType": "microsoft.compute/virtualmachines",
-      "criteria": {"odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
-      "allOf": [{"name": "cond0", "metricName": "Percentage CPU", "metricNamespace":
-      "microsoft.compute/virtualmachines", "timeAggregation": "Average", "dimensions":
-      [], "criterionType": "StaticThresholdCriterion", "operator": "GreaterThan",
-      "threshold": 90.0}]}, "actions": [{"actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1"}]}}'''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - monitor clone
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '988'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - --source-resource --target-resource
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-monitor/0.7.0 Azure-SDK-For-Python AZURECLI/2.1.0
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/vm2-88888888-0000-0000-0000-000000000001?api-version=2018-03-01
-  response:
-    body:
       string: "{\r\n  \"location\": \"global\",\r\n  \"type\": \"Microsoft.Insights/metricAlerts\",\r\n
-        \ \"name\": \"vm2-88888888-0000-0000-0000-000000000001\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/vm2-88888888-0000-0000-0000-000000000001\",\r\n
+        \ \"name\": \"alert1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/metricAlerts/alert1\",\r\n
         \ \"properties\": {\r\n    \"description\": \"High CPU\",\r\n    \"severity\":
-        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\"\r\n
+        2,\r\n    \"enabled\": true,\r\n    \"scopes\": [\r\n      \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\",\r\n
+        \     \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\",\r\n
+        \     \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3\"\r\n
         \   ],\r\n    \"evaluationFrequency\": \"PT1M\",\r\n    \"windowSize\": \"PT5M\",\r\n
         \   \"templateType\": 8,\r\n    \"criteria\": {\r\n      \"allOf\": [\r\n
         \       {\r\n          \"threshold\": 90.0,\r\n          \"name\": \"cond0\",\r\n
@@ -1807,9 +2651,10 @@ interactions:
         \         \"metricName\": \"Percentage CPU\",\r\n          \"dimensions\":
         [],\r\n          \"operator\": \"GreaterThan\",\r\n          \"timeAggregation\":
         \"Average\",\r\n          \"criterionType\": \"StaticThresholdCriterion\"\r\n
-        \       }\r\n      ],\r\n      \"odata.type\": \"Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria\"\r\n
-        \   },\r\n    \"targetResourceType\": \"microsoft.compute/virtualmachines\",\r\n
-        \   \"actions\": [\r\n      {\r\n        \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
+        \       }\r\n      ],\r\n      \"odata.type\": \"Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria\"\r\n
+        \   },\r\n    \"targetResourceType\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \   \"targetResourceRegion\": \"global\",\r\n    \"actions\": [\r\n      {\r\n
+        \       \"actionGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/actionGroups/ag1\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     headers:
       api-supported-versions:
@@ -1817,11 +2662,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1594'
+      - '1969'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 04:03:16 GMT
+      - Mon, 17 Feb 2020 06:10:55 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_vm_metric_alerts_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/recordings/test_monitor_clone_vm_metric_alerts_scenario.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T06:00:34Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:51:24Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:00:45 GMT
+      - Mon, 02 Mar 2020 05:51:32 GMT
       expires:
       - '-1'
       pragma:
@@ -109,13 +109,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:00:46 GMT
+      - Mon, 02 Mar 2020 05:51:34 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Mon, 17 Feb 2020 06:05:46 GMT
+      - Mon, 02 Mar 2020 05:56:34 GMT
       source-age:
-      - '84'
+      - '0'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -126,21 +126,21 @@ interactions:
       x-cache:
       - HIT, HIT
       x-cache-hits:
-      - 3, 1
+      - 2, 1
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 62bb33160ca0a4265cd2410af2d29fe778a965e2
+      - 417cc799aef3e5dd76ef0095bf62a06ef73601cc
       x-frame-options:
       - deny
       x-geo-block-list:
       - ''
       x-github-request-id:
-      - 155E:1821:1AEEF3:1D42A5:5E4A0FEA
+      - 649E:3977:3515AA:38D385:5E5C797C
       x-served-by:
-      - cache-tyo19937-TYO
+      - cache-sin18032-SIN
       x-timer:
-      - S1581919247.729939,VS0,VE165
+      - S1583128294.336475,VS0,VE238
       x-xss-protection:
       - 1; mode=block
     status:
@@ -177,7 +177,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:00:48 GMT
+      - Mon, 02 Mar 2020 05:51:35 GMT
       expires:
       - '-1'
       pragma:
@@ -247,10 +247,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_mOmr6nSDGMuHRZKBmcyMmRPnlkOqx7gh","name":"vm_deploy_mOmr6nSDGMuHRZKBmcyMmRPnlkOqx7gh","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12328411686541392177","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-17T06:00:56.682182Z","duration":"PT3.4993507S","correlationId":"165fbb0d-dfa6-430a-9d94-69485e1d969f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_3plnHlb43kSk05Xuxh4v1uycH9N05ZrE","name":"vm_deploy_3plnHlb43kSk05Xuxh4v1uycH9N05ZrE","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1593909882942689085","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-03-02T05:51:41.6732828Z","duration":"PT3.7434123S","correlationId":"75ba91ad-864c-44d0-8cee-1c13a5fb8409","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_mOmr6nSDGMuHRZKBmcyMmRPnlkOqx7gh/operationStatuses/08586196876322947994?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_3plnHlb43kSk05Xuxh4v1uycH9N05ZrE/operationStatuses/08586184785875477621?api-version=2019-07-01
       cache-control:
       - no-cache
       content-length:
@@ -258,7 +258,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:00:57 GMT
+      - Mon, 02 Mar 2020 05:51:43 GMT
       expires:
       - '-1'
       pragma:
@@ -268,7 +268,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1197'
     status:
       code: 201
       message: Created
@@ -289,7 +289,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184785875477621?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -301,7 +301,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:01:29 GMT
+      - Mon, 02 Mar 2020 05:52:14 GMT
       expires:
       - '-1'
       pragma:
@@ -332,7 +332,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184785875477621?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -344,7 +344,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:02:00 GMT
+      - Mon, 02 Mar 2020 05:52:44 GMT
       expires:
       - '-1'
       pragma:
@@ -375,7 +375,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184785875477621?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -387,7 +387,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:02:30 GMT
+      - Mon, 02 Mar 2020 05:53:14 GMT
       expires:
       - '-1'
       pragma:
@@ -418,136 +418,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 17 Feb 2020 06:03:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --admin-password --admin-username --authentication-type
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 17 Feb 2020 06:03:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --admin-password --admin-username --authentication-type
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 17 Feb 2020 06:04:02 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --admin-password --admin-username --authentication-type
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196876322947994?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184785875477621?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -559,7 +430,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:04:32 GMT
+      - Mon, 02 Mar 2020 05:53:46 GMT
       expires:
       - '-1'
       pragma:
@@ -593,7 +464,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_mOmr6nSDGMuHRZKBmcyMmRPnlkOqx7gh","name":"vm_deploy_mOmr6nSDGMuHRZKBmcyMmRPnlkOqx7gh","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12328411686541392177","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-17T06:04:02.6861895Z","duration":"PT3M9.5033582S","correlationId":"165fbb0d-dfa6-430a-9d94-69485e1d969f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_3plnHlb43kSk05Xuxh4v1uycH9N05ZrE","name":"vm_deploy_3plnHlb43kSk05Xuxh4v1uycH9N05ZrE","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1593909882942689085","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-03-02T05:53:22.3856184Z","duration":"PT1M44.4557479S","correlationId":"75ba91ad-864c-44d0-8cee-1c13a5fb8409","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'
     headers:
       cache-control:
       - no-cache
@@ -602,7 +473,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:04:32 GMT
+      - Mon, 02 Mar 2020 05:53:46 GMT
       expires:
       - '-1'
       pragma:
@@ -640,16 +511,16 @@ interactions:
     body:
       string: "{\r\n  \"name\": \"vm1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm1\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"cd6d1718-3adc-4529-9fea-565c605a877d\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"06494543-ab13-4f16-86e3-184af422959b\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202002080\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"vm1_disk1_b872e05ac914429eae6f760f14d28f9e\",\r\n
+        \"18.04.202002180\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"vm1_disk1_4da229dcef60467cbb1bda305633c839\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGG657KKXIHXHG4R6XVNKK5DGVMZKS7B2ISMHN7I33DSJBI7WON42CWKBMGFF7LWCSK/providers/Microsoft.Compute/disks/vm1_disk1_b872e05ac914429eae6f760f14d28f9e\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGNLNV4REOMEQAR6YMRAUWJ25X63OGOVLIZSWTJLKMHC4VTO4LBRQGSNC4XDFO2NTYX/providers/Microsoft.Compute/disks/vm1_disk1_4da229dcef60467cbb1bda305633c839\"\r\n
         \       },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n
         \     \"adminUsername\": \"testadmin\",\r\n      \"linuxConfiguration\": {\r\n
@@ -663,15 +534,15 @@ interactions:
         [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
         \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
         \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2020-02-17T06:04:33+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_disk1_b872e05ac914429eae6f760f14d28f9e\",\r\n
+        \"2020-03-02T05:53:48+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_disk1_4da229dcef60467cbb1bda305633c839\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-02-17T06:03:24.7183177+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-03-02T05:52:21.6695277+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2020-02-17T06:03:56.9216067+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2020-03-02T05:53:04.013275+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -679,11 +550,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '3172'
+      - '3171'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:04:35 GMT
+      - Mon, 02 Mar 2020 05:53:48 GMT
       expires:
       - '-1'
       pragma:
@@ -700,7 +571,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3996,Microsoft.Compute/LowCostGet30Min;31971
+      - Microsoft.Compute/LowCostGet3Min;3995,Microsoft.Compute/LowCostGet30Min;31985
     status:
       code: 200
       message: OK
@@ -727,12 +598,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\",\r\n
-        \ \"etag\": \"W/\\\"b528eb76-be35-44e3-b38c-ce9f0e36e1e5\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"99dd49a0-fd90-4edb-99db-8b7304e8dc60\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"c5e570dd-eb41-40ef-91f1-7db4ad1c9caf\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"fd96e07d-5366-4d0f-babf-390cd0e72ab4\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\",\r\n
-        \       \"etag\": \"W/\\\"b528eb76-be35-44e3-b38c-ce9f0e36e1e5\\\"\",\r\n
+        \       \"etag\": \"W/\\\"99dd49a0-fd90-4edb-99db-8b7304e8dc60\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
@@ -741,8 +612,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"vzvt5deiff2udcaatyypnl4kqb.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-1D-B2-36\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"gghzmrt5shjehct4zriu4doakb.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-8C-B4-28\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -756,9 +627,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:04:36 GMT
+      - Mon, 02 Mar 2020 05:53:52 GMT
       etag:
-      - W/"b528eb76-be35-44e3-b38c-ce9f0e36e1e5"
+      - W/"99dd49a0-fd90-4edb-99db-8b7304e8dc60"
       expires:
       - '-1'
       pragma:
@@ -775,7 +646,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - d27b8d49-e4da-450b-940a-308b8b58c04c
+      - 2cd8d965-e679-4e88-b02c-2228ccf08617
     status:
       code: 200
       message: OK
@@ -802,11 +673,11 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"8162e4e0-5f2e-4e1a-b7ce-ec4433497438\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"c7f85ec6-d550-4cc7-9e6c-012123eccaf1\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"d4dbc0be-65f3-43e6-a952-e6ef8af39d24\",\r\n
-        \   \"ipAddress\": \"40.121.11.154\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
-        \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"2583ab01-d4f8-47e9-a5de-32d2fcd394a9\",\r\n
+        \   \"ipAddress\": \"40.117.122.101\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -814,13 +685,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '997'
+      - '998'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:04:36 GMT
+      - Mon, 02 Mar 2020 05:53:53 GMT
       etag:
-      - W/"8162e4e0-5f2e-4e1a-b7ce-ec4433497438"
+      - W/"c7f85ec6-d550-4cc7-9e6c-012123eccaf1"
       expires:
       - '-1'
       pragma:
@@ -837,7 +708,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 164a6431-63ef-4b60-8fe6-0d9af82a0ac0
+      - 72ac99d1-6699-4ef4-8584-34fb84016693
     status:
       code: 200
       message: OK
@@ -863,7 +734,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T06:00:34Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:51:24Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -872,7 +743,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:04:38 GMT
+      - Mon, 02 Mar 2020 05:53:54 GMT
       expires:
       - '-1'
       pragma:
@@ -951,13 +822,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:04:39 GMT
+      - Mon, 02 Mar 2020 05:53:56 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Mon, 17 Feb 2020 06:09:39 GMT
+      - Mon, 02 Mar 2020 05:58:56 GMT
       source-age:
-      - '0'
+      - '142'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -968,21 +839,21 @@ interactions:
       x-cache:
       - HIT, HIT
       x-cache-hits:
-      - 3, 1
+      - 2, 2
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 481932013d6fcd0fd098b8a16cf23dcf2789da77
+      - 35ca432ed6f4829d5a7baeb3113bff2988ca46d0
       x-frame-options:
       - deny
       x-geo-block-list:
       - ''
       x-github-request-id:
-      - 155E:1821:1AEEF3:1D42A5:5E4A0FEA
+      - 649E:3977:3515AA:38D385:5E5C797C
       x-served-by:
-      - cache-tyo19946-TYO
+      - cache-sin18022-SIN
       x-timer:
-      - S1581919479.411123,VS0,VE265
+      - S1583128437.575133,VS0,VE0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -1012,14 +883,14 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\n      \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\",\r\n
-        \     \"etag\": \"W/\\\"95b7d44f-dbfe-42a7-9338-47945f160eff\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"383c3e5f-8004-4718-a224-c6a2b79ba515\\\"\",\r\n      \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
         \     \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
-        \"Succeeded\",\r\n        \"resourceGuid\": \"8c3f6bae-2988-4179-8800-9e30f6afca81\",\r\n
+        \"Succeeded\",\r\n        \"resourceGuid\": \"46968f31-917f-43d2-8a7e-cc514f0dc051\",\r\n
         \       \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n
         \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
         \"vm1Subnet\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\",\r\n
-        \           \"etag\": \"W/\\\"95b7d44f-dbfe-42a7-9338-47945f160eff\\\"\",\r\n
+        \           \"etag\": \"W/\\\"383c3e5f-8004-4718-a224-c6a2b79ba515\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"ipConfigurations\":
         [\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
@@ -1035,7 +906,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:04:40 GMT
+      - Mon, 02 Mar 2020 05:53:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1052,7 +923,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - ba04d5d0-d325-4069-85cf-05a1e299fae2
+      - c9911ec5-cc7f-4353-b7fd-3c5eb92b5fd4
     status:
       code: 200
       message: OK
@@ -1108,18 +979,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_1ffekicXUohnUlIVC6snMsDEZCDjwXu2","name":"vm_deploy_1ffekicXUohnUlIVC6snMsDEZCDjwXu2","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5137379213259568291","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-17T06:04:46.246396Z","duration":"PT2.6765175S","correlationId":"cdd4da59-d7fb-4445-98a5-5bf7615f48b3","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_7Yx4Gjgl8EMuaxlJoS3jPB0tvWOERq0p","name":"vm_deploy_7Yx4Gjgl8EMuaxlJoS3jPB0tvWOERq0p","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12127217334536644191","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-03-02T05:54:03.5909217Z","duration":"PT3.6753383S","correlationId":"d0c66d5b-2134-4b7a-96a5-c9380f66f45a","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_1ffekicXUohnUlIVC6snMsDEZCDjwXu2/operationStatuses/08586196874019077504?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_7Yx4Gjgl8EMuaxlJoS3jPB0tvWOERq0p/operationStatuses/08586184784455620465?api-version=2019-07-01
       cache-control:
       - no-cache
       content-length:
-      - '2442'
+      - '2444'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:04:47 GMT
+      - Mon, 02 Mar 2020 05:54:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1129,7 +1000,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1194'
     status:
       code: 201
       message: Created
@@ -1150,7 +1021,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196874019077504?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184784455620465?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1162,7 +1033,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:05:18 GMT
+      - Mon, 02 Mar 2020 05:54:36 GMT
       expires:
       - '-1'
       pragma:
@@ -1193,7 +1064,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196874019077504?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184784455620465?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1205,7 +1076,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:05:49 GMT
+      - Mon, 02 Mar 2020 05:55:06 GMT
       expires:
       - '-1'
       pragma:
@@ -1236,7 +1107,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196874019077504?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184784455620465?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1248,7 +1119,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:06:19 GMT
+      - Mon, 02 Mar 2020 05:55:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1279,7 +1150,50 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196874019077504?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184784455620465?api-version=2019-07-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 02 Mar 2020 05:56:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --admin-password --admin-username --authentication-type
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184784455620465?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1291,7 +1205,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:06:50 GMT
+      - Mon, 02 Mar 2020 05:56:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1325,16 +1239,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_1ffekicXUohnUlIVC6snMsDEZCDjwXu2","name":"vm_deploy_1ffekicXUohnUlIVC6snMsDEZCDjwXu2","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5137379213259568291","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-17T06:06:50.2879103Z","duration":"PT2M6.7180318S","correlationId":"cdd4da59-d7fb-4445-98a5-5bf7615f48b3","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_7Yx4Gjgl8EMuaxlJoS3jPB0tvWOERq0p","name":"vm_deploy_7Yx4Gjgl8EMuaxlJoS3jPB0tvWOERq0p","type":"Microsoft.Resources/deployments","properties":{"templateHash":"12127217334536644191","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-03-02T05:56:29.3549233Z","duration":"PT2M29.4393399S","correlationId":"d0c66d5b-2134-4b7a-96a5-c9380f66f45a","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm2PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm2VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm2"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3305'
+      - '3307'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:06:51 GMT
+      - Mon, 02 Mar 2020 05:56:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1372,16 +1286,16 @@ interactions:
     body:
       string: "{\r\n  \"name\": \"vm2\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm2\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"cb1b7ba2-13ee-479c-ab4d-628f8495c908\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"1605abbc-d417-4752-9651-1148b534bac7\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202002080\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"vm2_disk1_75f20397afea4cde96007ce89faf6b3a\",\r\n
+        \"18.04.202002180\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"vm2_disk1_192c9332abba44198b0752e57a15b720\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGG657KKXIHXHG4R6XVNKK5DGVMZKS7B2ISMHN7I33DSJBI7WON42CWKBMGFF7LWCSK/providers/Microsoft.Compute/disks/vm2_disk1_75f20397afea4cde96007ce89faf6b3a\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGNLNV4REOMEQAR6YMRAUWJ25X63OGOVLIZSWTJLKMHC4VTO4LBRQGSNC4XDFO2NTYX/providers/Microsoft.Compute/disks/vm2_disk1_192c9332abba44198b0752e57a15b720\"\r\n
         \       },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2\",\r\n
         \     \"adminUsername\": \"testadmin\",\r\n      \"linuxConfiguration\": {\r\n
@@ -1389,21 +1303,21 @@ interactions:
         true\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
         true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
         {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\"}]},\r\n
-        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
-        {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n        \"statuses\": [\r\n
-        \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
-        \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
-        Ready\",\r\n            \"message\": \"VM status blob is found but not yet
-        populated.\",\r\n            \"time\": \"2020-02-17T06:06:53+00:00\"\r\n          }\r\n
-        \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
-        \"vm2_disk1_75f20397afea4cde96007ce89faf6b3a\",\r\n          \"statuses\":
-        [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"computerName\":
+        \"vm2\",\r\n      \"osName\": \"ubuntu\",\r\n      \"osVersion\": \"18.04\",\r\n
+        \     \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.46\",\r\n        \"statuses\":
+        [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
+        \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
+        \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
+        \"2020-03-02T05:56:40+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm2_disk1_192c9332abba44198b0752e57a15b720\",\r\n
+        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-02-17T06:06:25.0474392+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-03-02T05:55:52.4040679+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2020-02-17T06:06:44.5006919+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2020-03-02T05:56:24.1698846+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -1411,11 +1325,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '3086'
+      - '3172'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:06:53 GMT
+      - Mon, 02 Mar 2020 05:56:41 GMT
       expires:
       - '-1'
       pragma:
@@ -1432,7 +1346,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3990,Microsoft.Compute/LowCostGet30Min;31969
+      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31984
     status:
       code: 200
       message: OK
@@ -1459,12 +1373,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm2VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic\",\r\n
-        \ \"etag\": \"W/\\\"42b659e6-33d2-40aa-b552-37854d9685be\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"1408ed30-dd2c-4b4c-b46e-5633e7db34a5\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"918c06a0-6665-46ce-8747-eb809275e88f\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"ecde75bc-dfd2-4685-ba6d-ec277b3f8b84\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm2\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\",\r\n
-        \       \"etag\": \"W/\\\"42b659e6-33d2-40aa-b552-37854d9685be\\\"\",\r\n
+        \       \"etag\": \"W/\\\"1408ed30-dd2c-4b4c-b46e-5633e7db34a5\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
@@ -1473,8 +1387,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"vzvt5deiff2udcaatyypnl4kqb.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-8D-0E-6D\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"gghzmrt5shjehct4zriu4doakb.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-11-3F-5E\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm2NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -1488,9 +1402,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:06:54 GMT
+      - Mon, 02 Mar 2020 05:56:42 GMT
       etag:
-      - W/"42b659e6-33d2-40aa-b552-37854d9685be"
+      - W/"1408ed30-dd2c-4b4c-b46e-5633e7db34a5"
       expires:
       - '-1'
       pragma:
@@ -1507,7 +1421,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 498c1dcf-5b9d-41b5-9a98-b5a0d067b50e
+      - ff1899de-2bfe-4689-aed3-9f31db0d6bbf
     status:
       code: 200
       message: OK
@@ -1534,11 +1448,11 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm2PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm2PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"3e85be94-e727-44ab-96e0-aebf7b3205c9\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"3ad1c8a8-6474-48b8-9dc4-1a944350d267\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"1a20e11a-7d65-4abf-9fc5-3177c6207f0d\",\r\n
-        \   \"ipAddress\": \"52.224.219.244\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"1a8122be-0bf5-4352-9d6f-4554ca3afc65\",\r\n
+        \   \"ipAddress\": \"13.82.131.229\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm2VMNic/ipConfigurations/ipconfigvm2\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -1546,13 +1460,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '998'
+      - '997'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:06:55 GMT
+      - Mon, 02 Mar 2020 05:56:43 GMT
       etag:
-      - W/"3e85be94-e727-44ab-96e0-aebf7b3205c9"
+      - W/"3ad1c8a8-6474-48b8-9dc4-1a944350d267"
       expires:
       - '-1'
       pragma:
@@ -1569,7 +1483,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e4f98e8d-527b-49ac-a44e-a6a953f9fde1
+      - 2f22b90b-6c60-4a83-9c39-a1988479c88b
     status:
       code: 200
       message: OK
@@ -1595,7 +1509,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-02-17T06:00:34Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-03-02T05:51:24Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1604,7 +1518,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:06:56 GMT
+      - Mon, 02 Mar 2020 05:56:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1683,13 +1597,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:06:58 GMT
+      - Mon, 02 Mar 2020 05:56:45 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Mon, 17 Feb 2020 06:11:58 GMT
+      - Mon, 02 Mar 2020 06:01:45 GMT
       source-age:
-      - '139'
+      - '31'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -1700,21 +1614,21 @@ interactions:
       x-cache:
       - HIT, HIT
       x-cache-hits:
-      - 3, 2
+      - 2, 1
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - a7588ce7b1bce1ef79c4c1948a6960c6e98e3eae
+      - fbdd13cc029900ea3fab07b80f852389c2d57b9f
       x-frame-options:
       - deny
       x-geo-block-list:
       - ''
       x-github-request-id:
-      - 155E:1821:1AEEF3:1D42A5:5E4A0FEA
+      - 649E:3977:3515AA:38D385:5E5C797C
       x-served-by:
-      - cache-tyo19946-TYO
+      - cache-sin18051-SIN
       x-timer:
-      - S1581919618.209163,VS0,VE0
+      - S1583128605.463884,VS0,VE220
       x-xss-protection:
       - 1; mode=block
     status:
@@ -1744,14 +1658,14 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"vm1VNET\",\r\n      \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET\",\r\n
-        \     \"etag\": \"W/\\\"56f2720b-88c1-4595-b69e-26dbf201af20\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"dff98f68-e11d-4c26-849b-ddf0def25be3\\\"\",\r\n      \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"eastus\",\r\n
         \     \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
-        \"Succeeded\",\r\n        \"resourceGuid\": \"8c3f6bae-2988-4179-8800-9e30f6afca81\",\r\n
+        \"Succeeded\",\r\n        \"resourceGuid\": \"46968f31-917f-43d2-8a7e-cc514f0dc051\",\r\n
         \       \"addressSpace\": {\r\n          \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n
         \         ]\r\n        },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
         \"vm1Subnet\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vm1VNET/subnets/vm1Subnet\",\r\n
-        \           \"etag\": \"W/\\\"56f2720b-88c1-4595-b69e-26dbf201af20\\\"\",\r\n
+        \           \"etag\": \"W/\\\"dff98f68-e11d-4c26-849b-ddf0def25be3\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"ipConfigurations\":
         [\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
@@ -1768,7 +1682,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:06:59 GMT
+      - Mon, 02 Mar 2020 05:56:46 GMT
       expires:
       - '-1'
       pragma:
@@ -1785,7 +1699,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 7acd28db-e618-478f-8b32-dc56a8e2de30
+      - eb6b537a-7e5d-49be-b21e-d3b2b1bc54ea
     status:
       code: 200
       message: OK
@@ -1841,18 +1755,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_ehW0iKMe2yAEqpvQmWNMOkPt6sLvp7Xw","name":"vm_deploy_ehW0iKMe2yAEqpvQmWNMOkPt6sLvp7Xw","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13073710376040538704","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-02-17T06:07:08.4473889Z","duration":"PT4.5452992S","correlationId":"c3cb2471-ee8f-45f0-b10f-fdb10f7542b9","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_Mbg6D8vfDVhVdG2t5znvGl6kRiYgtQSP","name":"vm_deploy_Mbg6D8vfDVhVdG2t5znvGl6kRiYgtQSP","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8100029313971362939","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-03-02T05:56:53.008244Z","duration":"PT3.9074986S","correlationId":"d6b40d6c-9387-4f69-9f3a-a3109eb7128a","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_ehW0iKMe2yAEqpvQmWNMOkPt6sLvp7Xw/operationStatuses/08586196872615755319?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_Mbg6D8vfDVhVdG2t5znvGl6kRiYgtQSP/operationStatuses/08586184782763768789?api-version=2019-07-01
       cache-control:
       - no-cache
       content-length:
-      - '2444'
+      - '2442'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:07:09 GMT
+      - Mon, 02 Mar 2020 05:56:54 GMT
       expires:
       - '-1'
       pragma:
@@ -1883,7 +1797,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184782763768789?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1895,7 +1809,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:07:41 GMT
+      - Mon, 02 Mar 2020 05:57:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1926,7 +1840,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184782763768789?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1938,7 +1852,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:08:11 GMT
+      - Mon, 02 Mar 2020 05:57:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1969,7 +1883,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184782763768789?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1981,7 +1895,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:08:43 GMT
+      - Mon, 02 Mar 2020 05:58:26 GMT
       expires:
       - '-1'
       pragma:
@@ -2012,7 +1926,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184782763768789?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -2024,7 +1938,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:09:13 GMT
+      - Mon, 02 Mar 2020 05:58:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2055,50 +1969,7 @@ interactions:
       - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
         azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 17 Feb 2020 06:09:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --image --admin-password --admin-username --authentication-type
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.1.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586196872615755319?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586184782763768789?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -2110,7 +1981,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:10:14 GMT
+      - Mon, 02 Mar 2020 05:59:28 GMT
       expires:
       - '-1'
       pragma:
@@ -2144,7 +2015,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_ehW0iKMe2yAEqpvQmWNMOkPt6sLvp7Xw","name":"vm_deploy_ehW0iKMe2yAEqpvQmWNMOkPt6sLvp7Xw","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13073710376040538704","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-02-17T06:10:05.2327952Z","duration":"PT3M1.3307055S","correlationId":"c3cb2471-ee8f-45f0-b10f-fdb10f7542b9","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_Mbg6D8vfDVhVdG2t5znvGl6kRiYgtQSP","name":"vm_deploy_Mbg6D8vfDVhVdG2t5znvGl6kRiYgtQSP","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8100029313971362939","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-03-02T05:59:02.1672847Z","duration":"PT2M13.0665393S","correlationId":"d6b40d6c-9387-4f69-9f3a-a3109eb7128a","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["eastus"]},{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm3PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm3VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm3"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP"}]}}'
     headers:
       cache-control:
       - no-cache
@@ -2153,7 +2024,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:10:15 GMT
+      - Mon, 02 Mar 2020 05:59:28 GMT
       expires:
       - '-1'
       pragma:
@@ -2191,16 +2062,16 @@ interactions:
     body:
       string: "{\r\n  \"name\": \"vm3\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/vm3\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"1e27caaa-79b5-4855-892d-11ddccc9133f\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"064b87e9-3d4b-46a8-8eee-2d8ab5a0dc21\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
         \"18.04-LTS\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"18.04.202002080\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"vm3_disk1_b44d271eeb2449ea9daa6686ffe56a6a\",\r\n
+        \"18.04.202002180\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"vm3_disk1_0ab41f6774a9455d9dd502c3933a9f9e\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGG657KKXIHXHG4R6XVNKK5DGVMZKS7B2ISMHN7I33DSJBI7WON42CWKBMGFF7LWCSK/providers/Microsoft.Compute/disks/vm3_disk1_b44d271eeb2449ea9daa6686ffe56a6a\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGNLNV4REOMEQAR6YMRAUWJ25X63OGOVLIZSWTJLKMHC4VTO4LBRQGSNC4XDFO2NTYX/providers/Microsoft.Compute/disks/vm3_disk1_0ab41f6774a9455d9dd502c3933a9f9e\"\r\n
         \       },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm3\",\r\n
         \     \"adminUsername\": \"testadmin\",\r\n      \"linuxConfiguration\": {\r\n
@@ -2208,21 +2079,21 @@ interactions:
         true\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
         true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
         {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic\"}]},\r\n
-        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
-        {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n        \"statuses\": [\r\n
-        \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
-        \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
-        Ready\",\r\n            \"message\": \"VM status blob is found but not yet
-        populated.\",\r\n            \"time\": \"2020-02-17T06:10:18+00:00\"\r\n          }\r\n
-        \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
-        \"vm3_disk1_b44d271eeb2449ea9daa6686ffe56a6a\",\r\n          \"statuses\":
-        [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"computerName\":
+        \"vm3\",\r\n      \"osName\": \"ubuntu\",\r\n      \"osVersion\": \"18.04\",\r\n
+        \     \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.46\",\r\n        \"statuses\":
+        [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
+        \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
+        \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
+        \"2020-03-02T05:59:29+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm3_disk1_0ab41f6774a9455d9dd502c3933a9f9e\",\r\n
+        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-02-17T06:09:18.2046308+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-03-02T05:58:42.2017811+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2020-02-17T06:10:00.6424017+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2020-03-02T05:58:56.9518804+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -2230,11 +2101,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '3086'
+      - '3172'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:10:17 GMT
+      - Mon, 02 Mar 2020 05:59:30 GMT
       expires:
       - '-1'
       pragma:
@@ -2251,7 +2122,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3993,Microsoft.Compute/LowCostGet30Min;31964
+      - Microsoft.Compute/LowCostGet3Min;3995,Microsoft.Compute/LowCostGet30Min;31979
     status:
       code: 200
       message: OK
@@ -2278,12 +2149,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm3VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic\",\r\n
-        \ \"etag\": \"W/\\\"aa02b95b-4575-4df1-8021-4b85d2c47829\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"121543ef-de36-4fbe-9c90-03ce675b77e4\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"7378e5be-1872-4a9b-8882-3cbf65bfb108\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"e126cdef-3888-4b60-84c7-80da52c41506\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm3\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic/ipConfigurations/ipconfigvm3\",\r\n
-        \       \"etag\": \"W/\\\"aa02b95b-4575-4df1-8021-4b85d2c47829\\\"\",\r\n
+        \       \"etag\": \"W/\\\"121543ef-de36-4fbe-9c90-03ce675b77e4\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.6\",\r\n          \"privateIPAllocationMethod\":
@@ -2292,8 +2163,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"vzvt5deiff2udcaatyypnl4kqb.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-18-D7-AD\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"gghzmrt5shjehct4zriu4doakb.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-11-92-07\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/vm3NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -2307,9 +2178,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:10:18 GMT
+      - Mon, 02 Mar 2020 05:59:32 GMT
       etag:
-      - W/"aa02b95b-4575-4df1-8021-4b85d2c47829"
+      - W/"121543ef-de36-4fbe-9c90-03ce675b77e4"
       expires:
       - '-1'
       pragma:
@@ -2326,7 +2197,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 478efa92-86c4-4090-b38b-e1bc300780b3
+      - c3a80c46-a188-4191-a08b-6661bf0ca4c2
     status:
       code: 200
       message: OK
@@ -2353,10 +2224,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm3PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/vm3PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"bf2aee70-caee-43cc-9bb2-04302c5c4cd9\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"4e9cdfaf-59b9-4c21-be37-44797ef4f1f2\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"236aeb87-8d6e-435a-aa0f-6107af486f00\",\r\n
-        \   \"ipAddress\": \"13.90.18.169\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"8c85c138-2bc1-41c1-adcc-ecf98f5245a6\",\r\n
+        \   \"ipAddress\": \"40.76.29.68\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
         \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/vm3VMNic/ipConfigurations/ipconfigvm3\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
@@ -2365,13 +2236,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '996'
+      - '995'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:10:19 GMT
+      - Mon, 02 Mar 2020 05:59:33 GMT
       etag:
-      - W/"bf2aee70-caee-43cc-9bb2-04302c5c4cd9"
+      - W/"4e9cdfaf-59b9-4c21-be37-44797ef4f1f2"
       expires:
       - '-1'
       pragma:
@@ -2388,7 +2259,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 877cffa6-f961-42d2-a306-5799b69f46fe
+      - 3895bab1-3357-4e9c-bb4d-bf9275405993
     status:
       code: 200
       message: OK
@@ -2431,7 +2302,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:10:27 GMT
+      - Mon, 02 Mar 2020 05:59:42 GMT
       expires:
       - '-1'
       pragma:
@@ -2443,7 +2314,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -2507,7 +2378,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:10:43 GMT
+      - Mon, 02 Mar 2020 05:59:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2525,7 +2396,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '297'
       x-powered-by:
       - ASP.NET
     status:
@@ -2581,7 +2452,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:10:45 GMT
+      - Mon, 02 Mar 2020 06:00:00 GMT
       expires:
       - '-1'
       pragma:
@@ -2666,7 +2537,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 17 Feb 2020 06:10:55 GMT
+      - Mon, 02 Mar 2020 06:00:06 GMT
       expires:
       - '-1'
       pragma:
@@ -2684,7 +2555,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
@@ -5,11 +5,13 @@
 
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
 import mock
+from msrestazure.tools import resource_id
 
 
 class MonitorGeneralScenarios(ScenarioTest):
     @ResourceGroupPreparer(location='eastus')
     def test_monitor_clone_vm_metric_alerts_scenario(self, resource_group):
+        self.test_guid_count = 0
         self.kwargs.update({
             'alert': 'alert1',
             'vm1': 'vm1',
@@ -53,7 +55,7 @@ class MonitorGeneralScenarios(ScenarioTest):
     @StorageAccountPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_2')
     def test_monitor_clone_storage_metric_alerts_scenario(self, resource_group, storage_account, storage_account_2):
-        from msrestazure.tools import resource_id
+        self.test_guid_count = 0
         self.kwargs.update({
             'alert': 'alert1',
             'sa': storage_account,
@@ -99,7 +101,7 @@ class MonitorGeneralScenarios(ScenarioTest):
 
     @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')
     def test_monitor_clone_public_ip_metric_alerts_scenario(self, resource_group):
-        from msrestazure.tools import resource_id
+        self.test_guid_count = 0
         self.kwargs.update({
             'alert': 'alert1',
             'alert2': 'alert2',

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
@@ -8,7 +8,7 @@ import mock
 from msrestazure.tools import resource_id
 
 
-class MonitorGeneralScenarios(ScenarioTest):
+class MonitorCloneVMScenarios(ScenarioTest):
     @ResourceGroupPreparer(location='eastus')
     def test_monitor_clone_vm_metric_alerts_scenario(self, resource_group):
         self.test_guid_count = 0
@@ -51,6 +51,8 @@ class MonitorGeneralScenarios(ScenarioTest):
                 self.check('length(scopes)', 3)
             ])
 
+
+class MonitorCloneStorageAccountScenarios(ScenarioTest):
     @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')
     @StorageAccountPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_2')
@@ -99,6 +101,8 @@ class MonitorGeneralScenarios(ScenarioTest):
                 self.check('length(criteria.allOf[1].dimensions)', 1),
             ])
 
+
+class MonitorClonePublicIpScenarios(ScenarioTest):
     @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')
     def test_monitor_clone_public_ip_metric_alerts_scenario(self, resource_group):
         self.test_guid_count = 0

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
@@ -1,3 +1,4 @@
+# --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
@@ -21,27 +21,30 @@ class MonitorGeneralScenarios(ScenarioTest):
                            'testadmin --authentication-type password').get_output_in_json()
         vm2_json = self.cmd('vm create -g {rg} -n {vm2} --image UbuntuLTS --admin-password TestPassword11!! --admin-username '
                            'testadmin --authentication-type password').get_output_in_json()
+        vm3_json = self.cmd('vm create -g {rg} -n {vm3} --image UbuntuLTS --admin-password TestPassword11!! --admin-username '
+                           'testadmin --authentication-type password').get_output_in_json()
         self.kwargs.update({
             'vm1_id': vm1_json['id'],
-            'vm2_id': vm2_json['id']
+            'vm2_id': vm2_json['id'],
+            'vm3_id': vm3_json['id']
         })
         self.cmd('monitor action-group create -g {rg} -n {ag1}')
-        self.cmd('monitor metrics alert create -g {rg} -n {alert} --scopes {vm1_id} --action {ag1} --condition "avg Percentage CPU > 90" --description "High CPU"', checks=[
+        self.cmd('monitor metrics alert create -g {rg} -n {alert} --scopes {vm1_id} {vm2_id} --action {ag1} --condition "avg Percentage CPU > 90" --description "High CPU"', checks=[
             self.check('description', 'High CPU'),
             self.check('severity', 2),
             self.check('autoMitigate', None),
             self.check('windowSize', '0:05:00'),
             self.check('evaluationFrequency', '0:01:00'),
-            self.check('length(scopes)', 1)
+            self.check('length(scopes)', 2)
         ])
         with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
-            self.cmd('monitor clone --source-resource {vm1_id} --target-resource {vm2_id}', checks=[
+            self.cmd('monitor clone --source-resource {vm1_id} --target-resource {vm3_id}', checks=[
                 self.check('description', 'High CPU'),
                 self.check('severity', 2),
                 self.check('autoMitigate', None),
                 self.check('windowSize', '0:05:00'),
                 self.check('evaluationFrequency', '0:01:00'),
-                self.check('length(scopes)', 1)
+                self.check('length(scopes)', 3)
             ])
 
     @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
@@ -5,6 +5,7 @@
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
 import mock
 
+
 class MonitorGeneralScenarios(ScenarioTest):
     @ResourceGroupPreparer(location='eastus')
     def test_monitor_clone_vm_metric_alerts_scenario(self, resource_group):
@@ -17,12 +18,12 @@ class MonitorGeneralScenarios(ScenarioTest):
             'rg': resource_group
         })
 
-        vm1_json = self.cmd('vm create -g {rg} -n {vm1} --image UbuntuLTS --admin-password TestPassword11!! --admin-username '
-                           'testadmin --authentication-type password').get_output_in_json()
-        vm2_json = self.cmd('vm create -g {rg} -n {vm2} --image UbuntuLTS --admin-password TestPassword11!! --admin-username '
-                           'testadmin --authentication-type password').get_output_in_json()
-        vm3_json = self.cmd('vm create -g {rg} -n {vm3} --image UbuntuLTS --admin-password TestPassword11!! --admin-username '
-                           'testadmin --authentication-type password').get_output_in_json()
+        vm1_json = self.cmd('vm create -g {rg} -n {vm1} --image UbuntuLTS --admin-password TestPassword11!! '
+                            '--admin-username testadmin --authentication-type password').get_output_in_json()
+        vm2_json = self.cmd('vm create -g {rg} -n {vm2} --image UbuntuLTS --admin-password TestPassword11!! '
+                            '--admin-username testadmin --authentication-type password').get_output_in_json()
+        vm3_json = self.cmd('vm create -g {rg} -n {vm3} --image UbuntuLTS --admin-password TestPassword11!! '
+                            '--admin-username testadmin --authentication-type password').get_output_in_json()
         self.kwargs.update({
             'vm1_id': vm1_json['id'],
             'vm2_id': vm2_json['id'],
@@ -94,7 +95,6 @@ class MonitorGeneralScenarios(ScenarioTest):
                 self.check('length(criteria.allOf[0].dimensions)', 2),
                 self.check('length(criteria.allOf[1].dimensions)', 1),
             ])
-
 
     @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')
     def test_monitor_clone_public_ip_metric_alerts_scenario(self, resource_group):

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
+
+class MonitorGeneralScenarios(ScenarioTest):
+    @ResourceGroupPreparer(location='eastus')
+    def test_monitor_clone_vm_metric_alerts_scenario(self, resource_group):
+        self.kwargs.update({
+            'alert': 'alert1',
+            'vm1': 'vm1',
+            'vm2': 'vm2',
+            'vm3': 'vm3',
+            'ag1': 'ag1',
+            'rg': resource_group
+        })
+
+        vm1_json = self.cmd('vm create -g {rg} -n {vm1} --image UbuntuLTS --admin-password TestPassword11!! --admin-username '
+                           'testadmin --authentication-type password').get_output_in_json()
+        vm2_json = self.cmd('vm create -g {rg} -n {vm2} --image UbuntuLTS --admin-password TestPassword11!! --admin-username '
+                           'testadmin --authentication-type password').get_output_in_json()
+        self.kwargs.update({
+            'vm1_id': vm1_json['id'],
+            'vm2_id': vm2_json['id']
+        })
+        self.cmd('monitor action-group create -g {rg} -n {ag1}')
+        self.cmd('monitor metrics alert create -g {rg} -n {alert} --scopes {vm1_id} --action {ag1} --condition "avg Percentage CPU > 90" --description "High CPU"', checks=[
+            self.check('description', 'High CPU'),
+            self.check('severity', 2),
+            self.check('autoMitigate', None),
+            self.check('windowSize', '0:05:00'),
+            self.check('evaluationFrequency', '0:01:00'),
+            self.check('length(scopes)', 1)
+        ])
+
+        self.cmd('monitor clone --source-resource {vm1_id} --target-resource {vm2_id}', checks=[
+            self.check('description', 'High CPU'),
+            self.check('severity', 2),
+            self.check('autoMitigate', None),
+            self.check('windowSize', '0:05:00'),
+            self.check('evaluationFrequency', '0:01:00'),
+            self.check('length(scopes)', 2)
+        ])

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_general_operations.py
@@ -3,6 +3,7 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
+import mock
 
 class MonitorGeneralScenarios(ScenarioTest):
     @ResourceGroupPreparer(location='eastus')
@@ -33,12 +34,103 @@ class MonitorGeneralScenarios(ScenarioTest):
             self.check('evaluationFrequency', '0:01:00'),
             self.check('length(scopes)', 1)
         ])
+        with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
+            self.cmd('monitor clone --source-resource {vm1_id} --target-resource {vm2_id}', checks=[
+                self.check('description', 'High CPU'),
+                self.check('severity', 2),
+                self.check('autoMitigate', None),
+                self.check('windowSize', '0:05:00'),
+                self.check('evaluationFrequency', '0:01:00'),
+                self.check('length(scopes)', 1)
+            ])
 
-        self.cmd('monitor clone --source-resource {vm1_id} --target-resource {vm2_id}', checks=[
-            self.check('description', 'High CPU'),
+    @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')
+    @StorageAccountPreparer()
+    @StorageAccountPreparer(parameter_name='storage_account_2')
+    def test_monitor_clone_storage_metric_alerts_scenario(self, resource_group, storage_account, storage_account_2):
+        from msrestazure.tools import resource_id
+        self.kwargs.update({
+            'alert': 'alert1',
+            'sa': storage_account,
+            'ag1': 'ag1',
+            'sub': self.get_subscription_id(),
+            'sa_id': resource_id(
+                resource_group=resource_group,
+                subscription=self.get_subscription_id(),
+                name=storage_account,
+                namespace='Microsoft.Storage',
+                type='storageAccounts'),
+            'sa_id_2': resource_id(
+                resource_group=resource_group,
+                subscription=self.get_subscription_id(),
+                name=storage_account_2,
+                namespace='Microsoft.Storage',
+                type='storageAccounts'),
+        })
+
+        self.cmd('monitor action-group create -g {rg} -n {ag1}')
+        self.cmd('monitor metrics alert create -g {rg} -n {alert} --scopes {sa_id} --action {ag1} --description "Test" --condition "total transactions > 5 where ResponseType includes Success and ApiName includes GetBlob" --condition "avg SuccessE2ELatency > 250 where ApiName includes GetBlob"', checks=[
+            self.check('description', 'Test'),
             self.check('severity', 2),
             self.check('autoMitigate', None),
             self.check('windowSize', '0:05:00'),
             self.check('evaluationFrequency', '0:01:00'),
-            self.check('length(scopes)', 2)
+            self.check('length(criteria.allOf)', 2),
+            self.check('length(criteria.allOf[0].dimensions)', 2),
+            self.check('length(criteria.allOf[1].dimensions)', 1)
         ])
+
+        with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
+            self.cmd('monitor clone --source-resource {sa_id} --target-resource {sa_id_2}', checks=[
+                self.check('description', 'Test'),
+                self.check('severity', 2),
+                self.check('autoMitigate', None),
+                self.check('windowSize', '0:05:00'),
+                self.check('evaluationFrequency', '0:01:00'),
+                self.check('length(criteria.allOf)', 2),
+                self.check('length(criteria.allOf[0].dimensions)', 2),
+                self.check('length(criteria.allOf[1].dimensions)', 1),
+            ])
+
+
+    @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')
+    def test_monitor_clone_public_ip_metric_alerts_scenario(self, resource_group):
+        from msrestazure.tools import resource_id
+        self.kwargs.update({
+            'alert': 'alert1',
+            'alert2': 'alert2',
+            'ag1': 'ag1',
+            'sub': self.get_subscription_id(),
+            'rg': resource_group,
+            'ip1': 'ip1',
+            'ip2': 'ip2'
+        })
+
+        ip1_json = self.cmd('network public-ip create -g {rg} -n {ip1}').get_output_in_json()
+        ip2_json = self.cmd('network public-ip create -g {rg} -n {ip2}').get_output_in_json()
+        self.kwargs.update({
+            'ip1_id': ip1_json['publicIp']['id'],
+            'ip2_id': ip2_json['publicIp']['id']
+        })
+
+        self.cmd('monitor action-group create -g {rg} -n {ag1}')
+        self.cmd('monitor metrics alert create -g {rg} -n {alert} --scopes {ip1_id} --action {ag1} --description "Test" --condition "total TCPBytesForwardedDDoS > 5"', checks=[
+            self.check('description', 'Test'),
+            self.check('severity', 2),
+            self.check('windowSize', '0:05:00'),
+            self.check('evaluationFrequency', '0:01:00'),
+            self.check('length(scopes)', 1)
+        ])
+
+        self.cmd('monitor metrics alert create -g {rg} -n {alert2} --scopes {ip1_id} --action {ag1} --description "Test2" --condition "max TCPBytesForwardedDDoS > 5"', checks=[
+            self.check('description', 'Test2'),
+            self.check('severity', 2),
+            self.check('windowSize', '0:05:00'),
+            self.check('evaluationFrequency', '0:01:00'),
+            self.check('length(scopes)', 1)
+        ])
+
+        with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
+            self.cmd('monitor clone --source-resource {ip1_id} --target-resource {ip2_id}', checks=[
+                self.check('length(@)', 2),
+            ])

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
@@ -222,16 +222,17 @@ class MonitorCloneStorageAccountAcrossSubsScenarios(ScenarioTest):
         self.cmd('monitor metrics alert create -g {ext_rg} --subscription {ext_sub} -n {alert} '
                  '--scopes {sa_id} --action {ag1} --description "Test" '
                  '--condition "total transactions > 5 where ResponseType includes Success and ApiName includes GetBlob" '
-                 '--condition "avg SuccessE2ELatency > 250 where ApiName includes GetBlob"', checks=[
-            self.check('description', 'Test'),
-            self.check('severity', 2),
-            self.check('autoMitigate', None),
-            self.check('windowSize', '0:05:00'),
-            self.check('evaluationFrequency', '0:01:00'),
-            self.check('length(criteria.allOf)', 2),
-            self.check('length(criteria.allOf[0].dimensions)', 2),
-            self.check('length(criteria.allOf[1].dimensions)', 1)
-        ])
+                 '--condition "avg SuccessE2ELatency > 250 where ApiName includes GetBlob"',
+                 checks=[
+                     self.check('description', 'Test'),
+                     self.check('severity', 2),
+                     self.check('autoMitigate', None),
+                     self.check('windowSize', '0:05:00'),
+                     self.check('evaluationFrequency', '0:01:00'),
+                     self.check('length(criteria.allOf)', 2),
+                     self.check('length(criteria.allOf[0].dimensions)', 2),
+                     self.check('length(criteria.allOf[1].dimensions)', 1)
+                 ])
 
         with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {sa_id} --target-resource {sa_id_2}', checks=[

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
+from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer, live_only
 import mock
 from msrestazure.tools import resource_id
 
@@ -43,12 +43,12 @@ class MonitorCloneVMScenarios(ScenarioTest):
         ])
         with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {vm1_id} --target-resource {vm3_id}', checks=[
-                self.check('@[0].description', 'High CPU'),
-                self.check('@[0].severity', 2),
-                self.check('@[0].autoMitigate', None),
-                self.check('@[0].windowSize', '0:05:00'),
-                self.check('@[0].evaluationFrequency', '0:01:00'),
-                self.check('length(@[0].scopes)', 3)
+                self.check('metricsAlert[0].description', 'High CPU'),
+                self.check('metricsAlert[0].severity', 2),
+                self.check('metricsAlert[0].autoMitigate', None),
+                self.check('metricsAlert[0].windowSize', '0:05:00'),
+                self.check('metricsAlert[0].evaluationFrequency', '0:01:00'),
+                self.check('length(metricsAlert[0].scopes)', 3)
             ])
 
 
@@ -91,14 +91,14 @@ class MonitorCloneStorageAccountScenarios(ScenarioTest):
 
         with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {sa_id} --target-resource {sa_id_2}', checks=[
-                self.check('@[0].description', 'Test'),
-                self.check('@[0].severity', 2),
-                self.check('@[0].autoMitigate', None),
-                self.check('@[0].windowSize', '0:05:00'),
-                self.check('@[0].evaluationFrequency', '0:01:00'),
-                self.check('length(@[0].criteria.allOf)', 2),
-                self.check('length(@[0].criteria.allOf[0].dimensions)', 2),
-                self.check('length(@[0].criteria.allOf[1].dimensions)', 1),
+                self.check('metricsAlert[0].description', 'Test'),
+                self.check('metricsAlert[0].severity', 2),
+                self.check('metricsAlert[0].autoMitigate', None),
+                self.check('metricsAlert[0].windowSize', '0:05:00'),
+                self.check('metricsAlert[0].evaluationFrequency', '0:01:00'),
+                self.check('length(metricsAlert[0].criteria.allOf)', 2),
+                self.check('length(metricsAlert[0].criteria.allOf[0].dimensions)', 2),
+                self.check('length(metricsAlert[0].criteria.allOf[1].dimensions)', 1),
             ])
 
 
@@ -142,5 +142,99 @@ class MonitorClonePublicIpScenarios(ScenarioTest):
 
         with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {ip1_id} --target-resource {ip2_id}', checks=[
-                self.check('length(@)', 2),
+                self.check('length(metricsAlert)', 2),
+            ])
+
+
+class MonitorClonePublicIpAlwaysScenarios(ScenarioTest):
+    @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')
+    def test_monitor_clone_public_ip_metric_alerts_always_scenario(self, resource_group):
+        self.test_guid_count = 0
+        self.kwargs.update({
+            'alert': 'alert1',
+            'alert2': 'alert2',
+            'ag1': 'ag1',
+            'sub': self.get_subscription_id(),
+            'rg': resource_group,
+            'ip1': 'ip1',
+            'ip2': 'ip2'
+        })
+
+        ip1_json = self.cmd('network public-ip create -g {rg} -n {ip1}').get_output_in_json()
+        ip2_json = self.cmd('network public-ip create -g {rg} -n {ip2}').get_output_in_json()
+        self.kwargs.update({
+            'ip1_id': ip1_json['publicIp']['id'],
+            'ip2_id': ip2_json['publicIp']['id']
+        })
+
+        self.cmd('monitor action-group create -g {rg} -n {ag1}')
+        self.cmd('monitor metrics alert create -g {rg} -n {alert} --scopes {ip1_id} --action {ag1} --description "Test" --condition "total TCPBytesForwardedDDoS > 5"', checks=[
+            self.check('description', 'Test'),
+            self.check('severity', 2),
+            self.check('windowSize', '0:05:00'),
+            self.check('evaluationFrequency', '0:01:00'),
+            self.check('length(scopes)', 1)
+        ])
+
+        self.cmd('monitor metrics alert create -g {rg} -n {alert2} --scopes {ip1_id} --action {ag1} --description "Test2" --condition "max TCPBytesForwardedDDoS > 5"', checks=[
+            self.check('description', 'Test2'),
+            self.check('severity', 2),
+            self.check('windowSize', '0:05:00'),
+            self.check('evaluationFrequency', '0:01:00'),
+            self.check('length(scopes)', 1)
+        ])
+
+        with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
+            self.cmd('monitor clone --source-resource {ip1_id} --target-resource {ip2_id}', checks=[
+                self.check('length(metricsAlert)', 2),
+            ])
+
+
+class MonitorCloneStorageAccountAcrossSubsScenarios(ScenarioTest):
+    @live_only()
+    @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')
+    def test_monitor_clone_storage_metric_alerts_across_subs_scenario(self, resource_group):
+        self.test_guid_count = 0
+        self.kwargs.update({
+            'alert': 'alert1',
+            'sa': self.create_random_name('sa', 24),
+            'sa2': self.create_random_name('sa', 24),
+            'ag1': 'ag1',
+            'rg': resource_group,
+            'ext_sub': 'f64d4ee8-be94-457d-ba26-3fa6b6506cef',
+            'ext_rg': self.create_random_name('test_rg', 24),
+        })
+
+        self.cmd('group create -l eastus -n {ext_rg} --subscription {ext_sub}')
+        sa1_json = self.cmd('storage account create -n {sa} -g {ext_rg} -l eastus --sku Standard_LRS --kind Storage --subscription {ext_sub}').get_output_in_json()
+        sa2_json = self.cmd('storage account create -n {sa2} -g {rg} -l eastus --sku Standard_LRS --kind Storage').get_output_in_json()
+        self.kwargs.update({
+            'sa_id': sa1_json['id'],
+            'sa_id_2': sa2_json['id'],
+        })
+        self.cmd('monitor action-group create -g {ext_rg} -n {ag1} --subscription {ext_sub}')
+        self.cmd('monitor metrics alert create -g {ext_rg} --subscription {ext_sub} -n {alert} '
+                 '--scopes {sa_id} --action {ag1} --description "Test" '
+                 '--condition "total transactions > 5 where ResponseType includes Success and ApiName includes GetBlob" '
+                 '--condition "avg SuccessE2ELatency > 250 where ApiName includes GetBlob"', checks=[
+            self.check('description', 'Test'),
+            self.check('severity', 2),
+            self.check('autoMitigate', None),
+            self.check('windowSize', '0:05:00'),
+            self.check('evaluationFrequency', '0:01:00'),
+            self.check('length(criteria.allOf)', 2),
+            self.check('length(criteria.allOf[0].dimensions)', 2),
+            self.check('length(criteria.allOf[1].dimensions)', 1)
+        ])
+
+        with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
+            self.cmd('monitor clone --source-resource {sa_id} --target-resource {sa_id_2}', checks=[
+                self.check('metricsAlert[0].description', 'Test'),
+                self.check('metricsAlert[0].severity', 2),
+                self.check('metricsAlert[0].autoMitigate', None),
+                self.check('metricsAlert[0].windowSize', '0:05:00'),
+                self.check('metricsAlert[0].evaluationFrequency', '0:01:00'),
+                self.check('length(metricsAlert[0].criteria.allOf)', 2),
+                self.check('length(metricsAlert[0].criteria.allOf[0].dimensions)', 2),
+                self.check('length(metricsAlert[0].criteria.allOf[1].dimensions)', 1),
             ])

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
@@ -146,50 +146,6 @@ class MonitorClonePublicIpScenarios(ScenarioTest):
             ])
 
 
-class MonitorClonePublicIpAlwaysScenarios(ScenarioTest):
-    @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')
-    def test_monitor_clone_public_ip_metric_alerts_always_scenario(self, resource_group):
-        self.test_guid_count = 0
-        self.kwargs.update({
-            'alert': 'alert1',
-            'alert2': 'alert2',
-            'ag1': 'ag1',
-            'sub': self.get_subscription_id(),
-            'rg': resource_group,
-            'ip1': 'ip1',
-            'ip2': 'ip2'
-        })
-
-        ip1_json = self.cmd('network public-ip create -g {rg} -n {ip1}').get_output_in_json()
-        ip2_json = self.cmd('network public-ip create -g {rg} -n {ip2}').get_output_in_json()
-        self.kwargs.update({
-            'ip1_id': ip1_json['publicIp']['id'],
-            'ip2_id': ip2_json['publicIp']['id']
-        })
-
-        self.cmd('monitor action-group create -g {rg} -n {ag1}')
-        self.cmd('monitor metrics alert create -g {rg} -n {alert} --scopes {ip1_id} --action {ag1} --description "Test" --condition "total TCPBytesForwardedDDoS > 5"', checks=[
-            self.check('description', 'Test'),
-            self.check('severity', 2),
-            self.check('windowSize', '0:05:00'),
-            self.check('evaluationFrequency', '0:01:00'),
-            self.check('length(scopes)', 1)
-        ])
-
-        self.cmd('monitor metrics alert create -g {rg} -n {alert2} --scopes {ip1_id} --action {ag1} --description "Test2" --condition "max TCPBytesForwardedDDoS > 5"', checks=[
-            self.check('description', 'Test2'),
-            self.check('severity', 2),
-            self.check('windowSize', '0:05:00'),
-            self.check('evaluationFrequency', '0:01:00'),
-            self.check('length(scopes)', 1)
-        ])
-
-        with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
-            self.cmd('monitor clone --source-resource {ip1_id} --target-resource {ip2_id}', checks=[
-                self.check('length(metricsAlert)', 2),
-            ])
-
-
 class MonitorCloneStorageAccountAcrossSubsScenarios(ScenarioTest):
     @live_only()
     @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
@@ -43,12 +43,12 @@ class MonitorCloneVMScenarios(ScenarioTest):
         ])
         with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {vm1_id} --target-resource {vm3_id}', checks=[
-                self.check('description', 'High CPU'),
-                self.check('severity', 2),
-                self.check('autoMitigate', None),
-                self.check('windowSize', '0:05:00'),
-                self.check('evaluationFrequency', '0:01:00'),
-                self.check('length(scopes)', 3)
+                self.check('@[0].description', 'High CPU'),
+                self.check('@[0].severity', 2),
+                self.check('@[0].autoMitigate', None),
+                self.check('@[0].windowSize', '0:05:00'),
+                self.check('@[0].evaluationFrequency', '0:01:00'),
+                self.check('length(@[0].scopes)', 3)
             ])
 
 
@@ -91,14 +91,14 @@ class MonitorCloneStorageAccountScenarios(ScenarioTest):
 
         with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {sa_id} --target-resource {sa_id_2}', checks=[
-                self.check('description', 'Test'),
-                self.check('severity', 2),
-                self.check('autoMitigate', None),
-                self.check('windowSize', '0:05:00'),
-                self.check('evaluationFrequency', '0:01:00'),
-                self.check('length(criteria.allOf)', 2),
-                self.check('length(criteria.allOf[0].dimensions)', 2),
-                self.check('length(criteria.allOf[1].dimensions)', 1),
+                self.check('@[0].description', 'Test'),
+                self.check('@[0].severity', 2),
+                self.check('@[0].autoMitigate', None),
+                self.check('@[0].windowSize', '0:05:00'),
+                self.check('@[0].evaluationFrequency', '0:01:00'),
+                self.check('length(@[0].criteria.allOf)', 2),
+                self.check('length(@[0].criteria.allOf[0].dimensions)', 2),
+                self.check('length(@[0].criteria.allOf[1].dimensions)', 1),
             ])
 
 

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
@@ -41,7 +41,7 @@ class MonitorCloneVMScenarios(ScenarioTest):
             self.check('evaluationFrequency', '0:01:00'),
             self.check('length(scopes)', 2)
         ])
-        with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
+        with mock.patch('azure.cli.command_modules.monitor.util.gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {vm1_id} --target-resource {vm3_id}', checks=[
                 self.check('metricsAlert[0].description', 'High CPU'),
                 self.check('metricsAlert[0].severity', 2),
@@ -89,7 +89,7 @@ class MonitorCloneStorageAccountScenarios(ScenarioTest):
             self.check('length(criteria.allOf[1].dimensions)', 1)
         ])
 
-        with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
+        with mock.patch('azure.cli.command_modules.monitor.util.gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {sa_id} --target-resource {sa_id_2}', checks=[
                 self.check('metricsAlert[0].description', 'Test'),
                 self.check('metricsAlert[0].severity', 2),
@@ -139,7 +139,7 @@ class MonitorCloneStorageAccountAlwaysScenarios(ScenarioTest):
             self.check('length(criteria.allOf[1].dimensions)', 1)
         ])
 
-        with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
+        with mock.patch('azure.cli.command_modules.monitor.util.gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {sa_id} --target-resource {sa_id_2} --always-clone', checks=[
                 self.check('metricsAlert[0].description', 'Test'),
                 self.check('metricsAlert[0].severity', 2),
@@ -190,7 +190,7 @@ class MonitorClonePublicIpScenarios(ScenarioTest):
             self.check('length(scopes)', 1)
         ])
 
-        with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
+        with mock.patch('azure.cli.command_modules.monitor.util.gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {ip1_id} --target-resource {ip2_id}', checks=[
                 self.check('length(metricsAlert)', 2),
             ])
@@ -234,7 +234,7 @@ class MonitorCloneStorageAccountAcrossSubsScenarios(ScenarioTest):
                      self.check('length(criteria.allOf[1].dimensions)', 1)
                  ])
 
-        with mock.patch('azure.cli.command_modules.monitor.util._gen_guid', side_effect=self.create_guid):
+        with mock.patch('azure.cli.command_modules.monitor.util.gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {sa_id} --target-resource {sa_id_2}', checks=[
                 self.check('metricsAlert[0].description', 'Test'),
                 self.check('metricsAlert[0].severity', 2),

--- a/src/azure-cli/azure/cli/command_modules/monitor/util.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/util.py
@@ -56,7 +56,7 @@ def get_autoscale_scale_direction_map():
             'in': ScaleDirection.decrease}
 
 
-def _gen_guid():
+def gen_guid():
     import uuid
     return uuid.uuid4()
 # endregion

--- a/src/azure-cli/azure/cli/command_modules/monitor/util.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/util.py
@@ -55,6 +55,7 @@ def get_autoscale_scale_direction_map():
     return {'to': ScaleDirection.none, 'out': ScaleDirection.increase,
             'in': ScaleDirection.decrease}
 
+
 def _gen_guid():
     import uuid
     return uuid.uuid4()

--- a/src/azure-cli/azure/cli/command_modules/monitor/util.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/util.py
@@ -54,4 +54,8 @@ def get_autoscale_scale_direction_map():
     from azure.mgmt.monitor.models import ScaleDirection
     return {'to': ScaleDirection.none, 'out': ScaleDirection.increase,
             'in': ScaleDirection.decrease}
+
+def _gen_guid():
+    import uuid
+    return uuid.uuid4()
 # endregion


### PR DESCRIPTION
**Background.**

Clone the metric alerts of one resource to another resource.
![image](https://user-images.githubusercontent.com/49134743/75136829-da399c00-5720-11ea-8f06-9c3c68310fc6.png)

The alert rules and the resource must be in the same subscription. Thus, I add a requirement for this command right now that the source_resource and the target_resource must be in the same sub first.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
