### PR TITLE
[Core] Remove color when stdout is not a tty

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -6,6 +6,7 @@
 import knack.output
 import sys
 
+
 class AzOutputProducer(knack.output.OutputProducer):
     def __init__(self, cli_ctx=None):
         super(AzOutputProducer, self).__init__(cli_ctx)

--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import knack.output
-
+import sys
 
 class AzOutputProducer(knack.output.OutputProducer):
     def __init__(self, cli_ctx=None):
@@ -38,6 +38,11 @@ class AzOutputProducer(knack.output.OutputProducer):
 
     def check_valid_format_type(self, format_type):
         return format_type in self._FORMAT_DICT
+
+    def get_formatter(self, format_type):
+        if not sys.stdout.isatty() and format_type in ['jsonc', 'yamlc']:
+            format_type = format_type[:-1]
+        return super(AzOutputProducer, self).get_formatter(format_type)
 
 
 def get_output_format(cli_ctx):


### PR DESCRIPTION
Fix #2924: JSONC is not parsed successfully by json.loads in Python2

On Linux, when the output format is set to `jsonc` or `yamlc` whether by changing the `~/.azure/config` file or by using `--output`, there will be ANSI control sequences for coloring like `^[[94m` in `stdout`. If `stdout` is redirected, downstream commands like `jq` will fail:

```sh
$ az vm list --output jsonc | jq '.[0]'
parse error: Invalid numeric literal at line 3, column 6

$ az vm list --output jsonc > out.txt
$ cat out.txt --show-nonprinting
[
  {
    ^[[94m"additionalCapabilities"^[[39;49;00m: ^[[34mnull^[[39;49;00m,
    ^[[94m"availabilitySet"^[[39;49;00m: ^[[34mnull^[[39;49;00m,
```

This PR detects whether `stdout` is a tty. If not, use `json` or `yaml` instead, thus allowing the output to be piped to downstream commands:

```sh
$ az vm list --output jsonc | jq '.[].name'
"azureclitestlinux"
"azureclitestwin"

$ az vm list --output json > out.txt
$ cat out.txt --show-nonprinting
[
  {
    "additionalCapabilities": null,
    "availabilitySet": null,
```

ℹ This issue doesn't happen on Windows because ANSI control sequences are removed by colorama.
