### PR TITLE
[ACS] BREAKING CHANGE: ARO remove vnet-peer, upgrade to 2019-10-27-preview API version

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -477,13 +477,6 @@ Release History
 
 * [BREAKING CHANGE] `az storage account create`: Change default storage account kind to StorageV2
 
-**Azure Red Hat OpenShift**
-
-* Upgrade CLI to API version 2019-10-27-preview.
-* Bump to azure-mgmt-containerservice to 8.2.0.
-* Add private cluster support: add parameters to `az openshift create` and add new command `az openshift update`.
-* Remove `vnet-peer` parameter as not used anymore.
-
 2.0.81
 ++++++
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -477,6 +477,13 @@ Release History
 
 * [BREAKING CHANGE] `az storage account create`: Change default storage account kind to StorageV2
 
+**Azure Red Hat OpenShift**
+
+* Upgrade CLI to API version 2019-10-27-preview.
+* Bump to azure-mgmt-containerservice to 8.2.0.
+* Add private cluster support: add parameters to `az openshift create` and add new command `az openshift update`.
+* Remove `vnet-peer` parameter as not used anymore.
+
 2.0.81
 ++++++
 

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -66,7 +66,7 @@ def get_container_service_client(cli_ctx, **_):
 def get_osa_container_service_client(cli_ctx, **_):
     from azure.mgmt.containerservice import ContainerServiceClient
 
-    return get_mgmt_service_client(cli_ctx, ContainerServiceClient, api_version='2019-09-30-preview')
+    return get_mgmt_service_client(cli_ctx, ContainerServiceClient, api_version='2019-10-27-preview')
 
 
 def get_graph_rbac_management_client(cli_ctx, **_):

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -931,39 +931,6 @@ short-summary: Manage Azure Red Hat OpenShift Services.
 helps['openshift create'] = """
 type: command
 short-summary: Create a new managed OpenShift cluster.
-parameters:
-  - name: --compute-vm-size -s
-    type: string
-    short-summary: Size of Virtual Machines to create as OpenShift nodes.
-  - name: --compute-count -c
-    type: int
-    short-summary: Number of nodes in the OpenShift node pool.
-  - name: --aad-client-app-id
-    type: string
-    short-summary: The ID of an Azure Active Directory client application. If not specified, a new Azure Active Directory client is created.
-  - name: --aad-client-app-secret
-    type: string
-    short-summary: The secret of an Azure Active Directory client application.
-  - name: --aad-tenant-id
-    type: string
-    short-summary: The ID of an Azure Active Directory tenant.
-  - name: --vnet-peer
-    type: string
-    short-summary: The ID or the name of a subnet in an existing VNet into which to peer the cluster.
-  - name: --vnet-prefix
-    type: string
-    short-summary: The CIDR used on the VNet into which to deploy the cluster.
-  - name: --subnet-prefix
-    type: string
-    short-summary: The CIDR used on the Subnet into which to deploy the cluster.
-  - name: --customer-admin-group-id
-    type: string
-    short-summary: The Object ID of an Azure Active Directory Group that memberships will get synced into the OpenShift group "osa-customer-admins". If not specified, no cluster admin access will be granted.
-  - name: --workspace-id
-    type: string
-    short-summary: The resource id of an existing Log Analytics Workspace to use for storing monitoring data.
-
-
 examples:
   - name: Create an OpenShift cluster and auto create an AAD Client
     text: az openshift create -g MyResourceGroup -n MyManagedCluster
@@ -971,10 +938,10 @@ examples:
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --customer-admin-group-id {GROUP_ID}
   - name: Create an OpenShift cluster with 5 compute nodes and a custom AAD Client.
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --aad-client-app-id {APP_ID} --aad-client-app-secret {APP_SECRET} --aad-tenant-id {TENANT_ID} --compute-count 5
-  - name: Create an Openshift cluster using a custom vnet
-    text: az openshift create -g MyResourceGroup -n MyManagedCluster --vnet-peer "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/openshift-vnet/providers/Microsoft.Network/virtualNetworks/test"
   - name: Create an Openshift cluster with Log Analytics monitoring enabled
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --workspace-id "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.OperationalInsights/workspaces/{workspace-id}"
+  - name: Create a private OpenShift cluster
+    text: az openshift create -g MyResourceGroup -n MyManagedCluster --private-cluster --management-subnet-cidr 10.0.1.0/24
 """
 
 helps['openshift delete'] = """
@@ -1044,4 +1011,17 @@ examples:
   - name: Disable Log Analytics monitoring.
     text: |-
         az openshift monitor disable -g MyResourceGroup -n MyManagedCluster
+"""
+
+helps['openshift update'] = """
+type: command
+short-summary: Commands to manage existing Openshift cluster.
+parameters:
+  - name: --refresh-cluster
+    type: boolean
+    short-summary: Trigger nodes rotation in order to pick up change in DNS settings.
+examples:
+  - name: Trigger nodes rotation.
+    text: az openshift update -g MyResourceGroup -n MyManagedCluster --refresh-cluster
+    crafted: true
 """

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -1019,7 +1019,6 @@ short-summary: Commands to manage existing Openshift cluster.
 parameters:
   - name: --refresh-cluster
     type: boolean
-    short-summary: Trigger nodes rotation in order to pick up change in DNS settings.
 examples:
   - name: Trigger nodes rotation.
     text: az openshift update -g MyResourceGroup -n MyManagedCluster --refresh-cluster

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -350,7 +350,7 @@ def load_arguments(self, _):
                    help='The Object ID of an Azure Active Directory Group that memberships will get synced into the OpenShift group "osa-customer-admins".'
                         'If not specified, no cluster admin access will be granted.')
         c.argument('management_subnet_cidr', help='CIDR of subnet used to create PLS needed for management of the cluster. If provided, also set --private-cluster flag.')
-        c.argument('private_cluster', help='Create private Openshift cluster. If this flag is set, also supply --management-subnet-cidr.')
+        c.argument('private_cluster', arg_type=get_three_state_flag(), help='Create private Openshift cluster. If this flag is set, also supply --management-subnet-cidr.')
         c.argument('subnet_prefix', help='The CIDR used on the Subnet into which to deploy the cluster.')
         c.argument('vnet_peer',
                    help='Vnet peering is no longer supported during cluster creation, instead it is possible to edit vnet properties after cluster creation')
@@ -358,7 +358,7 @@ def load_arguments(self, _):
         c.argument('workspace_id', help='The resource id of an existing Log Analytics Workspace to use for storing monitoring data.')
 
     with self.argument_context('openshift update') as c:
-        c.argument('refresh_cluster', arg_type=get_three_state_flag(), options_list='--refresh-cluster',
+        c.argument('refresh_cluster', arg_type=get_three_state_flag(),
                    help='Allow the nodes to be rotated. This can be used to update DNS settings on the nodes')
 
     with self.argument_context('openshift monitor enable') as c:

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -10,7 +10,7 @@ import platform
 
 from argcomplete.completers import FilesCompleter
 from azure.cli.core.commands.parameters import (
-    file_type, get_enum_type, get_resource_name_completion_list, name_type, tags_type, zones_type)
+    file_type, get_enum_type, get_resource_name_completion_list, name_type, tags_type, zones_type, get_three_state_flag)
 from azure.cli.core.commands.validators import validate_file_or_dict
 from knack.arguments import CLIArgumentType
 
@@ -341,9 +341,25 @@ def load_arguments(self, _):
 
     with self.argument_context('openshift create') as c:
         c.argument('name', validator=validate_linux_host_name)
-        c.argument('compute_vm_size', options_list=['--compute-vm-size', '-s'])
-        c.argument('customer_admin_group_id', options_list=['--customer-admin-group-id'])
-        c.argument('workspace_id')
+        c.argument('aad_client_app_id', help='The ID of an Azure Active Directory client application. If not specified, a new Azure Active Directory client is created.')
+        c.argument('aad_client_app_secret', help='The secret of an Azure Active Directory client application.')
+        c.argument('aad_tenant_id', help='The ID of an Azure Active Directory tenant.')
+        c.argument('compute_count', options_list=['--compute-count', '-c'], help='Number of nodes in the OpenShift node pool.')
+        c.argument('compute_vm_size', options_list=['--compute-vm-size', '-s'], help='Size of Virtual Machines to create as OpenShift nodes.')
+        c.argument('customer_admin_group_id',
+                   help='The Object ID of an Azure Active Directory Group that memberships will get synced into the OpenShift group "osa-customer-admins".'
+                        'If not specified, no cluster admin access will be granted.')
+        c.argument('management_subnet_cidr', help='CIDR of subnet used to create PLS needed for management of the cluster. If provided, also set --private-cluster flag.')
+        c.argument('private_cluster', help='Create private Openshift cluster. If this flag is set, also supply --management-subnet-cidr.')
+        c.argument('subnet_prefix', help='The CIDR used on the Subnet into which to deploy the cluster.')
+        c.argument('vnet_peer',
+                   help='Vnet peering is no longer supported during cluster creation, instead it is possible to edit vnet properties after cluster creation')
+        c.argument('vnet_prefix', help='The CIDR used on the VNet into which to deploy the cluster.')
+        c.argument('workspace_id', help='The resource id of an existing Log Analytics Workspace to use for storing monitoring data.')
+
+    with self.argument_context('openshift update') as c:
+        c.argument('refresh_cluster', arg_type=get_three_state_flag(), options_list='--refresh-cluster',
+                   help='Allow the nodes to be rotated. This can be used to update DNS settings on the nodes')
 
     with self.argument_context('openshift monitor enable') as c:
         c.argument('workspace_id', help='The resource ID of an existing Log Analytics Workspace to use for storing monitoring data.')

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -359,7 +359,7 @@ def load_arguments(self, _):
 
     with self.argument_context('openshift update') as c:
         c.argument('refresh_cluster', arg_type=get_three_state_flag(),
-                help='Allow nodes to be rotated. Use this flag to trigger nodes rotation after DNS settings change.')
+                   help='Allow nodes to be rotated. Use this flag to trigger nodes rotation after DNS settings change.')
 
     with self.argument_context('openshift monitor enable') as c:
         c.argument('workspace_id', help='The resource ID of an existing Log Analytics Workspace to use for storing monitoring data.')

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -359,7 +359,7 @@ def load_arguments(self, _):
 
     with self.argument_context('openshift update') as c:
         c.argument('refresh_cluster', arg_type=get_three_state_flag(),
-                   help='Allow the nodes to be rotated. This can be used to update DNS settings on the nodes')
+                help='Allow nodes to be rotated. Use this flag to trigger nodes rotation after DNS settings change.')
 
     with self.argument_context('openshift monitor enable') as c:
         c.argument('workspace_id', help='The resource ID of an existing Log Analytics Workspace to use for storing monitoring data.')

--- a/src/azure-cli/azure/cli/command_modules/acs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/commands.py
@@ -42,7 +42,7 @@ def load_command_table(self, _):
     )
 
     openshift_managed_clusters_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.containerservice.v2018_09_30_preview.operations.'
+        operations_tmpl='azure.mgmt.containerservice.v2019_10_27_preview.operations.'
                         '_open_shift_managed_clusters_operations#OpenShiftManagedClustersOperations.{}',
         client_factory=cf_openshift_managed_clusters
     )
@@ -119,6 +119,7 @@ def load_command_table(self, _):
     with self.command_group('openshift', openshift_managed_clusters_sdk,
                             client_factory=cf_openshift_managed_clusters) as g:
         g.custom_command('create', 'openshift_create', supports_no_wait=True)
+        g.custom_command('update', 'openshift_update', supports_no_wait=True)
         g.command('delete', 'delete', supports_no_wait=True, confirmation=True)
         g.custom_command('scale', 'openshift_scale', supports_no_wait=True)
         g.custom_show_command('show', 'openshift_show')

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3370,7 +3370,7 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
     else:
         monitor_profile = None
 
-    network_profile = NetworkProfile(vnet_cidr=vnet_prefix)
+    network_profile = NetworkProfile(vnet_cidr=vnet_prefix, management_subnet_cidr=management_subnet_cidr)
     osamc = OpenShiftManagedCluster(
         location=location, tags=tags,
         open_shift_version="v3.11",
@@ -3379,8 +3379,7 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
         agent_pool_profiles=agent_pool_profiles,
         master_pool_profile=agent_master_pool_profile,
         router_profiles=[default_router_profile],
-        monitor_profile=monitor_profile,
-        management_subnet_cidr=management_subnet_cidr)
+        monitor_profile=monitor_profile)
 
     try:
         # long_running_operation_timeout=300

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3402,7 +3402,8 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
 
 def openshift_update(cmd, client, resource_group_name, name, refresh_cluster=None, no_wait=False):
     instance = client.get(resource_group_name, name)
-    instance.refresh_cluster = True
+    if refresh_cluster:
+        instance.refresh_cluster = True
 
     return sdk_no_wait(no_wait, client.create_or_update, resource_group_name, name, instance)
 


### PR DESCRIPTION
This is a draft PR to allow early feedback. 
This PR updates ARO module to latest API version `2019-10-27-preview`.  It depends on https://github.com/Azure/azure-rest-api-specs/pull/8305 (in the process of being merged) and the consequent sdk-for-python build. 
In the new version vnet-peer has been removed from "create" operation. This is due to latest changes done on Azure side while implementing new API features it is now possible to edit vnet peering after the cluster creation. I have tried deprecation approach (https://github.com/Azure/azure-cli/blob/dev/doc/authoring_command_modules/authoring_commands.md#deprecating-commands-and-arguments) but unfortunately in this circumstances we have to remove it now rather than adding a deprecation notice. 

**History Notes:**  
[ACS] BREAKING CHANGE: az openshift create: remove --vnet-peer parameter.  
[ACS] az openshift create: add flags to support private cluster. 
[ACS] az openshift: upgrade to `2019-10-27-preview` API version.
[ACS] az openshift: add `update` command.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
