### PR TITLE
[KeyVault] Add new command `az keyvault secret download-all` for downloading all secrets at once

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -211,29 +211,51 @@ def load_arguments(self, _):
     # endregion
 
     # region KeyVault Secret
-    with self.argument_context('keyvault secret set') as c:
-        c.argument('content_type', options_list=['--description'], help='Description of the secret contents (e.g. password, connection string, etc)')
-        c.attributes_argument('secret', SecretAttributes, create=True)
+    for item in ['set']:
+        with self.argument_context('keyvault secret {}'.format(item)) as c:
+            c.argument('content_type', options_list=['--description'],
+                       help='Description of the secret contents (e.g. password, connection string, etc)')
+            c.attributes_argument('secret', SecretAttributes, create=True)
 
-    with self.argument_context('keyvault secret set', arg_group='Content Source') as c:
-        c.argument('value', options_list=['--value'], help="Plain text secret value. Cannot be used with '--file' or '--encoding'", required=False)
-        c.extra('file_path', options_list=['--file', '-f'], type=file_type, help="Source file for secret. Use in conjunction with '--encoding'", completer=FilesCompleter())
-        c.extra('encoding', arg_type=get_enum_type(secret_encoding_values, default='utf-8'), options_list=['--encoding', '-e'], help='Source file encoding. The value is saved as a tag (`file-encoding=<val>`) and used during download to automatically encode the resulting file.')
+        with self.argument_context('keyvault secret {}'.format(item), arg_group='Content Source') as c:
+            c.argument('value', options_list=['--value'],
+                       help="Plain text secret value. Cannot be used with '--file' or '--encoding'", required=False)
+            c.extra('file_path', options_list=['--file', '-f'], type=file_type,
+                    help="Source file for secret. Use in conjunction with '--encoding'", completer=FilesCompleter())
+            c.extra('encoding', arg_type=get_enum_type(secret_encoding_values, default='utf-8'),
+                    options_list=['--encoding', '-e'],
+                    help='Source file encoding. The value is saved as a tag (`file-encoding=<val>`) '
+                         'and used during download to automatically encode the resulting file.')
 
-    with self.argument_context('keyvault secret set-attributes') as c:
-        c.attributes_argument('secret', SecretAttributes)
+    for item in ['set-attributes']:
+        with self.argument_context('keyvault secret {}'.format(item)) as c:
+            c.attributes_argument('secret', SecretAttributes)
 
-    with self.argument_context('keyvault secret download') as c:
-        c.argument('file_path', options_list=['--file', '-f'], type=file_type, completer=FilesCompleter(), help='File to receive the secret contents.')
-        c.argument('encoding', arg_type=get_enum_type(secret_encoding_values), options_list=['--encoding', '-e'], help="Encoding of the secret. By default, will look for the 'file-encoding' tag on the secret. Otherwise will assume 'utf-8'.", default=None)
+    for item in ['download']:
+        with self.argument_context('keyvault secret {}'.format(item)) as c:
+            c.argument('file_path', options_list=['--file', '-f'], type=file_type, completer=FilesCompleter(),
+                       help='File to receive the secret contents.')
 
-    for scope in ['backup', 'restore']:
-        with self.argument_context('keyvault secret {}'.format(scope)) as c:
-            c.argument('file_path', options_list=['--file', '-f'], type=file_type, completer=FilesCompleter(), help='File to receive the secret contents.')
+    for item in ['download-all']:
+        with self.argument_context('keyvault secret {}'.format(item)) as c:
+            c.argument('dir_path', options_list=['--dir', '-d'], help='Directory to receive all secret files.')
 
-    for scope in ['list', 'list-deleted', 'list-versions']:
-        with self.argument_context('keyvault secret {}'.format(scope)) as c:
-            c.argument('maxresults', options_list=['--maxresults'], type=int)
+    for item in ['download', 'download-all']:
+        with self.argument_context('keyvault secret {}'.format(item)) as c:
+            c.argument('encoding', arg_type=get_enum_type(secret_encoding_values), options_list=['--encoding', '-e'],
+                       help="Encoding of the secret. By default, will look for the 'file-encoding' tag on the secret. "
+                            "Otherwise will assume 'utf-8'.", default=None)
+
+    for item in ['backup', 'restore']:
+        with self.argument_context('keyvault secret {}'.format(item)) as c:
+            c.argument('file_path', options_list=['--file', '-f'], type=file_type, completer=FilesCompleter(),
+                       help='File to receive the secret contents.')
+
+    for item in ['download-all', 'list', 'list-deleted', 'list-versions']:
+        with self.argument_context('keyvault secret {}'.format(item)) as c:
+            c.argument('maxresults', options_list=['--maxresults'], type=int,
+                       help='Maximum number of results to return in a page. If not specified, '
+                            'the service will return up to 25 results.')
 
     # endregion
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
@@ -125,6 +125,7 @@ def load_command_table(self, _):
         g.keyvault_command('purge', 'purge_deleted_secret')
         g.keyvault_command('recover', 'recover_deleted_secret')
         g.keyvault_custom('download', 'download_secret')
+        g.keyvault_custom('download-all', 'download_all_secrets')
         g.keyvault_custom('backup', 'backup_secret', doc_string_source=data_doc_string.format('backup_secret'))
         g.keyvault_custom('restore', 'restore_secret', doc_string_source=data_doc_string.format('restore_secret'))
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -830,7 +830,7 @@ def download_key(client, file_path, vault_base_url=None, key_name=None, key_vers
 # region KeyVault Secret
 def download_secret(client, file_path, vault_base_url=None, secret_name=None, encoding=None,
                     secret_version='', identifier=None):  # pylint: disable=unused-argument
-    """ Download a secret from a KeyVault. """
+    """ Download a secret from a Key Vault. """
     if os.path.isfile(file_path) or os.path.isdir(file_path):
         raise CLIError("File or directory named '{}' already exists.".format(file_path))
 
@@ -859,6 +859,24 @@ def download_secret(client, file_path, vault_base_url=None, secret_name=None, en
         if os.path.isfile(file_path):
             os.remove(file_path)
         raise ex
+
+
+def download_all_secrets(client, dir_path, vault_base_url, maxresults=None, encoding=None):
+    """ Download the latest version of all secrets from a Key Vault. """
+
+    if not os.path.exists(dir_path):
+        raise CLIError('Directory \'{}\' doesn\'t exist.'.format(dir_path))
+
+    if os.path.isfile(dir_path):
+        raise CLIError('--dir/-d needs to be a directory name not a file name.')
+
+    secrets = client.get_secrets(vault_base_url, maxresults=maxresults)
+    for secret in secrets:
+        secret_name = secret.id.split('/')[-1]
+        file_path = os.path.join(dir_path, secret_name)
+        if os.path.exists(file_path):
+            raise CLIError('File \'{}\' already exists.'.format(file_path))
+        download_secret(client, file_path, vault_base_url=vault_base_url, secret_name=secret_name, encoding=encoding)
 
 
 def backup_secret(client, file_path, vault_base_url=None,

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/recordings/test_keyvault_secret.yaml
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/recordings/test_keyvault_secret.yaml
@@ -31,19 +31,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 06 Feb 2020 11:49:01 GMT
+      - Tue, 18 Feb 2020 13:53:07 GMT
       duration:
-      - '1955790'
+      - '1970163'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - OQLywiI52PNERwXzjFjjauDsq3Wqe1LaqVZPFAotG7Q=
+      - Pv4UBIo2f7FKm/qOeGQAbn1U4hE/glaJfHaiirx+LwU=
       ocp-aad-session-key:
-      - u53UOFfT46_iCwhuAVkYnngjeLVpPaKOiMmuGxVjp_6GiFXSE2xNexkBqXngKFCdRCxoI0Uv7UBETwMyL51GodkxpU-6vxkXx4TVCKUCWEMR1xVvZZtJbadRMgwDJi4n.Hz9MDpYOHjhUie6oV4rDxynMwL_Ez20Ez4PW9WZDWQ4
+      - 6G_2Ju9BvDXYEjNIYN7lzWSDnmMYvU26PDsXdSaMu2pGxyNu00gpUcNH0rHFXvbvOOkxBd3gOCoC5fbIEz-3xvCgsy2KseToQd8SqcOdMJqIVxEf_0lTyTv-I-xwUt53.6l8cjG1uzCRy1aSoPLLiYajel26dF_E91Pqyh-XDN7s
       pragma:
       - no-cache
       request-id:
-      - a9d323cf-7b6d-47c3-b03c-c71ffa3e1a4e
+      - 272bee6f-0ee6-4776-9b8b-723d93e43c1e
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -81,8 +81,8 @@ interactions:
       ParameterSetName:
       - -g -n -l --sku
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-mgmt-keyvault/2.1.0
-        Azure-SDK-For-Python AZURECLI/2.0.81
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-mgmt-keyvault/2.1.1
+        Azure-SDK-For-Python AZURECLI/2.1.0
       accept-language:
       - en-US
     method: PUT
@@ -98,7 +98,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:07 GMT
+      - Tue, 18 Feb 2020 13:53:49 GMT
       expires:
       - '-1'
       pragma:
@@ -116,9 +116,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.0.269
+      - 1.1.0.271
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1184'
+      - '1198'
       x-powered-by:
       - ASP.NET
     status:
@@ -138,8 +138,8 @@ interactions:
       ParameterSetName:
       - -g -n -l --sku
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-mgmt-keyvault/2.1.0
-        Azure-SDK-For-Python AZURECLI/2.0.81
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-mgmt-keyvault/2.1.1
+        Azure-SDK-For-Python AZURECLI/2.1.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_keyvault_secret000001/providers/Microsoft.KeyVault/vaults/cli-test-kv-se-000002?api-version=2018-02-14
   response:
@@ -153,7 +153,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:38 GMT
+      - Tue, 18 Feb 2020 13:54:20 GMT
       expires:
       - '-1'
       pragma:
@@ -171,7 +171,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.0.269
+      - 1.1.0.271
       x-powered-by:
       - ASP.NET
     status:
@@ -209,7 +209,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:41 GMT
+      - Tue, 18 Feb 2020 13:54:26 GMT
       expires:
       - '-1'
       pragma:
@@ -226,11 +226,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -258,16 +258,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1?api-version=7.0
   response:
     body:
-      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/6c5d98a6801c421cb70842ea29715d6a","attributes":{"enabled":true,"created":1580989782,"updated":1580989782,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/bcb96e7388a041e88d08e21b8f9d6830","attributes":{"enabled":true,"created":1582034067,"updated":1582034067,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '256'
+      - '276'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:41 GMT
+      - Tue, 18 Feb 2020 13:54:27 GMT
       expires:
       - '-1'
       pragma:
@@ -281,11 +281,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -311,16 +311,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets?api-version=7.0
   response:
     body:
-      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1580989782,"updated":1580989782,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1582034067,"updated":1582034067,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '234'
+      - '254'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:43 GMT
+      - Tue, 18 Feb 2020 13:54:28 GMT
       expires:
       - '-1'
       pragma:
@@ -334,11 +334,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -364,16 +364,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets?maxresults=10&api-version=7.0
   response:
     body:
-      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1580989782,"updated":1580989782,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1582034067,"updated":1582034067,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '234'
+      - '254'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:44 GMT
+      - Tue, 18 Feb 2020 13:54:29 GMT
       expires:
       - '-1'
       pragma:
@@ -387,11 +387,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -420,16 +420,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1?api-version=7.0
   response:
     body:
-      string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/4731dc0b6cca4d52af7a8afa8df1cd4f","attributes":{"enabled":true,"created":1580989786,"updated":1580989786,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/815b8feff30441ea8a0419587fb9ac7b","attributes":{"enabled":true,"created":1582034071,"updated":1582034071,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '295'
+      - '315'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:45 GMT
+      - Tue, 18 Feb 2020 13:54:30 GMT
       expires:
       - '-1'
       pragma:
@@ -443,11 +443,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -473,16 +473,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/versions?api-version=7.0
   response:
     body:
-      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/4731dc0b6cca4d52af7a8afa8df1cd4f","attributes":{"enabled":true,"created":1580989786,"updated":1580989786,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/6c5d98a6801c421cb70842ea29715d6a","attributes":{"enabled":true,"created":1580989782,"updated":1580989782,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/815b8feff30441ea8a0419587fb9ac7b","attributes":{"enabled":true,"created":1582034071,"updated":1582034071,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/bcb96e7388a041e88d08e21b8f9d6830","attributes":{"enabled":true,"created":1582034067,"updated":1582034067,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '546'
+      - '586'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:46 GMT
+      - Tue, 18 Feb 2020 13:54:32 GMT
       expires:
       - '-1'
       pragma:
@@ -496,11 +496,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -526,16 +526,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/versions?maxresults=10&api-version=7.0
   response:
     body:
-      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/4731dc0b6cca4d52af7a8afa8df1cd4f","attributes":{"enabled":true,"created":1580989786,"updated":1580989786,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/6c5d98a6801c421cb70842ea29715d6a","attributes":{"enabled":true,"created":1580989782,"updated":1580989782,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/815b8feff30441ea8a0419587fb9ac7b","attributes":{"enabled":true,"created":1582034071,"updated":1582034071,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/bcb96e7388a041e88d08e21b8f9d6830","attributes":{"enabled":true,"created":1582034067,"updated":1582034067,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '546'
+      - '586'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:50 GMT
+      - Tue, 18 Feb 2020 13:54:33 GMT
       expires:
       - '-1'
       pragma:
@@ -549,11 +549,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -579,16 +579,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/?api-version=7.0
   response:
     body:
-      string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/4731dc0b6cca4d52af7a8afa8df1cd4f","attributes":{"enabled":true,"created":1580989786,"updated":1580989786,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/815b8feff30441ea8a0419587fb9ac7b","attributes":{"enabled":true,"created":1582034071,"updated":1582034071,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '295'
+      - '315'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:52 GMT
+      - Tue, 18 Feb 2020 13:54:34 GMT
       expires:
       - '-1'
       pragma:
@@ -602,11 +602,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -629,19 +629,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/6c5d98a6801c421cb70842ea29715d6a?api-version=7.0
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/bcb96e7388a041e88d08e21b8f9d6830?api-version=7.0
   response:
     body:
-      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/6c5d98a6801c421cb70842ea29715d6a","attributes":{"enabled":true,"created":1580989782,"updated":1580989782,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/bcb96e7388a041e88d08e21b8f9d6830","attributes":{"enabled":true,"created":1582034067,"updated":1582034067,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '256'
+      - '276'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:55 GMT
+      - Tue, 18 Feb 2020 13:54:38 GMT
       expires:
       - '-1'
       pragma:
@@ -655,11 +655,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -682,19 +682,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/6c5d98a6801c421cb70842ea29715d6a?api-version=7.0
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/bcb96e7388a041e88d08e21b8f9d6830?api-version=7.0
   response:
     body:
-      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/6c5d98a6801c421cb70842ea29715d6a","attributes":{"enabled":true,"created":1580989782,"updated":1580989782,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"value":"ABC123","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/bcb96e7388a041e88d08e21b8f9d6830","attributes":{"enabled":true,"created":1582034067,"updated":1582034067,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '256'
+      - '276'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:55 GMT
+      - Tue, 18 Feb 2020 13:54:39 GMT
       expires:
       - '-1'
       pragma:
@@ -708,11 +708,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -740,16 +740,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/?api-version=7.0
   response:
     body:
-      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/4731dc0b6cca4d52af7a8afa8df1cd4f","attributes":{"enabled":false,"created":1580989786,"updated":1580989797,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/815b8feff30441ea8a0419587fb9ac7b","attributes":{"enabled":false,"created":1582034071,"updated":1582034080,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '279'
+      - '299'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:57 GMT
+      - Tue, 18 Feb 2020 13:54:40 GMT
       expires:
       - '-1'
       pragma:
@@ -763,11 +763,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -795,7 +795,7 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/backup?api-version=7.0
   response:
     body:
-      string: '{"value":"KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLkpPbG50c2VXNDhtMm9zMmQweDl0dHRvVXM3RFR6M0dZSTZ0RjVJd3ozLXh2M2RGdXlYUWZOVE12RV9IZnFRX285OVFrWW04VU1xbEYtd3VEaXVjejBuVVJRcThPdU40STRfdTkxWkhpNVl4anludFREQkhuMklGb1otQjR2aTVEV3AtNVhKWGZfbGhFVGc1cVdwY3JxRlc5aUdlTjF5d1p1WkdXVHZMMElFVDhLZ29TSnJBaHhJWXlCSkhGczEybksyZlRmU2h4ZmxhTWlTNHJiNW5vYTF2MkpUcTFKcFZyQ2JEbHUwcjhzOWlLa3YyMDBscUcwdWlFLUJHUFZRYWVSRTlOZUtNRDVIUGJlbnREUFdnaTZOVnhJWHdTcXpzaHFBT1VrNnNRQThRa2N6NlpwTEdJMEtkMmpLRTRuYmhsQ0ZjUnhaREo2WEJ6eG9IazlQbHhwQS5ILVdJX2hyUjhGTFZ4aEl6cFJVUWh3LlJnMnF4ZGFLWjBFUVRCOFA1UVNvQ1kydENDVTU1V0tocVZhb2ktY1VWblZkNUFLU1RtZUtMdjR1ZVZxOXVFU2dKTU8xQlRMM2xmUTVWckhSeEVBUEc4OGdzSnk5SXV1R1pZeFNPSjZQQUgzeHBFWTR4Ty1KYW0xdGxETWwwWXBCeHFVekNGRGl3d1pmUDMwdUtKRUhpTkk5RjhITnd1OWNRQ3locEJiX3FaeDV5QWhGLWpOTVRONXJCREd6UUEzTXREZVJhTndMajlGcXQ4ZVpTOWNWTU96UjN0aGJubElvY0xDaUY1RldaektmTXdmUHp5Wng3cDE5YWQ2Z0VqQ2t2dFV4aG83S21qanBpTXh6R0xJS1NhaGt4bllXYm9BNmlBSXkzcElJeE9BUkFaUzFrU3R6ODVjMzF2eC1wQ3VnUHdWWklCaXFyQkJVUThOcmMwN1FramlrdmlZT2h2ekxrYXFZdERSOTJBcERjMXdrMngyNWptLWpfNWQ1Vi1KZ0c5SjhQdGMzNDAzZDI0VHNOTjZfSmQxVzhSOGduNTJlc3V5VUc0Umt5NnJibVdfWFRlNUdlUHZBMnJCd2M3OG93QTN6blhoOXVjeS1Tek1xekFBSS1NY2Y0SnM1Vkw3WGQ3T3lLQnVqOFQ4bzRrZHI5ZTVvMWNLMGQtd2I4YjJMUWFxdHVzY1VUQ1RpNEZkVE4xeEFuMWQ1Wmg0RmZCNTZkeFdXVnllXzJEVEJFQk5zc1ZTN3BUTnQxZi13bDRXRnJrODlYREw1WFZ6d0hPcXdUdk40SmZNYTk3aDJjR3dfNWxkUXQ1b1pqNWxUZXVfZVJhNTNpUmZIZ1hIWXQwQkxvaEFLNlV6czRkdy1VdTlaU1dYOWc1cmxMbklnajBRVHd3dFpjcU9RLUE4bjE5U0x6cXg3eklzN2hOWklYbkRlOVNtYUtreG44VWM3OWgyMUhVT3NOdmlkcnFTdi0tbmtwcEVkXzR0UENXSXdFMW5wczNhNTRYSmJ6bXNLbGhtUVloWmFaWjFaYlNlUVh3bmpkMzhSQjZ4NUhvRVZfLXVZaW1QQUk3V3JWTC1JcmpldUJnb3VoNXZKd05qczNxWFpFTTZzdGxPS0pZZWxsRVF5el9TSVRJWDBrQzllcU5UaWVtcUNrLU9EY1BETmlCelQ4ODlaRjVGY1llX0I3UktmbDN4UGotQ3VVaEo2U0lZMEdYOWpvQmI0T3JzUnJ1RU1PWXVWODMtTjdQTnVPaW1TMlJKNEpPNXNNMHNRbFQ4NUw5Z2M5cVRobUZWZGNzazE3WmxPZFpiSmlfVTB3a1d5dmZRS3hNcTc4cmQ2Q1ZfV3Zwa3QwbktQTVFFLTJkT3Q3UEY3S2phTlFOdUViOFdRRzVOY2lrNm1jMGRCZkdLOEowQUZhYW1nLVl5MjJ4WVZSU0NhcUxMdkYtNFd1WGZDeTFqY1Vxb2FjTVNCWVc0NGVKdGVhR2k3MGk5LTA2aU1pYzdsQm4wSnMyRU83Z0J3WWtkQVQtdGlpaEdnanJSNldJSTRGRi1HcDEyU0VEc1VuVlpSdTVBNmpNSndqbWI0NlMxODg5TTYwZmFzQ1J6S21uQlB1LXlVUXFvSHJadEtiWkJMTV9fcGZNSHNMVUNGRUh4QnhQa3EwdVU2ZXlxb0cyUnZTTGdNVWJZazBTZk5NNVJ2eFBXWklKSjdWbzBHa0lQemc3RTRHbnJYb2xOcWJQMUU0NUJEZnZqdURzM0locUlTeVdSVXdtZTRBaUkyaDI1VjJMcEQxem5pWHdvaWZ0eXctX1ZjMHBjR0JNcC1tRUlxQnlfQXN1bDhNdlppZ0hMakptM1R4d0pYYzloZmJXMjR6VURYMlBQQ0RkOG1nYnFrZjYxQ3pQQ0dBeFpPbDFFVGt5NHh6bEEyNEItbmw0alNoZm94WnVzMURrMXE4anZiRUViNzI2LWRKc1h2UmlfVXdfeGRJdzREOFpqNENsaG1yWkFWNnUxOEU4SnF6WFRSNmlwQnNRT0tLWUJiRjEzZWlYWDVXREN4WVpOZzJHcDFnaG1vRGNwQmVZbXhlLVpDb2JfalRDT24wTzhqV19NNk5Ud2V1SC11M213N1FBa3JDTy02Y0xJTktTNk9ZbWRGTWVkMEhQeW1ZSzEwaUwzaEtLMG5WSEt3TEljS2VwQjRLWkhOSGpzTDRNdTZvZE5Kd0JZMFlZZ3dPWHU2Z1JzTmM2SG0ybUMyVjdRaE9raDhkemdTODZUX1d4b2cxY0Q5R2dQM1NxSFpWbEI2WXQxQVhhN0E1cnl2ZkJrQzIyWmZ6SVdMbnNMNElfYWRfcThObU84cUQwUWt3QjdINThlT3JQNWRwMVE5XzY0dDNmaHNlRTl0U2RsZGNKbV9EeFcwYmNCYW5udmJUWHpTa1VOS1o1Szh2dDgwMHZETVBlNS1RMG5YcXlmRXdwczhuaVFDcDBHMnZoaFlQM1d5R1czSjFzQWN6X3g4S0VOUDJnWl9uMksyQmc1cTd1T2htck14d2dSLVh2eDdPY1ExTFR5TzF5S3hXX2JsT2NJeXRiVE9oSjg0b2ZNaEk4VzdCd3B4TFJRc1hFdlVKWUNvWGlMRmZOdTZONlhUWFFjd2ZYdTZYaGJKNWwyQ0Nvc3E5dW5uUUxtUUpsZF9Wd1pIMXRfLTVIM3ZONEZKODZsODY3eGNnWTdsQ2I3b2dQdEt5ZGJwTWt1YmwxbTNTZ0FaN25LS2UwdGI3dzZGaU1RMGRzUUFYejU3V01kMkkxeVZQRFVZODFYRkJPZlliT0VVc2ZVRTJ4T20wRWdTOU1OQUNuQk5GcW1LbXV0a0lCTmJMSkNDczhXY0JOVVpvTzhMY3lEN2R6YTlFeXIyRmtMZTBLNlpQYkI2ci01Z1lmZGF5NEIxUzVHMTVQSW54TVM5MGZseEtjR2daQlZIWEVmVy1MWER1VmZweGY4UHB4VWpnSlM2cDRlODAxcHBuVVNyUDlmN1NtNmx4Wmt3UEV3d1hJeE14cmZXY21FQkhLeFFyamxKcmsyZHM5MzRzOVM2cjZCVnhYWkxRbGRtOE9wU0xKOUQzWVp4RG5JVDNobXB4MllQbDhDLS1sNkxKcTd1cEw4TjlMWHhPcnVGcGRrZVRHSDVuZjhtY19selQ2aFN4cW9RQUdjN2V0eFVvX3VrX2IxcGhEb1BrMlR1MFFkbVBlOEQtSHJsWjJEMTFJT3k5S3lwNWx3QzJmOEVfMHZ5R3dlRGFYZkhFN0xtQmpqa1FvQ0MyRDJrVnZKNXJaREtqS3dpN3o0Q2J0WnhmOTFvbmEzOVNnWE93clZrMzJOclVHc1FUUWNiSUh3RTdyRmNlVlo0c2V2U2dhc2pBc0FoOVdlRXlacV9ma1BYZ0l3SmFYX0ZLSXdnM0Q2TVQzdkhiYmttMzRIRXVxNEJKLUpDczZ1c2xmX0c4QldCNGFjWFJBVHZtNWV4TzcxX29KOWlIcTY0NFRDQUt6dkRQbzZheXVlOVgzeEdsbU9veVJzZjRFam5VWHpTZW54aUsyMDMxeDd1LWV2LXp0dHJ5a28tbWVvbktaS0JfNW5zMTlyYmk4SE9ibDdMUGhVYlFZZXJOMC00alBRY2s4NDM4RTRtMDRTUHB0TS0yRG5USDIxNDZqd3Jvek05ZU5Va2FkdUN2dlpONm51MXR0T3pfQk13UW1iNTl0WjRWZHlPQlZFekhqaF9tTnczdU9vbVpxcENaRDc0aFp0WllpZUhQc19UVlJEOG9Xb29Vc3hydklfTW93SGdqendTenRJQWl2cVdZNjdsUHl6Q2E1R05fdFlhYmJxTkkyOEp3MUFpZkhJLWYwTk5UUkNTZ0hHS3dwNHNVZV9DcldyX3dNY1dBTVBaeFZhc3JISTE4MVN2cVBPd09ob0lJc2J3SzIxaFg2ZHRpZDhMRUNNZEJRY0lhSWpENnFiLVlfSGFxV2I4SnZ0Mlo1Y3ZXZmdDUDBGemo3ZThBczZNaUstRTFTeWhtY0tabW5JWEdDR2pmNGVzekRSWHFGMGxkVVpyRGNLcF8yVG50eG9MT1U3OEZUc2hTTkRyNDhja0s1QmFmcExLYjgtTWJvNlZBSHhVbHpDdXlJenlaYnJWQXhTV291aDJQYzNGZVpGNnEyWmNEZmZ0RDN3S0JkTWFtVXU0dWpFY09kTjlSV1c1Mnd3RGxEZjZiRmhjU3l5amh4RTJ2eU83T3FGMHJsNWgyYm0ya3hqcVJJNXVCbXNKa3FFX0lfaUJuWFphdGJjUExpUDlUdmZtbDIxV1pZUVRiMU9NZVZxM2E2Sy1FdE5XTlV5MHVLMkJLNENmMjV0eno3eGotUGFYN3pCcXN6Uk93aUlNcW9QX0liZnh4YzBHNUNodTV0M2tfdXByNFRETG5EenhXb1Y5bEVlZFdWdkpaczhGaDM4T0NMMFBHOGxVSW5rcWxKVGw2RXBUTVdtcUhVNklPT0pGT0VZWDE4S29ONjFRUEE2c0Rja1RKWVc5SnV5M1NPMTNDT0JjMGJkcEVDVkpQUlhZMUVKd1V3cnpSSkk2SGt0bExMVUJITVBHdHhZOWhzVzZqMmpDMFI2MjlQUVZpcV9CejIxMnRCV0s0c29DQVFlVVVKcmlmb3NEeUtiMjhNUWw5akZTc0hKSzZ2SXAtbEtnOWY5eFNKcjFJQzJkS0RRaEFiVlJ4ckM1Mzh5cTRWb0pnNVBvMk80R0E0VHFlU2xKcmh5eHZ5UmY5RTI0UHRkdHJrODk2SkNuUXlvWlptQm8wejZEUVRqX0hqMlUzbHpGdEFTTVpaa1pmVmJmSFg0bEVuUFhuRkh5VHVJMXdsM01VYUxxSkF2WG55S3QzajVJYURoV2JzbkNfMTdGcnZCNUVMbmw4V2x6cmZGN1hhc3A4ZWpWdU4wRVRJN0F2RzNSaXg1TFdnQWgzb2lDUk5tOUhhaFBhZkh6TFh1RlVlY3piZjcxSEd1VTdQZy00Sm5xZjNlSGFKbnd2bzBVNnNBLnliRmEyczdqNTQwVjgxNXF5UTBLUlE"}'
+      string: '{"value":"KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLm1PcXI5b2pRcXpra0tyMVpDNkpZb2FVb3FVYU12M052a21pN1kzMUxMSlN0X2loWEk4ZkpfazZxYk5QeWFjTTV2d2tneXJKZ0IxRW8xdEtibndjMUg5bGN5Y19Uc2N3RWcxVDRsbHVrOTJFRkRWcEhPdXQ4S0pRek5aejFJRWlLd2dqQnNjY1g2bkZmV0U0N2tWUWZ6Q2ZTTzJYMnRiSGpqU3h0RVB1dy1MU080VFZNUEpUV1BydTJTZkhqUmtSTzlnZ1dpYzFZc19KNmdmRUxZZFU2QlpvLXhMQUFvREU1M1p3eHJoNjlLZzN5a25CQk1IbldRZkNoM0JaU1V3RkVLdjZQRm9EZTJiWWZVaklxZ3UxQ3NYbkdnM3I0V3lIdGxXUHlfUm45aXpwWWZFTHBnb1UtT2U5NFA4dTlHYXlnV0xtVG01YWZnclRNN2YzMXA5NVEwUS5NcnF1dHlmZ3RzS2dlVU1CVVJDNEtBLmtYM21CZ0w0TFl3TWFiSTIxQ2FwN2ZqYzhoUXpYMTN2anFjaWxDUzctQVpZeWNmYWZjWlNKMWNla1NjMEM0by1SdUh4eVFyWENEWDZtTEdLWnNuUVY3RzVJNnVaY0pRVWZ1M3lRU25ZVUdkaEh6U1dPOFp4QXprTEZETXBRdFVqajV3N0R4cnRuTFljdktzb3hNUFBDSkdDSkdON1ZJTmhGaUo4Q1pZV21DdkdRVkhNSjlTRnVnTm9OU2J2aFczb3lRdXY3ekhIeFRjN3hHOHhxaVJveHktY1NoaFgyekpOd3N0ZkVSX0hUX1ZXWnRPYUhMeUM3Rmp0WHFWLUZBME5zeTB3YWlhTDllYWZReWhweE52Ym9mRzRYRlZlbVd6UXAxREJSQ092ejdFczAzZEhMVGpjNG9OZHVaWU82SDlzcXk4d0tZZUp0U2ZnX2loX3pqS2RuWUNydXhOaDdVZkkyS0l0R1dvUVcxYW12M3pqeThaWXladWVKNDRaN3NkQlNZazNuRkg2U19ZOWc3WTVNc0xmbGc4NVl5RHAyVUR5eEJ5WmVUVFhudkxBV2hyaHE0MC1MZ1UwNl9wYWNGak1XTGRxd3A5dFBwQ2pfN2JPejZTU2JaQmpFNi1fQlpYSnB6SGoyejlUZ2I0VDktaGY2TTFZZ0JCdnJxaUNWcEtuUU16dm9idjk5OE1LYjNZNXdDeFJXdFdETzRiQzFjbmJweUFBczQ2bTEwU1p0T2JxY015amZnajJvUjYzckdDZW5SRDJINUxtYnphZ0hsZUxiU2Z3ZWRUYTFzMnZycHZBVkRLeVFjOEg0N0oweGI3OHlGTmpJYVhsSXJnazduX1JlXzVtcENnWDJTMUhta1R0MUdBMmJDbHpyR2VydVJ0cWtiWFhLd1JkRDlHNnpqc05OV2Y3WkRMaXhLVU5PTW9Ud1RBek4zRnp2bXVyVGNUQ0dtNVdhaTY4Rk55ckl0MXJUU3N1d09zOTQ5S0Z2dWRkcjNxQ1dJMmM3UE9hd1BmN2E0WVgxRmlVUndlaE80SEtqWmxrblJXNmdSQlk2dmhQc0g4RGJpUEJyM1FIbFpJOXNoY0lZdGoxcmhJLWV2LUFQTmRydk9CeWZuUzh6dU1Qcmo4bTcxUVhvbEQzX2ZNb2lUTzkyMm5TazhBcmpOUl9YSTZSSGx3dWVxN2FjeHJUSEZjR0I2VDhRX1RCOWdTYzVxNW0tN2lHRzA3VElwaDRGUkdzQVg3dF9RckF0aG9idWE4MzZvV0dOQmxkU0UzeTJXMV9qaTlhVjF2Qm8wOE9DdlY1S2VLV2RPR1FvNTZWX214NnFPTm5JRXhSSlcxY3ROQzdMd1hEVlZZd1BMc2tkdERPbHc4dDloRWh5ZEpkNHVYRlV4VTNsZmJaVnZWMHVzYnF3Z284Rk16dHU2NXg0Ym01dVlzb0htbVlCZ182RV8yTVVJc1pyNEp6ZU9ZNVk2QjVqNFgxOXJKR0l2X2lmRzNMTEl0R1BNUVRjdF95UFBuZDR4UFdJZE5LZkRTcWtRRkg0MFgyb3Z4T1V3dXlCb2x1ZzZXRW5KOFRVTFhqVFc0Q1JUekZub3Zyemg0bVZOR1ZTRVZHYi1ncXpPS25XZkJvZi0xU2VfQ21nR2dId1FQdjRrOFJTMmRjendIZ0NsYWJzY2VJTURLV19taDJrQlFmb3phcGdTd0V0ZjY3TGZrcmpZdUpPUlVFb2xISE5hNHprNW81OG1CU1dnRzN1d3ZQbnpxaERuSTQtZ2FHNHV2Z0czRExEbW5saXU1YzdoaVFWbTNBUEhDVzNqVDlhQkxJMUkxWndBTHFVbVlhR2V4SG9BMTVKZ2lZdjNtYm1TVFFyOGR6MXkyRTN2UDFpcWlyY1psc1RsdUhMUXlmQ2tpMkZ2VjVuVHR0c1JfTDRWTnlBaENlTXI1LXMwanVMMlBfbTBxbU1EZndrY0FiZU5xZjlrN0cxSXBueHNlNGY3a3dRLVNtWkpjMUpZUkctUnJuTWNDSVR3clh6SlZlbV94VDN1czdFS0Iwb1RIMEdkZFBTQW9nVTlRek9nWnBhSFhqSjVSOTgxV1VOb0xUZUVpb1BVWkNGWUF2V2NwZUFBWms3cFFNenRaRi1XY0REdTVHY0t6ck5fTXFXSmQ5YlBvUWV5WlVHV0ZWMjU2azJuUVNhZC1maXQyNVpLSDBiUC1qLWMwUFJiQlFCTGZXaDVxT3AxYXh4MVQ0djRwNkpab1JrSUFxSE1TdU1NNTg1clVrMU9sMDYwRFctazJacGw4QW01dnZwWUtvNUcyb1VzTGNwRE9SZGt6eVVaOFRFOWs2elMwb1A0MWoyaEJ4b0hZUkNpcDVWTkxWdnNEa0NEOWlTTXBWQmU1ZTFVWEtGMTE1TjBnUDlMSlBxal9WNjU2SUt1bW11dmd4NnpWNG8xby1WdVY1Tll0cmhrTzhzYlFGS3hrdWdkbVJRM05yUFFvWWdwZkNNZEZkaS15M0dFZnZMY3Y5TktjM0pVR3dXbVFsTlZwS01zMld5MmllYzdEUnlIWG1sczFxdHRYcWRfTU95dkNmVzhwS3lfY2ZCYTFTOXhxbEJnSHRkVGwtczV6V1Fqa2paOGpiQTBHLUQyWkFPUUQ0R21Hb3ZlVDdxc0t0cHRzaTA0LU10dnFLS2xUMVVIQTVWZGRsZk53NU5SLTlZdjFaY1Z2Tml1cFNVeDV3dXlKbEJ6OWM0cmdyem56N1hWVGprV3hIaFg5UHZDNTExTHYybnR6ZGdfV0lBTEZvdTgweEdiRlE3MFhSNi1Lb1FzOW9WYjJSbWxjXzZRZGpyNFNDVURtTTdaQ0lBdHlaSTFPekxNTXpiUF9uNmRJM0dyMFV6WXJTMG1OUjZxTzdiS2laSTZ5UGxnV1dnbUxGQnpPM0llaXRtUmZudW42eVh4WTd1WDlNc25TYXVja1pzRldsRkJka2lJQjU5S0lLVVBSNklMVWNBbnhlX0hqV0drNHNuSklwQWNsbWhxNEVaQjVnWnAyeksyTXVUTTlZbm5abTZPWnBXYV9HTFhYNVc2M21ibDVISmRWLU8tUGR5MVA3aUNvY2l6QkVJNUQ5VWVRMzl1Y0dERVdZclpLUU43c0R5a2M1QnFldEs2NzZoUTMxMDF1b3prVG9NWFo3X3NuWThtNkIyaDhZMkJDWklWOUoyeGxKemo1azhGUWN2VHJJX2xIREF0cTJFZHRRZllpdjRlQlc1VXZ0THotWFVITFlGMTh5QnRjTjlRWURENkFkZTJzaXZvREhFS05Qa3VKQW5abjNWVXRqTUJ5NjltRU10dElYOFFuQ3VjaUdRbG5NWW5iVHJWTnJ4N3hYVDZNTmxla1B3OUcyRFRTVTFxeC1qQWZMRzBRWEJYb1htT3FQQmpGdUw1NzlNYVRMS1RsUkxDRllKNHhkZU0tSEMtSlVSYUo2cUlWWWJKV3ozQ2tVczhrR2U1SUNxRzIyZ05sV0w0UnVGcXlkSHZuWlNvcTI1UGlqNHcwZlJHQnhtalF2elkzbkxCVFRJaVZXcjJ5aUFNMm92N3dqOGdnOEo4bGl0VG5DVTZhaGE4NkVGb21jdW52MEdpLTBrcHd6eWlTMmw0emkxQThaZFJLQm0tWklnS0JWZGtJTENGcXhyRkd1Nm9GaVhZOU1sTktZM2NVdERaNHp6MC1yVXEwMTA0WmRRX05WRDZmV3MzR2dNc2JpUzZTZEc1R1dHYVVvejNfQ3VvZDVCeWx4NW1jTUFfNW9FYlU3eURuQWQza18xV3psNFFvOExtWVEzS0RBVXMtWTBrUThsR292Wm9RTEU2SkpRWDRSTzBFMzhVcHZVMlNURHVjbFlpX2VrOUZjSXNkNGJsdTNXbm1MX0wxVGtXV2FIc2xCWkEybDhUVGxwbjlVejZoTEI4M1ljeUpYc1RTdVYtU01tUkhQMEZ2ZHVyblE5MzRFWTJtdmVpZE95TEQ2X3pydThQVl9yalFJeDR4cmQ3QzJyMjIzX09sSW4zOTdUZGV0elAwVWZHNE00X1BiQ0dBaFRvZWk2OUI3UUd3TWhjaWV0SE5mTjhmc3NLREVlZ2VZTkR1TndQMGpCSnFTUVJ4QmNDVlMyV0RCcFVEOTY3SEl5dVQtdTR4VHBvSVA0Y3Rucmh3alp1YUx6MktNTzhjNk1waVgyNFNSVjl6Sy1WQTBlUXZPcmY3QzdEQWtjWTk0MGZBbFN0N2tyYzJYSUotRXNqLUlvbnY3RndUT25OcVJBUEgyZUIyeHg3UFNEM3AzU2s2TzF2Mm1oTzdnSGtEV18ySzJQTkw5QThuYkFONklMY3NuOWhuRFFMSC1oNEY2bnhveDk1SnJ3SlUyZDg2ejFKcVRRR2d1WUhNLURvMk96bkZLd05ISkNUeGFQWk16aGE3Wm9MT2JFV0FvQlNOQ2dVV1N1dXpHbEJmOW9NTEhCeEJDalhjU05VMWJya1lUSU1Tbk1UaHF2NmN2ODB5WndkRjRfaW9OY2ZId1hDa0NZYzZFWUNEQ2JTMXRnY3NzRU12elZJVDN5Z3QyTGNvSVQtcWduUVVRYmt0T2pNRnpoalBtbDV3d2lZLVlNNVJMUlU0eE1SZ0UyMWNvdzRXcV9oX3NBZUdEcDJPU0JjUlQ4NHJid0I5Q2t5TWFWekQ1S2lhQ190Ymo4dHdURjBYNG9EN1ZTaHVrV3BSNkZfYkU5T1I4SlpINkZQNk9IQXlGNXFqNDg1NU13WmZLUFRnb2ZtSy1ZYjJ3VUtDX012RjVyVTJrUER2dy04WjNiRVd0TmVGUGVNRGxJeUNuaGJRTXE3YmpESElvemtEUFBQd2JtMkxjSkVlMjhnWjM4SThyZHQ5Mm1GZG94ei10NTFVS1BPTkZ4dE0tUHg0bHFHejBWUmd1SVppdk1WX3N1a1ctNXBvaExwRWhfeVF5aWJuZzlKdkpwVFJ5R20zYlo3MGJxOE1Bb1pjZGNka0hjZ0NTZHRWWjF2ZWt3clFmd3VvLmdCWUNIeDlUWURmQnJxemxTLW5GNmc"}'
     headers:
       cache-control:
       - no-cache
@@ -804,7 +804,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:49:58 GMT
+      - Tue, 18 Feb 2020 13:54:41 GMT
       expires:
       - '-1'
       pragma:
@@ -818,11 +818,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -850,16 +850,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1?api-version=7.0
   response:
     body:
-      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/4731dc0b6cca4d52af7a8afa8df1cd4f","attributes":{"enabled":false,"created":1580989786,"updated":1580989797,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/815b8feff30441ea8a0419587fb9ac7b","attributes":{"enabled":false,"created":1582034071,"updated":1582034080,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '279'
+      - '299'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:00 GMT
+      - Tue, 18 Feb 2020 13:54:42 GMT
       expires:
       - '-1'
       pragma:
@@ -873,11 +873,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -912,7 +912,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:03 GMT
+      - Tue, 18 Feb 2020 13:54:44 GMT
       expires:
       - '-1'
       pragma:
@@ -926,18 +926,18 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLkpPbG50c2VXNDhtMm9zMmQweDl0dHRvVXM3RFR6M0dZSTZ0RjVJd3ozLXh2M2RGdXlYUWZOVE12RV9IZnFRX285OVFrWW04VU1xbEYtd3VEaXVjejBuVVJRcThPdU40STRfdTkxWkhpNVl4anludFREQkhuMklGb1otQjR2aTVEV3AtNVhKWGZfbGhFVGc1cVdwY3JxRlc5aUdlTjF5d1p1WkdXVHZMMElFVDhLZ29TSnJBaHhJWXlCSkhGczEybksyZlRmU2h4ZmxhTWlTNHJiNW5vYTF2MkpUcTFKcFZyQ2JEbHUwcjhzOWlLa3YyMDBscUcwdWlFLUJHUFZRYWVSRTlOZUtNRDVIUGJlbnREUFdnaTZOVnhJWHdTcXpzaHFBT1VrNnNRQThRa2N6NlpwTEdJMEtkMmpLRTRuYmhsQ0ZjUnhaREo2WEJ6eG9IazlQbHhwQS5ILVdJX2hyUjhGTFZ4aEl6cFJVUWh3LlJnMnF4ZGFLWjBFUVRCOFA1UVNvQ1kydENDVTU1V0tocVZhb2ktY1VWblZkNUFLU1RtZUtMdjR1ZVZxOXVFU2dKTU8xQlRMM2xmUTVWckhSeEVBUEc4OGdzSnk5SXV1R1pZeFNPSjZQQUgzeHBFWTR4Ty1KYW0xdGxETWwwWXBCeHFVekNGRGl3d1pmUDMwdUtKRUhpTkk5RjhITnd1OWNRQ3locEJiX3FaeDV5QWhGLWpOTVRONXJCREd6UUEzTXREZVJhTndMajlGcXQ4ZVpTOWNWTU96UjN0aGJubElvY0xDaUY1RldaektmTXdmUHp5Wng3cDE5YWQ2Z0VqQ2t2dFV4aG83S21qanBpTXh6R0xJS1NhaGt4bllXYm9BNmlBSXkzcElJeE9BUkFaUzFrU3R6ODVjMzF2eC1wQ3VnUHdWWklCaXFyQkJVUThOcmMwN1FramlrdmlZT2h2ekxrYXFZdERSOTJBcERjMXdrMngyNWptLWpfNWQ1Vi1KZ0c5SjhQdGMzNDAzZDI0VHNOTjZfSmQxVzhSOGduNTJlc3V5VUc0Umt5NnJibVdfWFRlNUdlUHZBMnJCd2M3OG93QTN6blhoOXVjeS1Tek1xekFBSS1NY2Y0SnM1Vkw3WGQ3T3lLQnVqOFQ4bzRrZHI5ZTVvMWNLMGQtd2I4YjJMUWFxdHVzY1VUQ1RpNEZkVE4xeEFuMWQ1Wmg0RmZCNTZkeFdXVnllXzJEVEJFQk5zc1ZTN3BUTnQxZi13bDRXRnJrODlYREw1WFZ6d0hPcXdUdk40SmZNYTk3aDJjR3dfNWxkUXQ1b1pqNWxUZXVfZVJhNTNpUmZIZ1hIWXQwQkxvaEFLNlV6czRkdy1VdTlaU1dYOWc1cmxMbklnajBRVHd3dFpjcU9RLUE4bjE5U0x6cXg3eklzN2hOWklYbkRlOVNtYUtreG44VWM3OWgyMUhVT3NOdmlkcnFTdi0tbmtwcEVkXzR0UENXSXdFMW5wczNhNTRYSmJ6bXNLbGhtUVloWmFaWjFaYlNlUVh3bmpkMzhSQjZ4NUhvRVZfLXVZaW1QQUk3V3JWTC1JcmpldUJnb3VoNXZKd05qczNxWFpFTTZzdGxPS0pZZWxsRVF5el9TSVRJWDBrQzllcU5UaWVtcUNrLU9EY1BETmlCelQ4ODlaRjVGY1llX0I3UktmbDN4UGotQ3VVaEo2U0lZMEdYOWpvQmI0T3JzUnJ1RU1PWXVWODMtTjdQTnVPaW1TMlJKNEpPNXNNMHNRbFQ4NUw5Z2M5cVRobUZWZGNzazE3WmxPZFpiSmlfVTB3a1d5dmZRS3hNcTc4cmQ2Q1ZfV3Zwa3QwbktQTVFFLTJkT3Q3UEY3S2phTlFOdUViOFdRRzVOY2lrNm1jMGRCZkdLOEowQUZhYW1nLVl5MjJ4WVZSU0NhcUxMdkYtNFd1WGZDeTFqY1Vxb2FjTVNCWVc0NGVKdGVhR2k3MGk5LTA2aU1pYzdsQm4wSnMyRU83Z0J3WWtkQVQtdGlpaEdnanJSNldJSTRGRi1HcDEyU0VEc1VuVlpSdTVBNmpNSndqbWI0NlMxODg5TTYwZmFzQ1J6S21uQlB1LXlVUXFvSHJadEtiWkJMTV9fcGZNSHNMVUNGRUh4QnhQa3EwdVU2ZXlxb0cyUnZTTGdNVWJZazBTZk5NNVJ2eFBXWklKSjdWbzBHa0lQemc3RTRHbnJYb2xOcWJQMUU0NUJEZnZqdURzM0locUlTeVdSVXdtZTRBaUkyaDI1VjJMcEQxem5pWHdvaWZ0eXctX1ZjMHBjR0JNcC1tRUlxQnlfQXN1bDhNdlppZ0hMakptM1R4d0pYYzloZmJXMjR6VURYMlBQQ0RkOG1nYnFrZjYxQ3pQQ0dBeFpPbDFFVGt5NHh6bEEyNEItbmw0alNoZm94WnVzMURrMXE4anZiRUViNzI2LWRKc1h2UmlfVXdfeGRJdzREOFpqNENsaG1yWkFWNnUxOEU4SnF6WFRSNmlwQnNRT0tLWUJiRjEzZWlYWDVXREN4WVpOZzJHcDFnaG1vRGNwQmVZbXhlLVpDb2JfalRDT24wTzhqV19NNk5Ud2V1SC11M213N1FBa3JDTy02Y0xJTktTNk9ZbWRGTWVkMEhQeW1ZSzEwaUwzaEtLMG5WSEt3TEljS2VwQjRLWkhOSGpzTDRNdTZvZE5Kd0JZMFlZZ3dPWHU2Z1JzTmM2SG0ybUMyVjdRaE9raDhkemdTODZUX1d4b2cxY0Q5R2dQM1NxSFpWbEI2WXQxQVhhN0E1cnl2ZkJrQzIyWmZ6SVdMbnNMNElfYWRfcThObU84cUQwUWt3QjdINThlT3JQNWRwMVE5XzY0dDNmaHNlRTl0U2RsZGNKbV9EeFcwYmNCYW5udmJUWHpTa1VOS1o1Szh2dDgwMHZETVBlNS1RMG5YcXlmRXdwczhuaVFDcDBHMnZoaFlQM1d5R1czSjFzQWN6X3g4S0VOUDJnWl9uMksyQmc1cTd1T2htck14d2dSLVh2eDdPY1ExTFR5TzF5S3hXX2JsT2NJeXRiVE9oSjg0b2ZNaEk4VzdCd3B4TFJRc1hFdlVKWUNvWGlMRmZOdTZONlhUWFFjd2ZYdTZYaGJKNWwyQ0Nvc3E5dW5uUUxtUUpsZF9Wd1pIMXRfLTVIM3ZONEZKODZsODY3eGNnWTdsQ2I3b2dQdEt5ZGJwTWt1YmwxbTNTZ0FaN25LS2UwdGI3dzZGaU1RMGRzUUFYejU3V01kMkkxeVZQRFVZODFYRkJPZlliT0VVc2ZVRTJ4T20wRWdTOU1OQUNuQk5GcW1LbXV0a0lCTmJMSkNDczhXY0JOVVpvTzhMY3lEN2R6YTlFeXIyRmtMZTBLNlpQYkI2ci01Z1lmZGF5NEIxUzVHMTVQSW54TVM5MGZseEtjR2daQlZIWEVmVy1MWER1VmZweGY4UHB4VWpnSlM2cDRlODAxcHBuVVNyUDlmN1NtNmx4Wmt3UEV3d1hJeE14cmZXY21FQkhLeFFyamxKcmsyZHM5MzRzOVM2cjZCVnhYWkxRbGRtOE9wU0xKOUQzWVp4RG5JVDNobXB4MllQbDhDLS1sNkxKcTd1cEw4TjlMWHhPcnVGcGRrZVRHSDVuZjhtY19selQ2aFN4cW9RQUdjN2V0eFVvX3VrX2IxcGhEb1BrMlR1MFFkbVBlOEQtSHJsWjJEMTFJT3k5S3lwNWx3QzJmOEVfMHZ5R3dlRGFYZkhFN0xtQmpqa1FvQ0MyRDJrVnZKNXJaREtqS3dpN3o0Q2J0WnhmOTFvbmEzOVNnWE93clZrMzJOclVHc1FUUWNiSUh3RTdyRmNlVlo0c2V2U2dhc2pBc0FoOVdlRXlacV9ma1BYZ0l3SmFYX0ZLSXdnM0Q2TVQzdkhiYmttMzRIRXVxNEJKLUpDczZ1c2xmX0c4QldCNGFjWFJBVHZtNWV4TzcxX29KOWlIcTY0NFRDQUt6dkRQbzZheXVlOVgzeEdsbU9veVJzZjRFam5VWHpTZW54aUsyMDMxeDd1LWV2LXp0dHJ5a28tbWVvbktaS0JfNW5zMTlyYmk4SE9ibDdMUGhVYlFZZXJOMC00alBRY2s4NDM4RTRtMDRTUHB0TS0yRG5USDIxNDZqd3Jvek05ZU5Va2FkdUN2dlpONm51MXR0T3pfQk13UW1iNTl0WjRWZHlPQlZFekhqaF9tTnczdU9vbVpxcENaRDc0aFp0WllpZUhQc19UVlJEOG9Xb29Vc3hydklfTW93SGdqendTenRJQWl2cVdZNjdsUHl6Q2E1R05fdFlhYmJxTkkyOEp3MUFpZkhJLWYwTk5UUkNTZ0hHS3dwNHNVZV9DcldyX3dNY1dBTVBaeFZhc3JISTE4MVN2cVBPd09ob0lJc2J3SzIxaFg2ZHRpZDhMRUNNZEJRY0lhSWpENnFiLVlfSGFxV2I4SnZ0Mlo1Y3ZXZmdDUDBGemo3ZThBczZNaUstRTFTeWhtY0tabW5JWEdDR2pmNGVzekRSWHFGMGxkVVpyRGNLcF8yVG50eG9MT1U3OEZUc2hTTkRyNDhja0s1QmFmcExLYjgtTWJvNlZBSHhVbHpDdXlJenlaYnJWQXhTV291aDJQYzNGZVpGNnEyWmNEZmZ0RDN3S0JkTWFtVXU0dWpFY09kTjlSV1c1Mnd3RGxEZjZiRmhjU3l5amh4RTJ2eU83T3FGMHJsNWgyYm0ya3hqcVJJNXVCbXNKa3FFX0lfaUJuWFphdGJjUExpUDlUdmZtbDIxV1pZUVRiMU9NZVZxM2E2Sy1FdE5XTlV5MHVLMkJLNENmMjV0eno3eGotUGFYN3pCcXN6Uk93aUlNcW9QX0liZnh4YzBHNUNodTV0M2tfdXByNFRETG5EenhXb1Y5bEVlZFdWdkpaczhGaDM4T0NMMFBHOGxVSW5rcWxKVGw2RXBUTVdtcUhVNklPT0pGT0VZWDE4S29ONjFRUEE2c0Rja1RKWVc5SnV5M1NPMTNDT0JjMGJkcEVDVkpQUlhZMUVKd1V3cnpSSkk2SGt0bExMVUJITVBHdHhZOWhzVzZqMmpDMFI2MjlQUVZpcV9CejIxMnRCV0s0c29DQVFlVVVKcmlmb3NEeUtiMjhNUWw5akZTc0hKSzZ2SXAtbEtnOWY5eFNKcjFJQzJkS0RRaEFiVlJ4ckM1Mzh5cTRWb0pnNVBvMk80R0E0VHFlU2xKcmh5eHZ5UmY5RTI0UHRkdHJrODk2SkNuUXlvWlptQm8wejZEUVRqX0hqMlUzbHpGdEFTTVpaa1pmVmJmSFg0bEVuUFhuRkh5VHVJMXdsM01VYUxxSkF2WG55S3QzajVJYURoV2JzbkNfMTdGcnZCNUVMbmw4V2x6cmZGN1hhc3A4ZWpWdU4wRVRJN0F2RzNSaXg1TFdnQWgzb2lDUk5tOUhhaFBhZkh6TFh1RlVlY3piZjcxSEd1VTdQZy00Sm5xZjNlSGFKbnd2bzBVNnNBLnliRmEyczdqNTQwVjgxNXF5UTBLUlE"}'
+    body: '{"value": "KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taWNyb3NvZnQuY29tZXlKcmFXUWlPaUkwTXpnMVlqQTNZaTFrTlRRM0xUUXlaVFV0WVdVNVpTMDJNVEJrWXpNNVpHWmhaamdpTENKaGJHY2lPaUpTVTBFdFQwRkZVQ0lzSW1WdVl5STZJa0V4TWpoRFFrTXRTRk15TlRZaWZRLm1PcXI5b2pRcXpra0tyMVpDNkpZb2FVb3FVYU12M052a21pN1kzMUxMSlN0X2loWEk4ZkpfazZxYk5QeWFjTTV2d2tneXJKZ0IxRW8xdEtibndjMUg5bGN5Y19Uc2N3RWcxVDRsbHVrOTJFRkRWcEhPdXQ4S0pRek5aejFJRWlLd2dqQnNjY1g2bkZmV0U0N2tWUWZ6Q2ZTTzJYMnRiSGpqU3h0RVB1dy1MU080VFZNUEpUV1BydTJTZkhqUmtSTzlnZ1dpYzFZc19KNmdmRUxZZFU2QlpvLXhMQUFvREU1M1p3eHJoNjlLZzN5a25CQk1IbldRZkNoM0JaU1V3RkVLdjZQRm9EZTJiWWZVaklxZ3UxQ3NYbkdnM3I0V3lIdGxXUHlfUm45aXpwWWZFTHBnb1UtT2U5NFA4dTlHYXlnV0xtVG01YWZnclRNN2YzMXA5NVEwUS5NcnF1dHlmZ3RzS2dlVU1CVVJDNEtBLmtYM21CZ0w0TFl3TWFiSTIxQ2FwN2ZqYzhoUXpYMTN2anFjaWxDUzctQVpZeWNmYWZjWlNKMWNla1NjMEM0by1SdUh4eVFyWENEWDZtTEdLWnNuUVY3RzVJNnVaY0pRVWZ1M3lRU25ZVUdkaEh6U1dPOFp4QXprTEZETXBRdFVqajV3N0R4cnRuTFljdktzb3hNUFBDSkdDSkdON1ZJTmhGaUo4Q1pZV21DdkdRVkhNSjlTRnVnTm9OU2J2aFczb3lRdXY3ekhIeFRjN3hHOHhxaVJveHktY1NoaFgyekpOd3N0ZkVSX0hUX1ZXWnRPYUhMeUM3Rmp0WHFWLUZBME5zeTB3YWlhTDllYWZReWhweE52Ym9mRzRYRlZlbVd6UXAxREJSQ092ejdFczAzZEhMVGpjNG9OZHVaWU82SDlzcXk4d0tZZUp0U2ZnX2loX3pqS2RuWUNydXhOaDdVZkkyS0l0R1dvUVcxYW12M3pqeThaWXladWVKNDRaN3NkQlNZazNuRkg2U19ZOWc3WTVNc0xmbGc4NVl5RHAyVUR5eEJ5WmVUVFhudkxBV2hyaHE0MC1MZ1UwNl9wYWNGak1XTGRxd3A5dFBwQ2pfN2JPejZTU2JaQmpFNi1fQlpYSnB6SGoyejlUZ2I0VDktaGY2TTFZZ0JCdnJxaUNWcEtuUU16dm9idjk5OE1LYjNZNXdDeFJXdFdETzRiQzFjbmJweUFBczQ2bTEwU1p0T2JxY015amZnajJvUjYzckdDZW5SRDJINUxtYnphZ0hsZUxiU2Z3ZWRUYTFzMnZycHZBVkRLeVFjOEg0N0oweGI3OHlGTmpJYVhsSXJnazduX1JlXzVtcENnWDJTMUhta1R0MUdBMmJDbHpyR2VydVJ0cWtiWFhLd1JkRDlHNnpqc05OV2Y3WkRMaXhLVU5PTW9Ud1RBek4zRnp2bXVyVGNUQ0dtNVdhaTY4Rk55ckl0MXJUU3N1d09zOTQ5S0Z2dWRkcjNxQ1dJMmM3UE9hd1BmN2E0WVgxRmlVUndlaE80SEtqWmxrblJXNmdSQlk2dmhQc0g4RGJpUEJyM1FIbFpJOXNoY0lZdGoxcmhJLWV2LUFQTmRydk9CeWZuUzh6dU1Qcmo4bTcxUVhvbEQzX2ZNb2lUTzkyMm5TazhBcmpOUl9YSTZSSGx3dWVxN2FjeHJUSEZjR0I2VDhRX1RCOWdTYzVxNW0tN2lHRzA3VElwaDRGUkdzQVg3dF9RckF0aG9idWE4MzZvV0dOQmxkU0UzeTJXMV9qaTlhVjF2Qm8wOE9DdlY1S2VLV2RPR1FvNTZWX214NnFPTm5JRXhSSlcxY3ROQzdMd1hEVlZZd1BMc2tkdERPbHc4dDloRWh5ZEpkNHVYRlV4VTNsZmJaVnZWMHVzYnF3Z284Rk16dHU2NXg0Ym01dVlzb0htbVlCZ182RV8yTVVJc1pyNEp6ZU9ZNVk2QjVqNFgxOXJKR0l2X2lmRzNMTEl0R1BNUVRjdF95UFBuZDR4UFdJZE5LZkRTcWtRRkg0MFgyb3Z4T1V3dXlCb2x1ZzZXRW5KOFRVTFhqVFc0Q1JUekZub3Zyemg0bVZOR1ZTRVZHYi1ncXpPS25XZkJvZi0xU2VfQ21nR2dId1FQdjRrOFJTMmRjendIZ0NsYWJzY2VJTURLV19taDJrQlFmb3phcGdTd0V0ZjY3TGZrcmpZdUpPUlVFb2xISE5hNHprNW81OG1CU1dnRzN1d3ZQbnpxaERuSTQtZ2FHNHV2Z0czRExEbW5saXU1YzdoaVFWbTNBUEhDVzNqVDlhQkxJMUkxWndBTHFVbVlhR2V4SG9BMTVKZ2lZdjNtYm1TVFFyOGR6MXkyRTN2UDFpcWlyY1psc1RsdUhMUXlmQ2tpMkZ2VjVuVHR0c1JfTDRWTnlBaENlTXI1LXMwanVMMlBfbTBxbU1EZndrY0FiZU5xZjlrN0cxSXBueHNlNGY3a3dRLVNtWkpjMUpZUkctUnJuTWNDSVR3clh6SlZlbV94VDN1czdFS0Iwb1RIMEdkZFBTQW9nVTlRek9nWnBhSFhqSjVSOTgxV1VOb0xUZUVpb1BVWkNGWUF2V2NwZUFBWms3cFFNenRaRi1XY0REdTVHY0t6ck5fTXFXSmQ5YlBvUWV5WlVHV0ZWMjU2azJuUVNhZC1maXQyNVpLSDBiUC1qLWMwUFJiQlFCTGZXaDVxT3AxYXh4MVQ0djRwNkpab1JrSUFxSE1TdU1NNTg1clVrMU9sMDYwRFctazJacGw4QW01dnZwWUtvNUcyb1VzTGNwRE9SZGt6eVVaOFRFOWs2elMwb1A0MWoyaEJ4b0hZUkNpcDVWTkxWdnNEa0NEOWlTTXBWQmU1ZTFVWEtGMTE1TjBnUDlMSlBxal9WNjU2SUt1bW11dmd4NnpWNG8xby1WdVY1Tll0cmhrTzhzYlFGS3hrdWdkbVJRM05yUFFvWWdwZkNNZEZkaS15M0dFZnZMY3Y5TktjM0pVR3dXbVFsTlZwS01zMld5MmllYzdEUnlIWG1sczFxdHRYcWRfTU95dkNmVzhwS3lfY2ZCYTFTOXhxbEJnSHRkVGwtczV6V1Fqa2paOGpiQTBHLUQyWkFPUUQ0R21Hb3ZlVDdxc0t0cHRzaTA0LU10dnFLS2xUMVVIQTVWZGRsZk53NU5SLTlZdjFaY1Z2Tml1cFNVeDV3dXlKbEJ6OWM0cmdyem56N1hWVGprV3hIaFg5UHZDNTExTHYybnR6ZGdfV0lBTEZvdTgweEdiRlE3MFhSNi1Lb1FzOW9WYjJSbWxjXzZRZGpyNFNDVURtTTdaQ0lBdHlaSTFPekxNTXpiUF9uNmRJM0dyMFV6WXJTMG1OUjZxTzdiS2laSTZ5UGxnV1dnbUxGQnpPM0llaXRtUmZudW42eVh4WTd1WDlNc25TYXVja1pzRldsRkJka2lJQjU5S0lLVVBSNklMVWNBbnhlX0hqV0drNHNuSklwQWNsbWhxNEVaQjVnWnAyeksyTXVUTTlZbm5abTZPWnBXYV9HTFhYNVc2M21ibDVISmRWLU8tUGR5MVA3aUNvY2l6QkVJNUQ5VWVRMzl1Y0dERVdZclpLUU43c0R5a2M1QnFldEs2NzZoUTMxMDF1b3prVG9NWFo3X3NuWThtNkIyaDhZMkJDWklWOUoyeGxKemo1azhGUWN2VHJJX2xIREF0cTJFZHRRZllpdjRlQlc1VXZ0THotWFVITFlGMTh5QnRjTjlRWURENkFkZTJzaXZvREhFS05Qa3VKQW5abjNWVXRqTUJ5NjltRU10dElYOFFuQ3VjaUdRbG5NWW5iVHJWTnJ4N3hYVDZNTmxla1B3OUcyRFRTVTFxeC1qQWZMRzBRWEJYb1htT3FQQmpGdUw1NzlNYVRMS1RsUkxDRllKNHhkZU0tSEMtSlVSYUo2cUlWWWJKV3ozQ2tVczhrR2U1SUNxRzIyZ05sV0w0UnVGcXlkSHZuWlNvcTI1UGlqNHcwZlJHQnhtalF2elkzbkxCVFRJaVZXcjJ5aUFNMm92N3dqOGdnOEo4bGl0VG5DVTZhaGE4NkVGb21jdW52MEdpLTBrcHd6eWlTMmw0emkxQThaZFJLQm0tWklnS0JWZGtJTENGcXhyRkd1Nm9GaVhZOU1sTktZM2NVdERaNHp6MC1yVXEwMTA0WmRRX05WRDZmV3MzR2dNc2JpUzZTZEc1R1dHYVVvejNfQ3VvZDVCeWx4NW1jTUFfNW9FYlU3eURuQWQza18xV3psNFFvOExtWVEzS0RBVXMtWTBrUThsR292Wm9RTEU2SkpRWDRSTzBFMzhVcHZVMlNURHVjbFlpX2VrOUZjSXNkNGJsdTNXbm1MX0wxVGtXV2FIc2xCWkEybDhUVGxwbjlVejZoTEI4M1ljeUpYc1RTdVYtU01tUkhQMEZ2ZHVyblE5MzRFWTJtdmVpZE95TEQ2X3pydThQVl9yalFJeDR4cmQ3QzJyMjIzX09sSW4zOTdUZGV0elAwVWZHNE00X1BiQ0dBaFRvZWk2OUI3UUd3TWhjaWV0SE5mTjhmc3NLREVlZ2VZTkR1TndQMGpCSnFTUVJ4QmNDVlMyV0RCcFVEOTY3SEl5dVQtdTR4VHBvSVA0Y3Rucmh3alp1YUx6MktNTzhjNk1waVgyNFNSVjl6Sy1WQTBlUXZPcmY3QzdEQWtjWTk0MGZBbFN0N2tyYzJYSUotRXNqLUlvbnY3RndUT25OcVJBUEgyZUIyeHg3UFNEM3AzU2s2TzF2Mm1oTzdnSGtEV18ySzJQTkw5QThuYkFONklMY3NuOWhuRFFMSC1oNEY2bnhveDk1SnJ3SlUyZDg2ejFKcVRRR2d1WUhNLURvMk96bkZLd05ISkNUeGFQWk16aGE3Wm9MT2JFV0FvQlNOQ2dVV1N1dXpHbEJmOW9NTEhCeEJDalhjU05VMWJya1lUSU1Tbk1UaHF2NmN2ODB5WndkRjRfaW9OY2ZId1hDa0NZYzZFWUNEQ2JTMXRnY3NzRU12elZJVDN5Z3QyTGNvSVQtcWduUVVRYmt0T2pNRnpoalBtbDV3d2lZLVlNNVJMUlU0eE1SZ0UyMWNvdzRXcV9oX3NBZUdEcDJPU0JjUlQ4NHJid0I5Q2t5TWFWekQ1S2lhQ190Ymo4dHdURjBYNG9EN1ZTaHVrV3BSNkZfYkU5T1I4SlpINkZQNk9IQXlGNXFqNDg1NU13WmZLUFRnb2ZtSy1ZYjJ3VUtDX012RjVyVTJrUER2dy04WjNiRVd0TmVGUGVNRGxJeUNuaGJRTXE3YmpESElvemtEUFBQd2JtMkxjSkVlMjhnWjM4SThyZHQ5Mm1GZG94ei10NTFVS1BPTkZ4dE0tUHg0bHFHejBWUmd1SVppdk1WX3N1a1ctNXBvaExwRWhfeVF5aWJuZzlKdkpwVFJ5R20zYlo3MGJxOE1Bb1pjZGNka0hjZ0NTZHRWWjF2ZWt3clFmd3VvLmdCWUNIeDlUWURmQnJxemxTLW5GNmc"}'
     headers:
       Accept:
       - application/json
@@ -958,16 +958,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/restore?api-version=7.0
   response:
     body:
-      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/4731dc0b6cca4d52af7a8afa8df1cd4f","attributes":{"enabled":false,"created":1580989786,"updated":1580989797,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/815b8feff30441ea8a0419587fb9ac7b","attributes":{"enabled":false,"created":1582034071,"updated":1582034080,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '279'
+      - '299'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:05 GMT
+      - Tue, 18 Feb 2020 13:54:46 GMT
       expires:
       - '-1'
       pragma:
@@ -981,11 +981,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1011,16 +1011,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/versions?api-version=7.0
   response:
     body:
-      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/4731dc0b6cca4d52af7a8afa8df1cd4f","attributes":{"enabled":false,"created":1580989786,"updated":1580989797,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/6c5d98a6801c421cb70842ea29715d6a","attributes":{"enabled":true,"created":1580989782,"updated":1580989782,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+      string: '{"value":[{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/815b8feff30441ea8a0419587fb9ac7b","attributes":{"enabled":false,"created":1582034071,"updated":1582034080,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"test":"foo","file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/bcb96e7388a041e88d08e21b8f9d6830","attributes":{"enabled":true,"created":1582034067,"updated":1582034067,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '547'
+      - '587'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:06 GMT
+      - Tue, 18 Feb 2020 13:54:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1034,11 +1034,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1066,16 +1066,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1?api-version=7.0
   response:
     body:
-      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/4731dc0b6cca4d52af7a8afa8df1cd4f","attributes":{"enabled":false,"created":1580989786,"updated":1580989797,"recoveryLevel":"Purgeable"},"tags":{"test":"foo","file-encoding":"utf-8"}}'
+      string: '{"contentType":"test type","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/secret1/815b8feff30441ea8a0419587fb9ac7b","attributes":{"enabled":false,"created":1582034071,"updated":1582034080,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"test":"foo","file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '279'
+      - '299'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:07 GMT
+      - Tue, 18 Feb 2020 13:54:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1089,11 +1089,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1128,7 +1128,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:08 GMT
+      - Tue, 18 Feb 2020 13:54:51 GMT
       expires:
       - '-1'
       pragma:
@@ -1142,11 +1142,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1181,7 +1181,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:09 GMT
+      - Tue, 18 Feb 2020 13:54:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1195,11 +1195,2026 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "tags": {"file-encoding":
+      "utf-8"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '109'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-8?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-8/ee47e27eaf3d46ffb4ff563f3eddd34f","attributes":{"enabled":true,"created":1582034094,"updated":1582034094,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '335'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:54:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "tags": {"file-encoding":
+      "utf-16le"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '112'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-16le?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-16le/e7fcdfc2ea1b4451b910cfc937e00a31","attributes":{"enabled":true,"created":1582034095,"updated":1582034095,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16le"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '341'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:54:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "tags": {"file-encoding":
+      "utf-16be"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '112'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-16be?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-16be/9573d367c81d4c0db7ab7cde4ed57ae6","attributes":{"enabled":true,"created":1582034097,"updated":1582034097,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16be"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '341'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:54:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecretTestSecretTestSecretTestSecret\n", "tags": {"file-encoding":
+      "ascii"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '109'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-ascii?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-ascii/64affe5363a3482bb64b55b1e238d920","attributes":{"enabled":true,"created":1582034098,"updated":1582034098,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"ascii"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '335'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:54:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n",
+      "tags": {"file-encoding": "base64"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-base64?api-version=7.0
+  response:
+    body:
+      string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-base64/aca4357ad71c467b9c55c3ba931fcfd3","attributes":{"enabled":true,"created":1582034100,"updated":1582034100,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"base64"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '353'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:54:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a",
+      "tags": {"file-encoding": "hex"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '149'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-hex?api-version=7.0
+  response:
+    body:
+      string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-hex/0065ad99c5204434ad89e862bd3de511","attributes":{"enabled":true,"created":1582034101,"updated":1582034101,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"hex"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '373'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecret2TestSecret2TestSecret2TestSecret2\n", "tags": {"file-encoding":
+      "utf-8"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '113'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-8?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret2TestSecret2TestSecret2TestSecret2\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-8/0b5d53d1a210409fb194fd6631b9a27e","attributes":{"enabled":true,"created":1582034103,"updated":1582034103,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '340'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecret2TestSecret2TestSecret2TestSecret2\n", "tags": {"file-encoding":
+      "utf-16le"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '116'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-16le?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret2TestSecret2TestSecret2TestSecret2\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-16le/2fc87cdd32c6461b833a65de5a053e2f","attributes":{"enabled":true,"created":1582034105,"updated":1582034105,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16le"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '346'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecret2TestSecret2TestSecret2TestSecret2\n", "tags": {"file-encoding":
+      "utf-16be"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '116'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-16be?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret2TestSecret2TestSecret2TestSecret2\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-16be/609009b4f29b4106bf56ba91ddd5ba65","attributes":{"enabled":true,"created":1582034108,"updated":1582034108,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16be"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '346'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecret2TestSecret2TestSecret2TestSecret2\n", "tags": {"file-encoding":
+      "ascii"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '113'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-ascii?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret2TestSecret2TestSecret2TestSecret2\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-ascii/57c2e6826eca4bdfb8e1b37e4be59f88","attributes":{"enabled":true,"created":1582034110,"updated":1582034110,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"ascii"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '340'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "VGVzdFNlY3JldDJUZXN0U2VjcmV0MlRlc3RTZWNyZXQyVGVzdFNlY3JldDINCg==\n",
+      "tags": {"file-encoding": "base64"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-base64?api-version=7.0
+  response:
+    body:
+      string: '{"value":"VGVzdFNlY3JldDJUZXN0U2VjcmV0MlRlc3RTZWNyZXQyVGVzdFNlY3JldDINCg==\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-base64/bb57496b37bb4b27ae0012cd74c38bab","attributes":{"enabled":true,"created":1582034114,"updated":1582034114,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"base64"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '362'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "54657374536563726574325465737453656372657432546573745365637265743254657374536563726574320d0a",
+      "tags": {"file-encoding": "hex"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '157'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-hex?api-version=7.0
+  response:
+    body:
+      string: '{"value":"54657374536563726574325465737453656372657432546573745365637265743254657374536563726574320d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-hex/a958c8773ab64b5f93e34d7b62da66de","attributes":{"enabled":true,"created":1582034116,"updated":1582034116,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"hex"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '382'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecret3TestSecret3TestSecret3TestSecret3\n", "tags": {"file-encoding":
+      "utf-8"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '113'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-8?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret3TestSecret3TestSecret3TestSecret3\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-8/cbea4a23419445d3b9d299c575a2c82d","attributes":{"enabled":true,"created":1582034118,"updated":1582034118,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '340'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecret3TestSecret3TestSecret3TestSecret3\n", "tags": {"file-encoding":
+      "utf-16le"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '116'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-16le?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret3TestSecret3TestSecret3TestSecret3\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-16le/34e968937fbc47e09fc7f6080f665a50","attributes":{"enabled":true,"created":1582034119,"updated":1582034119,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16le"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '346'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecret3TestSecret3TestSecret3TestSecret3\n", "tags": {"file-encoding":
+      "utf-16be"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '116'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-16be?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret3TestSecret3TestSecret3TestSecret3\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-16be/4e89b51af8044d29aab5b70399e94c1b","attributes":{"enabled":true,"created":1582034121,"updated":1582034121,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16be"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '346'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "TestSecret3TestSecret3TestSecret3TestSecret3\n", "tags": {"file-encoding":
+      "ascii"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '113'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-ascii?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret3TestSecret3TestSecret3TestSecret3\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-ascii/cd0fc5def03f4f0c81deea06e8310f88","attributes":{"enabled":true,"created":1582034122,"updated":1582034122,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"ascii"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '340'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "VGVzdFNlY3JldDNUZXN0U2VjcmV0M1Rlc3RTZWNyZXQzVGVzdFNlY3JldDMNCg==\n",
+      "tags": {"file-encoding": "base64"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-base64?api-version=7.0
+  response:
+    body:
+      string: '{"value":"VGVzdFNlY3JldDNUZXN0U2VjcmV0M1Rlc3RTZWNyZXQzVGVzdFNlY3JldDMNCg==\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-base64/207bd65cb0b44c51ad2aadc34b6e6f85","attributes":{"enabled":true,"created":1582034124,"updated":1582034124,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"base64"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '362'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"value": "54657374536563726574335465737453656372657433546573745365637265743354657374536563726574330d0a",
+      "tags": {"file-encoding": "hex"}, "attributes": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '157'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-hex?api-version=7.0
+  response:
+    body:
+      string: '{"value":"54657374536563726574335465737453656372657433546573745365637265743354657374536563726574330d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-hex/efaa5fa370594802a4ff450ee47fe982","attributes":{"enabled":true,"created":1582034125,"updated":1582034125,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"hex"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '382'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets?api-version=7.0
+  response:
+    body:
+      string: '{"value":[{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-ascii","attributes":{"enabled":true,"created":1582034098,"updated":1582034098,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"ascii"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-base64","attributes":{"enabled":true,"created":1582034100,"updated":1582034100,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"base64"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-hex","attributes":{"enabled":true,"created":1582034101,"updated":1582034101,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"hex"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-16be","attributes":{"enabled":true,"created":1582034097,"updated":1582034097,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16be"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-16le","attributes":{"enabled":true,"created":1582034095,"updated":1582034095,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16le"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-8","attributes":{"enabled":true,"created":1582034094,"updated":1582034094,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-ascii","attributes":{"enabled":true,"created":1582034110,"updated":1582034110,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"ascii"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-base64","attributes":{"enabled":true,"created":1582034114,"updated":1582034114,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"base64"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-hex","attributes":{"enabled":true,"created":1582034116,"updated":1582034116,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"hex"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-16be","attributes":{"enabled":true,"created":1582034108,"updated":1582034108,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16be"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-16le","attributes":{"enabled":true,"created":1582034105,"updated":1582034105,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16le"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-8","attributes":{"enabled":true,"created":1582034103,"updated":1582034103,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-ascii","attributes":{"enabled":true,"created":1582034122,"updated":1582034122,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"ascii"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-base64","attributes":{"enabled":true,"created":1582034124,"updated":1582034124,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"base64"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-hex","attributes":{"enabled":true,"created":1582034125,"updated":1582034125,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"hex"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-16be","attributes":{"enabled":true,"created":1582034121,"updated":1582034121,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16be"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-16le","attributes":{"enabled":true,"created":1582034119,"updated":1582034119,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16le"}},{"id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-8","attributes":{"enabled":true,"created":1582034118,"updated":1582034118,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4569'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-ascii/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-ascii/64affe5363a3482bb64b55b1e238d920","attributes":{"enabled":true,"created":1582034098,"updated":1582034098,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"ascii"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '335'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-base64/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-base64/aca4357ad71c467b9c55c3ba931fcfd3","attributes":{"enabled":true,"created":1582034100,"updated":1582034100,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"base64"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '353'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-hex/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-hex/0065ad99c5204434ad89e862bd3de511","attributes":{"enabled":true,"created":1582034101,"updated":1582034101,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"hex"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '373'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-16be/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-16be/9573d367c81d4c0db7ab7cde4ed57ae6","attributes":{"enabled":true,"created":1582034097,"updated":1582034097,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16be"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '341'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-16le/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-16le/e7fcdfc2ea1b4451b910cfc937e00a31","attributes":{"enabled":true,"created":1582034095,"updated":1582034095,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16le"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '341'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-8/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret-utf-8/ee47e27eaf3d46ffb4ff563f3eddd34f","attributes":{"enabled":true,"created":1582034094,"updated":1582034094,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '335'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-ascii/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret2TestSecret2TestSecret2TestSecret2\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-ascii/57c2e6826eca4bdfb8e1b37e4be59f88","attributes":{"enabled":true,"created":1582034110,"updated":1582034110,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"ascii"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '340'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-base64/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"VGVzdFNlY3JldDJUZXN0U2VjcmV0MlRlc3RTZWNyZXQyVGVzdFNlY3JldDINCg==\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-base64/bb57496b37bb4b27ae0012cd74c38bab","attributes":{"enabled":true,"created":1582034114,"updated":1582034114,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"base64"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '362'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-hex/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"54657374536563726574325465737453656372657432546573745365637265743254657374536563726574320d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-hex/a958c8773ab64b5f93e34d7b62da66de","attributes":{"enabled":true,"created":1582034116,"updated":1582034116,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"hex"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '382'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-16be/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret2TestSecret2TestSecret2TestSecret2\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-16be/609009b4f29b4106bf56ba91ddd5ba65","attributes":{"enabled":true,"created":1582034108,"updated":1582034108,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16be"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '346'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-16le/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret2TestSecret2TestSecret2TestSecret2\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-16le/2fc87cdd32c6461b833a65de5a053e2f","attributes":{"enabled":true,"created":1582034105,"updated":1582034105,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16le"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '346'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-8/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret2TestSecret2TestSecret2TestSecret2\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret2-utf-8/0b5d53d1a210409fb194fd6631b9a27e","attributes":{"enabled":true,"created":1582034103,"updated":1582034103,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '340'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-ascii/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret3TestSecret3TestSecret3TestSecret3\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-ascii/cd0fc5def03f4f0c81deea06e8310f88","attributes":{"enabled":true,"created":1582034122,"updated":1582034122,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"ascii"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '340'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-base64/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"VGVzdFNlY3JldDNUZXN0U2VjcmV0M1Rlc3RTZWNyZXQzVGVzdFNlY3JldDMNCg==\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-base64/207bd65cb0b44c51ad2aadc34b6e6f85","attributes":{"enabled":true,"created":1582034124,"updated":1582034124,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"base64"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '362'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-hex/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"54657374536563726574335465737453656372657433546573745365637265743354657374536563726574330d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-hex/efaa5fa370594802a4ff450ee47fe982","attributes":{"enabled":true,"created":1582034125,"updated":1582034125,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"hex"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '382'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-16be/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret3TestSecret3TestSecret3TestSecret3\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-16be/4e89b51af8044d29aab5b70399e94c1b","attributes":{"enabled":true,"created":1582034121,"updated":1582034121,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16be"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '346'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-16le/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret3TestSecret3TestSecret3TestSecret3\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-16le/34e968937fbc47e09fc7f6080f665a50","attributes":{"enabled":true,"created":1582034119,"updated":1582034119,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16le"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '346'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.2 azure-keyvault/7.0
+        Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-8/?api-version=7.0
+  response:
+    body:
+      string: '{"value":"TestSecret3TestSecret3TestSecret3TestSecret3\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-all-test-secret3-utf-8/cbea4a23419445d3b9d299c575a2c82d","attributes":{"enabled":true,"created":1582034118,"updated":1582034118,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '340'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 18 Feb 2020 13:55:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1228,16 +3243,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8?api-version=7.0
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/470eb2d262e945e49c8f4a07a4fa22d5","attributes":{"enabled":true,"created":1580989811,"updated":1580989811,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/e14cb7302d984f97938d96712103fd31","attributes":{"enabled":true,"created":1582034148,"updated":1582034148,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '299'
+      - '319'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:11 GMT
+      - Tue, 18 Feb 2020 13:55:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1251,11 +3266,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1281,16 +3296,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/?api-version=7.0
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/470eb2d262e945e49c8f4a07a4fa22d5","attributes":{"enabled":true,"created":1580989811,"updated":1580989811,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-8"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-8/e14cb7302d984f97938d96712103fd31","attributes":{"enabled":true,"created":1582034148,"updated":1582034148,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-8"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '299'
+      - '319'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:12 GMT
+      - Tue, 18 Feb 2020 13:55:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1304,11 +3319,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1337,16 +3352,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le?api-version=7.0
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/6fb2dd2afd564502a62127566c721f3e","attributes":{"enabled":true,"created":1580989815,"updated":1580989815,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16le"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/8664ec2d8dbf4714b554013401b826b6","attributes":{"enabled":true,"created":1582034151,"updated":1582034151,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16le"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '305'
+      - '325'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:14 GMT
+      - Tue, 18 Feb 2020 13:55:51 GMT
       expires:
       - '-1'
       pragma:
@@ -1360,11 +3375,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1390,16 +3405,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/?api-version=7.0
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/6fb2dd2afd564502a62127566c721f3e","attributes":{"enabled":true,"created":1580989815,"updated":1580989815,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16le"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16le/8664ec2d8dbf4714b554013401b826b6","attributes":{"enabled":true,"created":1582034151,"updated":1582034151,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16le"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '305'
+      - '325'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:16 GMT
+      - Tue, 18 Feb 2020 13:55:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1413,11 +3428,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1446,16 +3461,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be?api-version=7.0
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/a7cbb901aecb472086c1495695dc9fe7","attributes":{"enabled":true,"created":1580989818,"updated":1580989818,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16be"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/127c4a0d6b6f4a83a7de7285f8b82b56","attributes":{"enabled":true,"created":1582034154,"updated":1582034154,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16be"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '305'
+      - '325'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:18 GMT
+      - Tue, 18 Feb 2020 13:55:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1469,11 +3484,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1499,16 +3514,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/?api-version=7.0
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/a7cbb901aecb472086c1495695dc9fe7","attributes":{"enabled":true,"created":1580989818,"updated":1580989818,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"utf-16be"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-utf-16be/127c4a0d6b6f4a83a7de7285f8b82b56","attributes":{"enabled":true,"created":1582034154,"updated":1582034154,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"utf-16be"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '305'
+      - '325'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:19 GMT
+      - Tue, 18 Feb 2020 13:55:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1522,11 +3537,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1555,16 +3570,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii?api-version=7.0
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/9debeb3a64334a5a94aa0c640801c46b","attributes":{"enabled":true,"created":1580989822,"updated":1580989822,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"ascii"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/ada2aa0b2c9341ffa3cae3ee26f0c85f","attributes":{"enabled":true,"created":1582034159,"updated":1582034159,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"ascii"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '299'
+      - '319'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:21 GMT
+      - Tue, 18 Feb 2020 13:55:59 GMT
       expires:
       - '-1'
       pragma:
@@ -1578,11 +3593,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1608,16 +3623,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/?api-version=7.0
   response:
     body:
-      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/9debeb3a64334a5a94aa0c640801c46b","attributes":{"enabled":true,"created":1580989822,"updated":1580989822,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"ascii"}}'
+      string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-ascii/ada2aa0b2c9341ffa3cae3ee26f0c85f","attributes":{"enabled":true,"created":1582034159,"updated":1582034159,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"ascii"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '299'
+      - '319'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:23 GMT
+      - Tue, 18 Feb 2020 13:55:59 GMT
       expires:
       - '-1'
       pragma:
@@ -1631,11 +3646,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1664,16 +3679,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64?api-version=7.0
   response:
     body:
-      string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/42565e9678104752a82072e257d7c6b3","attributes":{"enabled":true,"created":1580989828,"updated":1580989828,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"base64"}}'
+      string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/98dbbc59de9a4c2ab860c12d7ca8a533","attributes":{"enabled":true,"created":1582034162,"updated":1582034162,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"base64"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '317'
+      - '337'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:28 GMT
+      - Tue, 18 Feb 2020 13:56:01 GMT
       expires:
       - '-1'
       pragma:
@@ -1687,11 +3702,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1717,16 +3732,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/?api-version=7.0
   response:
     body:
-      string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/42565e9678104752a82072e257d7c6b3","attributes":{"enabled":true,"created":1580989828,"updated":1580989828,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"base64"}}'
+      string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-base64/98dbbc59de9a4c2ab860c12d7ca8a533","attributes":{"enabled":true,"created":1582034162,"updated":1582034162,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"base64"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '317'
+      - '337'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:30 GMT
+      - Tue, 18 Feb 2020 13:56:02 GMT
       expires:
       - '-1'
       pragma:
@@ -1740,11 +3755,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1773,16 +3788,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex?api-version=7.0
   response:
     body:
-      string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/6fd219bf234542d2af406d67964bbfc9","attributes":{"enabled":true,"created":1580989835,"updated":1580989835,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"hex"}}'
+      string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/adafda3f56a1428b9b88e97481a7ce4c","attributes":{"enabled":true,"created":1582034165,"updated":1582034165,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"hex"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '337'
+      - '357'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:34 GMT
+      - Tue, 18 Feb 2020 13:56:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1796,11 +3811,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:
@@ -1826,16 +3841,16 @@ interactions:
     uri: https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/?api-version=7.0
   response:
     body:
-      string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/6fd219bf234542d2af406d67964bbfc9","attributes":{"enabled":true,"created":1580989835,"updated":1580989835,"recoveryLevel":"Purgeable"},"tags":{"file-encoding":"hex"}}'
+      string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-kv-se-000002.vault.azure.net/secrets/download-hex/adafda3f56a1428b9b88e97481a7ce4c","attributes":{"enabled":true,"created":1582034165,"updated":1582034165,"recoveryLevel":"Purgeable","recoverableDays":0},"tags":{"file-encoding":"hex"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '337'
+      - '357'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 06 Feb 2020 11:50:36 GMT
+      - Tue, 18 Feb 2020 13:56:06 GMT
       expires:
       - '-1'
       pragma:
@@ -1849,11 +3864,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=59.63.206.47;act_addr_fam=InterNetwork;
+      - addr=101.69.107.42;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.893
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_secret2.txt
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_secret2.txt
@@ -1,0 +1,1 @@
+TestSecret2TestSecret2TestSecret2TestSecret2

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_secret3.txt
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_secret3.txt
@@ -1,0 +1,1 @@
+TestSecret3TestSecret3TestSecret3TestSecret3


### PR DESCRIPTION
This is for supporting #7692 
Command usage: `az keyvault secret download-all --vault-name {kv} --dir/-d {local_dir} --encoding/-e {e} --maxresults {mr}`

---
This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
