### PR TITLE
{doc} Import Directive from docutils.parsers.rst

### DIFF
--- a/doc/sphinx/azhelpgen/azhelpgen.py
+++ b/doc/sphinx/azhelpgen/azhelpgen.py
@@ -9,7 +9,11 @@ from mock import patch
 from os.path import expanduser
 from docutils import nodes
 from docutils.statemachine import ViewList
-from sphinx.util.compat import Directive
+try:
+    # Deprecated in 1.6 and removed in 1.7
+    from sphinx.util.compat import Directive
+except ImportError:
+    from docutils.parsers.rst import Directive  # pylint: disable=import-error
 from sphinx.util.nodes import nested_parse_with_titles
 
 

--- a/doc/sphinx/cligroup/cligroup.py
+++ b/doc/sphinx/cligroup/cligroup.py
@@ -6,7 +6,11 @@ import copy
 from docutils import nodes
 from sphinx import addnodes
 from sphinx.directives import ObjectDescription
-from sphinx.util.compat import Directive
+try:
+    # Deprecated in 1.6 and removed in 1.7
+    from sphinx.util.compat import Directive
+except ImportError:
+    from docutils.parsers.rst import Directive  # pylint: disable=import-error
 from sphinx.util.docfields import Field
 
 cli_field_types = [


### PR DESCRIPTION
sphinx.util.compat is deprecated since 1.6 and removed in 1.7.

http://www.sphinx-doc.org/en/master/extdev/deprecated.html
