### PR TITLE
{Packaging/Ubuntu} Remove cosmic packaging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -983,7 +983,6 @@ jobs:
    - BuildUbuntuBionic
    - BuildDebianJessie
    - BuildDebianStretch
-   - BuildUbuntuCosmic
    - BuildUbuntuDisco
    - BuildUbuntuEoan
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
@@ -1020,13 +1019,6 @@ jobs:
     inputs:
       TargetPath: '$(Build.ArtifactStagingDirectory)/debian'
       artifactName: ubuntu-bionic
-
-
-  - task: DownloadPipelineArtifact@1
-    displayName: 'Download Ubuntu:Cosmic Builds'
-    inputs:
-      TargetPath: '$(Build.ArtifactStagingDirectory)/debian'
-      artifactName: ubuntu-cosmic
 
 
   - task: DownloadPipelineArtifact@1
@@ -1077,8 +1069,8 @@ jobs:
        done
 
        # Distros that do require libssl1.1
-       DISTROS=(bionic cosmic disco eoan buster)
-       BASE_IMAGES=(ubuntu:bionic ubuntu:cosmic ubuntu:disco ubuntu:eoan debian:buster)
+       DISTROS=(bionic disco eoan buster)
+       BASE_IMAGES=(ubuntu:bionic ubuntu:disco ubuntu:eoan debian:buster)
 
        for i in ${!DISTROS[@]}; do
            echo "== Test debian package on ${DISTROS[$i]} =="
@@ -1090,36 +1082,6 @@ jobs:
            docker run --rm -v $SYSTEM_ARTIFACTSDIRECTORY/debian:/mnt/artifacts ${BASE_IMAGES[$i]} /bin/bash -c "apt-get update && apt-get install -y libssl1.1 apt-transport-https && dpkg -i /mnt/artifacts/azure-cli_$CLI_VERSION-1~${DISTROS[$i]}_all.deb && time az self-test && time az --version && sleep 5"
        done
     displayName: 'Bash Script'
-
-- job: BuildUbuntuCosmic
-  displayName: Build Ubuntu Cosmic
-
-  dependsOn: BuildPythonWheel
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - task: DownloadPipelineArtifact@1
-    displayName: 'Download Build Artifacts'
-    inputs:
-      TargetPath: '$(Build.ArtifactStagingDirectory)/pypi'
-      artifactName: pypi
-
-
-  - task: Bash@3
-    displayName: 'Bash Script'
-    inputs:
-      targetType: 'filePath'
-      filePath: scripts/release/debian/pipeline.sh
-    env:
-      DISTRO: cosmic
-      DISTRO_BASE_IMAGE: ubuntu:cosmic
-
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish Artifact: debian'
-    inputs:
-      TargetPath: $(Build.ArtifactStagingDirectory)
-      ArtifactName: ubuntu-cosmic
 
 - job: CheckStyle
   displayName: "Check CLI Style"


### PR DESCRIPTION
Ubuntu Cosmic has reached end-of-life since July 2019. Ubuntu repo no longer provides the release file for Cosmic. See https://wiki.ubuntu.com/Releases

Will update corresponding ADO tasks as well.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
