### PR TITLE
[AKS] Add support of creating private cluster

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -325,6 +325,9 @@ parameters:
   - name: --attach-acr
     type: string
     short-summary: Grant the 'acrpull' role assignment to the ACR specified by name or resource ID.
+  - name: --enable-private-cluster
+    type: string
+    short-summary: Enable private cluster.
   - name: --api-server-authorized-ip-ranges
     type: string
     short-summary: Comma seperated list of authorized apiserver IP ranges. Set to 0.0.0.0/32 to restrict apiserver traffic to node pools.

--- a/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
@@ -8,13 +8,16 @@ from distutils.version import StrictVersion  # pylint: disable=no-name-in-module
 from azure.mgmt.containerservice.v2019_11_01.models import ManagedClusterAPIServerAccessProfile
 
 
-def _populate_api_server_access_profile(api_server_authorized_ip_ranges, instance=None):
+def _populate_api_server_access_profile(api_server_authorized_ip_ranges, enable_private_cluster, instance=None):
     if instance is None or instance.api_server_access_profile is None:
         profile = ManagedClusterAPIServerAccessProfile()
     else:
         profile = instance.api_server_access_profile
 
-    if api_server_authorized_ip_ranges == "":
+    if enable_private_cluster:
+        profile.enable_private_cluster = True
+
+    if api_server_authorized_ip_ranges is None or api_server_authorized_ip_ranges == "":
         authorized_ip_ranges = []
     else:
         authorized_ip_ranges = [ip.strip() for ip in api_server_authorized_ip_ranges.split(",")]

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -198,6 +198,7 @@ def load_arguments(self, _):
         c.argument('skip_subnet_role_assignment', action='store_true')
         c.argument('api_server_authorized_ip_ranges', type=str, validator=validate_ip_ranges)
         c.argument('attach_acr', acr_arg_type)
+        c.argument('enable_private_cluster', action='store_true')
         c.argument('nodepool_tags', nargs='*', validator=validate_nodepool_tags, help='space-separated tags: key[=value] [key[=value] ...]. Use "" to clear existing tags.')
 
     with self.argument_context('aks update') as c:

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1680,6 +1680,7 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
                zones=None,
                generate_ssh_keys=False,  # pylint: disable=unused-argument
                api_server_authorized_ip_ranges=None,
+               enable_private_cluster=False,
                attach_acr=None,
                no_wait=False):
     _validate_ssh_key(no_ssh_key, ssh_key_value)
@@ -1802,8 +1803,13 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
         )
 
     api_server_access_profile = None
-    if api_server_authorized_ip_ranges:
-        api_server_access_profile = _populate_api_server_access_profile(api_server_authorized_ip_ranges)
+    if enable_private_cluster and load_balancer_sku.lower() != "standard":
+        raise CLIError("Please use standard load balancer for private cluster")
+    if api_server_authorized_ip_ranges or enable_private_cluster:
+        api_server_access_profile = _populate_api_server_access_profile(
+            api_server_authorized_ip_ranges,
+            enable_private_cluster
+        )
 
     # Check that both --disable-rbac and --enable-rbac weren't provided
     if all([disable_rbac, enable_rbac]):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_helpers.py
@@ -10,13 +10,18 @@ from azure.cli.command_modules.acs import _helpers as helpers
 class TestPopulateApiServerAccessProfile(unittest.TestCase):
     def test_single_cidr_with_spaces(self):
         api_server_authorized_ip_ranges = "0.0.0.0/32 "
-        profile = helpers._populate_api_server_access_profile(api_server_authorized_ip_ranges)
+        profile = helpers._populate_api_server_access_profile(api_server_authorized_ip_ranges, False)
         self.assertListEqual(profile.authorized_ip_ranges, ["0.0.0.0/32"])
 
     def test_multi_cidr_with_spaces(self):
         api_server_authorized_ip_ranges = " 0.0.0.0/32 , 129.1.1.1/32"
-        profile = helpers._populate_api_server_access_profile(api_server_authorized_ip_ranges)
+        profile = helpers._populate_api_server_access_profile(api_server_authorized_ip_ranges, False)
         self.assertListEqual(profile.authorized_ip_ranges, ["0.0.0.0/32", "129.1.1.1/32"])
+
+    def test_private_cluster(self):
+        profile = helpers._populate_api_server_access_profile(None, True)
+        self.assertListEqual(profile.authorized_ip_ranges, [])
+        self.assertEqual(profile.enable_private_cluster, True)
 
 
 class TestSetVmSetType(unittest.TestCase):


### PR DESCRIPTION
**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[AKS] aks create: add `--enable-private-cluster`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
