### PR TITLE
[functionapp] fixing flag cited in warning message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2339,7 +2339,7 @@ def create_function(cmd, resource_group_name, name, storage_account, plan=None,
     # pylint: disable=too-many-statements, too-many-branches
     if functions_version is None:
         logger.warning("No functions version specified so defaulting to 2. In the future, specifying a version will "
-                       "be required. To create a 2.x function you would pass in the flag `--functions_version 2`")
+                       "be required. To create a 2.x function you would pass in the flag `--functions-version 2`")
         functions_version = '2'
     if deployment_source_url and deployment_local_git:
         raise CLIError('usage error: --deployment-source-url <url> | --deployment-local-git')


### PR DESCRIPTION

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[functionapp] (az command: functionapp create) This fixes the warning message that appears with `functionapp create` today which cites a `--functions_version` flag but erroneously uses a `_` instead of a `-` in the flag name.
