### PR TITLE
[ACR] `az acr import`: Modify help and error message to clarify the usage of --source and --registry

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -230,7 +230,7 @@ helps['acr import'] = """
 type: command
 short-summary: Imports an image to an Azure Container Registry from another Container Registry. Import removes the need to docker pull, docker tag, docker push.
 examples:
-  - name: Import an image from 'sourceregistry' to 'MyRegistry'. The image inherits its source repository and tag names. 
+  - name: Import an image from 'sourceregistry' to 'MyRegistry'. The image inherits its source repository and tag names.
     text: >
         az acr import -n MyRegistry --source sourceregistry.azurecr.io/sourcerepository:sourcetag
   - name: Import an image from a public repository on Docker Hub. The image uses the specified repository and tag names.

--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -230,16 +230,19 @@ helps['acr import'] = """
 type: command
 short-summary: Imports an image to an Azure Container Registry from another Container Registry. Import removes the need to docker pull, docker tag, docker push.
 examples:
-  - name: Import an image and inherit source tag from an Azure container registry in the same subscription.
+  - name: Import an image from 'sourceregistry' to 'MyRegistry'. The image inherits its source repository and tag names. 
     text: >
         az acr import -n MyRegistry --source sourceregistry.azurecr.io/sourcerepository:sourcetag
+  - name: Import an image from a public repository on Docker Hub. The image uses the specified repository and tag names.
+    text: >
+        az acr import -n MyRegistry --source docker.io/library/hello-world:latest -t targetrepository:targettag
+  - name: Import an image from a private repository using its username and password. This also applies to registries outside Azure.
+    text: >
+        az acr import -n MyRegistry --source myprivateregistry.azurecr.io/hello-world:latest -u username -p password
   - name: Import an image from an Azure container registry in a different subscription.
     text: |
         az acr import -n MyRegistry --source sourcerepository:sourcetag -t targetrepository:targettag \\
             -r /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceResourceGroup/providers/Microsoft.ContainerRegistry/registries/sourceRegistry
-  - name: Import an image from a public repository in Docker Hub.
-    text: >
-        az acr import -n MyRegistry --source docker.io/library/hello-world:latest -t targetrepository:targettag
 """
 
 helps['acr list'] = """

--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -230,14 +230,14 @@ helps['acr import'] = """
 type: command
 short-summary: Imports an image to an Azure Container Registry from another Container Registry. Import removes the need to docker pull, docker tag, docker push.
 examples:
-  - name: Import an image to the target registry and inherits sourcerepository:sourcetag from the source registry.
+  - name: Import an image and inherit source tag from an Azure container registry in the same subscription.
     text: >
         az acr import -n MyRegistry --source sourceregistry.azurecr.io/sourcerepository:sourcetag
-  - name: Import an image from a registry in a different subscription.
+  - name: Import an image from an Azure container registry in a different subscription.
     text: |
         az acr import -n MyRegistry --source sourcerepository:sourcetag -t targetrepository:targettag \\
             -r /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceResourceGroup/providers/Microsoft.ContainerRegistry/registries/sourceRegistry
-  - name: Import an image from a public repository in Docker Hub
+  - name: Import an image from a public repository in Docker Hub.
     text: >
         az acr import -n MyRegistry --source docker.io/library/hello-world:latest -t targetrepository:targettag
 """

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -73,8 +73,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                        help='Default action to apply when no rule matches. Only applicable to Premium SKU.')
 
     with self.argument_context('acr import') as c:
-        c.argument('source_image', options_list=['--source'], help="The source identifier will be either a source image name or a fully qualified source.")
-        c.argument('source_registry', options_list=['--registry', '-r'], help='The source container registry can be name, login server or resource ID of the source registry.')
+        c.argument('source_image', options_list=['--source'], help="The source identifier. If --registry is not specified, this parameter must be a fully qualified source (contains login server). If source registry is specified with --registry, this parameter must be a source image name (not contain login server).")
+        c.argument('source_registry', options_list=['--registry', '-r'], help='The source Azure container registry. This can be name, login server or resource ID of the source registry.')
         c.argument('source_registry_username', options_list=['--username', '-u'], help='The username of source container registry')
         c.argument('source_registry_password', options_list=['--password', '-p'], help='The password of source container registry')
         c.argument('target_tags', options_list=['--image', '-t'], help="The name and tag of the image using the format: '-t repo/image:tag'. Multiple tags are supported by passing -t multiple times.", action='append')

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -73,7 +73,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                        help='Default action to apply when no rule matches. Only applicable to Premium SKU.')
 
     with self.argument_context('acr import') as c:
-        c.argument('source_image', options_list=['--source'], help="The source identifier. If --registry is not specified, this parameter must be a fully qualified source (contains login server). If source registry is specified with --registry, this parameter must be a source image name (not contain login server).")
+        c.argument('source_image', options_list=['--source'], help="Source image name or fully qualified source containing the registry login server. If `--registry` is used, `--source` will always be interpreted as a source image, even if it contains the login server.")
         c.argument('source_registry', options_list=['--registry', '-r'], help='The source Azure container registry. This can be name, login server or resource ID of the source registry.')
         c.argument('source_registry_username', options_list=['--username', '-u'], help='The username of source container registry')
         c.argument('source_registry_password', options_list=['--password', '-p'], help='The password of source container registry')

--- a/src/azure-cli/azure/cli/command_modules/acr/import.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/import.py
@@ -113,8 +113,9 @@ def _handle_result(cmd, result_poller, source_registry, source_image, registry):
 
                 if registry.login_server.lower() in source_image.lower():
                     logger.warning("Import from source failed.\n\tsource image: '%s'\n"
-                                   "Attention: When source registry is specified with --registry, "
-                                   "--source is considered to be a source image name. ", "{}/{}"
+                                   "Attention: When source registry is specified with `--registry`, "
+                                   "`--source` is considered to be a source image name. "
+                                   "Do not prefix `--source` with the registry login server name.", "{}/{}"
                                    .format(registry.login_server, source_image))
         except (ClientException, CLIError) as unexpected_ex:  # raise exception
             logger.debug("Unexpected exception: %s", unexpected_ex)

--- a/src/azure-cli/azure/cli/command_modules/acr/import.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/import.py
@@ -131,8 +131,7 @@ def _split_registry_and_image(source_image):
         raise CLIError(SOURCE_NOT_FOUND)
 
     registry_uri = source_image[:slash]
-    dot = registry_uri.find('.')
-    if dot <= 0:
+    if '.' not in registry_uri:
         raise CLIError(LOGIN_SERVER_NOT_VALID)
 
     source_image = source_image[slash + 1:]

--- a/src/azure-cli/azure/cli/command_modules/acr/import.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/import.py
@@ -54,33 +54,28 @@ def acr_import(cmd,
         else:
             registry = get_registry_from_name_or_login_server(cmd.cli_ctx, source_registry, source_registry)
             if registry:
+                # For Azure container registry
                 source = ImportSource(resource_id=registry.id, source_image=source_image)
             else:
+                # For non-Azure container registry
                 raise CLIError(SOURCE_REGISTRY_NOT_FOUND)
 
     else:
-        slash = source_image.find('/')
-        if slash > 0:
-            registry_uri = source_image[:slash]
-            dot = registry_uri.find('.')
-            if dot > 0:
-                source_image = source_image[slash + 1:]
-                if source_registry_password:
-                    ImportSourceCredentials = cmd.get_models('ImportSourceCredentials')
-                    source = ImportSource(registry_uri=registry_uri,
-                                          source_image=source_image,
-                                          credentials=ImportSourceCredentials(password=source_registry_password,
-                                                                              username=source_registry_username))
-                else:
-                    registry = get_registry_from_name_or_login_server(cmd.cli_ctx, registry_uri)
-                    if registry:
-                        source = ImportSource(resource_id=registry.id, source_image=source_image)
-                    else:
-                        source = ImportSource(registry_uri=registry_uri, source_image=source_image)
-            else:
-                raise CLIError(LOGIN_SERVER_NOT_VALID)
+        registry_uri, source_image = _split_registry_and_image(source_image)
+        if source_registry_password:
+            ImportSourceCredentials = cmd.get_models('ImportSourceCredentials')
+            source = ImportSource(registry_uri=registry_uri,
+                                  source_image=source_image,
+                                  credentials=ImportSourceCredentials(password=source_registry_password,
+                                                                      username=source_registry_username))
         else:
-            raise CLIError(SOURCE_NOT_FOUND)
+            registry = get_registry_from_name_or_login_server(cmd.cli_ctx, registry_uri)
+            if registry:
+                # For Azure container registry
+                source = ImportSource(resource_id=registry.id, source_image=source_image)
+            else:
+                # For non-Azure container registry
+                source = ImportSource(registry_uri=registry_uri, source_image=source_image)
 
     if not target_tags and not repository:
         index = source_image.find("@")
@@ -117,7 +112,9 @@ def _handle_result(cmd, result_poller, source_registry, source_image, registry):
                         registry = get_registry_from_name_or_login_server(cmd.cli_ctx, source_registry, source_registry)
 
                 if registry.login_server.lower() in source_image.lower():
-                    logger.warning("Import from source failed.\n\tsource image: '%s'", "{}/{}"
+                    logger.warning("Import from source failed.\n\tsource image: '%s'\n"
+                                   "Attention: When source registry is specified with --registry, "
+                                   "--source is considered to be a source image name. ", "{}/{}"
                                    .format(registry.login_server, source_image))
         except (ClientException, CLIError) as unexpected_ex:  # raise exception
             logger.debug("Unexpected exception: %s", unexpected_ex)
@@ -125,3 +122,17 @@ def _handle_result(cmd, result_poller, source_registry, source_image, registry):
         raise e  # regardless re-raise the CLIError as this is an error from the service
 
     return result
+
+
+def _split_registry_and_image(source_image):
+    slash = source_image.find('/')
+    if slash <= 0:
+        raise CLIError(SOURCE_NOT_FOUND)
+
+    registry_uri = source_image[:slash]
+    dot = registry_uri.find('.')
+    if dot <= 0:
+        raise CLIError(LOGIN_SERVER_NOT_VALID)
+
+    source_image = source_image[slash + 1:]
+    return registry_uri, source_image

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_split_registry_and_image.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_split_registry_and_image.py
@@ -1,0 +1,54 @@
+import unittest
+import importlib
+
+from knack.util import CLIError
+
+
+acr_import = importlib.import_module('azure.cli.command_modules.acr.import')
+
+
+class TestSplitRegistryAndImage(unittest.TestCase):
+
+    VALID_ACR_LOGIN_SERVER = 'myregistry.azurecr.io'
+    VALID_DOCKER_LOGIN_SERVER = 'docker.io'
+    VALID_IMAGE = 'myrepo/myimage:latest'
+
+    VALID_SOURCE_PATTERN = '{}/{}'
+    VALID_ACR_SOURCE = VALID_SOURCE_PATTERN.format(VALID_ACR_LOGIN_SERVER, VALID_IMAGE)
+    VALID_DOCKER_SOURCE = VALID_SOURCE_PATTERN.format(VALID_DOCKER_LOGIN_SERVER, VALID_IMAGE)
+
+    SINGLE_SLASH = '/'
+    SINGLE_DOT = '.'
+    EMPTY_SOURCE = ''
+
+    def test_split_valid_acr_source(self):
+        login_server, image = acr_import._split_registry_and_image(TestSplitRegistryAndImage.VALID_ACR_SOURCE)
+        self.assertEqual((login_server, image), (TestSplitRegistryAndImage.VALID_ACR_LOGIN_SERVER, TestSplitRegistryAndImage.VALID_IMAGE))
+
+    def test_split_valid_docker_source(self):
+        login_server, image = acr_import._split_registry_and_image(TestSplitRegistryAndImage.VALID_DOCKER_SOURCE)
+        self.assertEqual((login_server, image), (TestSplitRegistryAndImage.VALID_DOCKER_LOGIN_SERVER, TestSplitRegistryAndImage.VALID_IMAGE))
+
+    def test_split_single_login_server(self):
+        with self.assertRaises(CLIError):
+            acr_import._split_registry_and_image(TestSplitRegistryAndImage.VALID_ACR_LOGIN_SERVER)
+
+    def test_split_single_image(self):
+        with self.assertRaises(CLIError):
+            acr_import._split_registry_and_image(TestSplitRegistryAndImage.VALID_IMAGE)
+
+    def test_split_single_slash(self):
+        with self.assertRaises(CLIError):
+            acr_import._split_registry_and_image(TestSplitRegistryAndImage.SINGLE_SLASH)
+
+    def test_split_single_dot(self):
+        with self.assertRaises(CLIError):
+            acr_import._split_registry_and_image(TestSplitRegistryAndImage.SINGLE_DOT)
+
+    def test_split_empy_source(self):
+        with self.assertRaises(CLIError):
+            acr_import._split_registry_and_image(TestSplitRegistryAndImage.EMPTY_SOURCE)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_split_registry_and_image.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_split_registry_and_image.py
@@ -1,8 +1,12 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 import unittest
 import importlib
 
 from knack.util import CLIError
-
 
 acr_import = importlib.import_module('azure.cli.command_modules.acr.import')
 

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_split_registry_and_image.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_split_registry_and_image.py
@@ -8,51 +8,43 @@ import importlib
 
 from knack.util import CLIError
 
+# The path contains a reserved keyword 'import', so we need a workaround here
 acr_import = importlib.import_module('azure.cli.command_modules.acr.import')
 
 
 class TestSplitRegistryAndImage(unittest.TestCase):
 
-    VALID_ACR_LOGIN_SERVER = 'myregistry.azurecr.io'
-    VALID_DOCKER_LOGIN_SERVER = 'docker.io'
-    VALID_IMAGE = 'myrepo/myimage:latest'
-
-    VALID_SOURCE_PATTERN = '{}/{}'
-    VALID_ACR_SOURCE = VALID_SOURCE_PATTERN.format(VALID_ACR_LOGIN_SERVER, VALID_IMAGE)
-    VALID_DOCKER_SOURCE = VALID_SOURCE_PATTERN.format(VALID_DOCKER_LOGIN_SERVER, VALID_IMAGE)
-
-    SINGLE_SLASH = '/'
-    SINGLE_DOT = '.'
-    EMPTY_SOURCE = ''
-
     def test_split_valid_acr_source(self):
-        login_server, image = acr_import._split_registry_and_image(TestSplitRegistryAndImage.VALID_ACR_SOURCE)
-        self.assertEqual((login_server, image), (TestSplitRegistryAndImage.VALID_ACR_LOGIN_SERVER, TestSplitRegistryAndImage.VALID_IMAGE))
+        valid_acr_source = 'myregistry.azurecr.io/myrepo/myimage:latest'
+        login_server, image = acr_import._split_registry_and_image(valid_acr_source)
+        self.assertEqual((login_server, image), ('myregistry.azurecr.io', 'myrepo/myimage:latest'))
 
     def test_split_valid_docker_source(self):
-        login_server, image = acr_import._split_registry_and_image(TestSplitRegistryAndImage.VALID_DOCKER_SOURCE)
-        self.assertEqual((login_server, image), (TestSplitRegistryAndImage.VALID_DOCKER_LOGIN_SERVER, TestSplitRegistryAndImage.VALID_IMAGE))
+        valid_docker_source = 'docker.io/myrepo/myimage:latest'
+        login_server, image = acr_import._split_registry_and_image(valid_docker_source)
+        self.assertEqual((login_server, image), ('docker.io', 'myrepo/myimage:latest'))
 
     def test_split_single_login_server(self):
+        single_login_server = 'myregistry.azurecr.io'
         with self.assertRaises(CLIError):
-            acr_import._split_registry_and_image(TestSplitRegistryAndImage.VALID_ACR_LOGIN_SERVER)
+            acr_import._split_registry_and_image(single_login_server)
 
     def test_split_single_image(self):
+        single_image = 'myrepo/myimage:latest'
         with self.assertRaises(CLIError):
-            acr_import._split_registry_and_image(TestSplitRegistryAndImage.VALID_IMAGE)
+            acr_import._split_registry_and_image(single_image)
 
     def test_split_single_slash(self):
+        single_slash = '/'
         with self.assertRaises(CLIError):
-            acr_import._split_registry_and_image(TestSplitRegistryAndImage.SINGLE_SLASH)
+            acr_import._split_registry_and_image(single_slash)
 
     def test_split_single_dot(self):
+        single_dot = '.'
         with self.assertRaises(CLIError):
-            acr_import._split_registry_and_image(TestSplitRegistryAndImage.SINGLE_DOT)
+            acr_import._split_registry_and_image(single_dot)
 
     def test_split_empy_source(self):
+        empty_source = ''
         with self.assertRaises(CLIError):
-            acr_import._split_registry_and_image(TestSplitRegistryAndImage.EMPTY_SOURCE)
-
-
-if __name__ == '__main__':
-    unittest.main()
+            acr_import._split_registry_and_image(empty_source)


### PR DESCRIPTION
Fix #10243
- Modify help and error message to clarify the usage of --source and --registry
- Modify example description
- Optimize code structure
- Add unit test for helper method

**[Behavior]**
Help:
![image](https://user-images.githubusercontent.com/8113721/76044943-bd119280-5f96-11ea-88c4-f0dc2c04bd6a.png)



Specify registry in both --source and --registry
![image](https://user-images.githubusercontent.com/8113721/76045076-1b3e7580-5f97-11ea-863f-e6a4e895193a.png)



**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
