### PR TITLE
{KeyVault} Fix the case sensitive issue while running commands without specifying resource group name

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -36,7 +36,7 @@ def _get_resource_group_from_vault_name(cli_ctx, vault_name):
     client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_KEYVAULT).vaults
     for vault in client.list():
         id_comps = parse_resource_id(vault.id)
-        if id_comps['name'] == vault_name:
+        if 'name' in id_comps and id_comps['name'].lower() == vault_name.lower():
             return id_comps['resource_group']
     return None
 


### PR DESCRIPTION
Scenario: 
If I created a vault named `kvTest` and I want to query it this way: `az keyvault show -n kvtest` (lowercase), the CLI will throw an exception: `cli.azure.cli.core.util : The Resource 'Microsoft.KeyVault/vaults/kvtest' not found within subscription.`
But if I specified the `-g`, everything works well.

Why didn't I add tests for this:
Since our test framework always records the lowercase, so it's nearly impossible for me to add tests for this without any change on test framework itself. The code change is minor and I have done the manual test in my local machine, so I think it's fine.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
