### PR TITLE
{Release} Use PAT for github requests

### DIFF
--- a/scripts/release/generate_history_notes.py
+++ b/scripts/release/generate_history_notes.py
@@ -14,9 +14,11 @@
 
 import fileinput
 import json
+import os
 import re
 import subprocess
 import requests
+from requests.auth import HTTPBasicAuth
 
 base_url = 'https://api.github.com/repos/azure/azure-cli'
 commit_pr_url = '{}/commits/commit_id/pulls'.format(base_url)
@@ -27,6 +29,7 @@ history_notes = {}
 
 def generate_history_notes():
     dev_commits = get_commits()
+    print("Get PRs for {} commits.".format(len(dev_commits)))
     for commit in dev_commits:
         prs = get_prs_for_commit(commit['sha'])
         # parse PR if one commit is mapped to one PR
@@ -118,7 +121,7 @@ def get_commits():
 def get_prs_for_commit(commit: str):
     headers = {'Accept': 'application/vnd.github.groot-preview+json'}
     url = commit_pr_url.replace('commit_id', commit)
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, auth=HTTPBasicAuth('anything', os.environ.get('PAT_TOKEN')))
     if response.status_code != 200:
         raise Exception("Request to {} failed with {}".format(
             url, response.status_code))


### PR DESCRIPTION
Github has a rate limit of 60/hr for unauthed request, which may not be enough when querying the PRs of all customer-facing changes commits in a Sprint. Use PAT to increase to 5000/hr.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
