### PR TITLE
{Core} Relax humanfriendly dependency

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/progress.py
+++ b/src/azure-cli-core/azure/cli/core/commands/progress.py
@@ -114,7 +114,7 @@ class IndeterminateStandardOut(ProgressViewBase):
         :param args: dictionary containing key 'message'
         """
         if self.spinner is None:
-            self.spinner = humanfriendly.Spinner(
+            self.spinner = humanfriendly.Spinner(  # pylint: disable=no-member
                 label='In Progress', stream=self.out, hide_cursor=False)
         msg = args.get('message', 'In Progress')
         try:

--- a/src/azure-cli-core/azure/cli/core/tests/test_progress.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_progress.py
@@ -60,7 +60,7 @@ class TestProgress(unittest.TestCase):
         before = view.spinner.total
         view.write({})
         after = view.spinner.total
-        self.assertTrue(after >= before)
+        self.assertTrue(after == before)
         view.write({'message': 'TESTING'})
 
     def test_progress_indicator_det_stdview(self):

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -55,7 +55,7 @@ DEPENDENCIES = [
     'argcomplete~=1.8',
     'azure-cli-telemetry',
     'colorama>=0.3.9',
-    'humanfriendly~=4.7',
+    'humanfriendly>=4.7,<9.0',
     'jmespath',
     'knack~=0.6.2',
     'msrest>=0.4.4',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -91,7 +91,7 @@ colorama==0.4.1
 ConfigArgParse==0.14.0
 cryptography==2.8
 fabric==2.4.0
-humanfriendly==4.18
+humanfriendly==8.0
 idna==2.8
 invoke==1.2.0
 isodate==0.6.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -91,7 +91,7 @@ colorama==0.4.1
 ConfigArgParse==0.14.0
 cryptography==2.8
 fabric==2.4.0
-humanfriendly==4.18
+humanfriendly==8.0
 idna==2.8
 invoke==1.2.0
 isodate==0.6.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -89,7 +89,7 @@ chardet==3.0.4
 colorama==0.4.1
 cryptography==2.8
 fabric==2.4.0
-humanfriendly==4.18
+humanfriendly==8.0
 idna==2.8
 invoke==1.2.0
 isodate==0.6.0


### PR DESCRIPTION
Fix #12283: Please support newer versions of humanfriendly

Tested with humanfriendly 8.0, and `az deployment group create -g {} --template-file template.json --parameters "@parameters.json"` works as expected:

```
 - Running ..  
```