### PR TITLE
{Compute} Delay vm image accept-terms expiration

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/commands.py
@@ -322,7 +322,7 @@ def load_command_table(self, _):
         g.command('list-skus', 'list_skus')
         g.custom_command('list', 'list_vm_images')
         g.custom_command('accept-terms', 'accept_market_ordering_terms',
-                         deprecate_info=g.deprecate(redirect='az vm image terms accept', expiration='2.2.0'))
+                         deprecate_info=g.deprecate(redirect='az vm image terms accept', expiration='3.0.0'))
         g.custom_show_command('show', 'show_vm_image')
 
     with self.command_group('vm image terms', compute_vm_image_term_sdk, validator=None) as g:


### PR DESCRIPTION
Delay `vm image accept-terms` expiration from `2.2.0` to `3.0.0`.