### PR TITLE
[Profile] az login: Show warning for MFA error

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -879,7 +879,7 @@ class SubscriptionFinder(object):
                 # because user creds went through the 'common' tenant, the error here must be
                 # tenant specific, like the account was disabled. For such errors, we will continue
                 # with other tenants.
-                msg = getattr(ex, 'error_response', {}).get('error_description', '')
+                msg = (getattr(ex, 'error_response', None) or {}).get('error_description') or ''
                 if 'AADSTS50076' in msg:
                     logger.warning("Tenant %s requires Multi-Factor Authentication (MFA). "
                                    "To access this tenant, use 'az login --tenant' to explicitly "

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -879,7 +879,13 @@ class SubscriptionFinder(object):
                 # because user creds went through the 'common' tenant, the error here must be
                 # tenant specific, like the account was disabled. For such errors, we will continue
                 # with other tenants.
-                logger.warning("Failed to authenticate '%s' due to error '%s'", t, ex)
+                msg = getattr(ex, 'error_response', {}).get('error_description', '')
+                if 'AADSTS50076' in msg:
+                    logger.warning("Tenant %s requires Multi-Factor Authentication (MFA). "
+                                   "To access this tenant, use 'az login --tenant' to explicitly "
+                                   "login to this tenant.", tenant_id)
+                else:
+                    logger.warning("Failed to authenticate '%s' due to error '%s'", t, ex)
                 continue
             subscriptions = self._find_using_specific_tenant(
                 tenant_id,

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -1849,6 +1849,50 @@ class TestProfile(unittest.TestCase):
 
     @mock.patch('adal.AuthenticationContext', autospec=True)
     @mock.patch('azure.cli.core._profile._get_authorization_code', autospec=True)
+    def test_find_using_common_tenant_mfa_warning(self, _get_authorization_code_mock, mock_auth_context):
+        # Assume 2 tenants with subscriptions in them
+        # tenant1: subscription1
+        # tenant2_mfa: subscription2
+        import adal
+        cli = DummyCli()
+        mock_arm_client = mock.MagicMock()
+        tenant2_mfa_id = 'tenant2-0000-0000-0000-000000000000'
+        mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id), TenantStub(tenant2_mfa_id)]
+        mock_arm_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
+        token_cache = adal.TokenCache()
+        finder = SubscriptionFinder(cli, lambda _, _1, _2: mock_auth_context, token_cache, lambda _: mock_arm_client)
+
+        adal_error_mfa = adal.AdalError(error_msg="", error_response={
+            'error': 'interaction_required',
+            'error_description': "AADSTS50076: Due to a configuration change made by your administrator, "
+                                 "or because you moved to a new location, you must use multi-factor "
+                                 "authentication to access '797f4846-ba00-4fd7-ba43-dac1f8f63013'.\n"
+                                 "Trace ID: 00000000-0000-0000-0000-000000000000\n"
+                                 "Correlation ID: 00000000-0000-0000-0000-000000000000\n"
+                                 "Timestamp: 2020-03-10 04:42:59Z",
+            'error_codes': [50076],
+            'timestamp': '2020-03-10 04:42:59Z',
+            'trace_id': '00000000-0000-0000-0000-000000000000',
+            'correlation_id': '00000000-0000-0000-0000-000000000000',
+            'error_uri': 'https://login.microsoftonline.com/error?code=50076',
+            'suberror': 'basic_action'})
+
+        # adal_error_mfa are raised on the second call
+        mock_auth_context.acquire_token.side_effect = [self.token_entry1, adal_error_mfa]
+
+        # action
+        all_subscriptions = finder._find_using_common_tenant(access_token="token1",
+                                                             resource='https://management.core.windows.net/')
+
+        # assert
+        # subscriptions are correctly returned
+        self.assertEqual(all_subscriptions, [self.subscription1])
+        self.assertEqual(mock_auth_context.acquire_token.call_count, 2)
+
+        # With pytest, use -o log_cli=True to manually check the log
+
+    @mock.patch('adal.AuthenticationContext', autospec=True)
+    @mock.patch('azure.cli.core._profile._get_authorization_code', autospec=True)
     def test_find_using_specific_tenant(self, _get_authorization_code_mock, mock_auth_context):
         """ Test tenant_id -> home_tenant_id mapping and token tenant attachment
         """

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -1850,9 +1850,7 @@ class TestProfile(unittest.TestCase):
     @mock.patch('adal.AuthenticationContext', autospec=True)
     @mock.patch('azure.cli.core._profile._get_authorization_code', autospec=True)
     def test_find_using_common_tenant_mfa_warning(self, _get_authorization_code_mock, mock_auth_context):
-        # Assume 2 tenants with subscriptions in them
-        # tenant1: subscription1
-        # tenant2_mfa: subscription2
+        # Assume 2 tenants. Home tenant tenant1 doesn't require MFA, but tenant2 does
         import adal
         cli = DummyCli()
         mock_arm_client = mock.MagicMock()


### PR DESCRIPTION
Partially mitigate https://github.com/Azure/azure-cli/issues/6962. MFA cross-tenant trust is still under development by service team.

During `az login`, show warning for MFA error. This happens when the home tenant doesn't require MFA but the other tenants where the user is a guest of do. When getting access token with refresh token for those MFA tenants, CLI gives the raw error which isn't very instructive:

> AADSTS50076: Due to a configuration change made by your administrator, or because you moved to a new location, you must use multi-factor authentication to access 'xxx'.

This PR checks the exception and provides instructions on how to work with MFA tenants:

> Tenant da086fa3-023f-4500-bf56-0f19d3065440 requires Multi-Factor Authentication (MFA). To access this tenant, use 'az login --tenant' to explicitly login to this tenant.

For the test, since CI still uses nosetests while we locally use pytest, it is difficult to verify captured logs in both test frameworks: https://docs.pytest.org/en/latest/logging.html#caplog-fixture

We can manually run the test with `-o log_cli=True` to check that the warning is displayed correctly:

```
pytest -o log_cli=True src/azure-cli-core/azure/cli/core/tests/test_profile.py::TestProfile::test_find_using_common_tenant_mfa_warning
```