### PR TITLE
{Core} Only lower provisioning_state when it has value

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -681,10 +681,12 @@ def _cli_wait_command(context, name, getter_op, custom_command=False, **kwargs):
                     return None
                 provisioning_state = get_provisioning_state(instance)
                 # until we have any needs to wait for 'Failed', let us bail out on this
-                if provisioning_state.casefold() == 'failed':
+                if provisioning_state:
+                    provisioning_state = provisioning_state.lower()
+                if provisioning_state == 'failed':
                     progress_indicator.stop()
                     raise CLIError('The operation failed')
-                if ((wait_for_created or wait_for_updated) and provisioning_state.casefold() == 'succeeded') or \
+                if ((wait_for_created or wait_for_updated) and provisioning_state == 'succeeded') or \
                         custom_condition and bool(verify_property(instance, custom_condition)):
                     progress_indicator.end()
                     return None


### PR DESCRIPTION
Fix the regression in https://github.com/Azure/azure-cli/pull/12154: `provisioning_state.casefold()` raises exception `AttributeError: 'NoneType' object has no attribute 'casefold'` when `provisioning_state` is `None`.

This causes issue to `az sql server wait` since sql server doesn't use `"provisioningState": "Succeeded"`, but `"state": "Ready"`: https://github.com/Azure/azure-cli/issues/12313

Only lower `provisioning_state` when it has value (not `None` or empty string `''`).

Tested with

```
az vm wait --ids {} --created
```

Also, use `lower()` to be consistent with other code.