### PR TITLE
{Core} Fix is_preview for commands

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -1157,11 +1157,9 @@ class AzCommandGroup(CommandGroup):
         merged_kwargs = self._flatten_kwargs(kwargs, get_command_type_kwarg(custom_command))
         # don't inherit deprecation or preview info from command group
         merged_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)
+        merged_kwargs['preview_info'] = None
         if kwargs.get('is_preview', False):
-            merged_kwargs['preview_info'] = PreviewItem(
-                self.command_loader.cli_ctx,
-                object_type='command'
-            )
+            merged_kwargs['preview_info'] = PreviewItem(self.command_loader.cli_ctx, object_type='command')
         operations_tmpl = merged_kwargs['operations_tmpl']
         command_name = '{} {}'.format(self.group_name, name) if self.group_name else name
         self.command_loader._cli_command(command_name,  # pylint: disable=protected-access
@@ -1203,7 +1201,9 @@ class AzCommandGroup(CommandGroup):
         merged_kwargs_custom = self._flatten_kwargs(kwargs, get_command_type_kwarg(custom_command=True))
         # don't inherit deprecation or preview info from command group
         merged_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)
-        merged_kwargs['preview_info'] = kwargs.get('preview_info', None)
+        merged_kwargs['preview_info'] = None
+        if kwargs.get('is_preview', False):
+            merged_kwargs['preview_info'] = PreviewItem(self.command_loader.cli_ctx, object_type='command')
 
         getter_op = self._resolve_operation(merged_kwargs, getter_name, getter_type)
         setter_op = self._resolve_operation(merged_kwargs, setter_name, setter_type)
@@ -1236,7 +1236,9 @@ class AzCommandGroup(CommandGroup):
         merged_kwargs = self._flatten_kwargs(kwargs, get_command_type_kwarg(custom_command))
         # don't inherit deprecation or preview info from command group
         merged_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)
-        merged_kwargs['preview_info'] = kwargs.get('preview_info', None)
+        merged_kwargs['preview_info'] = None
+        if kwargs.get('is_preview', False):
+            merged_kwargs['preview_info'] = PreviewItem(self.command_loader.cli_ctx, object_type='command')
 
         if getter_type:
             merged_kwargs = _merge_kwargs(getter_type.settings, merged_kwargs, CLI_COMMAND_KWARGS)
@@ -1256,7 +1258,9 @@ class AzCommandGroup(CommandGroup):
         merged_kwargs = self._flatten_kwargs(kwargs, get_command_type_kwarg(custom_command))
         # don't inherit deprecation or preview info from command group
         merged_kwargs['deprecate_info'] = kwargs.get('deprecate_info', None)
-        merged_kwargs['preview_info'] = kwargs.get('preview_info', None)
+        merged_kwargs['preview_info'] = None
+        if kwargs.get('is_preview', False):
+            merged_kwargs['preview_info'] = PreviewItem(self.command_loader.cli_ctx, object_type='command')
 
         if getter_type:
             merged_kwargs = _merge_kwargs(getter_type.settings, merged_kwargs, CLI_COMMAND_KWARGS)


### PR DESCRIPTION
When a command group is marked as preview:

```py
    with self.command_group('vm', compute_vm_sdk, is_preview=True) as g:
```

during invocation, the warning message isn't very accurate - what is invoked is actually a command, not a command group.

```sh
> az vm list
This command group is in preview. It may be changed/removed in a future release.
```

This PR corrects the behavior by removing the inheritance of `preview_info` from command group to command, so that the implicit preview resolution is activated - it searches `preview_info` from the command to its parent group, then the parent group's parent group (if any). Otherwise, preview resolution stops at the command level (L711).

https://github.com/Azure/azure-cli/blob/d7d7a25236f360fbbb3b799b18f46d6cc206cd20/src/azure-cli-core/azure/cli/core/commands/__init__.py#L709-L725

Now it shows a more accurate warning following Knack's behavior:

```sh
> az vm list
Command group 'vm' is in preview. It may be changed/removed in a future release.
```

Also, this PR fixes `show_command`, `wait_command` and `generic_update_command` where `is_preview` doesn't work before.
