### PR TITLE
[Core] Add experimental tag for extensions

### DIFF
--- a/doc/extensions/metadata.md
+++ b/doc/extensions/metadata.md
@@ -53,6 +53,9 @@ Example: `"azext.maxCliCoreVersion": "2.0.15"`
 ### azext.isPreview
 Description: Indicate that the extension is in preview.
 
+### azext.isExperimental
+Description: Indicate that the extension is experimental and not covered by customer support.
+
 Type: `boolean`
 
 Example: `"azext.isPreview": true`

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -213,7 +213,8 @@ class MainCommandsLoader(CLICommandsLoader):
                             cmd.command_source = ExtensionCommandSource(
                                 extension_name=ext_name,
                                 overrides_command=cmd_name in module_commands,
-                                preview=ext.preview)
+                                preview=ext.preview,
+                                experimental=ext.experimental)
 
                         self.command_table.update(extension_command_table)
                         self.command_group_table.update(extension_group_table)

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -220,9 +220,10 @@ class MainCommandsLoader(CLICommandsLoader):
                         self.command_group_table.update(extension_group_table)
                         elapsed_time = timeit.default_timer() - start_time
                         logger.debug("Loaded extension '%s' in %.3f seconds.", ext_name, elapsed_time)
-                    except Exception:  # pylint: disable=broad-except
+                    except Exception as ex:  # pylint: disable=broad-except
                         self.cli_ctx.raise_event(EVENT_FAILED_EXTENSION_LOAD, extension_name=ext_name)
-                        logger.warning("Unable to load extension '%s'. Use --debug for more information.", ext_name)
+                        logger.warning("Unable to load extension '%s: %s'. Use --debug for more information.",
+                                       ext_name, ex)
                         logger.debug(traceback.format_exc())
 
         def _wrap_suppress_extension_func(func, ext):

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -115,7 +115,7 @@ class CLIPrintMixin(CLIHelp):
         if isinstance(help_file.command_source, ExtensionCommandSource):
             logger.warning(help_file.command_source.get_command_warn_msg())
             if help_file.command_source.preview:
-                logger.warning(help_file.command_source.get_preview_warn_msg())
+                logger.warning(help_file.command_source.get_preview_experimental_warn_msg())
 
 
 class AzCliHelp(CLIPrintMixin, CLIHelp):

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -114,8 +114,11 @@ class CLIPrintMixin(CLIHelp):
             return
         if isinstance(help_file.command_source, ExtensionCommandSource):
             logger.warning(help_file.command_source.get_command_warn_msg())
-            if help_file.command_source.preview:
-                logger.warning(help_file.command_source.get_preview_experimental_warn_msg())
+            # If experimental is true, it overrides preview
+            if help_file.command_source.experimental:
+                logger.warning(help_file.command_source.get_experimental_warn_msg())
+            elif help_file.command_source.preview:
+                logger.warning(help_file.command_source.get_preview_warn_msg())
 
 
 class AzCliHelp(CLIPrintMixin, CLIHelp):

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -994,13 +994,15 @@ class ExtensionCommandSource(object):
             return "This command is from the following extension: {}".format(self.extension_name)
         return "This command is from an extension."
 
-    def get_preview_experimental_warn_msg(self):
-        # If experimental is true, it overrides preview
+    def get_preview_warn_msg(self):
+        if self.preview:
+            return "The extension is in preview"
+        return None
+
+    def get_experimental_warn_msg(self):
         if self.experimental:
             return "The extension is experimental and not covered by customer support. " \
                    "Please use with discretion."
-        if self.preview:
-            return "The extension is in preview"
         return None
 
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -976,12 +976,13 @@ def _load_module_command_loader(loader, args, mod):
 class ExtensionCommandSource(object):
     """ Class for commands contributed by an extension """
 
-    def __init__(self, overrides_command=False, extension_name=None, preview=False):
+    def __init__(self, overrides_command=False, extension_name=None, preview=False, experimental=False):
         super(ExtensionCommandSource, self).__init__()
         # True if the command overrides a CLI command
         self.overrides_command = overrides_command
         self.extension_name = extension_name
         self.preview = preview
+        self.experimental = experimental
 
     def get_command_warn_msg(self):
         if self.overrides_command:
@@ -993,7 +994,11 @@ class ExtensionCommandSource(object):
             return "This command is from the following extension: {}".format(self.extension_name)
         return "This command is from an extension."
 
-    def get_preview_warn_msg(self):
+    def get_preview_experimental_warn_msg(self):
+        # If experimental is true, it overrides preview
+        if self.experimental:
+            return "The extension is experimental and not covered by customer support. " \
+                   "Please use with discretion."
         if self.preview:
             return "The extension is in preview"
         return None

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -29,6 +29,7 @@ AZEXT_METADATA_FILENAME = 'azext_metadata.json'
 EXT_METADATA_MINCLICOREVERSION = 'azext.minCliCoreVersion'
 EXT_METADATA_MAXCLICOREVERSION = 'azext.maxCliCoreVersion'
 EXT_METADATA_ISPREVIEW = 'azext.isPreview'
+EXT_METADATA_ISEXPERIMENTAL = 'azext.isExperimental'
 
 WHEEL_INFO_RE = re.compile(
     r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.+?))?)
@@ -57,6 +58,7 @@ class Extension(object):
         self._version = None
         self._metadata = None
         self._preview = None
+        self._experimental = None
 
     @property
     def version(self):
@@ -94,6 +96,19 @@ class Extension(object):
         except Exception:  # pylint: disable=broad-except
             logger.debug("Unable to get extension preview status: %s", traceback.format_exc())
         return self._preview
+
+    @property
+    def experimental(self):
+        """
+        Lazy load experimental status.
+        Returns the experimental status of the extension.
+        """
+        try:
+            if not isinstance(self._experimental, bool):
+                self._experimental = bool(self.metadata.get(EXT_METADATA_ISEXPERIMENTAL))
+        except Exception:  # pylint: disable=broad-except
+            logger.debug("Unable to get extension experimental status: %s", traceback.format_exc())
+        return self._experimental
 
     def get_version(self):
         raise NotImplementedError()

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -224,8 +224,8 @@ def add_extension(cmd, source=None, extension_name=None, index_url=None, yes=Non
         except NoExtensionCandidatesError as err:
             logger.debug(err)
             raise CLIError("No matching extensions for '{}'. Use --debug for more information.".format(extension_name))
-    extension_name = _add_whl_ext(cmd=cmd, source=source, ext_sha256=ext_sha256, pip_extra_index_urls=pip_extra_index_urls,
-                 pip_proxy=pip_proxy)
+    extension_name = _add_whl_ext(cmd=cmd, source=source, ext_sha256=ext_sha256,
+                                  pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy)
     _augment_telemetry_with_ext_info(extension_name)
     try:
         if extension_name and get_extension(extension_name).experimental:

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -18,7 +18,8 @@ from pkg_resources import parse_version
 
 from azure.cli.core.util import CLIError, reload_module
 from azure.cli.core.extension import (extension_exists, get_extension_path, get_extensions, get_extension_modname,
-                                      get_extension, ext_compat_with_cli, EXT_METADATA_ISPREVIEW,
+                                      get_extension, ext_compat_with_cli,
+                                      EXT_METADATA_ISPREVIEW, EXT_METADATA_ISEXPERIMENTAL,
                                       WheelExtension, DevExtension, ExtensionNotInstalledException, WHEEL_INFO_RE)
 from azure.cli.core.telemetry import set_extension_management_detail
 
@@ -34,6 +35,8 @@ OUT_KEY_NAME = 'name'
 OUT_KEY_VERSION = 'version'
 OUT_KEY_TYPE = 'extensionType'
 OUT_KEY_METADATA = 'metadata'
+OUT_KEY_PREVIEW = 'preview'
+OUT_KEY_EXPERIMENTAL = 'experimental'
 
 IS_WINDOWS = sys.platform.lower() in ['windows', 'win32']
 LIST_FILE_PATH = os.path.join(os.sep, 'etc', 'apt', 'sources.list.d', 'azure-cli.list')
@@ -156,6 +159,7 @@ def _add_whl_ext(cmd, source, ext_sha256=None, pip_extra_index_urls=None, pip_pr
     shutil.copyfile(ext_file, dst)
     logger.debug('Saved the whl to %s', dst)
     colorama.deinit()
+    return extension_name
 
 
 def is_valid_sha256sum(a_file, expected_sum):
@@ -220,11 +224,14 @@ def add_extension(cmd, source=None, extension_name=None, index_url=None, yes=Non
         except NoExtensionCandidatesError as err:
             logger.debug(err)
             raise CLIError("No matching extensions for '{}'. Use --debug for more information.".format(extension_name))
-    _add_whl_ext(cmd=cmd, source=source, ext_sha256=ext_sha256, pip_extra_index_urls=pip_extra_index_urls,
+    extension_name = _add_whl_ext(cmd=cmd, source=source, ext_sha256=ext_sha256, pip_extra_index_urls=pip_extra_index_urls,
                  pip_proxy=pip_proxy)
     _augment_telemetry_with_ext_info(extension_name)
     try:
-        if extension_name and get_extension(extension_name).preview:
+        if extension_name and get_extension(extension_name).experimental:
+            logger.warning("The installed extension '%s' is experimental and not covered by customer support. "
+                           "Please use with discretion.", extension_name)
+        elif extension_name and get_extension(extension_name).preview:
             logger.warning("The installed extension '%s' is in preview.", extension_name)
     except ExtensionNotInstalledException:
         pass
@@ -250,7 +257,8 @@ def remove_extension(extension_name):
 
 
 def list_extensions():
-    return [{OUT_KEY_NAME: ext.name, OUT_KEY_VERSION: ext.version, OUT_KEY_TYPE: ext.ext_type}
+    return [{OUT_KEY_NAME: ext.name, OUT_KEY_VERSION: ext.version, OUT_KEY_TYPE: ext.ext_type,
+             OUT_KEY_PREVIEW: ext.preview, OUT_KEY_EXPERIMENTAL: ext.experimental}
             for ext in get_extensions()]
 
 
@@ -324,6 +332,7 @@ def list_available_extensions(index_url=None, show_details=False):
             'version': latest['metadata']['version'],
             'summary': latest['metadata']['summary'],
             'preview': latest['metadata'].get(EXT_METADATA_ISPREVIEW, False),
+            'experimental': latest['metadata'].get(EXT_METADATA_ISEXPERIMENTAL, False),
             'installed': installed
         })
     return results

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
@@ -268,6 +268,14 @@ class TestExtensionCommands(unittest.TestCase):
                     'name': 'test_sample_extension1',
                     'summary': 'my summary',
                     'version': '0.1.0'
+                }}],
+            'test_sample_extension2': [{
+                'metadata': {
+                    'name': 'test_sample_extension2',
+                    'summary': 'my summary',
+                    'version': '0.1.0',
+                    'azext.isPreview': True,
+                    'azext.isExperimental': True
                 }}]
         }
         with mock.patch('azure.cli.core.extension.operations.get_index_extensions', return_value=sample_index_extensions):
@@ -278,6 +286,16 @@ class TestExtensionCommands(unittest.TestCase):
             self.assertEqual(res[0]['summary'], 'my summary')
             self.assertEqual(res[0]['version'], '0.1.0')
             self.assertEqual(res[0]['preview'], False)
+            self.assertEqual(res[0]['experimental'], False)
+        with mock.patch('azure.cli.core.extension.operations.get_index_extensions', return_value=sample_index_extensions):
+            res = list_available_extensions()
+            self.assertIsInstance(res, list)
+            self.assertEqual(len(res), len(sample_index_extensions))
+            self.assertEqual(res[1]['name'], 'test_sample_extension2')
+            self.assertEqual(res[1]['summary'], 'my summary')
+            self.assertEqual(res[1]['version'], '0.1.0')
+            self.assertEqual(res[1]['preview'], True)
+            self.assertEqual(res[1]['experimental'], True)
 
     def test_list_available_extensions_incompatible_cli_version(self):
         sample_index_extensions = {

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -152,9 +152,9 @@ class TestCommandRegistration(unittest.TestCase):
         return ext_name
 
     def _mock_get_extensions():
-        MockExtension = namedtuple('Extension', ['name', 'preview', 'path', 'get_metadata'])
-        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False, path=None, get_metadata=lambda: {}),
-                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False, path=None, get_metadata=lambda: {})]
+        MockExtension = namedtuple('Extension', ['name', 'preview', 'experimental', 'path', 'get_metadata'])
+        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False, experimental=False, path=None, get_metadata=lambda: {}),
+                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False, experimental=False, path=None, get_metadata=lambda: {})]
 
     def _mock_load_command_loader(loader, args, name, prefix):
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -144,9 +144,9 @@ class TestParser(unittest.TestCase):
         return ext_name
 
     def _mock_get_extensions():
-        MockExtension = namedtuple('Extension', ['name', 'preview', 'path', 'get_metadata'])
-        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False, path=None, get_metadata=lambda: {}),
-                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False, path=None, get_metadata=lambda: {})]
+        MockExtension = namedtuple('Extension', ['name', 'preview', 'experimental', 'path', 'get_metadata'])
+        return [MockExtension(name=__name__ + '.ExtCommandsLoader', preview=False, experimental=False, path=None, get_metadata=lambda: {}),
+                MockExtension(name=__name__ + '.Ext2CommandsLoader', preview=False, experimental=False, path=None, get_metadata=lambda: {})]
 
     def _mock_load_command_loader(loader, args, name, prefix):
         from enum import Enum


### PR DESCRIPTION
An extension can now be marked as **experimental** by adding `"azext.isExperimental": true` to `azext_metadata.json`:

```jsonc
{
    "azext.minCliCoreVersion": "2.0.46",
    "azext.isPreview": true,
    "azext.isExperimental": true   // Add here
}
```

## When it appears

Same as **preview**, **experimental** appears when 

### Installing the extension from index

```sh
> az extension add -n webapp
The installed extension 'webapp' is experimental and not covered by customer support. Please use with discretion.
```

### Installing the extension from wheel 

This is newly added, also applies to preview

```sh
> az extension add -s "webapp-0.2.24-py2.py3-none-any.whl"
The installed extension 'webapp' is experimental and not covered by customer support. Please use with discretion.
```

### Command help

```sh
> az webapp container up -h
This command is from the following extension: webapp
The extension is experimental and not covered by customer support. Please use with discretion.
```

ℹ If `true`, `azext.isExperimental` will override `azext.isPreview`
ℹ Experimental/Preview warning doesn't appear when invoking a command within an experimental/preview extension

## Change of existing commands

For `extension list-available`, `extension` property is added to each entry.

```jsonc
[
  {
    "experimental": false,   // New
    "installed": false,
    "name": "vm-repair",
    "preview": false,
    "summary": "Auto repair commands to fix VMs.",
    "version": "0.2.6"
  },
  {
    "experimental": false,   // New
    "installed": true,
    "name": "webapp",
    "preview": true,
    "summary": "Additional commands for Azure AppService.",
    "version": "0.2.24"
  },
  ...
]
```

For `extension list`, `preview` and `extension` properties are added to each entry. 

```jsonc
> az extension list
[
  {
    "experimental": false,   // New
    "extensionType": "whl",
    "name": "support",
    "preview": true,         // New
    "version": "0.1.1"
  },
  {
    "experimental": true,    // New
    "extensionType": "whl",
    "name": "webapp",
    "preview": true,         // New
    "version": "0.2.24"
  },
  ...
]
```
