### PR TITLE
[Rest] az rest: Use configured ARM's resource ID

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -403,6 +403,18 @@ class TestHandleException(unittest.TestCase):
                                         params={'p1': 'v1', 'p2': 'v2'}, data=test_body,
                                         headers=expected_header_with_auth, verify=(not should_disable_connection_verify()))
 
+        # Test uri https://management.azure.com:443/subscriptions/01/resourcegroups/02?api-version=2019-07-01
+        # Port is included
+        test_arm_endpoint_with_port = 'https://management.azure.com:443/'
+        full_arm_rest_url_with_port = test_arm_endpoint_with_port.rstrip('/') + arm_resource_id
+        send_raw_request(cli_ctx, 'PUT', full_arm_rest_url_with_port, uri_parameters=tets_uri_parameters,
+                         body=test_body, generated_client_request_id_name=None)
+
+        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_resource_id)
+        request_mock.assert_called_with('PUT', full_arm_rest_url_with_port,
+                                        params={'p1': 'v1', 'p2': 'v2'}, data=test_body,
+                                        headers=expected_header_with_auth, verify=(not should_disable_connection_verify()))
+
         # Test uri https://graph.microsoft.com/beta/appRoleAssignments/01
         send_raw_request(cli_ctx, 'PATCH', 'https://graph.microsoft.com/beta/appRoleAssignments/01',
                          uri_parameters=tets_uri_parameters, body=test_body, generated_client_request_id_name=None)

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -359,7 +359,7 @@ class TestHandleException(unittest.TestCase):
             'command': 'rest',
             'safe_params': ['method', 'uri']
         }
-        test_arm_resource_id = 'https://management.core.windows.net/'
+        test_arm_active_directory_resource_id = 'https://management.core.windows.net/'
         test_arm_endpoint = 'https://management.azure.com/'
 
         arm_resource_id = '/subscriptions/01/resourcegroups/02?api-version=2019-07-01'
@@ -389,7 +389,7 @@ class TestHandleException(unittest.TestCase):
         send_raw_request(cli_ctx, 'PUT', arm_resource_id, uri_parameters=tets_uri_parameters, body=test_body,
                          generated_client_request_id_name=None)
 
-        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_resource_id)
+        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
         request_mock.assert_called_with('PUT', full_arm_rest_url,
                                         params={'p1': 'v1', 'p2': 'v2'}, data=test_body,
                                         headers=expected_header_with_auth, verify=(not should_disable_connection_verify()))
@@ -398,7 +398,7 @@ class TestHandleException(unittest.TestCase):
         send_raw_request(cli_ctx, 'PUT', full_arm_rest_url, uri_parameters=tets_uri_parameters,
                          body=test_body, generated_client_request_id_name=None)
 
-        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_resource_id)
+        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
         request_mock.assert_called_with('PUT', full_arm_rest_url,
                                         params={'p1': 'v1', 'p2': 'v2'}, data=test_body,
                                         headers=expected_header_with_auth, verify=(not should_disable_connection_verify()))
@@ -410,7 +410,7 @@ class TestHandleException(unittest.TestCase):
         send_raw_request(cli_ctx, 'PUT', full_arm_rest_url_with_port, uri_parameters=tets_uri_parameters,
                          body=test_body, generated_client_request_id_name=None)
 
-        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_resource_id)
+        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
         request_mock.assert_called_with('PUT', full_arm_rest_url_with_port,
                                         params={'p1': 'v1', 'p2': 'v2'}, data=test_body,
                                         headers=expected_header_with_auth, verify=(not should_disable_connection_verify()))

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -380,8 +380,8 @@ class TestHandleException(unittest.TestCase):
 
         get_raw_token_mock.assert_not_called()
         request_mock.assert_called_with('PUT', test_arm_endpoint + test_url,
-                                    params={'p1': 'v1', 'p2': 'v2'}, data=test_body,
-                                    headers=expected_header, verify=(not should_disable_connection_verify()))
+                                        params={'p1': 'v1', 'p2': 'v2'}, data=test_body,
+                                        headers=expected_header, verify=(not should_disable_connection_verify()))
 
         # Test Authorization header is added
         expected_header_with_auth = expected_header.copy()

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -583,7 +583,12 @@ def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  #
     uri_parameters = result or None
 
     if '://' not in uri:
+        # Default to Azure Resource Manager
         uri = cli_ctx.cloud.endpoints.resource_manager + uri.lstrip('/')
+        # Use configured ARM's resource ID, following the same behavior as
+        # azure.cli.core.commands.client_factory._get_mgmt_service_client
+        resource = resource or cli_ctx.cloud.endpoints.active_directory_resource_id
+
     # Replace common tokens with real values. It is for smooth experience if users copy and paste the url from
     # Azure Rest API doc
     from azure.cli.core._profile import Profile

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -582,12 +582,11 @@ def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  #
             result[key] = value
     uri_parameters = result or None
 
+    # If uri is an ARM resource ID, like /subscriptions/xxx/resourcegroups/xxx?api-version=2019-07-01,
+    # default to Azure Resource Manager.
+    # https://management.azure.com/ + subscriptions/xxx/resourcegroups/xxx?api-version=2019-07-01
     if '://' not in uri:
-        # Default to Azure Resource Manager
         uri = cli_ctx.cloud.endpoints.resource_manager + uri.lstrip('/')
-        # Use configured ARM's resource ID, following the same behavior as
-        # azure.cli.core.commands.client_factory._get_mgmt_service_client
-        resource = resource or cli_ctx.cloud.endpoints.active_directory_resource_id
 
     # Replace common tokens with real values. It is for smooth experience if users copy and paste the url from
     # Azure Rest API doc
@@ -599,15 +598,21 @@ def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  #
     if not skip_authorization_header and uri.lower().startswith('https://'):
         if not resource:
             endpoints = cli_ctx.cloud.endpoints
-            from azure.cli.core.cloud import CloudEndpointNotSetException
-            for p in [x for x in dir(endpoints) if not x.startswith('_')]:
-                try:
-                    value = getattr(endpoints, p)
-                except CloudEndpointNotSetException:
-                    continue
-                if isinstance(value, six.string_types) and uri.lower().startswith(value.lower()):
-                    resource = value
-                    break
+            # If uri starts with ARM endpoint, like https://management.azure.com/,
+            # use active_directory_resource_id for resource.
+            # This follows the same behavior as azure.cli.core.commands.client_factory._get_mgmt_service_client
+            if uri.lower().startswith(endpoints.resource_manager.rstrip('/')):
+                resource = cli_ctx.cloud.endpoints.active_directory_resource_id
+            else:
+                from azure.cli.core.cloud import CloudEndpointNotSetException
+                for p in [x for x in dir(endpoints) if not x.startswith('_')]:
+                    try:
+                        value = getattr(endpoints, p)
+                    except CloudEndpointNotSetException:
+                        continue
+                    if isinstance(value, six.string_types) and uri.lower().startswith(value.lower()):
+                        resource = value
+                        break
         if resource:
             token_info, _, _ = profile.get_raw_token(resource)
             logger.debug('Retrievd AAD token for resource: %s', resource or 'ARM')

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -602,7 +602,7 @@ def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  #
             # use active_directory_resource_id for resource.
             # This follows the same behavior as azure.cli.core.commands.client_factory._get_mgmt_service_client
             if uri.lower().startswith(endpoints.resource_manager.rstrip('/')):
-                resource = cli_ctx.cloud.endpoints.active_directory_resource_id
+                resource = endpoints.active_directory_resource_id
             else:
                 from azure.cli.core.cloud import CloudEndpointNotSetException
                 for p in [x for x in dir(endpoints) if not x.startswith('_')]:

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -100,8 +100,7 @@ jmespath==0.9.4
 jsmin==2.2.2
 knack==0.6.3
 MarkupSafe==1.1.1
-mock==2.0.0
-msrest==0.6.9
+mock==4.0.2
 msrestazure==0.6.2
 multidict==4.5.2
 oauthlib==3.0.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -100,7 +100,7 @@ jmespath==0.9.4
 jsmin==2.2.2
 knack==0.6.3
 MarkupSafe==1.1.1
-mock==2.0.0
+mock==4.0.2
 msrest==0.6.9
 msrestazure==0.6.2
 multidict==4.5.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -98,7 +98,7 @@ jmespath==0.9.4
 jsmin==2.2.2
 knack==0.6.3
 MarkupSafe==1.1.1
-mock==2.0.0
+mock==4.0.2
 msrest==0.6.9
 msrestazure==0.6.2
 oauthlib==3.0.1

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -131,7 +131,7 @@ DEPENDENCIES = [
     'fabric~=2.4',
     'jsmin~=2.2.2',
     'knack~=0.6,>=0.6.3',
-    'mock~=2.0',
+    'mock~=4.0',
     'paramiko>=2.0.8,<3.0.0',
     'pygments~=2.4',
     'pyOpenSSL>=17.1.0',


### PR DESCRIPTION
Fix #12566: `az rest` fails to retrieve access token and fail with 

> Get Token request returned http error: 400 and server response: 
> AADSTS65001: The user or administrator has not consented to use the application with ID '04b07795-8ddb-461a-bbee-02f9e1bf7b46' named 'Microsoft Azure CLI'. Send an interactive authorization request for this user and resource

## Cause

To retrieve an access token for ARM API `--endpoint-resource-manager`, the client needs to provide a resource ID configured by `--endpoint-active-directory-resource-id` representing this API. The resource ID may or may not be the same as the API's URL. 

Say for public cloud `AzureCloud`

https://github.com/Azure/azure-cli/blob/a221f49b9af6cf889cde20bbe4b42956900acd37/src/azure-cli-core/azure/cli/core/cloud.py#L226

https://github.com/Azure/azure-cli/blob/a221f49b9af6cf889cde20bbe4b42956900acd37/src/azure-cli-core/azure/cli/core/cloud.py#L231

its API URL is `https://management.azure.com/`, and AAD accepts both `https://management.core.windows.net/` and `https://management.azure.com/` as resource ID, so it doesn't have issue with `az rest`. But still `https://management.core.windows.net/` is the official resource ID.

For dogfood environment 
```
az cloud register
--endpoint-resource-manager https://api-dogfood.resources.windows-int.net/
--endpoint-active-directory-resource-id https://management.core.windows.net/
```
only `https://management.core.windows.net/` is accepted as the resource ID of the ARM API `https://api-dogfood.resources.windows-int.net/`. Using `https://api-dogfood.resources.windows-int.net/` as resource ID will cause AAD to return the mentioned error.

## Change

This PR changes the behavior of `az rest` to follow the same behavior as `azure.cli.core.commands.client_factory._get_mgmt_service_client` 

https://github.com/Azure/azure-cli/blob/a221f49b9af6cf889cde20bbe4b42956900acd37/src/azure-cli-core/azure/cli/core/commands/client_factory.py#L126

so that it uses `active_directory_resource_id` as resource ID, instead of `resource_manager`.