### PR TITLE
{RBAC} az ad sp create-for-rbac: Fix #12585: Fix typo in 'Role assignment already exists' message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1360,7 +1360,7 @@ def create_service_principal_for_rbac(
                                        _RETRY_TIMES)
                         continue
                     elif _error_caused_by_role_assignment_exists(ex):
-                        logger.warning('  Role assignment already exits.\n')
+                        logger.warning('  Role assignment already exists.\n')
                         break
                     else:
                         # dump out history for diagnoses


### PR DESCRIPTION
Fix #12585: Fix typo in 'Role assignment already exists' message

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
