### PR TITLE
{Core} hotfix the name of extension of dev type is None if it has incompatibility problem

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -193,6 +193,11 @@ class DevExtension(Extension):
                             key = key.lower()
                             if key == 'version':
                                 metadata[key] = '{}'.format(val.strip())
+                            elif key == 'name':
+                                # temporary fix extension name is None
+                                # until wheel upgrade and metadata structure in azure-cli-extensions has upgraded too.
+                                # https://github.com/Azure/azure-cli/pull/12583
+                                metadata[key] = val.strip()
                         except ValueError:
                             continue
 


### PR DESCRIPTION
Temporary hotfix the name not found problem when an extension has incompatibility problem.
Fix https://github.com/Azure/azure-cli/issues/12597

![image](https://user-images.githubusercontent.com/14357159/76736496-de962980-67a1-11ea-981b-1413b1b16914.png)

### Background:
CLI and extension currently relies on metadata.json to load/record meta info, which is generated from wheel <= 0.30.0 while packaging. However it's buggy and wheel starting from 0.32.0, has removed the metadata.json as wheel. 

Also, src/index.json use that that to update. and azdev and extension release pipeline

So, we cannot upgrade wheel for now until we decide to migrate metadata infrastructure. It takes a big effort

**That's why I named the PR title "hotfix"**. It involves how we extract metadata from Python package considering breaking changes of wheel. It's a small step of upgrade wheel.

**Additional context**
1. [request for upgrade wheel](https://github.com/Azure/azure-cli/pull/12583)
2. [PEP 426, the metadata of Python Package](https://www.python.org/dev/peps/pep-0426/)
3. [Decided to pin wheel version in CLI](https://github.com/Azure/azure-cli/pull/8896)
4. [Change logs of wheel](https://github.com/pypa/wheel/blob/master/docs/news.rst)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
