### PR TITLE
[Core] Allow disabling color

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -85,8 +85,8 @@ class AzCli(CLI):
 
     def show_version(self):
         from azure.cli.core.util import get_az_version_string
-        from azure.cli.core.commands.constants import SURVEY_PROMPT
-        import colorama
+        from azure.cli.core.commands.constants import SURVEY_PROMPT, SURVEY_PROMPT_COLOR
+
         ver_string, updates_available = get_az_version_string()
         print(ver_string)
         if updates_available == -1:
@@ -98,9 +98,7 @@ class AzCli(CLI):
         else:
             print('Your CLI is up-to-date.')
 
-        colorama.init()  # This could be removed when knack fix is released
-        print('\n' + SURVEY_PROMPT)
-        colorama.deinit()  # This could be removed when knack fix is released
+        print('\n' + (SURVEY_PROMPT_COLOR if self.enable_color else SURVEY_PROMPT))
 
     def exception_handler(self, ex):  # pylint: disable=no-self-use
         from azure.cli.core.util import handle_exception
@@ -448,6 +446,7 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
             kwargs['deprecate_info'].target = group_name
         if kwargs.get('is_preview', False):
             kwargs['preview_info'] = PreviewItem(
+                cli_ctx=self.cli_ctx,
                 target=group_name,
                 object_type='command group'
             )

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import argparse
 
 from azure.cli.core.commands import ExtensionCommandSource
-from azure.cli.core.commands.constants import SURVEY_PROMPT
+from azure.cli.core.commands.constants import SURVEY_PROMPT, SURVEY_PROMPT_COLOR
 
 from knack.help import (HelpFile as KnackHelpFile, CommandHelpFile as KnackCommandHelpFile,
                         GroupHelpFile as KnackGroupHelpFile, ArgumentGroupRegistry as KnackArgumentGroupRegistry,
@@ -64,6 +64,7 @@ class CLIPrintMixin(CLIHelp):
     def _print_detailed_help(self, cli_name, help_file):
         CLIPrintMixin._print_extensions_msg(help_file)
         super(CLIPrintMixin, self)._print_detailed_help(cli_name, help_file)
+        self._print_az_find_message(help_file.command, self.cli_ctx.enable_color)
 
     @staticmethod
     def _get_choices_defaults_sources_str(p):
@@ -75,7 +76,6 @@ class CLIPrintMixin(CLIHelp):
 
     @staticmethod
     def _print_examples(help_file):
-        from colorama import Style
         indent = 0
         _print_indent('Examples', indent)
         for e in help_file.examples:
@@ -86,9 +86,15 @@ class CLIPrintMixin(CLIHelp):
                 _print_indent(u'{0}'.format(e.long_summary), indent)
             _print_indent(u'{0}'.format(e.command), indent)
             print('')
+
+    @staticmethod
+    def _print_az_find_message(command, enable_color):
+        from colorama import Style
         indent = 0
-        message = 'For more specific examples, use: az find "az {}"'.format(help_file.command)
-        _print_indent(Style.BRIGHT + message + Style.RESET_ALL + '\n', indent)
+        message = 'For more specific examples, use: az find "az {}"'.format(command)
+        if enable_color:
+            message = Style.BRIGHT + message + Style.RESET_ALL
+        _print_indent(message + '\n', indent)
 
     @staticmethod
     def _process_value_sources(p):
@@ -150,8 +156,6 @@ class AzCliHelp(CLIPrintMixin, CLIHelp):
     def show_help(self, cli_name, nouns, parser, is_group):
         self.update_loaders_with_help_file_contents(nouns)
 
-        import colorama
-        colorama.init(autoreset=True)
         delimiters = ' '.join(nouns)
         help_file = self.command_help_cls(self, delimiters, parser) if not is_group \
             else self.group_help_cls(self, delimiters, parser)
@@ -162,7 +166,8 @@ class AzCliHelp(CLIPrintMixin, CLIHelp):
             AzCliHelp.update_examples(help_file)
         self._print_detailed_help(cli_name, help_file)
 
-        print(SURVEY_PROMPT)
+        from colorama import Fore, Style
+        print(SURVEY_PROMPT_COLOR if self.cli_ctx.enable_color else SURVEY_PROMPT)
 
     def _register_help_loaders(self):
         import azure.cli.core._help_loaders as help_loaders

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -686,8 +686,6 @@ class AzCliCommandInvoker(CommandInvoker):
         self._resolve_extension_override_warning(cmd)
 
     def _resolve_preview_and_deprecation_warnings(self, cmd, parsed_args):
-        import colorama
-
         deprecations = [] + getattr(parsed_args, '_argument_deprecations', [])
         if cmd.deprecate_info:
             deprecations.append(cmd.deprecate_info)
@@ -724,12 +722,10 @@ class AzCliCommandInvoker(CommandInvoker):
                 del preview_kwargs['_get_message']
                 previews.append(ImplicitPreviewItem(**preview_kwargs))
 
-        colorama.init()
         for d in deprecations:
             print(d.message, file=sys.stderr)
         for p in previews:
             print(p.message, file=sys.stderr)
-        colorama.deinit()
 
     def _resolve_extension_override_warning(self, cmd):  # pylint: disable=no-self-use
         if isinstance(cmd.command_source, ExtensionCommandSource) and cmd.command_source.overrides_command:
@@ -864,11 +860,7 @@ class LongRunningOperation(object):  # pylint: disable=too-few-public-methods
                                 logger.info(result)
 
     def __call__(self, poller):
-        import colorama
         from msrest.exceptions import ClientException
-
-        # https://github.com/azure/azure-cli/issues/3555
-        colorama.init()
 
         correlation_message = ''
         self.cli_ctx.get_progress_controller().begin()
@@ -910,7 +902,6 @@ class LongRunningOperation(object):  # pylint: disable=too-few-public-methods
             handle_long_running_operation_exception(client_exception)
 
         self.cli_ctx.get_progress_controller().end()
-        colorama.deinit()
 
         return result
 

--- a/src/azure-cli-core/azure/cli/core/commands/constants.py
+++ b/src/azure-cli-core/azure/cli/core/commands/constants.py
@@ -31,5 +31,6 @@ DEFAULT_QUERY_TIME_RANGE = 3600000
 
 BLACKLISTED_MODS = ['context', 'shell', 'documentdb', 'component']
 
-SURVEY_PROMPT = Fore.YELLOW + Style.BRIGHT + 'Please let us know how we are doing: ' + Fore.BLUE \
-    + 'https://aka.ms/clihats' + Style.RESET_ALL
+SURVEY_PROMPT = 'Please let us know how we are doing: https://aka.ms/clihats'
+SURVEY_PROMPT_COLOR = Fore.YELLOW + Style.BRIGHT + 'Please let us know how we are doing: ' + Fore.BLUE \
+                + 'https://aka.ms/clihats' + Style.RESET_ALL

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -77,8 +77,6 @@ def _validate_whl_extension(ext_file):
 
 
 def _add_whl_ext(cmd, source, ext_sha256=None, pip_extra_index_urls=None, pip_proxy=None):  # pylint: disable=too-many-statements
-    import colorama
-    colorama.init()  # Required for displaying the spinner correctly on windows issue #9140
     cmd.cli_ctx.get_progress_controller().add(message='Analyzing')
     if not source.endswith('.whl'):
         raise ValueError('Unknown extension type. Only Python wheels are supported.')
@@ -155,7 +153,6 @@ def _add_whl_ext(cmd, source, ext_sha256=None, pip_extra_index_urls=None, pip_pr
     dst = os.path.join(extension_path, whl_filename)
     shutil.copyfile(ext_file, dst)
     logger.debug('Saved the whl to %s', dst)
-    colorama.deinit()
 
 
 def is_valid_sha256sum(a_file, expected_sum):
@@ -201,10 +198,7 @@ def add_extension(cmd, source=None, extension_name=None, index_url=None, yes=Non
                   pip_extra_index_urls=None, pip_proxy=None):
     ext_sha256 = None
     if extension_name:
-        import colorama
-        colorama.init()  # Required for displaying the spinner correctly on windows issue #9140
         cmd.cli_ctx.get_progress_controller().add(message='Searching')
-        colorama.deinit()
         ext = None
         try:
             ext = get_extension(extension_name)


### PR DESCRIPTION
Fix #6080, #9903

This PR requires https://github.com/microsoft/knack/pull/171

Azure CLI can now disable color by

- Setting `AZURE_CORE_NO_COLOR` environment variable to `True`
- Using config
    ```
    [core]
    no_color=True
    ```

This PR removes unnecessary Colorama initializations as this is done centrally by Knack. Some command module still initializes Colorama by itself but that won't cause issue. We can gradually remove them in the future. 

Whether color should be enabled can now be retrieved at `cli_ctx.enable_color`. Using this field, the string literal of these two sentences are changed so that they can be shown without color. 

```
For more specific examples, use: az find "az vm list"

Please let us know how we are doing: https://aka.ms/clihats
```