### PR TITLE
Move yaml output to Knack

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -9,32 +9,6 @@ import knack.output
 class AzOutputProducer(knack.output.OutputProducer):
     def __init__(self, cli_ctx=None):
         super(AzOutputProducer, self).__init__(cli_ctx)
-        additional_formats = {
-            'yaml': self.format_yaml,
-            'yamlc': self.format_yaml_color,
-            'none': self.format_none
-        }
-        super(AzOutputProducer, self)._FORMAT_DICT.update(additional_formats)
-
-    @staticmethod
-    def format_yaml(obj):
-        from yaml import (safe_dump, representer)
-        import json
-
-        try:
-            return safe_dump(obj.result, default_flow_style=False)
-        except representer.RepresenterError:
-            # yaml.safe_dump fails when obj.result is an OrderedDict. knack's --query implementation converts the result to an OrderedDict. https://github.com/microsoft/knack/blob/af674bfea793ff42ae31a381a21478bae4b71d7f/knack/query.py#L46. # pylint: disable=line-too-long
-            return safe_dump(json.loads(json.dumps(obj.result)), default_flow_style=False)
-
-    @staticmethod
-    def format_yaml_color(obj):
-        from pygments import highlight, lexers, formatters
-        return highlight(AzOutputProducer.format_yaml(obj), lexers.YamlLexer(), formatters.TerminalFormatter())  # pylint: disable=no-member
-
-    @staticmethod
-    def format_none(_):
-        return ""
 
     def check_valid_format_type(self, format_type):
         return format_type in self._FORMAT_DICT

--- a/src/azure-cli-core/azure/cli/core/tests/test_output.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_output.py
@@ -38,7 +38,7 @@ class TestCoreCLIOutput(unittest.TestCase):
         }
 
         output_producer = AzOutputProducer(DummyCli())
-        yaml_output = output_producer.format_yaml(CommandResultItem(result=OrderedDict(account_dict)))
+        yaml_output = output_producer.get_formatter('yaml')(CommandResultItem(result=OrderedDict(account_dict)))
         self.assertEqual(account_dict, yaml.safe_load(yaml_output))
 
 


### PR DESCRIPTION
Correspond to https://github.com/microsoft/knack/pull/173

The functionality of YAML output is moved to Knack. 