### PR TITLE
[AMS] Fix #12469: adding Fairplay content-key-policy fails due to problems with 'ask' parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/ams/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/_help.py
@@ -250,10 +250,6 @@ helps['ams content-key-policy'] = """
 helps['ams content-key-policy create'] = """
     type: command
     short-summary: Create a new content key policy.
-    examples:
-        - name: Create an content-key-policy with a FairPlay Configuration.
-          text: >
-            az ams content-key-policy create -a amsAccount -g resourceGroup -n contentKeyPolicyName --policy-option-name policyOptionName --open-restriction --ask "ask-32-chars-hex-string" --fair-play-pfx pfxPath --fair-play-pfx-password "pfxPassword" --rental-and-lease-key-type PersistentUnlimited --rental-duration 5000
 """
 
 helps['ams content-key-policy show'] = """

--- a/src/azure-cli/azure/cli/command_modules/ams/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/_help.py
@@ -250,6 +250,10 @@ helps['ams content-key-policy'] = """
 helps['ams content-key-policy create'] = """
     type: command
     short-summary: Create a new content key policy.
+    examples:
+        - name: Create an content-key-policy with a FairPlay Configuration.
+          text: >
+            az ams content-key-policy create -a amsAccount -g resourceGroup -n contentKeyPolicyName --policy-option-name policyOptionName --open-restriction --ask "ask-32-chars-hex-string" --fair-play-pfx pfxPath --fair-play-pfx-password "pfxPassword" --rental-and-lease-key-type PersistentUnlimited --rental-duration 5000
 """
 
 helps['ams content-key-policy show'] = """

--- a/src/azure-cli/azure/cli/command_modules/ams/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/_params.py
@@ -217,7 +217,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                    help='The type of token. Allowed values: {}.'.format(", ".join(get_token_type_completion_list())))
         c.argument('open_id_connect_discovery_document', arg_group='Token Restriction', help='The OpenID connect discovery document.')
         c.argument('widevine_template', arg_group='Widevine Configuration', help='JSON Widevine license template. Use @{file} to load from a file.')
-        c.argument('ask', arg_group='FairPlay Configuration', help='The key that must be used as FairPlay Application Secret Key.')
+        c.argument('ask', arg_group='FairPlay Configuration', help='The key that must be used as FairPlay Application Secret Key, which is a 32 character hex string.')
         c.argument('fair_play_pfx_password', arg_group='FairPlay Configuration', help='The password encrypting FairPlay certificate in PKCS 12 (pfx) format.')
         c.argument('fair_play_pfx', arg_group='FairPlay Configuration', help='The filepath to a FairPlay certificate file in PKCS 12 (pfx) format (including private key).')
         c.argument('rental_and_lease_key_type', arg_group='FairPlay Configuration', help='The rental and lease key type. Available values: {}.'.format(", ".join(get_fairplay_rentalandlease_completion_list())))

--- a/src/azure-cli/azure/cli/command_modules/ams/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/_params.py
@@ -217,7 +217,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                    help='The type of token. Allowed values: {}.'.format(", ".join(get_token_type_completion_list())))
         c.argument('open_id_connect_discovery_document', arg_group='Token Restriction', help='The OpenID connect discovery document.')
         c.argument('widevine_template', arg_group='Widevine Configuration', help='JSON Widevine license template. Use @{file} to load from a file.')
-        c.argument('ask', arg_group='FairPlay Configuration', help='The key that must be used as FairPlay Application Secret Key, which is a 32 character hex string.')
+        c.argument('ask', arg_group='FairPlay Configuration', help='The key that must be used as FairPlay Application Secret Key.')
         c.argument('fair_play_pfx_password', arg_group='FairPlay Configuration', help='The password encrypting FairPlay certificate in PKCS 12 (pfx) format.')
         c.argument('fair_play_pfx', arg_group='FairPlay Configuration', help='The filepath to a FairPlay certificate file in PKCS 12 (pfx) format (including private key).')
         c.argument('rental_and_lease_key_type', arg_group='FairPlay Configuration', help='The rental and lease key type. Available values: {}.'.format(", ".join(get_fairplay_rentalandlease_completion_list())))

--- a/src/azure-cli/azure/cli/command_modules/ams/operations/content_key_policy.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/operations/content_key_policy.py
@@ -196,7 +196,7 @@ def update_content_key_policy_option(client, resource_group_name, account_name, 
             policy_option.configuration = ContentKeyPolicyWidevineConfiguration(widevine_template=widevine_template)
     elif isinstance(policy_option.configuration, ContentKeyPolicyFairPlayConfiguration):
         if ask is not None:
-            policy_option.configuration.ask = bytearray(ask, 'utf-8')
+            policy_option.configuration.ask = bytearray.fromhex(ask)
 
         if fair_play_pfx_password is not None:
             policy_option.configuration.fair_play_pfx_password = fair_play_pfx_password
@@ -269,7 +269,7 @@ def _generate_content_key_policy_option(policy_option_name, clear_key_configurat
 
     if valid_fairplay_configuration:
         configuration = ContentKeyPolicyFairPlayConfiguration(
-            ask=bytearray(ask, 'utf-8'), fair_play_pfx_password=fair_play_pfx_password,
+            ask=bytearray.fromhex(ask), fair_play_pfx_password=fair_play_pfx_password,
             fair_play_pfx=_b64_to_str(_read_binary(fair_play_pfx)).decode('ascii'),
             rental_and_lease_key_type=rental_and_lease_key_type,
             rental_duration=rental_duration)

--- a/src/azure-cli/azure/cli/command_modules/ams/operations/content_key_policy.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/operations/content_key_policy.py
@@ -196,7 +196,7 @@ def update_content_key_policy_option(client, resource_group_name, account_name, 
             policy_option.configuration = ContentKeyPolicyWidevineConfiguration(widevine_template=widevine_template)
     elif isinstance(policy_option.configuration, ContentKeyPolicyFairPlayConfiguration):
         if ask is not None:
-            policy_option.configuration.ask = bytearray.fromhex(ask)
+            policy_option.configuration.ask = bytearray(ask, 'utf-8')
 
         if fair_play_pfx_password is not None:
             policy_option.configuration.fair_play_pfx_password = fair_play_pfx_password
@@ -269,7 +269,7 @@ def _generate_content_key_policy_option(policy_option_name, clear_key_configurat
 
     if valid_fairplay_configuration:
         configuration = ContentKeyPolicyFairPlayConfiguration(
-            ask=bytearray.fromhex(ask), fair_play_pfx_password=fair_play_pfx_password,
+            ask=bytearray(ask, 'utf-8'), fair_play_pfx_password=fair_play_pfx_password,
             fair_play_pfx=_b64_to_str(_read_binary(fair_play_pfx)).decode('ascii'),
             rental_and_lease_key_type=rental_and_lease_key_type,
             rental_duration=rental_duration)

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_content_key_policy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_content_key_policy_scenarios.py
@@ -180,7 +180,7 @@ class AmsContentKeyPolicyTests(ScenarioTest):
             'description': 'ExampleDescription',
             'policyOptionName': policy_option_name,
             'configurationODataType': '#Microsoft.Media.ContentKeyPolicyFairPlayConfiguration',
-            'ask': '1234567890ABCDEF1234567890ABCDEF',
+            'ask': 'testtesttesttest',
             'fairPlayPfx': _get_test_data_file('TestCert2.pfx'),
             'fairPlayPfxPassword': 'password',
             'rentalAndLeaseKeyType': 'Undefined',

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_content_key_policy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_content_key_policy_scenarios.py
@@ -180,7 +180,7 @@ class AmsContentKeyPolicyTests(ScenarioTest):
             'description': 'ExampleDescription',
             'policyOptionName': policy_option_name,
             'configurationODataType': '#Microsoft.Media.ContentKeyPolicyFairPlayConfiguration',
-            'ask': 'testtesttesttest',
+            'ask': '1234567890ABCDEF1234567890ABCDEF',
             'fairPlayPfx': _get_test_data_file('TestCert2.pfx'),
             'fairPlayPfxPassword': 'password',
             'rentalAndLeaseKeyType': 'Undefined',


### PR DESCRIPTION
Issue #12469 
When adding the ASK key to Fairplay content-key-policy CLI is expecting a bytearray when it should be expecting a 32 character hexadecimal string.
Reverting the changes made in this [PR ](https://github.com/Azure/azure-cli/pull/11240)

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
