### PR TITLE
{RBAC} Polich error message for service principal resolution

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1661,7 +1661,9 @@ def _resolve_object_id(cli_ctx, assignee, fallback_to_object_id=False):
 
         # 2+ matches should never happen, so we only check 'no match' here
         if not result:
-            raise CLIError("No matches in graph database for '{}'".format(assignee))
+            raise CLIError("Cannot find user or service principal in graph database for '{}'. "
+                           "If the assignee is an appId, make sure the corresponding service principal is created "
+                           "with 'az ad sp create --id {}'.".format(assignee, assignee))
 
         return result[0].object_id
     except (CloudError, GraphErrorException):

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1661,9 +1661,9 @@ def _resolve_object_id(cli_ctx, assignee, fallback_to_object_id=False):
 
         # 2+ matches should never happen, so we only check 'no match' here
         if not result:
-            raise CLIError("Cannot find user or service principal in graph database for '{}'. "
+            raise CLIError("Cannot find user or service principal in graph database for '{assignee}'. "
                            "If the assignee is an appId, make sure the corresponding service principal is created "
-                           "with 'az ad sp create --id {}'.".format(assignee, assignee))
+                           "with 'az ad sp create --id {assignee}'.".format(assignee=assignee))
 
         return result[0].object_id
     except (CloudError, GraphErrorException):

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -303,7 +303,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTest):
                     self.cmd('role assignment delete --assignee {upn} --scope "" --role reader')
 
                 # test role assignment on empty scope
-                with self.assertRaisesRegexp(CLIError, "No matches in graph database for 'fake'"):
+                with self.assertRaisesRegexp(CLIError, "Cannot find user or service principal in graph database for 'fake'."):
                     self.cmd('role assignment create --assignee fake --role contributor')
             finally:
                 self.cmd('ad user delete --upn-or-object-id {upn}')


### PR DESCRIPTION
Resolve https://github.com/Azure/azure-cli/issues/12615

When the user creates an app but doesn't create the corresponding service principal, then does role assignment

```pwsh
# pwsh
$AppRegistrationName = 'myapp0317'
$appId = az ad app create --display-name $AppRegistrationName --reply-urls https://api.loganalytics.io/ --available-to-other-tenants false --query 'appId' --output tsv
# az ad sp create --id $appId

$rgName = 'myrg0317'
az group create -n $rgName -l westus
az role assignment create --role Reader --assignee $appId --resource-group $rgName
```

`az role assignment create` fails with

> No matches in graph database for '64ba0967-d3b7-4346-b7b6-803fdea011a4'

This PR polishes the error message to make it more instructive:

> Cannot find user or service principal in graph database for '64ba0967-d3b7-4346-b7b6-803fdea011a4'. If the assignee is an appId, make sure the corresponding service principal is created with 'az ad sp create --id 64ba0967-d3b7-4346-b7b6-803fdea011a4'.

ℹ Clean up:
```pwsh
az ad app delete --id $appId
```
