### PR TITLE
[Storage] az storage account management-policy create: Add [Required] flag for policy

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -411,12 +411,11 @@ def reject_private_endpoint_connection(cmd, client, resource_group_name, account
     )
 
 
-def create_management_policies(client, resource_group_name, account_name, policy=None):
-    if policy:
-        if os.path.exists(policy):
-            policy = get_file_json(policy)
-        else:
-            policy = shell_safe_json_parse(policy)
+def create_management_policies(client, resource_group_name, account_name, policy):
+    if os.path.exists(policy):
+        policy = get_file_json(policy)
+    else:
+        policy = shell_safe_json_parse(policy)
     return client.create_or_update(resource_group_name, account_name, policy=policy)
 
 


### PR DESCRIPTION
**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---
Fix issue #12153.
As mentioned in the issue, `--policy` is required parameter when for `create` command, but previous command interface doesn't have required flag for `--policy` as follows:
![image](https://user-images.githubusercontent.com/49508232/76944124-6cf1e300-693b-11ea-9427-8445d2137ff1.png)

Currently the command shows up as follows:
![image](https://user-images.githubusercontent.com/49508232/76943984-34520980-693b-11ea-99a4-91b07265c6b8.png)



This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
