### PR TITLE
{Core} Disable extension preview/experimental warning

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -114,11 +114,15 @@ class CLIPrintMixin(CLIHelp):
             return
         if isinstance(help_file.command_source, ExtensionCommandSource):
             logger.warning(help_file.command_source.get_command_warn_msg())
-            # If experimental is true, it overrides preview
-            if help_file.command_source.experimental:
-                logger.warning(help_file.command_source.get_experimental_warn_msg())
-            elif help_file.command_source.preview:
-                logger.warning(help_file.command_source.get_preview_warn_msg())
+
+            # Extension preview/experimental warning is disabled because it can be confusing when displayed together
+            # with command or command group preview/experimental warning. See #12556
+
+            # # If experimental is true, it overrides preview
+            # if help_file.command_source.experimental:
+            #     logger.warning(help_file.command_source.get_experimental_warn_msg())
+            # elif help_file.command_source.preview:
+            #     logger.warning(help_file.command_source.get_preview_warn_msg())
 
 
 class AzCliHelp(CLIPrintMixin, CLIHelp):


### PR DESCRIPTION
Extension preview/experimental warning is disabled because it can be confusing when displayed together with command or command group preview/experimental warning. See #12556

```sh
> az support services list -h
This command is from the following extension: support
The extension is experimental and not covered by customer support. Please use with discretion.

Command
    az support services list : Lists all the Azure services available for support ticket creation.
    Always use the service and it's corresponding problem classification(s) obtained
    programmatically for support ticket creation. This practice ensures that you always have the
    most recent set of service and problem classification Ids.
        Command group 'support services' is in preview. It may be changed/removed in a future
        release.
```

Notice these 2 warnings are conflicting:

> The extension is experimental and not covered by customer support. Please use with discretion.

> Command group 'support services' is in preview. It may be changed/removed in a future release.

Since command group's `-h` doesn't have extension preview/experimental warning, we remove it from command's `-h` as well.