### PR TITLE
{CI} Enable incremental test on commnad modules only

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -424,6 +424,7 @@ jobs:
       filePath: ./scripts/ci/test_automation.sh
     env:
       REDUCE_SDK: 'True'
+      ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: RunAutomationReduced20190301
   displayName: Run Automation Reduced Python 3.6, Profile 2019-03-01
@@ -451,6 +452,7 @@ jobs:
     env:
       REDUCE_SDK: 'True'
       AZURE_CLI_TEST_TARGET_PROFILE: '2019-03-01'
+      ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: RunAutomation20180301
   displayName: Run Automation, Profile 2018-03-01
@@ -477,6 +479,7 @@ jobs:
       filePath: ./scripts/ci/test_automation.sh
     env:
       AZURE_CLI_TEST_TARGET_PROFILE: '2018-03-01'
+      ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: RunAutomationReducedPython3_8
   displayName: Run Automation Reduced Python 3.8
@@ -504,6 +507,7 @@ jobs:
       filePath: ./scripts/ci/test_automation.sh
     env:
       REDUCE_SDK: 'True'
+      ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: RunAutomationReduced20190301Python3_8
   displayName: Run Automation Reduced Python 3.8, Profile 2019-03-01
@@ -531,6 +535,7 @@ jobs:
     env:
       REDUCE_SDK: 'True'
       AZURE_CLI_TEST_TARGET_PROFILE: '2019-03-01'
+      ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: TestExtensionsLoading
   displayName: Test Extensions Loading
@@ -578,7 +583,8 @@ jobs:
       targetType: 'filePath'
       filePath: ./scripts/ci/test_automation.sh
     env:
-      AZURE_CLI_TEST_TARGET_PROFILE: '2018-03-01'      
+      AZURE_CLI_TEST_TARGET_PROFILE: '2018-03-01'
+      ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: BuildHomebrewFormula
   displayName: Build Homebrew Formula

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -398,7 +398,7 @@ jobs:
     - bash: ./scripts/ci/test_profile_integration.sh
       displayName: 'Run Integration Test against Profiles'
 
-- job: RunAutomationReducedPython3_6
+- job: RunAutomationPython3_6
   displayName: Run Automation Reduced Python 3.6
   dependsOn: BuildPythonWheel
   timeoutInMinutes: 90
@@ -423,7 +423,6 @@ jobs:
       targetType: 'filePath'
       filePath: ./scripts/ci/test_automation.sh
     env:
-      REDUCE_SDK: 'True'
       ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: RunAutomationReduced20190301
@@ -481,7 +480,7 @@ jobs:
       AZURE_CLI_TEST_TARGET_PROFILE: '2018-03-01'
       ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
-- job: RunAutomationReducedPython3_8
+- job: RunAutomationPython3_8
   displayName: Run Automation Reduced Python 3.8
   dependsOn: BuildPythonWheel
   timeoutInMinutes: 90
@@ -506,7 +505,6 @@ jobs:
       targetType: 'filePath'
       filePath: ./scripts/ci/test_automation.sh
     env:
-      REDUCE_SDK: 'True'
       ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: RunAutomationReduced20190301Python3_8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -399,7 +399,7 @@ jobs:
       displayName: 'Run Integration Test against Profiles'
 
 - job: RunAutomationPython3_6
-  displayName: Run Automation Reduced Python 3.6
+  displayName: Run Automation Python 3.6
   dependsOn: BuildPythonWheel
   timeoutInMinutes: 90
 
@@ -481,7 +481,7 @@ jobs:
       ADO_PULL_REQUEST_TARGET_BRANCH: $(System.PullRequest.TargetBranch)
 
 - job: RunAutomationPython3_8
-  displayName: Run Automation Reduced Python 3.8
+  displayName: Run Automation Python 3.8
   dependsOn: BuildPythonWheel
   timeoutInMinutes: 90
 

--- a/scripts/ci/test_automation.sh
+++ b/scripts/ci/test_automation.sh
@@ -53,9 +53,5 @@ fi
 az -v
 az -h
 
-# for the test below
-export ADO_PULL_REQUEST_TARGET_BRANCH=$(System.PullRequest.TargetBranch)
-echo "${ADO_PULL_REQUEST_TARGET_BRANCH}"
-
 title 'Running tests'
 python -m automation test --ci --profile $target_profile

--- a/scripts/ci/test_automation.sh
+++ b/scripts/ci/test_automation.sh
@@ -53,5 +53,8 @@ fi
 az -v
 az -h
 
+# for the test below
+export ADO_PULL_REQUEST_TARGET_BRANCH=$(System.PullRequest.TargetBranch)
+
 title 'Running tests'
 python -m automation test --ci --profile $target_profile

--- a/scripts/ci/test_automation.sh
+++ b/scripts/ci/test_automation.sh
@@ -55,6 +55,7 @@ az -h
 
 # for the test below
 export ADO_PULL_REQUEST_TARGET_BRANCH=$(System.PullRequest.TargetBranch)
+echo "${ADO_PULL_REQUEST_TARGET_BRANCH}"
 
 title 'Running tests'
 python -m automation test --ci --profile $target_profile

--- a/tools/automation/tests/__init__.py
+++ b/tools/automation/tests/__init__.py
@@ -19,6 +19,66 @@ IS_WINDOWS = sys.platform.lower() in ['windows', 'win32']
 TEST_INDEX_FORMAT = 'testIndex_{}.json'
 
 
+def _separator_line():
+    print('-' * 100)
+
+
+def _extract_module_name(path):
+    _CORE_NAME_REGEX = re.compile(r'azure-cli-(?P<name>[^/\\]+)[/\\]azure[/\\]cli')
+    _MOD_NAME_REGEX = re.compile(r'azure-cli[/\\]azure[/\\]cli[/\\]command_modules[/\\](?P<name>[^/\\]+)')
+    _EXT_NAME_REGEX = re.compile(r'.*(?P<name>azext_[^/\\]+).*')
+
+    for expression in [_MOD_NAME_REGEX, _CORE_NAME_REGEX, _EXT_NAME_REGEX]:
+        match = re.search(expression, path)
+        if not match:
+            continue
+        return match.groupdict().get('name')
+    raise ValueError('unexpected error: unable to extract name from path: {}'.format(path))
+
+
+def _extract_modified_files(target_branch=None):
+    if target_branch is None:
+        ado_pr_target_branch = os.environ.get('ADO_PULL_REQUEST_TARGET_BRANCH')
+        qualified_target_branch = 'origin/{}'.format(ado_pr_target_branch)
+    else:
+        qualified_target_branch = target_branch
+
+    cmd_tpl = 'git --no-pager diff --name-only --diff-filter=ACMRT {} -- src/'
+    cmd = cmd_tpl.format(qualified_target_branch)
+
+    modified_files = check_output(cmd, shell=True).decode('utf-8').split('\n')
+    modified_files = [f for f in modified_files if len(f) > 0]
+
+    _separator_line()
+    if modified_files:
+        print('modified files in src/ :', '\n'.join(modified_files))
+    else:
+        print('no modified files in src/')
+
+    return modified_files
+
+
+def _extract_top_level_modified_modules():
+    modified_modules = set()
+
+    modified_files = _extract_modified_files()
+
+    for file_path in modified_files:
+        try:
+            mod = _extract_module_name(file_path)
+            modified_modules.add(mod)
+        except ValueError:
+            continue
+
+    _separator_line()
+    if modified_modules:
+        print('related top level modules:', list(modified_modules))
+    else:
+        print('mo related top level modules.')
+
+    return modified_modules
+
+
 def extract_module_name(path):
     mod_name_regex = re.compile(r'azure[/\\]cli[/\\]([^/\\]+)')
     ext_name_regex = re.compile(r'.*(azext_[^/\\]+).*')
@@ -42,6 +102,20 @@ def execute(args):
         output('Running in CI Mode')
         selected_modules = [('All modules', 'azure.cli', 'azure.cli'),
                             ('CLI Linter', 'automation.cli_linter', 'automation.cli_linter')]
+
+        modified_modules = _extract_top_level_modified_modules()
+        if any(base_mod in modified_modules for base_mod in ['core', 'testsdk', 'telemetry']):
+            pass
+        else:
+            test_paths = []
+            for mod in modified_modules:
+                try:
+                    test_paths.append(os.path.normpath(test_index[mod]))
+                except KeyError:
+                    display("no tests found in module: {}".format(mod))
+            args.tests = test_paths
+
+            selected_modules = filter_user_selected_modules_with_tests(modified_modules, args.profile)
     elif not (args.tests or args.src_file):
         # Default is to run with modules (possibly via environment variable)
         if os.environ.get('AZURE_CLI_TEST_MODULES', None):

--- a/tools/automation/tests/__init__.py
+++ b/tools/automation/tests/__init__.py
@@ -41,7 +41,9 @@ def _extract_modified_files(target_branch=os.environ.get('ADO_PULL_REQUEST_TARGE
 
     if target_branch == ado_raw_env_replacement:
         # in ADO env but not in PR stage
-        return ['core']
+
+        # dummy file name src/azure-cli-core/azure/cli/core/__init__.py
+        return [os.path.join('src', 'azure-cli-core', 'azure', 'cli', 'core', '__init__.py')]
     else:
         qualified_target_branch = 'origin/{}'.format(target_branch)
 

--- a/tools/automation/tests/__init__.py
+++ b/tools/automation/tests/__init__.py
@@ -53,7 +53,7 @@ def _extract_modified_files(target_branch=None):
     if modified_files:
         print('modified files in src/ :', '\n'.join(modified_files))
     else:
-        print('no modified files in src/')
+        print('no modified files in src/, no need to run automation test')
 
     return modified_files
 
@@ -74,7 +74,7 @@ def _extract_top_level_modified_modules():
     if modified_modules:
         print('related top level modules:', list(modified_modules))
     else:
-        print('mo related top level modules.')
+        print('no related top level modules modified, no need to run automation test')
 
     return modified_modules
 
@@ -115,7 +115,7 @@ def execute(args):
                     display("no tests found in module: {}".format(mod))
             args.tests = test_paths
 
-            selected_modules = filter_user_selected_modules_with_tests(modified_modules, args.profile)
+            selected_modules = []
     elif not (args.tests or args.src_file):
         # Default is to run with modules (possibly via environment variable)
         if os.environ.get('AZURE_CLI_TEST_MODULES', None):

--- a/tools/automation/tests/__init__.py
+++ b/tools/automation/tests/__init__.py
@@ -111,10 +111,10 @@ def execute(args):
         if any(base_mod in modified_modules for base_mod in ['core', 'testsdk', 'telemetry']):
             pass    # if modified modules contains those 3 modules, run all tests
         else:
-            test_paths = []
+            test_paths = set()
             for mod in modified_modules:
                 try:
-                    test_paths.append(os.path.normpath(test_index[mod]))
+                    test_paths.add(os.path.normpath(test_index[mod]))
                 except KeyError:
                     display("no tests found in module: {}".format(mod))
             args.tests = test_paths

--- a/tools/automation/tests/main.py
+++ b/tools/automation/tests/main.py
@@ -16,7 +16,7 @@ def run_tests(modules, parallel, run_live, tests):
 
     if not modules and not tests:
         display('No tests set to run.')
-        sys.exit(1)
+        sys.exit(0)
 
     display("""
 =============


### PR DESCRIPTION
Scenario of modified files:
1. Modified files in `src/azure-cli-core/azure/cli/core` (https://github.com/Azure/azure-cli/pull/12658) - 83mins
2. Modified files in `src/azure-cli-telemetry/` (https://github.com/Azure/azure-cli/pull/12662) - 53mins
3. Modified files in `src/azure-cli/azure/cli/command_modules/network` (https://github.com/Azure/azure-cli/pull/12661) take 11 mins.
4. Modified files in `srv/azure-cli/azure/cli/command_modules/vm` (https://github.com/Azure/azure-cli/pull/12664) take 11 mins.
5. Modified files in `src/azure-cli-testsdk/` (https://github.com/Azure/azure-cli/pull/12666) - 48mins
6. Modified files in vm and network (https://github.com/Azure/azure-cli/pull/12665) - 14mins.
7. Modified files in network and storage (https://github.com/Azure/azure-cli/pull/12676), - 14 mins.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
