### PR TITLE
{Cloud} add extension index endpoint

### DIFF
--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -72,7 +72,8 @@ class CloudEndpoints(object):  # pylint: disable=too-few-public-methods,too-many
                  ossrdbms_resource_id=None,
                  log_analytics_resource_id=None,
                  app_insights_resource_id=None,
-                 app_insights_telemetry_channel_resource_id=None):
+                 app_insights_telemetry_channel_resource_id=None,
+                 extension_index_resource_id=None):
         # Attribute names are significant. They are used when storing/retrieving clouds from config
         self.management = management
         self.resource_manager = resource_manager
@@ -90,6 +91,7 @@ class CloudEndpoints(object):  # pylint: disable=too-few-public-methods,too-many
         self.log_analytics_resource_id = log_analytics_resource_id
         self.app_insights_resource_id = app_insights_resource_id
         self.app_insights_telemetry_channel_resource_id = app_insights_telemetry_channel_resource_id
+        self.extension_index_resource_id = extension_index_resource_id
 
     def has_endpoint_set(self, endpoint_name):
         try:

--- a/src/azure-cli-core/azure/cli/core/extension/_index.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_index.py
@@ -21,9 +21,10 @@ TRIES = 3
 
 
 # pylint: disable=inconsistent-return-statements
-def get_index(index_url=None):
+# pylint: disable=line-too-long
+def get_index(cli_ctx=None, index_url=None):
     from azure.cli.core.util import should_disable_connection_verify
-    index_url = index_url or DEFAULT_INDEX_URL
+    index_url = index_url or (cli_ctx.cloud.endpoints.extension_index_resource_id if cli_ctx and cli_ctx.cloud.endpoints.has_endpoint_set('extension_index_resource_id') else DEFAULT_INDEX_URL)
 
     for try_number in range(TRIES):
         try:
@@ -45,8 +46,8 @@ def get_index(index_url=None):
             continue
 
 
-def get_index_extensions(index_url=None):
-    index = get_index(index_url=index_url)
+def get_index_extensions(cli_ctx=None, index_url=None):
+    index = get_index(cli_ctx=cli_ctx, index_url=index_url)
     extensions = index.get('extensions')
     if extensions is None:
         logger.warning(ERR_UNABLE_TO_GET_EXTENSIONS)

--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -53,11 +53,11 @@ def _is_greater_than_cur_version(cur_version):
     return filter_func
 
 
-def resolve_from_index(extension_name, cur_version=None, index_url=None):
+def resolve_from_index(cli_ctx, extension_name, cur_version=None, index_url=None):
     """
     Gets the download Url and digest for the matching extension
     """
-    candidates = get_index_extensions(index_url=index_url).get(extension_name, [])
+    candidates = get_index_extensions(cli_ctx, index_url=index_url).get(extension_name, [])
     if not candidates:
         raise NoExtensionCandidatesError("No extension found with name '{}'".format(extension_name))
 

--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -53,11 +53,11 @@ def _is_greater_than_cur_version(cur_version):
     return filter_func
 
 
-def resolve_from_index(cli_ctx, extension_name, cur_version=None, index_url=None):
+def resolve_from_index(extension_name, cli_ctx=None, cur_version=None, index_url=None):
     """
     Gets the download Url and digest for the matching extension
     """
-    candidates = get_index_extensions(cli_ctx, index_url=index_url).get(extension_name, [])
+    candidates = get_index_extensions(cli_ctx=cli_ctx, index_url=index_url).get(extension_name, [])
     if not candidates:
         raise NoExtensionCandidatesError("No extension found with name '{}'".format(extension_name))
 

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -220,7 +220,7 @@ def add_extension(cmd, source=None, extension_name=None, index_url=None, yes=Non
                 return
             logger.warning("Overriding development version of '%s' with production version.", extension_name)
         try:
-            source, ext_sha256 = resolve_from_index(cmd.cli_ctx, extension_name, index_url=index_url)
+            source, ext_sha256 = resolve_from_index(extension_name, cli_ctx=cmd.cli_ctx, index_url=index_url)
         except NoExtensionCandidatesError as err:
             logger.debug(err)
             raise CLIError("No matching extensions for '{}'. Use --debug for more information.".format(extension_name))
@@ -279,7 +279,7 @@ def update_extension(cmd, extension_name, index_url=None, pip_extra_index_urls=N
         ext = get_extension(extension_name, ext_type=WheelExtension)
         cur_version = ext.get_version()
         try:
-            download_url, ext_sha256 = resolve_from_index(cmd.cli_ctx, extension_name, cur_version=cur_version, index_url=index_url)
+            download_url, ext_sha256 = resolve_from_index(extension_name, cli_ctx=cmd.cli_ctx, cur_version=cur_version, index_url=index_url)
         except NoExtensionCandidatesError as err:
             logger.debug(err)
             raise CLIError("No updates available for '{}'. Use --debug for more information.".format(extension_name))
@@ -309,7 +309,7 @@ def update_extension(cmd, extension_name, index_url=None, pip_extra_index_urls=N
 
 
 def list_available_extensions(cmd, index_url=None, show_details=False):
-    index_data = get_index_extensions(cmd.cli_ctx, index_url=index_url)
+    index_data = get_index_extensions(cli_ctx=cmd.cli_ctx, index_url=index_url)
     if show_details:
         return index_data
     installed_extensions = get_extensions(ext_type=WheelExtension)

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -220,7 +220,7 @@ def add_extension(cmd, source=None, extension_name=None, index_url=None, yes=Non
                 return
             logger.warning("Overriding development version of '%s' with production version.", extension_name)
         try:
-            source, ext_sha256 = resolve_from_index(extension_name, index_url=index_url)
+            source, ext_sha256 = resolve_from_index(cmd.cli_ctx, extension_name, index_url=index_url)
         except NoExtensionCandidatesError as err:
             logger.debug(err)
             raise CLIError("No matching extensions for '{}'. Use --debug for more information.".format(extension_name))
@@ -273,12 +273,13 @@ def show_extension(extension_name):
         raise CLIError(e)
 
 
+# pylint: disable=line-too-long
 def update_extension(cmd, extension_name, index_url=None, pip_extra_index_urls=None, pip_proxy=None):
     try:
         ext = get_extension(extension_name, ext_type=WheelExtension)
         cur_version = ext.get_version()
         try:
-            download_url, ext_sha256 = resolve_from_index(extension_name, cur_version=cur_version, index_url=index_url)
+            download_url, ext_sha256 = resolve_from_index(cmd.cli_ctx, extension_name, cur_version=cur_version, index_url=index_url)
         except NoExtensionCandidatesError as err:
             logger.debug(err)
             raise CLIError("No updates available for '{}'. Use --debug for more information.".format(extension_name))
@@ -307,8 +308,8 @@ def update_extension(cmd, extension_name, index_url=None, pip_extra_index_urls=N
         raise CLIError(e)
 
 
-def list_available_extensions(index_url=None, show_details=False):
-    index_data = get_index_extensions(index_url=index_url)
+def list_available_extensions(cmd, index_url=None, show_details=False):
+    index_data = get_index_extensions(cmd.cli_ctx, index_url=index_url)
     if show_details:
         return index_data
     installed_extensions = get_extensions(ext_type=WheelExtension)

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
@@ -248,18 +248,18 @@ class TestExtensionCommands(unittest.TestCase):
     def test_list_available_extensions_default(self):
         with mock.patch('azure.cli.core.extension.operations.get_index_extensions', autospec=True) as c:
             list_available_extensions(self.cmd)
-            c.assert_called_once_with(None)
+            c.assert_called_once_with(self.cmd.cli_ctx, None)
 
     def test_list_available_extensions_operations_index_url(self):
         with mock.patch('azure.cli.core.extension.operations.get_index_extensions', autospec=True) as c:
             index_url = 'http://contoso.com'
             list_available_extensions(self.cmd, index_url=index_url)
-            c.assert_called_once_with(index_url)
+            c.assert_called_once_with(self.cmd.cli_ctx, index_url)
 
     def test_list_available_extensions_show_details(self):
         with mock.patch('azure.cli.core.extension.operations.get_index_extensions', autospec=True) as c:
             list_available_extensions(self.cmd, show_details=True)
-            c.assert_called_once_with(None)
+            c.assert_called_once_with(self.cmd.cli_ctx, None)
 
     def test_list_available_extensions_no_show_details(self):
         sample_index_extensions = {

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
@@ -247,18 +247,18 @@ class TestExtensionCommands(unittest.TestCase):
 
     def test_list_available_extensions_default(self):
         with mock.patch('azure.cli.core.extension.operations.get_index_extensions', autospec=True) as c:
-            list_available_extensions()
+            list_available_extensions(self.cmd)
             c.assert_called_once_with(None)
 
     def test_list_available_extensions_operations_index_url(self):
         with mock.patch('azure.cli.core.extension.operations.get_index_extensions', autospec=True) as c:
             index_url = 'http://contoso.com'
-            list_available_extensions(index_url=index_url)
+            list_available_extensions(self.cmd, index_url=index_url)
             c.assert_called_once_with(index_url)
 
     def test_list_available_extensions_show_details(self):
         with mock.patch('azure.cli.core.extension.operations.get_index_extensions', autospec=True) as c:
-            list_available_extensions(show_details=True)
+            list_available_extensions(self.cmd, show_details=True)
             c.assert_called_once_with(None)
 
     def test_list_available_extensions_no_show_details(self):
@@ -279,7 +279,7 @@ class TestExtensionCommands(unittest.TestCase):
                 }}]
         }
         with mock.patch('azure.cli.core.extension.operations.get_index_extensions', return_value=sample_index_extensions):
-            res = list_available_extensions()
+            res = list_available_extensions(self.cmd)
             self.assertIsInstance(res, list)
             self.assertEqual(len(res), len(sample_index_extensions))
             self.assertEqual(res[0]['name'], 'test_sample_extension1')
@@ -288,7 +288,7 @@ class TestExtensionCommands(unittest.TestCase):
             self.assertEqual(res[0]['preview'], False)
             self.assertEqual(res[0]['experimental'], False)
         with mock.patch('azure.cli.core.extension.operations.get_index_extensions', return_value=sample_index_extensions):
-            res = list_available_extensions()
+            res = list_available_extensions(self.cmd)
             self.assertIsInstance(res, list)
             self.assertEqual(len(res), len(sample_index_extensions))
             self.assertEqual(res[1]['name'], 'test_sample_extension2')
@@ -308,7 +308,7 @@ class TestExtensionCommands(unittest.TestCase):
                 }}]
         }
         with mock.patch('azure.cli.core.extension.operations.get_index_extensions', return_value=sample_index_extensions):
-            res = list_available_extensions()
+            res = list_available_extensions(self.cmd)
             self.assertIsInstance(res, list)
             self.assertEqual(len(res), 0)
 

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_index_get.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_index_get.py
@@ -85,6 +85,26 @@ class TestExtensionIndexGet(unittest.TestCase):
                 self.assertEqual(get_index_extensions(), None)
                 logger_mock.assert_called_once_with(ERR_UNABLE_TO_GET_EXTENSIONS)
 
+    # pylint: disable=line-too-long
+    def test_get_index_cloud(self):
+        from azure.cli.core.mock import DummyCli
+        cli_ctx = DummyCli()
+
+        default_data = {'extensions': {}}
+        obj = object()
+        cloud_data = {'extensions': {'myext': obj}}
+        # cli_ctx not passed
+        with mock.patch('requests.get', side_effect=mock_index_get_generator(DEFAULT_INDEX_URL, default_data)):
+            self.assertEqual(get_index_extensions(), {})
+        # cli_ctx passed but endpoint not set
+        delattr(cli_ctx.cloud.endpoints, 'extension_index_resource_id')
+        with mock.patch('requests.get', side_effect=mock_index_get_generator(DEFAULT_INDEX_URL, default_data)):
+            self.assertEqual(get_index_extensions(cli_ctx=cli_ctx), {})
+        # cli_ctx passed and the endpoint is set
+        cli_ctx.cloud.endpoints.extension_index_resource_id = 'http://contoso.com/cli-index'
+        with mock.patch('requests.get', side_effect=mock_index_get_generator('http://contoso.com/cli-index', cloud_data)):
+            self.assertEqual(get_index_extensions(cli_ctx=cli_ctx).get('myext'), obj)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/extension/_completers.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/_completers.py
@@ -16,4 +16,4 @@ def extension_name_completion_list(cmd, prefix, namespace, **kwargs):  # pylint:
 
 @Completer
 def extension_name_from_index_completion_list(cmd, prefix, namespace, **kwargs):  # pylint: disable=unused-argument
-    return get_index_extensions().keys()
+    return get_index_extensions(cmd.cli_ctx).keys()

--- a/src/azure-cli/azure/cli/command_modules/extension/_completers.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/_completers.py
@@ -16,4 +16,4 @@ def extension_name_completion_list(cmd, prefix, namespace, **kwargs):  # pylint:
 
 @Completer
 def extension_name_from_index_completion_list(cmd, prefix, namespace, **kwargs):  # pylint: disable=unused-argument
-    return get_index_extensions(cmd.cli_ctx).keys()
+    return get_index_extensions(cli_ctx=cmd.cli_ctx).keys()

--- a/src/azure-cli/azure/cli/command_modules/extension/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/custom.py
@@ -34,5 +34,5 @@ def update_extension_cmd(cmd, extension_name, index_url=None, pip_extra_index_ur
                             pip_proxy=pip_proxy)
 
 
-def list_available_extensions_cmd(index_url=None, show_details=False):
-    return list_available_extensions(index_url=index_url, show_details=show_details)
+def list_available_extensions_cmd(cmd, index_url=None, show_details=False):
+    return list_available_extensions(cmd, index_url=index_url, show_details=show_details)


### PR DESCRIPTION
We will upload extensions to another storage account for JEDI and install extensions from a corresponding index.json. This PR adds a new endpoint for index url to support downloading from different index urls for different clouds.

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
