### PR TITLE
{Packaging} Remove universal=1

### DIFF
--- a/src/azure-cli-command_modules-nspkg/setup.cfg
+++ b/src/azure-cli-command_modules-nspkg/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/src/azure-cli-core/setup.cfg
+++ b/src/azure-cli-core/setup.cfg
@@ -1,3 +1,2 @@
 [bdist_wheel]
-universal=1
 azure-namespace-package=azure-cli-nspkg

--- a/src/azure-cli-nspkg/setup.cfg
+++ b/src/azure-cli-nspkg/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/src/azure-cli-telemetry/setup.cfg
+++ b/src/azure-cli-telemetry/setup.cfg
@@ -1,3 +1,2 @@
 [bdist_wheel]
-universal=1
 azure-namespace-package=azure-cli-nspkg

--- a/src/azure-cli-testsdk/setup.cfg
+++ b/src/azure-cli-testsdk/setup.cfg
@@ -1,3 +1,2 @@
 [bdist_wheel]
-universal=1
 azure-namespace-package=azure-cli-nspkg

--- a/src/azure-cli/setup.cfg
+++ b/src/azure-cli/setup.cfg
@@ -1,3 +1,2 @@
 [bdist_wheel]
-universal=1
 azure-namespace-package=azure-cli-nspkg


### PR DESCRIPTION
Remove `universal=1` so that PyPI doesn't mark the package as Python 2 supported: 

https://pypi.org/project/azure-cli/#files

azure_cli-2.2.0-py2.py3-none-any.whl (1.5 MB) | Wheel | py2.py3
-- | -- | --
