### PR TITLE
[ACR] Add a validator for argument 'registry_name'

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -34,7 +34,8 @@ from ._validators import (
     validate_secret_arg,
     validate_set,
     validate_set_secret,
-    validate_retention_days
+    validate_retention_days,
+    validate_registry_name
 )
 from .scope_map import ScopeMapActions
 
@@ -53,7 +54,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
 
     with self.argument_context('acr') as c:
         c.argument('tags', arg_type=tags_type)
-        c.argument('registry_name', options_list=['--name', '-n'], help='The name of the container registry. You can configure the default registry name using `az configure --defaults acr=<registry name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE), configured_default='acr')
+        c.argument('registry_name', options_list=['--name', '-n'], help='The name of the container registry. You can configure the default registry name using `az configure --defaults acr=<registry name>`', completer=get_resource_name_completion_list(REGISTRY_RESOURCE_TYPE), configured_default='acr', validator=validate_registry_name)
         c.argument('tenant_suffix', options_list=['--suffix'], help="The tenant suffix in registry login server. You may specify '--suffix tenant' if your registry login server is in the format 'registry-tenant.azurecr.io'. Applicable if you\'re accessing the registry from a different subscription or you have permission to access images but not the permission to manage the registry resource.")
         c.argument('sku', help='The SKU of the container registry', arg_type=get_enum_type(SkuName))
         c.argument('admin_enabled', help='Indicates whether the admin user is enabled', arg_type=get_three_state_flag())
@@ -122,14 +123,14 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('image', options_list=['--image', '-t'], help="The name of the image. May include a tag in the format 'name:tag'.")
 
     with self.argument_context('acr create') as c:
-        c.argument('registry_name', completer=None)
+        c.argument('registry_name', completer=None, validator=None)
         c.argument('deployment_name', validator=None)
         c.argument('location', validator=get_default_location_from_resource_group)
         c.argument('workspace', is_preview=True,
                    help='Name or ID of the Log Analytics workspace to send registry diagnostic logs to. All events will be enabled. You can use "az monitor log-analytics workspace create" to create one. Extra billing may apply.')
 
     with self.argument_context('acr check-name') as c:
-        c.argument('registry_name', completer=None)
+        c.argument('registry_name', completer=None, validator=None)
 
     with self.argument_context('acr webhook') as c:
         c.argument('registry_name', options_list=['--registry', '-r'])

--- a/src/azure-cli/azure/cli/command_modules/acr/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_validators.py
@@ -5,6 +5,9 @@
 
 import os
 from knack.util import CLIError
+from knack.log import get_logger
+
+logger = get_logger(__name__)
 
 
 def validate_headers(namespace):
@@ -85,3 +88,14 @@ def validate_retention_days(namespace):
     days = namespace.days
     if days and (days < 0 or days > 365):
         raise CLIError("Invalid value for days: should be from 0 to 365")
+
+
+def validate_registry_name(cmd, namespace):
+    """Omit login server endpoint suffix."""
+    registry = namespace.registry_name
+    if registry:
+        suffix = cmd.cli_ctx.cloud.suffixes.acr_login_server_endpoint
+        pos = registry.find(suffix)
+        if pos > 0:
+            logger.warning("The login server endpoint suffix '%s' is automatically omitted.", suffix)
+            namespace.registry_name = registry[:pos]

--- a/src/azure-cli/azure/cli/command_modules/acr/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_validators.py
@@ -93,9 +93,11 @@ def validate_retention_days(namespace):
 def validate_registry_name(cmd, namespace):
     """Omit login server endpoint suffix."""
     registry = namespace.registry_name
-    if registry:
-        suffix = cmd.cli_ctx.cloud.suffixes.acr_login_server_endpoint
-        pos = registry.find(suffix)
+    suffixes = cmd.cli_ctx.cloud.suffixes
+    # Some clouds do not define 'acr_login_server_endpoint' (e.g. AzureGermanCloud)
+    if registry and hasattr(suffixes, 'acr_login_server_endpoint'):
+        acr_suffix = suffixes.acr_login_server_endpoint
+        pos = registry.find(acr_suffix)
         if pos > 0:
-            logger.warning("The login server endpoint suffix '%s' is automatically omitted.", suffix)
+            logger.warning("The login server endpoint suffix '%s' is automatically omitted.", acr_suffix)
             namespace.registry_name = registry[:pos]


### PR DESCRIPTION
Resolve #12631
Add a validator for argument 'registry_name' to omit login server endpoint suffix.
The validator applies to all `az acr` commands, except `az acr create` and `az acr check-name`. 

**Behavior**
(specify registry name with --registry)
![image](https://user-images.githubusercontent.com/8113721/77146292-ace4d180-6ac5-11ea-9a4c-511db58a8c3d.png)


(specify login server with --registry)
![image](https://user-images.githubusercontent.com/8113721/77146245-92aaf380-6ac5-11ea-9594-8e004f6cc0a2.png)

(specify login server with --name)
![image](https://user-images.githubusercontent.com/8113721/77146583-53c96d80-6ac6-11ea-8b2d-292c15490723.png)


**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
