### PR TITLE
{Core} Add . in prefix for operation handler

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -534,7 +534,7 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
         from azure.cli.core.profiles._shared import get_versioned_sdk_path
 
         for rt in AZURE_API_PROFILES[self.cli_ctx.cloud.profile]:
-            if operation.startswith(rt.import_prefix):
+            if operation.startswith(rt.import_prefix + '.'):
                 operation = operation.replace(rt.import_prefix,
                                               get_versioned_sdk_path(self.cli_ctx.cloud.profile, rt,
                                                                      operation_group=operation_group))


### PR DESCRIPTION
**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---
`Description:`
`ResourceType` is defined as enum with the following structure for each element:
`DATA_STORAGE = ('azure.multiapi.storage', None)`

If we have two Resource Types named `DATA_STORAGE` and `DATA_STORAGESYNC` with the following definition:
```
DATA_STORAGESYNC = ('azure.multiapi.storagesync.', None)
DATA_STORAGE = ('azure.multiapi.storage.', None)
```
and the following api versions in latest profile:
```
ResourceType.DATA_STORAGESYNC: '2015-12-01',
ResourceType.DATA_STORAGE: '2016-09-01',
```
For the command type with `operations_tmpl = 'azure.mgmt.storagesync.operations#ManagementPoliciesOperations.{}'`, the condition will be fit for resource type `DATA_STORAGE` in original code and CLI will go into the path `azure.multiapi.storage` 
 with api version defined in  `DATA_STORAGE`, not `azure.multiapi.storagesync` :
https://github.com/Azure/azure-cli/blob/ac20369eb7465e56f2b6043b131230310786ec02/src/azure-cli-core/azure/cli/core/__init__.py#L537-L540

But the right api version should be in `ResourceType.DATA_STORAGESYNC`.
With the change, we can prevent such scenario and go into  azure-multiapi-storagesync package as expected.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
