### PR TITLE
{Profile} az login: Refine warning messages

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -877,7 +877,10 @@ class SubscriptionFinder(object):
         tenants = client.tenants.list()
         for t in tenants:
             tenant_id = t.tenant_id
-            t.display_name = t.additional_properties['displayName']  # remove this line once SDK is fixed
+            if not hasattr(t, 'display_name'):  # Available since 2018-06-01
+                t.display_name = ""
+            if hasattr(t, 'additional_properties'):  # remove this line once SDK is fixed
+                t.display_name = t.additional_properties['displayName']
             temp_context = self._create_auth_context(tenant_id)
             try:
                 temp_credentials = temp_context.acquire_token(resource, self.user_id, _CLIENT_ID)

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -214,9 +214,12 @@ class Profile(object):
                     username, password, tenant, self._ad_resource_uri)
 
         if not allow_no_subscriptions and not subscriptions:
-            raise CLIError("No subscriptions were found for '{}'. If this is expected, use "
-                           "'--allow-no-subscriptions' to have tenant level access".format(
-                               username))
+            if username:
+                msg = "No subscriptions found for {}.".format(username)
+            else:
+                # Don't show username if bare 'az login' is used
+                msg = "No subscriptions found."
+            raise CLIError(msg)
 
         if is_service_principal:
             self._creds_cache.save_service_principal_cred(sp_auth.get_entry_to_persist(username,
@@ -867,11 +870,14 @@ class SubscriptionFinder(object):
         from msrest.authentication import BasicTokenAuthentication
 
         all_subscriptions = []
+        empty_tenants = []
+        mfa_tenants = []
         token_credential = BasicTokenAuthentication({'access_token': access_token})
         client = self._arm_client_factory(token_credential)
         tenants = client.tenants.list()
         for t in tenants:
             tenant_id = t.tenant_id
+            t.display_name = t.additional_properties['displayName']  # remove this line once SDK is fixed
             temp_context = self._create_auth_context(tenant_id)
             try:
                 temp_credentials = temp_context.acquire_token(resource, self.user_id, _CLIENT_ID)
@@ -881,15 +887,17 @@ class SubscriptionFinder(object):
                 # with other tenants.
                 msg = (getattr(ex, 'error_response', None) or {}).get('error_description') or ''
                 if 'AADSTS50076' in msg:
-                    logger.warning("Tenant %s requires Multi-Factor Authentication (MFA). "
-                                   "To access this tenant, use 'az login --tenant' to explicitly "
-                                   "login to this tenant.", tenant_id)
+                    # The tenant requires MFA and can't be accessed with home tenant's refresh token
+                    mfa_tenants.append(t)
                 else:
                     logger.warning("Failed to authenticate '%s' due to error '%s'", t, ex)
                 continue
             subscriptions = self._find_using_specific_tenant(
                 tenant_id,
                 temp_credentials[_ACCESS_TOKEN])
+
+            if not subscriptions:
+                empty_tenants.append(t)
 
             # When a subscription can be listed by multiple tenants, only the first appearance is retained
             for sub_to_add in subscriptions:
@@ -898,7 +906,7 @@ class SubscriptionFinder(object):
                     if sub_to_add.subscription_id == sub_to_compare.subscription_id:
                         logger.warning("Subscription %s '%s' can be accessed from tenants %s(default) and %s. "
                                        "To select a specific tenant when accessing this subscription, "
-                                       "please include --tenant in 'az login'.",
+                                       "use 'az login --tenant TENANT_ID'.",
                                        sub_to_add.subscription_id, sub_to_add.display_name,
                                        sub_to_compare.tenant_id, sub_to_add.tenant_id)
                         add_sub = False
@@ -906,6 +914,19 @@ class SubscriptionFinder(object):
                 if add_sub:
                     all_subscriptions.append(sub_to_add)
 
+        # Show warning for empty tenants
+        if empty_tenants:
+            logger.warning("The following tenants don't contain accessible subscriptions. "
+                           "Use 'az login --allow-no-subscriptions' to have tenant level access.")
+            for t in empty_tenants:
+                logger.warning("%s '%s'", t.tenant_id, t.display_name)
+
+        # Show warning for MFA tenants
+        if mfa_tenants:
+            logger.warning("The following tenants require Multi-Factor Authentication (MFA). "
+                           "Use 'az login --tenant TENANT_ID' to explicitly login to a tenant.")
+            for t in mfa_tenants:
+                logger.warning("%s '%s'", t.tenant_id, t.display_name)
         return all_subscriptions
 
     def _find_using_specific_tenant(self, tenant, access_token):

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -1952,8 +1952,10 @@ class ManagedByTenantStub(ManagedByTenant):  # pylint: disable=too-few-public-me
 
 class TenantStub(object):  # pylint: disable=too-few-public-methods
 
-    def __init__(self, tenant_id):
+    def __init__(self, tenant_id, display_name="DISPLAY_NAME"):
         self.tenant_id = tenant_id
+        self.display_name = display_name
+        self.additional_properties = {'displayName': display_name}
 
 
 class MSRestAzureAuthStub:

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -67,7 +67,7 @@ DEPENDENCIES = [
     'requests~=2.20',
     'six~=1.12',
     'wheel==0.30.0',
-    'azure-mgmt-resource~=8.0.1',
+    'azure-mgmt-resource==8.0.1',
 ]
 
 TESTS_REQUIRE = [

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -112,7 +112,7 @@ DEPENDENCIES = [
     'azure-mgmt-relay~=0.1.0',
     # 'azure-mgmt-reservations~=0.6.0',
     'azure-mgmt-reservations==0.6.0',  # TODO: Use requirements.txt instead of '==' #9781
-    'azure-mgmt-resource~=8.0.1',
+    'azure-mgmt-resource==8.0.1',
     'azure-mgmt-search~=2.0',
     'azure-mgmt-security~=0.1.0',
     'azure-mgmt-servicebus~=0.6.0',


### PR DESCRIPTION
Refine and unify the warning messages for 

### MFA tenants (#12516)

> The following tenants require Multi-Factor Authentication (MFA). Use 'az login --tenant TENANT_ID' to explicitly login to a tenant.
> da086fa3-023f-4500-bf56-0f19d3065440 'Inbarck Labs'
> ...

### Empty tenants (#2929)

> The following tenants doesn't contain accessible subscriptions. Use 'az login --allow-no-subscriptions' to have tenant level access.
> 3f85f91a-b450-4dbb-b0f5-703606d9161f 'Contoso'
> ...

### Multi-tenant subscriptions (#11886)

> Subscription 95350823-1b99-4afd-92f8-b1d6db6f7ab2 'Visual Studio Enterprise' can be accessed from tenants 72f988bf-86f1-41af-91ab-2d7cd011db47(default) and 2b8e6bbc-631a-4bf6-b0c6-d4947b3c79dd. To select a specific tenant when accessing this subscription, use 'az login --tenant TENANT_ID'.

⚠ azure-mgmt-resource SDK version is temporarily locked due to missing properties added in https://github.com/Azure/azure-rest-api-specs/pull/8384
