### PR TITLE
{Core} Extract User-Agent generation to get_az_user_agent

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -3,20 +3,16 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import os
-
-from azure.cli.core import __version__ as core_version
 import azure.cli.core._debug as _debug
 from azure.cli.core.extension import EXTENSIONS_MOD_PREFIX
 from azure.cli.core.profiles._shared import get_client_class, SDKProfile
 from azure.cli.core.profiles import ResourceType, CustomResourceType, get_api_version, get_sdk
+from azure.cli.core.util import get_az_user_agent
 
 from knack.log import get_logger
 from knack.util import CLIError
 
 logger = get_logger(__name__)
-UA_AGENT = "AZURECLI/{}".format(core_version)
-ENV_ADDITIONAL_USER_AGENT = 'AZURE_HTTP_USER_AGENT'
 
 
 def resolve_client_arg_name(operation, kwargs):
@@ -82,11 +78,7 @@ def configure_common_settings(cli_ctx, client):
 
     client.config.enable_http_logger = True
 
-    client.config.add_user_agent(UA_AGENT)
-    try:
-        client.config.add_user_agent(os.environ[ENV_ADDITIONAL_USER_AGENT])
-    except KeyError:
-        pass
+    client.config.add_user_agent(get_az_user_agent())
 
     try:
         command_ext_name = cli_ctx.data['command_extension_name']
@@ -185,12 +177,7 @@ def get_subscription_id(cli_ctx):
 def _get_add_headers_callback(cli_ctx):
 
     def _add_headers(request):
-        agents = [request.headers['User-Agent'], UA_AGENT]
-        try:
-            agents.append(os.environ[ENV_ADDITIONAL_USER_AGENT])
-        except KeyError:
-            pass
-
+        agents = [request.headers['User-Agent'], get_az_user_agent()]
         request.headers['User-Agent'] = ' '.join(agents)
 
         try:

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -14,7 +14,7 @@ import json
 from azure.cli.core.util import \
     (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string,
      open_page_in_browser, can_launch_browser, handle_exception, ConfiguredDefaultSetter, send_raw_request,
-     should_disable_connection_verify, parse_proxy_resource_id)
+     should_disable_connection_verify, parse_proxy_resource_id, get_az_user_agent)
 from azure.cli.core.mock import DummyCli
 
 
@@ -198,6 +198,140 @@ class TestUtils(unittest.TestCase):
             result = can_launch_browser()
             self.assertFalse(result)
 
+    def test_configured_default_setter(self):
+        config = mock.MagicMock()
+        config.use_local_config = None
+        with ConfiguredDefaultSetter(config, True):
+            self.assertEqual(config.use_local_config, True)
+        self.assertIsNone(config.use_local_config)
+
+        config.use_local_config = True
+        with ConfiguredDefaultSetter(config, False):
+            self.assertEqual(config.use_local_config, False)
+        self.assertTrue(config.use_local_config)
+
+    @mock.patch('azure.cli.core.__version__', '7.8.9')
+    def test_get_az_user_agent(self):
+        actual = get_az_user_agent()
+        self.assertEqual(actual, 'AZURECLI/7.8.9')
+
+    @mock.patch('azure.cli.core._profile.Profile.get_raw_token', autospec=True)
+    @mock.patch('requests.Session.send', autospec=True)
+    def test_send_raw_requests(self, send_mock, get_raw_token_mock):
+        return_val = mock.MagicMock()
+        return_val.is_ok = True
+        send_mock.return_value = return_val
+        get_raw_token_mock.return_value = ("Bearer", "eyJ0eXAiOiJKV1", None), None, None
+
+        cli_ctx = DummyCli()
+        cli_ctx.data = {
+            'command': 'rest',
+            'safe_params': ['method', 'uri']
+        }
+        test_arm_active_directory_resource_id = 'https://management.core.windows.net/'
+        test_arm_endpoint = 'https://management.azure.com/'
+        arm_resource_id = '/subscriptions/01/resourcegroups/02?api-version=2019-07-01'
+        full_arm_rest_url = test_arm_endpoint.rstrip('/') + arm_resource_id
+        test_body = '{"b1": "v1"}'
+
+        expected_header = {
+            'User-Agent': get_az_user_agent(),
+            'Accept-Encoding': 'gzip, deflate',
+            'Accept': '*/*',
+            'Connection': 'keep-alive',
+            'Content-Type': 'application/json',
+            'CommandName': 'rest',
+            'ParameterSetName': 'method uri',
+            'Content-Length': '12'
+        }
+        expected_header_with_auth = expected_header.copy()
+        expected_header_with_auth['Authorization'] = 'Bearer eyJ0eXAiOiJKV1'
+
+        # Test basic usage
+        # Mock Put Blob https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob
+        # Authenticate with service SAS https://docs.microsoft.com/en-us/rest/api/storageservices/create-service-sas
+        sas_token = ['sv=2019-02-02', '{"srt": "s"}', "{'ss': 'bf'}"]
+        send_raw_request(cli_ctx, 'PUT', 'https://myaccount.blob.core.windows.net/mycontainer/myblob?timeout=30',
+                         uri_parameters=sas_token, body=test_body,
+                         generated_client_request_id_name=None)
+
+        get_raw_token_mock.assert_not_called()
+        request = send_mock.call_args.args[1]
+        self.assertEqual(request.method, 'PUT')
+        self.assertEqual(request.url, 'https://myaccount.blob.core.windows.net/mycontainer/myblob?timeout=30&sv=2019-02-02&srt=s&ss=bf')
+        self.assertEqual(request.body, '{"b1": "v1"}')
+        # Verify no Authorization header
+        self.assertDictEqual(dict(request.headers), expected_header)
+        self.assertEqual(send_mock.call_args.kwargs["verify"], not should_disable_connection_verify())
+
+        # Test Authorization header is skipped
+        send_raw_request(cli_ctx, 'GET', full_arm_rest_url, body=test_body, skip_authorization_header=True,
+                         generated_client_request_id_name=None)
+
+        get_raw_token_mock.assert_not_called()
+        request = send_mock.call_args.args[1]
+        self.assertDictEqual(dict(request.headers), expected_header)
+
+        # Test Authorization header is already provided
+        send_raw_request(cli_ctx, 'GET', full_arm_rest_url,
+                         body=test_body, headers={'Authorization=Basic ABCDE'},
+                         generated_client_request_id_name=None)
+
+        get_raw_token_mock.assert_not_called()
+        request = send_mock.call_args.args[1]
+        self.assertDictEqual(dict(request.headers), {**expected_header, 'Authorization': 'Basic ABCDE'})
+
+        # Test Authorization header is auto appended
+        send_raw_request(cli_ctx, 'GET', full_arm_rest_url,
+                         body=test_body,
+                         generated_client_request_id_name=None)
+
+        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
+        request = send_mock.call_args.args[1]
+        self.assertDictEqual(dict(request.headers), expected_header_with_auth)
+
+        # Test ARM resource ID /subscriptions/01/resourcegroups/02?api-version=2019-07-01
+        send_raw_request(cli_ctx, 'GET', arm_resource_id, body=test_body,
+                         generated_client_request_id_name=None)
+
+        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
+        request = send_mock.call_args.args[1]
+        self.assertEqual(request.url, 'https://management.azure.com/subscriptions/01/resourcegroups/02?api-version=2019-07-01')
+        self.assertDictEqual(dict(request.headers), expected_header_with_auth)
+
+        # Test full ARM URL https://management.azure.com/subscriptions/01/resourcegroups/02?api-version=2019-07-01
+        send_raw_request(cli_ctx, 'GET', full_arm_rest_url)
+
+        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
+        request = send_mock.call_args.args[1]
+        self.assertEqual(request.url, 'https://management.azure.com/subscriptions/01/resourcegroups/02?api-version=2019-07-01')
+
+        # Test full ARM URL with port https://management.azure.com:443/subscriptions/01/resourcegroups/02?api-version=2019-07-01
+        test_arm_endpoint_with_port = 'https://management.azure.com:443/'
+        full_arm_rest_url_with_port = test_arm_endpoint_with_port.rstrip('/') + arm_resource_id
+        send_raw_request(cli_ctx, 'GET', full_arm_rest_url_with_port)
+
+        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
+        request = send_mock.call_args.args[1]
+        self.assertEqual(request.url, 'https://management.azure.com:443/subscriptions/01/resourcegroups/02?api-version=2019-07-01')
+
+        # Test non-ARM API, such as MS Graph API https://graph.microsoft.com/beta/appRoleAssignments/01
+        send_raw_request(cli_ctx, 'PATCH', 'https://graph.microsoft.com/beta/appRoleAssignments/01',
+                         body=test_body, generated_client_request_id_name=None)
+
+        get_raw_token_mock.assert_called_with(mock.ANY, 'https://graph.microsoft.com/')
+        request = send_mock.call_args.args[1]
+        self.assertEqual(request.method, 'PATCH')
+        self.assertEqual(request.url, 'https://graph.microsoft.com/beta/appRoleAssignments/01')
+
+        # Test custom case-insensitive User-Agent
+        with mock.patch.dict('os.environ', {'AZURE_HTTP_USER_AGENT': "env-ua"}):
+            send_raw_request(cli_ctx, 'GET', full_arm_rest_url, headers={'user-agent=ARG-UA'})
+
+            get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
+            request = send_mock.call_args.args[1]
+            self.assertEqual(request.headers['User-Agent'], get_az_user_agent() + ' env-ua ARG-UA')
+
 
 class TestBase64ToHex(unittest.TestCase):
 
@@ -332,135 +466,6 @@ class TestHandleException(unittest.TestCase):
         self.assertTrue(mock_logger_error.called)
         self.assertEqual(mock.call(mock_http_error), mock_logger_error.call_args)
         self.assertEqual(ex_result, 1)
-
-    def test_configured_default_setter(self):
-        config = mock.MagicMock()
-        config.use_local_config = None
-        with ConfiguredDefaultSetter(config, True):
-            self.assertEqual(config.use_local_config, True)
-        self.assertIsNone(config.use_local_config)
-
-        config.use_local_config = True
-        with ConfiguredDefaultSetter(config, False):
-            self.assertEqual(config.use_local_config, False)
-        self.assertTrue(config.use_local_config)
-
-    @mock.patch('azure.cli.core._profile.Profile.get_raw_token', autospec=True)
-    @mock.patch('requests.Session.send', autospec=True)
-    def test_send_raw_requests(self, send_mock, get_raw_token_mock):
-        from azure.cli.core.commands.client_factory import UA_AGENT
-        return_val = mock.MagicMock()
-        return_val.is_ok = True
-        send_mock.return_value = return_val
-        get_raw_token_mock.return_value = ("Bearer", "eyJ0eXAiOiJKV1", None), None, None
-
-        cli_ctx = DummyCli()
-        cli_ctx.data = {
-            'command': 'rest',
-            'safe_params': ['method', 'uri']
-        }
-        test_arm_active_directory_resource_id = 'https://management.core.windows.net/'
-        test_arm_endpoint = 'https://management.azure.com/'
-        arm_resource_id = '/subscriptions/01/resourcegroups/02?api-version=2019-07-01'
-        full_arm_rest_url = test_arm_endpoint.rstrip('/') + arm_resource_id
-        test_body = '{"b1": "v1"}'
-
-        expected_header = {
-            'User-Agent': UA_AGENT,
-            'Accept-Encoding': 'gzip, deflate',
-            'Accept': '*/*',
-            'Connection': 'keep-alive',
-            'Content-Type': 'application/json',
-            'CommandName': 'rest',
-            'ParameterSetName': 'method uri',
-            'Content-Length': '12'
-        }
-        expected_header_with_auth = expected_header.copy()
-        expected_header_with_auth['Authorization'] = 'Bearer eyJ0eXAiOiJKV1'
-
-        # Test basic usage
-        # Mock Put Blob https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob
-        # Authenticate with service SAS https://docs.microsoft.com/en-us/rest/api/storageservices/create-service-sas
-        sas_token = ['sv=2019-02-02', '{"srt": "s"}', "{'ss': 'bf'}"]
-        send_raw_request(cli_ctx, 'PUT', 'https://myaccount.blob.core.windows.net/mycontainer/myblob?timeout=30',
-                         uri_parameters=sas_token, body=test_body,
-                         generated_client_request_id_name=None)
-
-        get_raw_token_mock.assert_not_called()
-        request = send_mock.call_args.args[1]
-        self.assertEqual(request.method, 'PUT')
-        self.assertEqual(request.url, 'https://myaccount.blob.core.windows.net/mycontainer/myblob?timeout=30&sv=2019-02-02&srt=s&ss=bf')
-        self.assertEqual(request.body, '{"b1": "v1"}')
-        # Verify no Authorization header
-        self.assertDictEqual(dict(request.headers), expected_header)
-        self.assertEqual(send_mock.call_args.kwargs["verify"], not should_disable_connection_verify())
-
-        # Test Authorization header is skipped
-        send_raw_request(cli_ctx, 'GET', full_arm_rest_url, body=test_body, skip_authorization_header=True,
-                         generated_client_request_id_name=None)
-
-        get_raw_token_mock.assert_not_called()
-        request = send_mock.call_args.args[1]
-        self.assertDictEqual(dict(request.headers), expected_header)
-
-        # Test Authorization header is already provided
-        send_raw_request(cli_ctx, 'GET', full_arm_rest_url,
-                         body=test_body, headers={'Authorization=Basic ABCDE'},
-                         generated_client_request_id_name=None)
-
-        get_raw_token_mock.assert_not_called()
-        request = send_mock.call_args.args[1]
-        self.assertDictEqual(dict(request.headers), {**expected_header, 'Authorization': 'Basic ABCDE'})
-
-        # Test Authorization header is auto appended
-        send_raw_request(cli_ctx, 'GET', full_arm_rest_url,
-                         body=test_body,
-                         generated_client_request_id_name=None)
-
-        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
-        request = send_mock.call_args.args[1]
-        self.assertDictEqual(dict(request.headers), expected_header_with_auth)
-
-        # Test ARM resource ID /subscriptions/01/resourcegroups/02?api-version=2019-07-01
-        send_raw_request(cli_ctx, 'GET', arm_resource_id, body=test_body,
-                         generated_client_request_id_name=None)
-
-        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
-        request = send_mock.call_args.args[1]
-        self.assertEqual(request.url, 'https://management.azure.com/subscriptions/01/resourcegroups/02?api-version=2019-07-01')
-        self.assertDictEqual(dict(request.headers), expected_header_with_auth)
-
-        # Test full ARM URL https://management.azure.com/subscriptions/01/resourcegroups/02?api-version=2019-07-01
-        send_raw_request(cli_ctx, 'GET', full_arm_rest_url)
-
-        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
-        request = send_mock.call_args.args[1]
-        self.assertEqual(request.url, 'https://management.azure.com/subscriptions/01/resourcegroups/02?api-version=2019-07-01')
-
-        # Test full ARM URL with port https://management.azure.com:443/subscriptions/01/resourcegroups/02?api-version=2019-07-01
-        test_arm_endpoint_with_port = 'https://management.azure.com:443/'
-        full_arm_rest_url_with_port = test_arm_endpoint_with_port.rstrip('/') + arm_resource_id
-        send_raw_request(cli_ctx, 'GET', full_arm_rest_url_with_port)
-
-        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
-        request = send_mock.call_args.args[1]
-        self.assertEqual(request.url, 'https://management.azure.com:443/subscriptions/01/resourcegroups/02?api-version=2019-07-01')
-
-        # Test non-ARM API, such as MS Graph API https://graph.microsoft.com/beta/appRoleAssignments/01
-        send_raw_request(cli_ctx, 'PATCH', 'https://graph.microsoft.com/beta/appRoleAssignments/01',
-                         body=test_body, generated_client_request_id_name=None)
-
-        get_raw_token_mock.assert_called_with(mock.ANY, 'https://graph.microsoft.com/')
-        request = send_mock.call_args.args[1]
-        self.assertEqual(request.method, 'PATCH')
-        self.assertEqual(request.url, 'https://graph.microsoft.com/beta/appRoleAssignments/01')
-
-        # Test custom case-insensitive User-Agent
-        send_raw_request(cli_ctx, 'GET', full_arm_rest_url, headers={'user-agent=MY UA'})
-
-        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
-        request = send_mock.call_args.args[1]
-        self.assertEqual(request.headers['User-Agent'], 'MY UA')
 
     @staticmethod
     def _get_mock_HttpOperationError(response_text):

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -5,6 +5,7 @@
 
 # pylint: disable=line-too-long
 from collections import namedtuple
+import os
 import sys
 import unittest
 import mock
@@ -215,9 +216,13 @@ class TestUtils(unittest.TestCase):
         actual = get_az_user_agent()
         self.assertEqual(actual, 'AZURECLI/7.8.9')
 
+    @mock.patch.dict('os.environ')
     @mock.patch('azure.cli.core._profile.Profile.get_raw_token', autospec=True)
     @mock.patch('requests.Session.send', autospec=True)
     def test_send_raw_requests(self, send_mock, get_raw_token_mock):
+        if 'AZURE_HTTP_USER_AGENT' in os.environ:
+            del os.environ['AZURE_HTTP_USER_AGENT']  # Clear env var possibly added by DevOps
+
         return_val = mock.MagicMock()
         return_val.is_ok = True
         send_mock.return_value = return_val

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -43,7 +43,7 @@ from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.util import in_cloud_console, shell_safe_json_parse, open_page_in_browser, get_json_object, \
     ConfiguredDefaultSetter, sdk_no_wait
-from azure.cli.core.commands.client_factory import UA_AGENT
+from azure.cli.core.util import get_az_user_agent
 from azure.cli.core.profiles import ResourceType
 
 from .tunnel import TunnelServer
@@ -358,7 +358,7 @@ def enable_zip_deploy(cmd, resource_group_name, name, src, timeout=None, slot=No
     headers = authorization
     headers['Content-Type'] = 'application/octet-stream'
     headers['Cache-Control'] = 'no-cache'
-    headers['User-Agent'] = UA_AGENT
+    headers['User-Agent'] = get_az_user_agent()
 
     import requests
     import os
@@ -827,7 +827,7 @@ def _get_app_settings_from_scm(cmd, resource_group_name, name, slot=None):
     headers = {
         'Content-Type': 'application/octet-stream',
         'Cache-Control': 'no-cache',
-        'User-Agent': UA_AGENT
+        'User-Agent': get_az_user_agent()
     }
 
     import requests


### PR DESCRIPTION
Extract `User-Agent` generation to `get_az_user_agent` so that PR https://github.com/Azure/azure-cli/pull/12717 can also apply to `az rest`.

The logic to append custom `User-Agent` via `AZURE_HTTP_USER_AGENT` env var is removed from mgmt and data client factory, as this is already [handled by msrest](https://github.com/Azure/msrest-for-python/blob/4cc8bc84e96036f03b34716466230fb257e27b36/msrest/pipeline/universal.py#L70) and causes duplication:

```pwsh
> $env:AZURE_HTTP_USER_AGENT='myua'
> az group list --debug
msrest.http_logger :     'User-Agent': 'python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.1
1 myua msrest_azure/0.6.2 azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.2.0 myua'
```

Note that `myua` appeared twice. 

 On the other hand, this logic is added to `az rest` to align with msrest. `az rest` previously can't handle `AZURE_HTTP_USER_AGENT`.