### PR TITLE
{RBAC} az ad sp create-for-rbac: Fix grammar error

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1388,7 +1388,7 @@ def create_service_principal_for_rbac(
     }
     if cert_file:
         logger.warning(
-            "Please copy %s to a safe place. When run 'az login' provide the file path to the --password argument",
+            "Please copy %s to a safe place. When you run 'az login', provide the file path in the --password argument",
             cert_file)
         result['fileWithCertAndPrivateKey'] = cert_file
     return result


### PR DESCRIPTION
**Description of PR (Mandatory)**  
Fix grammar errors in `az ad sp create-for-rbac`. Be consistent with the [doc change](https://github.com/MicrosoftDocs/azure-docs-cli/pull/1889/files#diff-5fcc6b8791abb8deec28c88634d4b424R88). 
