### PR TITLE
{Docs} Remove stale reference in README to closed issue about extensions

### DIFF
--- a/doc/extensions/README.md
+++ b/doc/extensions/README.md
@@ -12,8 +12,6 @@ What is an Extension?
 - Currently, we support one extension type, a [Python Wheel](http://pythonwheels.com/).
 - All extension documentation here refers to this type of extension.
 
-> Extensions should be built with wheel `0.29.0` or `0.30.0` until [#6441](https://github.com/Azure/azure-cli/issues/6441) is resolved
-
 
 What an Extension is not
 ------------------------


### PR DESCRIPTION
**Description of PR (Mandatory)**  

The extensions README had a stale warning to only use two specific versions of the wheel. The issue linked to  ( #6441 ) has been closed for well over a year. This change removes that stale warning.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
