### PR TITLE
{Extension} insert extension directory in head of sys.path

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -228,7 +228,7 @@ class MainCommandsLoader(CLICommandsLoader):
                         continue
                     ext_name = ext.name
                     ext_dir = ext.path or get_extension_path(ext_name)
-                    sys.path.append(ext_dir)
+                    sys.path.insert(0, ext_dir)
                     try:
                         ext_mod = get_extension_modname(ext_name, ext_dir=ext_dir)
                         # Add to the map. This needs to happen before we load commands as registering a command

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -339,7 +339,7 @@ def reload_extension(extension_name, extension_module=None):
 
 def add_extension_to_path(extension_name, ext_dir=None):
     ext_dir = ext_dir or get_extension(extension_name).path
-    sys.path.append(ext_dir)
+    sys.path.insert(0, ext_dir)
 
 
 def get_lsb_release():


### PR DESCRIPTION
**Description of PR (Mandatory)**  
(Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process)
Fix #12062.
The extension directory was appended to the sys.path, and the virtual env site-package directory was in front of it. So CLI will load the SDK installed in the virtual env instead of the one in extension directory. Now we put extension directory in front position of sys.path to be loaded priorly.

**Testing Guide**  
(Example commands with explanations)

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
