### PR TITLE
[AKS]az aks list -o table should show privateFqdn as fqdn for private clusters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_format.py
@@ -58,7 +58,7 @@ def _aks_table_format(result):
         resourceGroup: resourceGroup,
         kubernetesVersion: kubernetesVersion,
         provisioningState: provisioningState,
-        fqdn: fqdn
+        fqdn: fqdn || privateFqdn
     }""")
     # use ordered dicts so headers are predictable
     return parsed.search(result, Options(dict_cls=OrderedDict))


### PR DESCRIPTION
**Description of PR (Mandatory)**  
(Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process)
`az aks list -o table` does not have fqdn info for private clusters. The fqdn of private cluster is in `.privateFqdn` for private clusters, while it is `.fqdn` for public clusters. This is to make cli show correct fqdn for private clusters.

**Testing Guide**  
(Example commands with explanations)
`az aks list -o table` will show correct fqdn for private clusters

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
