### PR TITLE
{Core} Remove message in zsh when registering auto-completion

### DIFF
--- a/src/azure-cli/az.completion.sh
+++ b/src/azure-cli/az.completion.sh
@@ -1,6 +1,6 @@
 case $SHELL in
 */zsh)
-   echo 'Enabling ZSH compatibility mode';
+   # Enable ZSH compatibility mode
    autoload bashcompinit && bashcompinit
    ;;
 */bash)


### PR DESCRIPTION
**Description of PR (Mandatory)**  
Fix #12046: Loading az completion in ZSH adds a debug line

This PR removes the message in zsh when registering auto-completion. 

**Testing Guide**  
To repro, make `/usr/bin/zsh` the default shell following [this guide](https://www.tecmint.com/change-a-users-default-shell-in-linux/), the re-login. The terminal shows:

```
Enabling ZSH compatibility mode
```

This line is now removed. 
