### PR TITLE
{Profile} Hotfix: az login: fix KeyError: 'displayName'

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -877,10 +877,12 @@ class SubscriptionFinder(object):
         tenants = client.tenants.list()
         for t in tenants:
             tenant_id = t.tenant_id
-            if not hasattr(t, 'display_name'):  # Available since 2018-06-01
-                t.display_name = ""
-            if hasattr(t, 'additional_properties'):  # remove this line once SDK is fixed
-                t.display_name = t.additional_properties['displayName']
+            # display_name is available since /tenants?api-version=2018-06-01,
+            # not available in /tenants?api-version=2016-06-01
+            if not hasattr(t, 'display_name'):
+                t.display_name = None
+            if hasattr(t, 'additional_properties'):  # Remove this line once SDK is fixed
+                t.display_name = t.additional_properties.get('displayName')
             temp_context = self._create_auth_context(tenant_id)
             try:
                 temp_credentials = temp_context.acquire_token(resource, self.user_id, _CLIENT_ID)
@@ -922,14 +924,20 @@ class SubscriptionFinder(object):
             logger.warning("The following tenants don't contain accessible subscriptions. "
                            "Use 'az login --allow-no-subscriptions' to have tenant level access.")
             for t in empty_tenants:
-                logger.warning("%s '%s'", t.tenant_id, t.display_name)
+                if t.display_name:
+                    logger.warning("%s '%s'", t.tenant_id, t.display_name)
+                else:
+                    logger.warning("%s", t.tenant_id)
 
         # Show warning for MFA tenants
         if mfa_tenants:
             logger.warning("The following tenants require Multi-Factor Authentication (MFA). "
                            "Use 'az login --tenant TENANT_ID' to explicitly login to a tenant.")
             for t in mfa_tenants:
-                logger.warning("%s '%s'", t.tenant_id, t.display_name)
+                if t.display_name:
+                    logger.warning("%s '%s'", t.tenant_id, t.display_name)
+                else:
+                    logger.warning("%s", t.tenant_id)
         return all_subscriptions
 
     def _find_using_specific_tenant(self, tenant, access_token):

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ===============
 
+2.3.1
+++++++
+
+**Profile**
+
+* az login: Fix login failure with cloud profiles other than `latest`
+
 2.3.0
 ++++++
 


### PR DESCRIPTION
**Description of PR (Mandatory)**  
Fix #12818: az login fails

The regression is introduced by #12726. `display_name` is only available since `/tenants?api-version=2018-06-01`, not available in `/tenants?api-version=2016-06-01`. We should retrieve `display_name` from `additional_properties` with a fallback. 

Actually this line shouldn't even be here due to the delay of REST spec fix and SDK release. 

**Testing Guide**  
```
> az cloud update -n AzureCloud --profile 2017-03-09-profile

> az login
The following tenants don't contain accessible subscriptions. Use 'az login --allow-no-subscriptions' to have tenant level access.
ca97aaa0-5a12-4ae3-8929-c8fb57dd93d6

> az cloud update -n AzureCloud --profile latest

> az login
The following tenants don't contain accessible subscriptions. Use 'az login --allow-no-subscriptions' to have tenant level access.
ca97aaa0-5a12-4ae3-8929-c8fb57dd93d6 'mycorp'
```
