### PR TITLE
{CI} Add explicitly timeout limit in Automation Full Test pipeline

### DIFF
--- a/azure-pipelines-full-tests.yml
+++ b/azure-pipelines-full-tests.yml
@@ -59,6 +59,8 @@ jobs:
     displayName: Automation Test
     dependsOn: BuildPythonWheel
     condition: succeeded()
+    timeoutInMinutes: 90
+
     pool:
       vmImage: 'ubuntu-16.04'
     strategy:


### PR DESCRIPTION
**Description of PR (Mandatory)**  
Add explicitly timeout limit to avoid CI job get cancelled implicitly by ADO like this [build](https://github.com/Azure/azure-cli/runs/550901673) which is against the configuration described [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#timeouts).

> To avoid taking up resources when your job is hung or waiting too long, it's a good idea to set a limit on how long your job is allowed to run. Use the job timeout setting to specify the limit in minutes for running the job. Setting the value to zero means that the job can run:
> - Forever on self-hosted agents
> - For 360 minutes (6 hours) on Microsoft-hosted agents with a public project and public repository

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
