### PR TITLE
{Core} Add accurate extension directory information in debug information

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -228,6 +228,7 @@ class MainCommandsLoader(CLICommandsLoader):
                         continue
                     ext_name = ext.name
                     ext_dir = ext.path or get_extension_path(ext_name)
+                    logger.debug("Extensions directory: '%s'", ext_dir)
                     sys.path.append(ext_dir)
                     try:
                         ext_mod = get_extension_modname(ext_name, ext_dir=ext_dir)

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -307,7 +307,6 @@ def get_extension_path(ext_name):
 
 
 def get_extensions(ext_type=None):
-    # logger.debug("Extensions directory: '%s'", EXTENSIONS_DIR)
     extensions = []
     if not ext_type:
         ext_type = EXTENSION_TYPES

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -307,7 +307,7 @@ def get_extension_path(ext_name):
 
 
 def get_extensions(ext_type=None):
-    logger.debug("Extensions directory: '%s'", EXTENSIONS_DIR)
+    # logger.debug("Extensions directory: '%s'", EXTENSIONS_DIR)
     extensions = []
     if not ext_type:
         ext_type = EXTENSION_TYPES


### PR DESCRIPTION
**Description of PR (Mandatory)**  
(Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process)
If you have extension installed which may be in dev mode or whl, the debug information will always show up the extension directory information in one specific value multiple times as shown below:

Here I have 4 extensions installed and `storage-ors-preview` is in dev mode, whose path should be local source path. But it still show up as `Extensions directory: 'C:\Users\zuh\.azure\cliextensions'`, which is not correct.

![image](https://user-images.githubusercontent.com/49508232/78215308-cb959000-74e9-11ea-8380-7fde0a03151d.png)

With the changes in PR, we can get accurate extension directory information as shown below:
![image](https://user-images.githubusercontent.com/49508232/78215240-a4d75980-74e9-11ea-8440-fb7898e680f6.png)

**Testing Guide**  
(Example commands with explanations)

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
