### PR TITLE
[ARM] az deployment group/mg/sub/tenant validate: Improve the error message when deployment verification fails (#12241)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -36,7 +36,7 @@ from azure.cli.command_modules.resource._validators import _parse_lock_id
 
 from knack.log import get_logger
 from knack.prompting import prompt, prompt_pass, prompt_t_f, prompt_choice_list, prompt_int, NoTTYException
-from knack.util import CLIError
+from knack.util import CLIError, todict
 
 from ._validators import MSI_LOCAL_ID
 
@@ -333,7 +333,7 @@ def _deploy_arm_template_core_unmodified(cli_ctx, resource_group_name, template_
     validation_result = deployment_client.validate(resource_group_name=resource_group_name, deployment_name=deployment_name, properties=properties)
 
     if validation_result and validation_result.error:
-        raise CLIError(validation_result.error)
+        raise CLIError(todict(validation_result.error))
     if validate_only:
         return validation_result
 
@@ -414,7 +414,7 @@ def _deploy_arm_template_at_subscription_scope(cli_ctx,
     validation_result = mgmt_client.validate_at_subscription_scope(deployment_name=deployment_name, properties=deployment_properties, location=deployment_location)
 
     if validation_result and validation_result.error:
-        raise CLIError(validation_result.error)
+        raise CLIError(todict(validation_result.error))
     if validate_only:
         return validation_result
 
@@ -467,7 +467,7 @@ def _deploy_arm_template_at_resource_group(cli_ctx,
     validation_result = mgmt_client.validate(resource_group_name=resource_group_name, deployment_name=deployment_name, properties=deployment_properties)
 
     if validation_result and validation_result.error:
-        raise CLIError(validation_result.error)
+        raise CLIError(todict(validation_result.error))
     if validate_only:
         return validation_result
 
@@ -518,7 +518,7 @@ def _deploy_arm_template_at_management_group(cli_ctx,
     validation_result = mgmt_client.validate_at_management_group_scope(group_id=management_group_id, deployment_name=deployment_name, properties=deployment_properties, location=deployment_location)
 
     if validation_result and validation_result.error:
-        raise CLIError(validation_result.error)
+        raise CLIError(todict(validation_result.error))
     if validate_only:
         return validation_result
 
@@ -564,7 +564,7 @@ def _deploy_arm_template_at_tenant_scope(cli_ctx,
     validation_result = mgmt_client.validate_at_tenant_scope(deployment_name=deployment_name, properties=deployment_properties, location=deployment_location)
 
     if validation_result and validation_result.error:
-        raise CLIError(validation_result.error)
+        raise CLIError(todict(validation_result.error))
     if validate_only:
         return validation_result
 


### PR DESCRIPTION
**Description of PR (Mandatory)**  
Issue: #12241

Because the array of `deltails` object in `validation_result.error` cannot print the value of the property directly into the returned result (only the address of the object is printed out), so the information of returned error message  is lost.
Therefore, through the `dict()` method, all the attribute values in `validation_result.error` are parsed and printed into the returned results to solve the problem.

**For example:**
before:
```
{'additional_properties': {}, 'code': 'InvalidTemplate', 'message': "Deployment template validation failed: 'The template parameters 'name' in the parameters file are not valid; they are not present in the original template and can therefore not be provided at deployment time. The only supported parameters for this template are 'function-app-name, sku, storageAccountType, location, deploymentEnvironment, applicationSettings'. Please see https://aka.ms/arm-deploy/#parameter-file for usage details.'.", 'target': None, 'details': None, 'additional_info': [<azure.mgmt.resource.resources.v2019_07_01.models._models_py3.ErrorAdditionalInfo object at 0x04D15FE8>]}
```
>  'additional_info': [<azure.mgmt.resource.resources.v2019_07_01.models._models_py3.ErrorAdditionalInfo object at 0x04D15FE8>]

after:
```
{'additionalProperties': {}, 'code': 'InvalidTemplate', 'message': "Deployment template validation failed: 'The template parameters 'name' in the parameters file are not valid; they are not present in the original template and can therefore not be provided at deployment time. The only supported parameters for this template are 'function-app-name, sku, storageAccountType, location, deploymentEnvironment, applicationSettings'. Please see https://aka.ms/arm-deploy/#parameter-file for usage details.'.", 'target': None, 'details': None, 'additionalInfo': [{'additionalProperties': {}, 'type': 'TemplateViolation', 'info': {'lineNumber': 0, 'linePosition': 0, 'path': ''}}]}
```
 > 'additionalInfo': [{'additionalProperties': {}, 'type': 'TemplateViolation', 'info': {'lineNumber': 0, 'linePosition': 0, 'path': ''}}]


**Testing Guide**  
Use the templates that will fail to deploy when executing `az deployment group/mg/sub/tenant validate` command.

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
