### PR TITLE
{Profile} az login: In WSL use powershell.exe to open the default browser

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -398,7 +398,9 @@ def open_page_in_browser(url):
 
     if is_wsl():   # windows 10 linux subsystem
         try:
-            return subprocess.call(['cmd.exe', '/c', "start {}".format(url.replace('&', '^&'))])
+            # https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe
+            # Ampersand (&) should be quoted
+            return subprocess.call(['powershell.exe', '-Command', 'Start-Process "{}"'.format(url)])
         except OSError:  # WSL might be too old  # FileNotFoundError introduced in Python 3
             pass
     elif platform_name == 'darwin':


### PR DESCRIPTION
## Description
Fix https://github.com/Azure/azure-cli/issues/11927: az login uses `cmd.exe` when using WSL which doesn't support UNC paths

`az login` in WSL shows warning:

```
user2@DESKTOP-37TQVO0:~$ az login
'\\wsl$\Ubuntu\home\user2'
CMD.EXE was started with the above path as the current directory.
UNC paths are not supported.  Defaulting to Windows directory.
```

This can also be reproduced by running `cmd.exe` directly in WSL:

```
user2@DESKTOP-37TQVO0:~$ cmd.exe
'\\wsl$\Ubuntu\home\user2'
CMD.EXE was started with the above path as the current directory.
UNC paths are not supported.  Defaulting to Windows directory.
Microsoft Windows [Version 10.0.18363.720]
(c) 2019 Microsoft Corporation. All rights reserved.

C:\Windows>
```

`powershell.exe` on the other hand doesn't have this problem and can handle UNC paths correctly:
```
user2@DESKTOP-37TQVO0:~$ powershell.exe
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

Try the new cross-platform PowerShell https://aka.ms/pscore6

PS Microsoft.PowerShell.Core\FileSystem::\\wsl$\Ubuntu\home\user2>   
```

This PR removes the UNC path warning by calling `powershell.exe` instead of `cmd.exe` to open the browser.

## Testing Guide
Use either method:

### Install Azure CLI in WSL from source

```sh
# Go to the CLI source folder D:\cli
cd /mnt/d/cli

# Create a virtual environment
python3 -m venv envwsl

# Activate the virtual environment
. envwsl/bin/activate

pip install azdev
azdev setup -c

az login
```

### Install Azure CLI in WSL with apt

Follow [Install Azure CLI with apt](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest). Then replace 
`C:\Users\{username}\AppData\Local\Packages\CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc\LocalState\rootfs\opt\az\lib\python3.6\site-packages\azure\cli\core\util.py` with the `util.py` file in this PR.

Then run `az login`. The warning is gone.