### PR TITLE
[WIP][Extension] Support installing extensions in a system directory

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -316,8 +316,6 @@ def build_extension_path(ext_name, system=None):
 
 def get_extensions(ext_type=None):
     logger.debug("Extensions directory: '%s'", EXTENSIONS_DIR)
-    if os.path.isdir(EXTENSIONS_SYS_DIR):
-        logger.debug("Extensions system directory: '%s'", EXTENSIONS_SYS_DIR)
     extensions = []
     if not ext_type:
         ext_type = EXTENSION_TYPES

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -8,7 +8,6 @@ import os
 import traceback
 import json
 import re
-import sys
 import pkginfo
 
 from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
@@ -312,7 +311,7 @@ def get_extension_path(ext_name):
 
 def build_extension_path(ext_name, system=None):
     # This will simply form the path for a WHEEL extension.
-    return os.path.join(EXTENSIONS_SYS_DIR,ext_name) if system else os.path.join(EXTENSIONS_DIR, ext_name)
+    return os.path.join(EXTENSIONS_SYS_DIR, ext_name) if system else os.path.join(EXTENSIONS_DIR, ext_name)
 
 
 def get_extensions(ext_type=None):

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+# pylint: disable=line-too-long
+
 from collections import OrderedDict
 import sys
 import os

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -140,6 +140,7 @@ def _update_latest_from_pypi(versions):
     return versions, success
 
 
+# pylint: disable=too-many-statements
 def get_az_version_string():
     from azure.cli.core.extension import get_extensions, EXTENSIONS_DIR, DEV_EXTENSION_SOURCES, EXTENSIONS_SYS_DIR
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -141,7 +141,7 @@ def _update_latest_from_pypi(versions):
 
 
 def get_az_version_string():
-    from azure.cli.core.extension import get_extensions, EXTENSIONS_DIR, DEV_EXTENSION_SOURCES
+    from azure.cli.core.extension import get_extensions, EXTENSIONS_DIR, DEV_EXTENSION_SOURCES, EXTENSIONS_SYS_DIR
 
     output = six.StringIO()
     versions = {}
@@ -191,6 +191,9 @@ def get_az_version_string():
         _print()
     _print("Python location '{}'".format(sys.executable))
     _print("Extensions directory '{}'".format(EXTENSIONS_DIR))
+    import os
+    if os.path.isdir(EXTENSIONS_SYS_DIR):
+        _print("Extensions system directory '{}'".format(EXTENSIONS_SYS_DIR))
     if DEV_EXTENSION_SOURCES:
         _print("Development extension sources:")
         for source in DEV_EXTENSION_SOURCES:

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -140,9 +140,8 @@ def _update_latest_from_pypi(versions):
     return versions, success
 
 
-# pylint: disable=too-many-statements
 def get_az_version_string():
-    from azure.cli.core.extension import get_extensions, EXTENSIONS_DIR, DEV_EXTENSION_SOURCES, EXTENSIONS_SYS_DIR
+    from azure.cli.core.extension import get_extensions, EXTENSIONS_DIR, DEV_EXTENSION_SOURCES
 
     output = six.StringIO()
     versions = {}
@@ -192,9 +191,6 @@ def get_az_version_string():
         _print()
     _print("Python location '{}'".format(sys.executable))
     _print("Extensions directory '{}'".format(EXTENSIONS_DIR))
-    import os
-    if os.path.isdir(EXTENSIONS_SYS_DIR):
-        _print("Extensions system directory '{}'".format(EXTENSIONS_SYS_DIR))
     if DEV_EXTENSION_SOURCES:
         _print("Development extension sources:")
         for source in DEV_EXTENSION_SOURCES:

--- a/src/azure-cli/azure/cli/command_modules/extension/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/__init__.py
@@ -64,9 +64,10 @@ class ExtensionCommandsLoader(AzCommandsLoader):
             c.argument('pip_extra_index_urls', options_list=['--pip-extra-index-urls'], nargs='+',
                        help='Space-separated list of extra URLs of package indexes to use. This should point to a repository compliant with PEP 503 (the simple repository API) or a local directory laid out in the same format.', arg_group='Experimental Pip')
             c.ignore('_subscription')  # hide global subscription param
+            c.argument('system', action='store_true', help='Use a system directory for the extension. Default path is azure-cli-extensions folder under the CLI running python environment lib path, configurable by environment variable AZURE_EXTENSION_SYS_DIR.')
+
 
         with self.argument_context('extension add') as c:
-            c.argument('extension_name', completer=extension_name_from_index_completion_list)
             c.argument('source', options_list=['--source', '-s'], help='Filepath or URL to an extension', completer=FilesCompleter())
             c.argument('yes', options_list=['--yes', '-y'], action='store_true', help='Do not prompt for confirmation.')
 

--- a/src/azure-cli/azure/cli/command_modules/extension/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/__init__.py
@@ -66,8 +66,8 @@ class ExtensionCommandsLoader(AzCommandsLoader):
             c.ignore('_subscription')  # hide global subscription param
             c.argument('system', action='store_true', help='Use a system directory for the extension. Default path is azure-cli-extensions folder under the CLI running python environment lib path, configurable by environment variable AZURE_EXTENSION_SYS_DIR.')
 
-
         with self.argument_context('extension add') as c:
+            c.argument('extension_name', completer=extension_name_from_index_completion_list)
             c.argument('source', options_list=['--source', '-s'], help='Filepath or URL to an extension', completer=FilesCompleter())
             c.argument('yes', options_list=['--yes', '-y'], action='store_true', help='Do not prompt for confirmation.')
 

--- a/src/azure-cli/azure/cli/command_modules/extension/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/_help.py
@@ -24,6 +24,8 @@ examples:
     text: az extension add --source ~/anextension-0.0.1-py2.py3-none-any.whl
   - name: Add extension from local disk and use pip proxy for dependencies
     text: az extension add --source ~/anextension-0.0.1-py2.py3-none-any.whl --pip-proxy https://user:pass@proxy.server:8080
+  - name: Add extension to system directory
+    text: az extension add --name anextension --system
 """
 
 helps['extension list'] = """

--- a/src/azure-cli/azure/cli/command_modules/extension/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/custom.py
@@ -12,9 +12,9 @@ logger = get_logger(__name__)
 
 
 def add_extension_cmd(cmd, source=None, extension_name=None, index_url=None, yes=None,
-                      pip_extra_index_urls=None, pip_proxy=None):
+                      pip_extra_index_urls=None, pip_proxy=None, system=None):
     return add_extension(cmd=cmd, source=source, extension_name=extension_name, index_url=index_url, yes=yes,
-                         pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy)
+                         pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, system=system)
 
 
 def remove_extension_cmd(extension_name):


### PR DESCRIPTION
**Description of PR (Mandatory)**  
(Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process)
Resolve #9831.
Currently users can set `AZURE_EXTENSION_DIR` env variable to install extensions in a customized path. But this has a limit to install all extensions in one directory. 

This PR adds an option `--system` to `az extension add`. So users can choose to install an extension in either a user path or a system path, but not able to install the same extension in two paths. az will load the extensions from both paths. 

The system directory is also configurable by env var `AZURE_EXTENSION_SYS_DIR`. The default is the `azure-cli-extensions` folder under the lib path of the python that az is using.

**Testing Guide**  
(Example commands with explanations)

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Extension] az extension add: Add --system to enable installing extensions in a system path

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
