### PR TITLE
[Profile] Support authentication via environment variables

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -163,6 +163,7 @@ def load_env_var_subscription():
             }
         }
         return env_var_subscription
+    return None
 
 
 # pylint: disable=too-many-lines,too-many-instance-attributes
@@ -1053,7 +1054,7 @@ class CredsCache(object):
         # If not logged in, use service principal credential configured by environment variables
         if not self._service_principal_creds and load_env_var_subscription():
             logger.info("Using service principal credential configured by environment variables")
-            self._service_principal_creds=[{
+            self._service_principal_creds = [{
                 _SERVICE_PRINCIPAL_ID: os.environ[_AZURE_CLIENT_ID],
                 _SERVICE_PRINCIPAL_TENANT: os.environ[_AZURE_TENANT_ID],
                 _ACCESS_TOKEN: os.environ[_AZURE_CLIENT_SECRET]

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -449,7 +449,8 @@ def set_cloud_subscription(cli_ctx, cloud_name, subscription):
 
 def _set_active_subscription(cli_ctx, cloud_name):
     from azure.cli.core._profile import (Profile, _ENVIRONMENT_NAME, _SUBSCRIPTION_ID,
-                                         _STATE, _SUBSCRIPTION_NAME)
+                                         _STATE, _SUBSCRIPTION_NAME, _AZURE_SUBSCRIPTION_ID, load_env_var_subscription,
+                                         _AZ_LOGIN_MESSAGE)
     profile = Profile(cli_ctx=cli_ctx)
     subscription_to_use = get_cloud_subscription(cloud_name) or \
                           next((s[_SUBSCRIPTION_ID] for s in profile.load_cached_subscriptions()  # noqa
@@ -465,9 +466,12 @@ def _set_active_subscription(cli_ctx, cloud_name):
             logger.warning(e)
             logger.warning("Unable to automatically switch the active subscription. "
                            "Use 'az account set'.")
+    elif load_env_var_subscription():
+        logger.warning("Use subscription %s configured by environment variable %s. "
+                       "Use 'az login' to override.", load_env_var_subscription()[_SUBSCRIPTION_ID],
+                       _AZURE_SUBSCRIPTION_ID)
     else:
-        logger.warning("Use 'az login' to log in to this cloud.")
-        logger.warning("Use 'az account set' to set the active subscription.")
+        logger.warning(_AZ_LOGIN_MESSAGE)
 
 
 def switch_active_cloud(cli_ctx, cloud_name):

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -449,7 +449,8 @@ def set_cloud_subscription(cli_ctx, cloud_name, subscription):
 
 def _set_active_subscription(cli_ctx, cloud_name):
     from azure.cli.core._profile import (Profile, _ENVIRONMENT_NAME, _SUBSCRIPTION_ID,
-                                         _STATE, _SUBSCRIPTION_NAME, _AZURE_SUBSCRIPTION_ID, load_env_var_subscription,
+                                         _STATE, _SUBSCRIPTION_NAME, _AZURE_SUBSCRIPTION_ID,
+                                         env_var_auth_configured, load_env_var_subscription,
                                          _AZ_LOGIN_MESSAGE)
     profile = Profile(cli_ctx=cli_ctx)
     subscription_to_use = get_cloud_subscription(cloud_name) or \
@@ -466,8 +467,8 @@ def _set_active_subscription(cli_ctx, cloud_name):
             logger.warning(e)
             logger.warning("Unable to automatically switch the active subscription. "
                            "Use 'az account set'.")
-    elif load_env_var_subscription():
-        logger.warning("Use subscription %s configured by environment variable %s. "
+    elif env_var_auth_configured():
+        logger.warning("Using subscription %s configured by environment variable %s. "
                        "Use 'az login' to override.", load_env_var_subscription()[_SUBSCRIPTION_ID],
                        _AZURE_SUBSCRIPTION_ID)
     else:

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -354,7 +354,8 @@ def register_global_subscription_argument(cli_ctx):
                         sub_id = sub['id']
                         break
                 if not sub_id:
-                    logger.warning("Subscription '%s' not recognized.", value)
+                    # User may be using env var auth
+                    logger.debug("Subscription '%s' not found in local cache.", value)
                     sub_id = value
                 namespace._subscription = sub_id  # pylint: disable=protected-access
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -143,7 +143,7 @@ class TestProfile(unittest.TestCase):
                                      'Q8U2g9kXHrbYFeY2gJxF_hnfLvNKxUKUBnftmyYxZwKi0GDS0BvdJnJnsqSRSpxUx__Ra9QJkG1IaDzj'
                                      'ZcSZPHK45T6ohK9Hk9ktZo0crVl7Tmw')
 
-        cls.env_var_credential={
+        cls.env_var_credential = {
             _AZURE_CLIENT_ID: "clientid-0000-0000-0000-000000000000",
             _AZURE_CLIENT_SECRET: "clientsecret-0000-0000-0000-000000000000",
             _AZURE_TENANT_ID: "tenantid-0000-0000-0000-000000000000",

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -15,7 +15,7 @@ import json
 from azure.cli.core.util import \
     (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string,
      open_page_in_browser, can_launch_browser, handle_exception, ConfiguredDefaultSetter, send_raw_request,
-     should_disable_connection_verify, parse_proxy_resource_id, get_az_user_agent)
+     should_disable_connection_verify, parse_proxy_resource_id, get_az_user_agent, is_guid, assert_guid)
 from azure.cli.core.mock import DummyCli
 
 
@@ -340,6 +340,18 @@ class TestUtils(unittest.TestCase):
             get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
             request = send_mock.call_args.args[1]
             self.assertEqual(request.headers['User-Agent'], get_az_user_agent() + ' env-ua ARG-UA')
+
+    def test_guid(self):
+        self.assertTrue(is_guid("00000000-1bf0-4dda-aec3-cb9272f09590"))
+        self.assertFalse(is_guid(""))
+        self.assertFalse(is_guid(None))
+        self.assertFalse(is_guid("foo"))
+
+        from knack.util import CLIError
+        assert_guid("00000000-1bf0-4dda-aec3-cb9272f09590")
+        assert_guid("00000000-1bf0-4dda-aec3-cb9272f09590", "myname")
+        self.assertRaisesRegex(CLIError, "myname must be a GUID.", assert_guid, "foo", "myname")
+        self.assertRaisesRegex(CLIError, "foo is not a GUID.", assert_guid, "foo")
 
 
 class TestBase64ToHex(unittest.TestCase):

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -828,3 +828,19 @@ def user_confirmation(message, yes=False):
     except NoTTYException:
         raise CLIError(
             'Unable to prompt for confirmation as no tty available. Use --yes.')
+
+
+def is_guid(guid):
+    import uuid
+    try:
+        uuid.UUID(guid)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def assert_guid(guid, name=None):
+    if not is_guid(guid):
+        if name:
+            raise CLIError("{} must be a GUID.".format(name))
+        raise CLIError("{} is not a GUID.".format(guid))


### PR DESCRIPTION
**Description of PR (Mandatory)**

Resolve #10241, #10903, #9282

Support authentication via environment variables for service principals:

Variable name | Value
-- | --
`AZURE_CLIENT_ID` | Azure Active Directory application ID
`AZURE_CLIENT_SECRET` | Application's client secrets
`AZURE_TENANT_ID` | The application's Azure Active Directory tenant ID
`AZURE_SUBSCRIPTION_ID` | Optional. Default subscription ID. If specified, it can be overridden by `--subscription`; otherwise, `--subscription` is required.

This is already widely supported by

- [Ruby SDK](https://github.com/Azure/azure-sdk-for-ruby#option-1---environment-variables)
- [Go SDK](https://github.com/Azure/azure-sdk-for-go#more-authentication-details)
- [Python SDK](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity#environment-variables)

`az login` takes higher priority. In other words, environment variable credential is only considered when there is no logged-in credentials.

ℹ Service principal certificate is not yet supported:

```json
# ~\.azure\accessTokens.json
{
    "servicePrincipalId": "a87260b8-d8be-4bf7-98e5-f65b5f95a497",
    "servicePrincipalTenant": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "certificateFile": "C:\\Users\\me\\tmprya5ijry.pem",
    "thumbprint": "ED:EA:C9:29:E4:93:BF:69:F6:96:92:DA:82:E5:93:6F:BA:9A:5E:59"
}
```

We need to update this doc later: https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli?view=azure-cli-latest

**Testing Guide**

For example, in PowerShell terminal:

```pwsh
# Create a service principal
az ad sp create-for-rbac
```

Provide the credential and default subscription:

```pwsh
# Configure the credential in environment variables
# Use 'export' in Bash, and 'set' in Windows
$env:AZURE_CLIENT_ID="22272fc1-8d0d-4da2-a70b-a44514d0aca4"
$env:AZURE_CLIENT_SECRET="00000000-0000-0000-0000-000000000000"
$env:AZURE_TENANT_ID="54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"
$env:AZURE_SUBSCRIPTION_ID="0b1f6471-1bf0-4dda-aec3-cb9272f09590"
```

Then test that normal commands work as expected.

```
> az account show
{
  "id": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
  "name": "Environment Variable Subscription",
  "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "user": {
    "name": "22272fc1-8d0d-4da2-a70b-a44514d0aca4",
    "type": "servicePrincipal"
  }
}

> az account list
[
  {
    "id": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "name": "Environment Variable Subscription",
    "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "user": {
      "name": "22272fc1-8d0d-4da2-a70b-a44514d0aca4",
      "type": "servicePrincipal"
    }
  }
]

> az account get-access-token
{
  "accessToken": "eyJ0eXAiOiJ...",
  "expiresOn": "2020-04-03 16:50:17.489711",
  "subscription": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
  "tenant": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "tokenType": "Bearer"
}

> az group list
[
  {
    "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/Default-Networking",
    "location": "westus",
    "managedBy": null,
...

```

If `AZURE_SUBSCRIPTION_ID` is not provided:
```pwsh
$env:AZURE_CLIENT_ID="22272fc1-8d0d-4da2-a70b-a44514d0aca4"
$env:AZURE_CLIENT_SECRET="00000000-0000-0000-0000-000000000000"
$env:AZURE_TENANT_ID="54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"
```

```
> az account show
{
  "id": null,
  "name": "Environment Variable Subscription",
  "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "user": {
    "name": "22272fc1-8d0d-4da2-a70b-a44514d0aca4",
    "type": "servicePrincipal"
  }
}

> az account list
[
  {
    "id": null,
    "name": "Environment Variable Subscription",
    "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "user": {
      "name": "22272fc1-8d0d-4da2-a70b-a44514d0aca4",
      "type": "servicePrincipal"
    }
  }
]

> az account get-access-token
{
  "accessToken": "eyJ0eXAiOiJK...",
  "expiresOn": "2020-04-04 17:28:09.766739",
  "tenant": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "tokenType": "Bearer"
}

> az group list --subscription 0b1f6471-1bf0-4dda-aec3-cb9272f09590
[
  {
    "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/Default-Networking",
    "location": "westus",
    "managedBy": null,
...

```



**History Notes:**
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
