### PR TITLE
[ACR] az acr run --cmd: disable working directory override

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_utils.py
@@ -256,7 +256,7 @@ def get_yaml_template(cmd_value, timeout, file):
     """
     yaml_template = "version: v1.1.0\n"
     if cmd_value:
-        yaml_template += "steps: \n  - cmd: {0}\n".format(cmd_value)
+        yaml_template += "steps: \n  - cmd: {0}\n    disableWorkingDirectoryOverride: true\n".format(cmd_value)
         if timeout:
             yaml_template += "    timeout: {0}\n".format(timeout)
     else:


### PR DESCRIPTION
**Description of PR (Mandatory)**  
az acr run -r myregistry --cmd mcr.microsoft.com/dotnet/core/samples:dotnetapp /dev/null

The `dotnetapp` image sets the `workdir` to `/app` folder. Its `entrypoint` and `cmd` settings assume the current working directory is `/app` folder. However ACR Tasks by default launches the container using `/workspace` as the workdir so the above cli command will fail.

Since the main usage of `--cmd` is to launch the container image as it is, it's better to minimize the override behavior, especially avoid overriding the workdir folder.

So when generating the task step in the request, the cli command should pass `disableWorkingDirectoryOverride: true`

https://github.com/Azure/acr/issues/346

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
