### PR TITLE
{Monitor} Move antlr4-python3-runtime to src/azure-cli/setup.py

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -102,8 +102,6 @@ setup(
         ":python_version<'3.4'": ['enum34'],
         ":python_version<'2.7.9'": ['pyopenssl', 'ndg-httpsclient', 'pyasn1'],
         ':python_version<"3.0"': ['futures'],
-        ":python_version<'3.0'": ['antlr4-python2-runtime'],
-        ":python_version>='3.0'": ['antlr4-python3-runtime'],
         "test": TESTS_REQUIRE,
     },
     tests_require=TESTS_REQUIRE,

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -50,6 +50,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
+    'antlr4-python3-runtime~=4.7.2',
     'azure-batch~=9.0',
     'azure-cli-command_modules-nspkg~=2.0',
     'azure-cli-core=={}.*'.format(VERSION),
@@ -169,6 +170,9 @@ setup(
     ],
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=DEPENDENCIES,
+    extras_require={
+        ":python_version<'3.0'": ['antlr4-python2-runtime']
+    },
     package_data={
         'azure.cli.core': ['auth_landing_pages/*.html'],
         'azure.cli.command_modules.acr': ['*.json'],

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -170,9 +170,6 @@ setup(
     ],
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=DEPENDENCIES,
-    extras_require={
-        ":python_version<'3.0'": ['antlr4-python2-runtime']
-    },
     package_data={
         'azure.cli.core': ['auth_landing_pages/*.html'],
         'azure.cli.command_modules.acr': ['*.json'],


### PR DESCRIPTION
antlr4 is used in monitor. We use 4.7.2 antlr4 tool to generate some codes in monitor. We still need a antlr4 runtime. But we didn't define it as a requirement in azure-cli before. In azure-cli-core, the version is not locked and the new version is 4.8.0. It would cause warning if two versions are not same.

Fix #12892

**Description of PR (Mandatory)**  
(Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process)

**Testing Guide**  
(Example commands with explanations)

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
