### PR TITLE
{Core} Make CLI respect file logging configuration option: enable_log_file and AZURE_LOGGING_ENABLE_LOG_FILE env variable

### DIFF
--- a/src/azure-cli-core/azure/cli/core/azlogging.py
+++ b/src/azure-cli-core/azure/cli/core/azlogging.py
@@ -77,8 +77,10 @@ class AzCliLogging(CLILogging):
 
             cmd_logger = logging.getLogger(AzCliLogging._COMMAND_METADATA_LOGGER)
 
-            self._init_command_logfile_handlers(cmd_logger, args)  # pylint: disable=protected-access
-            get_logger(__name__).debug("metadata file logging enabled - writing logs to '%s'.", self.command_log_dir)
+            if self.file_log_enabled:
+                self._init_command_logfile_handlers(cmd_logger, args)  # pylint: disable=protected-access
+                get_logger(__name__).debug("metadata file logging enabled - writing logs to '%s'.",
+                                           self.command_log_dir)
 
             _delete_old_logs(self.command_log_dir)
 

--- a/src/azure-cli-core/azure/cli/core/azlogging.py
+++ b/src/azure-cli-core/azure/cli/core/azlogging.py
@@ -82,7 +82,7 @@ class AzCliLogging(CLILogging):
                 get_logger(__name__).debug("metadata file logging enabled - writing logs to '%s'.",
                                            self.command_log_dir)
 
-            _delete_old_logs(self.command_log_dir)
+                _delete_old_logs(self.command_log_dir)
 
     def _init_command_logfile_handlers(self, command_metadata_logger, args):
 

--- a/src/azure-cli-core/azure/cli/core/azlogging.py
+++ b/src/azure-cli-core/azure/cli/core/azlogging.py
@@ -77,6 +77,9 @@ class AzCliLogging(CLILogging):
 
             cmd_logger = logging.getLogger(AzCliLogging._COMMAND_METADATA_LOGGER)
 
+            # overwrite CLILogging._is_file_log_enabled() from knack
+            self.file_log_enabled = cli_ctx.config.getboolean('logging', 'enable_log_file', fallback=True)
+
             if self.file_log_enabled:
                 self._init_command_logfile_handlers(cmd_logger, args)  # pylint: disable=protected-access
                 get_logger(__name__).debug("metadata file logging enabled - writing logs to '%s'.",


### PR DESCRIPTION
**Description of PR (Mandatory)**  
I am migrating test framwork from nose to pytest and found CLI would log every command's invocation output to a filep even though I configured in ~/.azure/config
```
[logging]
enable_log_file = no
```
And consequently, pytest wouldn't clear the AzCLI instance cleanly such that the test process would crash because of holding too many file descriptor (over the limit by OS):
![image](https://user-images.githubusercontent.com/14357159/78963857-65cd8780-7b2b-11ea-8ec5-5a2779920c9f.png)
![image](https://user-images.githubusercontent.com/14357159/78966209-c2cc3c00-7b31-11ea-9fd2-a4c8d7a83f8f.png)

**So, here, I want to enable the ability to repect the logging configuratin even though I won't use it in CI. I will fire another PR to fix the bug that CLI holding too many opened files.**

**Testing Guide**  
It affects two instance variables' assignment `command_logger_handler` and `command_metadata_logger`.
In the places they are referenced, there is a fault protection, so, it won't be a problem if user disbale the output of a logger to a log file.

Verify by running command with prefix `AZURE_LOGGING_ENABLE_LOG_FILE=no` or config in ~/.azure/config like above, then there should be no files under `~/.azure/commands/`. Otherwise, there should be a file under that folder

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
