### PR TITLE
[Core] fix generic remove property NoneType exception

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -922,9 +922,11 @@ def remove_properties(instance, argument_values):
         list_to_remove_from = _find_property(instance, list_attribute_path)
         try:
             list_to_remove_from.pop(int(list_index))
-        except (IndexError, AttributeError):
+        except IndexError:
             raise CLIError('index {} doesn\'t exist on {}'
                            .format(list_index, list_attribute_path[-1]))
+        except AttributeError:
+            raise CLIError('{} doesn\'t exist'.format(list_attribute_path[-1]))
 
 
 def throw_and_show_options(instance, part, path):

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -922,7 +922,7 @@ def remove_properties(instance, argument_values):
         list_to_remove_from = _find_property(instance, list_attribute_path)
         try:
             list_to_remove_from.pop(int(list_index))
-        except IndexError:
+        except (IndexError, AttributeError):
             raise CLIError('index {} doesn\'t exist on {}'
                            .format(list_index, list_attribute_path[-1]))
 


### PR DESCRIPTION
**Description of PR (Mandatory)**  
(Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process)

This PR is trying to fix #12119 

It is also a common problem for generic update.

When we try to remove an element from a list, previously we only catch the `IndexError`. However the list itself could also be None. So we also need to catch `AttributeError` here.

With this change, user will see a clean error message instead of previous trace stack.

**Testing Guide**  
`az vmss create -g myRG -n myVMSS --image UbuntuLTS`

`az vmss update --resource-group myRG--name myVMSS --remove virtualMachineProfile.networkProfile.networkInterfaceConfigurations[0].ipConfigurations[0].loadBalancerInboundNatPools 0`

`az vmss update --resource-group myRG--name myVMSS --remove virtualMachineProfile.networkProfile.networkInterfaceConfigurations[0].ipConfigurations[0].loadBalancerInboundNatPools 0`

Previously, it will print the trace stack. After this change, it will promt the error `index 0 doesn't exist on loadBalancerInboundNatPools `

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
