### PR TITLE
[RBAC] az ad app create/update: support --optional-claims as a parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -47,6 +47,26 @@ examples:
             "isEnabled": "true",
             "value": "approver"
         }]
+  - name: Create an application with optional claims
+    text: |
+        az ad app create --display-name mytestapp --optional-claims @manifest.json
+        ("manifest.json" contains the following content)
+        {
+            "idToken": [
+                {
+                    "name": "auth_time",
+                    "source": null,
+                    "essential": false
+                }
+            ],
+            "accessToken": [
+                {
+                    "name": "email",
+                    "source": null,
+                    "essential": false
+                }
+            ]
+        }
 """
 
 helps['ad app credential'] = """
@@ -220,6 +240,26 @@ examples:
             "isEnabled": "true",
             "value": "approver"
         }]
+  - name: update optional claims
+    text: |
+        az ad app update --id e042ec79-34cd-498f-9d9f-123456781234 --optional-claims @manifest.json
+        ("manifest.json" contains the following content)
+        {
+            "idToken": [
+                {
+                    "name": "auth_time",
+                    "source": null,
+                    "essential": false
+                }
+            ],
+            "accessToken": [
+                {
+                    "name": "email",
+                    "source": null,
+                    "essential": false
+                }
+            ]
+        }
   - name: update an application's group membership claims to "All"
     text: >
         az ad app update --id e042ec79-34cd-498f-9d9f-123456781234 --set groupMembershipClaims=All

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -50,7 +50,7 @@ def load_arguments(self, _):
         c.argument('app_roles', type=validate_file_or_dict,
                    help="declare the roles you want to associate with your application. Should be in manifest json format. See examples below for details")
         c.argument('optional_claims', type=validate_file_or_dict,
-                   help="declare the optional claims for the application. Should be in manifest json format. See examples below for details")
+                   help="declare the optional claims for the application. Should be in manifest json format. See examples below for details. Please reference https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-optional-claims#optionalclaim-type for optional claim properties.")
         c.argument('native_app', arg_type=get_three_state_flag(), help="an application which can be installed on a user's device or computer")
         c.argument('credential_description', help="the description of the password")
 

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -49,6 +49,8 @@ def load_arguments(self, _):
                    help="resource scopes and roles the application requires access to. Should be in manifest json format. See examples below for details")
         c.argument('app_roles', type=validate_file_or_dict,
                    help="declare the roles you want to associate with your application. Should be in manifest json format. See examples below for details")
+        c.argument('optional_claims', type=validate_file_or_dict,
+                   help="declare the optional claims for the application. Should be in manifest json format. See examples below for details")
         c.argument('native_app', arg_type=get_three_state_flag(), help="an application which can be installed on a user's device or computer")
         c.argument('credential_description', help="the description of the password")
 

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_application_optional_claims.yaml
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_application_optional_claims.yaml
@@ -1,0 +1,864 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --display-name --optional-claims
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=startswith%28displayName%2C%27cli-app-000001%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '121'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:43:59 GMT
+      duration:
+      - '2674154'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - uvrAXxHuwBAr8JNuoZkH79/eGbGp3gwUxtYjjvn8UBQ=
+      ocp-aad-session-key:
+      - iwiblHo14oAFpIeyCl64Wy3kJl69bPNNFsxi_Njq-AUnZi6hWQSTTARi58wZqpHwcWatba2kasuCJ-BazJNkPVPTJFUR_qaOpV5xt2Fvu8OW8dUmamvOisOZrsCcUocYatwnK46CXFpIXMV-MWcYUIBKyoH-Q0KvHyMli_PKZgQ.dMJFIgMdKbBYzHliYcA3SS-rHQMk9Euy0tG8mkAALkQ
+      pragma:
+      - no-cache
+      request-id:
+      - 4e862bd4-8257-4c82-94cd-283e2238a91f
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"availableToOtherTenants": false, "optionalClaims": {"idToken": [{"name":
+      "auth_time", "essential": false}], "accessToken": [{"name": "email", "essential":
+      false}]}, "displayName": "cli-app-000001", "identifierUris": []}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '221'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --display-name --optional-claims
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
+        "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
+        "objectId": "617fbbb1-ed37-4c5a-b37b-10d31986da8f", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "935437d7-3e90-4101-a813-f6eb44d9a842",
+        "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
+        false, "displayName": "cli-app-000001", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": null, "identifierUris": [], "informationalUrls": {"termsOfService":
+        null, "support": null, "privacy": null, "marketing": null}, "isDeviceOnlyAuthSupported":
+        null, "keyCredentials": [], "knownClientApplications": [], "logoutUrl": null,
+        "logo@odata.mediaEditLink": "directoryObjects/617fbbb1-ed37-4c5a-b37b-10d31986da8f/Microsoft.DirectoryServices.Application/logo",
+        "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/617fbbb1-ed37-4c5a-b37b-10d31986da8f/Microsoft.DirectoryServices.Application/mainLogo",
+        "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
+        "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
+        "Allow the application to access cli-app-000001 on behalf of the signed-in
+        user.", "adminConsentDisplayName": "Access cli-app-000001", "id": "94139c08-ae6e-4247-b6aa-6a125211b037",
+        "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
+        to access cli-app-000001 on your behalf.", "userConsentDisplayName": "Access
+        cli-app-000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        false, "optionalClaims": {"idToken": [{"name": "auth_time", "source": null,
+        "essential": false, "additionalProperties": []}], "accessToken": [{"name":
+        "email", "source": null, "essential": false, "additionalProperties": []}],
+        "saml2Token": []}, "orgRestrictions": [], "parentalControlSettings": {"countriesBlockedForMinors":
+        [], "legalAgeGroupRule": "Allow"}, "passwordCredentials": [], "publicClient":
+        null, "publisherDomain": "AzureSDKTeam.onmicrosoft.com", "recordConsentConditions":
+        null, "replyUrls": [], "requiredResourceAccess": [], "samlMetadataUrl": null,
+        "signInAudience": "AzureADMyOrg", "tokenEncryptionKeyId": null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2243'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:44:00 GMT
+      duration:
+      - '6876566'
+      expires:
+      - '-1'
+      location:
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/617fbbb1-ed37-4c5a-b37b-10d31986da8f/Microsoft.DirectoryServices.Application
+      ocp-aad-diagnostics-server-name:
+      - RJjorT7LceYEXxbDrNf0B9MqGGzbDbl6fylpEel6t1E=
+      ocp-aad-session-key:
+      - jbg2NHlzNlu4oOiogCqqzH5MOC_yJLzZdY05zCNFh5L_57ZvoE0uiY7N_Gvk3VIDhBoZqNrE4x1ne9Zcsm9a5CHhklKOYinkcae5hV9pqGEpfFsIGwhqct7V0S5_81h1roz5va5EjZio_fOK0vOwJ07Fg9p08jLX-4dtxlQSeUU.0OExU-0ZB7OI6KqLBDGFErI3Oa22rtf83d9DguSDfDA
+      pragma:
+      - no-cache
+      request-id:
+      - 0c984d3d-8f5d-4db5-9504-84bfd68a26b0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --display-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=startswith%28displayName%2C%27cli-app-000002%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '121'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:44:01 GMT
+      duration:
+      - '2275730'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - lgZlTUtjxs+sezsNpB7fJkHWu/zZfG+so0+IbGvyvyw=
+      ocp-aad-session-key:
+      - WrrAzGMY2sCdUEi6dJiV8vlO4m3Jk3bKQuwxzbbngQqVENQT2t7OT3Qnl4mhzkg_DLozTgupUDcn7He8T8k7XmbgYZfyr6DfbYllYEBAkSTn-X7pgSqM_ZZ7y0teRxySv0QcnweShuzJbiQmqj-sO20z3k4Es4X9JL0kZeRASUQ.syhCwKXtNeUEmklV9kCF-z9KMWqe6pBofB9-oloy69Y
+      pragma:
+      - no-cache
+      request-id:
+      - 2cdc502a-7b3b-4f67-a23e-93b2a087a802
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"availableToOtherTenants": false, "displayName": "cli-app-000002", "identifierUris":
+      []}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --display-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
+        "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
+        "objectId": "47244f24-0f51-418c-a1a8-81d7a08a06f1", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "531275b1-2e0a-424c-9f4d-ac1aecae1397",
+        "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
+        false, "displayName": "cli-app-000002", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": null, "identifierUris": [], "informationalUrls": {"termsOfService":
+        null, "support": null, "privacy": null, "marketing": null}, "isDeviceOnlyAuthSupported":
+        null, "keyCredentials": [], "knownClientApplications": [], "logoutUrl": null,
+        "logo@odata.mediaEditLink": "directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/logo",
+        "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/mainLogo",
+        "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
+        "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
+        "Allow the application to access cli-app-000002 on behalf of the signed-in
+        user.", "adminConsentDisplayName": "Access cli-app-000002", "id": "65af943b-c5e4-43e5-9d25-d3cff5a04345",
+        "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
+        to access cli-app-000002 on your behalf.", "userConsentDisplayName": "Access
+        cli-app-000002", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
+        {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
+        [], "publicClient": null, "publisherDomain": "AzureSDKTeam.onmicrosoft.com",
+        "recordConsentConditions": null, "replyUrls": [], "requiredResourceAccess":
+        [], "samlMetadataUrl": null, "signInAudience": "AzureADMyOrg", "tokenEncryptionKeyId":
+        null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2048'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:44:01 GMT
+      duration:
+      - '6651962'
+      expires:
+      - '-1'
+      location:
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application
+      ocp-aad-diagnostics-server-name:
+      - u3v7vH98c5Xh4F3h5guFNpqXkOL+kbXZm4SUo+XECj0=
+      ocp-aad-session-key:
+      - -fJIYbABARQ_SpVmGWd-1tMfHOJt0Y-itlvmcPTeT0jmrqEDHBGWgJlrReRMbno8HXH94kmxc7WlFZRaIpaz09Cq4CwZ94eMhH8k6vs9RJscHg6AcnkGL6km82Z7IxwY7vB_Kwv9jCGq4P5-5-Xf1K_W9f61iHbdE7POXorkETQ.YzIkp9zQQ8ZKy0unWZ_c1yO7ZU_SEHoqwcQpjc3UrFg
+      pragma:
+      - no-cache
+      request-id:
+      - 7b908045-b2e8-4927-aec5-3403ffcffedc
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --optional-claims
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27531275b1-2e0a-424c-9f4d-ac1aecae1397%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '121'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:44:02 GMT
+      duration:
+      - '4936133'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - PUhCJZ7KyZ5o6ef0Us9BFmguFbGDZMzmiMGiemZ1QH8=
+      ocp-aad-session-key:
+      - bfcV9xE1RoLxzWgrmh7NfN4tKvHJPAt082biNxw93bhDsKyYAuUrmQ7Wk3O-xXLOSietLERJydj71GLBbrkJvkhctxcQtURG_ddg-G0afdMTCnq7mlNwHR4Nq67x-HDihqxUQgVe0IwMpbbs3HQUj4dz-ORrYFoPdyp57WPusR8.MG4snl2epvTzVUBYSQQbfiUE8LFN6OUEcQVdIUOelLo
+      pragma:
+      - no-cache
+      request-id:
+      - 1b59e76c-a997-4a93-b31f-afa712c82499
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --optional-claims
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27531275b1-2e0a-424c-9f4d-ac1aecae1397%27&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"47244f24-0f51-418c-a1a8-81d7a08a06f1","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"531275b1-2e0a-424c-9f4d-ac1aecae1397","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000002","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-app-000002 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-app-000002","id":"65af943b-c5e4-43e5-9d25-d3cff5a04345","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-app-000002 on your behalf.","userConsentDisplayName":"Access
+        cli-app-000002","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1965'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:44:03 GMT
+      duration:
+      - '2548788'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - n9EoHNORiYgBMsgALSud/hDyl4oSD9YeWVgLLFS/oSM=
+      ocp-aad-session-key:
+      - DNX8KGylJiIfKmbCEAr-QiP38_t5aPsQPiSId_dUAR5bm6JXEGpjeFXiredIXid3IV9LhOJIc-zFgHcZKr6A-vCRqQ_wGu05xMmcSahMLEv1H7cAB4zYkZghwenWRnZHKiSaGIQamWjm9i2ejy7hPBhDaBTYW7Hb9uUlnMqr4L0.6cbCGMoXGi3wx-A5HHhLtiPOtK9tS3OEneF9nb2-Kyc
+      pragma:
+      - no-cache
+      request-id:
+      - deaffa03-155d-48d5-a436-1f9fa25aec2e
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --optional-claims
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/47244f24-0f51-418c-a1a8-81d7a08a06f1?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"47244f24-0f51-418c-a1a8-81d7a08a06f1","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"531275b1-2e0a-424c-9f4d-ac1aecae1397","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000002","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-app-000002 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-app-000002","id":"65af943b-c5e4-43e5-9d25-d3cff5a04345","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-app-000002 on your behalf.","userConsentDisplayName":"Access
+        cli-app-000002","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1962'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:44:04 GMT
+      duration:
+      - '2312136'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - ShIjrw587DYvfeHzo+m0e8NPQEtKerPYlrYJRqpr9Ak=
+      ocp-aad-session-key:
+      - U6ZNQFGOr_XVqrIXo7-ieG_jlAeYdr553fSyQTy_uFhX83O5LnbiJiTcBB4Kpjn8fZAEhmVEI-Xv7COA-S310YbyTbK476HMSSXxwCQdAUqoFe68Hj5hOlnISK4GV_94l_uQ6aNrgPnHeoi9Y0hTPME_CpVFvd4SXlhk_nEFOpU.FcrUNXhBgIb_6wZg7M3WE33RWEOAIxUe3tCHI8A0-Ic
+      pragma:
+      - no-cache
+      request-id:
+      - 26b7ba29-ae72-4145-a9aa-2914016f9383
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --optional-claims
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27531275b1-2e0a-424c-9f4d-ac1aecae1397%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '121'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:44:04 GMT
+      duration:
+      - '2242234'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - 3rF5dNvuHO6o1tAJ9yOBRpCQjpIX3MtrAUMmsK1IkuE=
+      ocp-aad-session-key:
+      - KE6a9c2LYemZuAAFay8f4yAhVmlg6KILcAitJCni9tonwZ85NikjStbgoUm38HerBzx5-OeULgGTPPyc9hQ5cVPwwoSdRLA7how1tXXltP3eW8QV6h5qE_1IzfcmX-A1CBx9mWdenbJp9CQxl0Z2VLQ19Ht6FpFlDQdLYDthY0M.0C0Qyo0yGpeM_rAIGYK12Cggkdmio_FrYAiQ6u1SS0s
+      pragma:
+      - no-cache
+      request-id:
+      - 1502044e-19ab-4008-8697-57596e28016a
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --optional-claims
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27531275b1-2e0a-424c-9f4d-ac1aecae1397%27&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"47244f24-0f51-418c-a1a8-81d7a08a06f1","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"531275b1-2e0a-424c-9f4d-ac1aecae1397","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000002","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-app-000002 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-app-000002","id":"65af943b-c5e4-43e5-9d25-d3cff5a04345","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-app-000002 on your behalf.","userConsentDisplayName":"Access
+        cli-app-000002","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1965'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:44:05 GMT
+      duration:
+      - '2436849'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - SFbJInTaT683Cen+qrs+HFFI8cgxwxtSRzegXrfGI4E=
+      ocp-aad-session-key:
+      - wpIP-v5DPiOMvvh_W814-8xN9wbGhyvlcvUEDylTGXjU9xp9D5tC0qVWwSvC9-ltQSVuU2r8Bqug5I8l1Qf6QpqhIiPk2yzekWHPDdOhU1-UNq1yADU6-C0zWR3Jsf_a666O6EI0_CyEy6w8qIqR7I4vRIxQ3P2JYzSQLaOy-Ag.PnPqLKiw1ibJRpKiRckfgSqw877szHMFmzGw3Zkvf_Y
+      pragma:
+      - no-cache
+      request-id:
+      - ed8c2cc5-5609-405d-b706-a958b9839e13
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"appRoles": [], "availableToOtherTenants": false, "informationalUrls":
+      {}, "knownClientApplications": [], "oauth2AllowImplicitFlow": false, "oauth2AllowUrlPathMatching":
+      false, "oauth2Permissions": [{"adminConsentDescription": "Allow the application
+      to access cli-app-000002 on behalf of the signed-in user.", "adminConsentDisplayName":
+      "Access cli-app-000002", "id": "65af943b-c5e4-43e5-9d25-d3cff5a04345", "isEnabled":
+      true, "type": "User", "userConsentDescription": "Allow the application to access
+      cli-app-000002 on your behalf.", "userConsentDisplayName": "Access cli-app-000002",
+      "value": "user_impersonation"}], "oauth2RequirePostResponse": false, "orgRestrictions":
+      [], "optionalClaims": {"idToken": [{"name": "auth_time", "essential": false}],
+      "accessToken": [{"name": "email", "essential": false}]}, "publisherDomain":
+      "AzureSDKTeam.onmicrosoft.com", "replyUrls": [], "requiredResourceAccess": [],
+      "signInAudience": "AzureADMyOrg", "displayName": "cli-app-000002", "identifierUris":
+      []}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '997'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --id --optional-claims
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PATCH
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/47244f24-0f51-418c-a1a8-81d7a08a06f1?api-version=1.6
+  response:
+    body:
+      string: ''
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      date:
+      - Fri, 10 Apr 2020 08:44:06 GMT
+      duration:
+      - '6262384'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - h41duery3CPm5kxowuKN7pvEekwLyNG/wkcjkTUIbY0=
+      ocp-aad-session-key:
+      - 85-0k6GhiKnpN9avcT1w4lgHvnNzQ-_t63Mbmsd9KWpv1AWfb7pzx-066VARrXWr0yoqt7iS6FqEyrwHO8bFYb0QmK8QQ9CNOBP0jymgbM9pwwiCUQMuKQXYJP-Dwk5mUzG2p4AkQFFJ0xYUW18NSItNeoscZa-LjIEcLLzIiYY.0OFSd9lNpIUuhxD1ZDwnPFV-oo79ew7zn_cR9XrDD9k
+      pragma:
+      - no-cache
+      request-id:
+      - 335fd119-1e97-45dd-b6db-a44b9c835da8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27531275b1-2e0a-424c-9f4d-ac1aecae1397%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '121'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:44:06 GMT
+      duration:
+      - '2243066'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - uw2DI55YPxO27iCQ9gmp7jkFjvTBnlg/TMjn48ai3jY=
+      ocp-aad-session-key:
+      - fR9_RlPndZcyoecncaDHpwXMEGjlg1-BhaCoEp5oef2LvRaFAdbulebdtt8zvXTm3Gbr2AeRSu_MQww0hdgUHbhuebeFAOfHQxoNiq2e1mS8LM90TjuyJKCmUMfd5bq7G8VLwwuAl9lAES9a21A1tb31pCPKvtz00kUhFD5HZQc.NHWoOxtR_8a94NH8-Jdx__Gf7SLZLhtr_zfMZPMZqS8
+      pragma:
+      - no-cache
+      request-id:
+      - 43613cea-1793-4698-9de4-0742724abd8c
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27531275b1-2e0a-424c-9f4d-ac1aecae1397%27&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"47244f24-0f51-418c-a1a8-81d7a08a06f1","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"531275b1-2e0a-424c-9f4d-ac1aecae1397","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000002","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-app-000002 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-app-000002","id":"65af943b-c5e4-43e5-9d25-d3cff5a04345","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-app-000002 on your behalf.","userConsentDisplayName":"Access
+        cli-app-000002","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":{"idToken":[{"name":"auth_time","source":null,"essential":false,"additionalProperties":[]}],"accessToken":[{"name":"email","source":null,"essential":false,"additionalProperties":[]}],"saml2Token":[]},"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2160'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:44:08 GMT
+      duration:
+      - '2235582'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - QvTnWe952z9A9XUm7LYocRUrZR1+xahkvqMczXNjN/0=
+      ocp-aad-session-key:
+      - wsC5PodSGicZCltXtmhoSil41C1lTJBXPVxGoV0FKObV8icb6Stmz-IycyWxpJZBUYgg9M1h0mMacyYeZP5ZmhAEDW2dAqAzh8Wj59emqMe-XR1X0WrpCCRJ4NGXRj_cfv7oCpO1uWxG4iMHSL2EiiDuppiPD9z2YLA_hS3nrxY.X3FCfTNU7gIyDl-PMouMgIeddLUv4alRx8x8bBi66oA
+      pragma:
+      - no-cache
+      request-id:
+      - 4f18682f-630a-4080-be3a-ec8a3f4e93ab
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/47244f24-0f51-418c-a1a8-81d7a08a06f1?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"47244f24-0f51-418c-a1a8-81d7a08a06f1","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"531275b1-2e0a-424c-9f4d-ac1aecae1397","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000002","errorUrl":null,"groupMembershipClaims":null,"homepage":null,"identifierUris":[],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/47244f24-0f51-418c-a1a8-81d7a08a06f1/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-app-000002 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-app-000002","id":"65af943b-c5e4-43e5-9d25-d3cff5a04345","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-app-000002 on your behalf.","userConsentDisplayName":"Access
+        cli-app-000002","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":{"idToken":[{"name":"auth_time","source":null,"essential":false,"additionalProperties":[]}],"accessToken":[{"name":"email","source":null,"essential":false,"additionalProperties":[]}],"saml2Token":[]},"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2157'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 10 Apr 2020 08:44:08 GMT
+      duration:
+      - '2972202'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - hfufYGeQyn5Pi6PUGsgtSbgnWQoj0HViM9+IAB7dSp8=
+      ocp-aad-session-key:
+      - xrRx10PpGz8E5GmZN0pMu7ZixwLJOyIs29UdL0XWR2FjxiGvlIoDiL2Dl9LpfZ-hO8pWaOa8HrLoJ-zpqTCtg4QrIxC4CMe8wYFOvIFKbU4exnpEY8T19oP4BNpzpmSXcDgderI115C74gS7uQ9jtl9ePqNutBIfIrv8g-FeRkM.okU_7xa7XiuBgtfK8z96kiZrZOmu49tkhk6-rzdlumY
+      pragma:
+      - no-cache
+      request-id:
+      - 9bad4395-a547-4677-a6a4-cf1d7a77d6e4
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -211,6 +211,47 @@ class ApplicationSetScenarioTest(ScenarioTest):
             self.assertEqual(self.cmd('ad app show --id non-exist-identifierUris').exit_code, 3)
             self.assertEqual(self.cmd('ad app show --id 00000000-0000-0000-0000-000000000000').exit_code, 3)
 
+    def test_application_optional_claims(self):
+        name1 = self.create_random_name(prefix='cli-app-', length=14)
+        name2 = self.create_random_name(prefix='cli-app-', length=14)
+        self.kwargs.update({
+            'name1': name1,
+            'name2': name2,
+            'optional_claims': json.dumps({
+                "idToken": [
+                    {
+                        "name": "auth_time",
+                        "source": None,
+                        "essential": False
+                    }
+                ],
+                "accessToken": [
+                    {
+                        "name": "email",
+                        "source": None,
+                        "essential": False
+                    }
+                ]
+            })
+        })
+        self.cmd("ad app create --display-name {name1} --optional-claims '{optional_claims}'",
+                 checks=[
+                     self.check('displayName', '{name1}'),
+                     self.check('length(optionalClaims.idToken)', 1),
+                     self.check('length(optionalClaims.accessToken)', 1)
+                 ])
+        app_id = self.cmd('ad app create --display-name {name2}').get_output_in_json()['appId']
+        self.kwargs.update({
+            'app_id': app_id
+        })
+        self.cmd("ad app update --id {app_id} --optional-claims '{optional_claims}'")
+        self.cmd('ad app show --id {app_id}',
+                 checks=[
+                     self.check('displayName', '{name2}'),
+                     self.check('length(optionalClaims.idToken)', 1),
+                     self.check('length(optionalClaims.accessToken)', 1)
+                 ])
+
 
 class CreateForRbacScenarioTest(ScenarioTest):
 
@@ -543,47 +584,3 @@ class GraphAppRequiredAccessScenarioTest(ScenarioTest):
         finally:
             if app_id:
                 self.cmd('ad app delete --id ' + app_id)
-
-
-class ApplicationOptionalClaimsScenarioTest(ScenarioTest):
-
-    def test_application_optional_claims(self):
-        name1 = self.create_random_name(prefix='cli-app-', length=14)
-        name2 = self.create_random_name(prefix='cli-app-', length=14)
-        self.kwargs.update({
-            'name1': name1,
-            'name2': name2,
-            'optional_claims': json.dumps({
-                "idToken": [
-                    {
-                        "name": "auth_time",
-                        "source": None,
-                        "essential": False
-                    }
-                ],
-                "accessToken": [
-                    {
-                        "name": "email",
-                        "source": None,
-                        "essential": False
-                    }
-                ]
-            })
-        })
-        self.cmd("ad app create --display-name {name1} --optional-claims '{optional_claims}'",
-                 checks=[
-                     self.check('displayName', '{name1}'),
-                     self.check('length(optionalClaims.idToken)', 1),
-                     self.check('length(optionalClaims.accessToken)', 1)
-                 ])
-        app_id = self.cmd('ad app create --display-name {name2}').get_output_in_json()['appId']
-        self.kwargs.update({
-            'app_id': app_id
-        })
-        self.cmd("ad app update --id {app_id} --optional-claims '{optional_claims}'")
-        self.cmd('ad app show --id {app_id}',
-                 checks=[
-                     self.check('displayName', '{name2}'),
-                     self.check('length(optionalClaims.idToken)', 1),
-                     self.check('length(optionalClaims.accessToken)', 1)
-                 ])


### PR DESCRIPTION
**Description of PR (Mandatory)**  

This PR is to fix #11534 

There are three attributes of optional claims, `idToken`, `accessToken` and `samlToken`.

As a result of the graph api version problem, version 2.0 has deprecated `samlToken` and use a new `saml2Token` instead. Although we use version 1.6, service side still not accept `samlToken` any more. So Azure CLI will only support `idToken` and `accessToken`.

This may change if we migrate to the latest Microsoft Graph API in the future.

**Testing Guide**  
Please reference the case in test_graph.py.

**History Notes:**  
(Fill in the following template if multiple notes are needed, otherwise PR title will be used for history note.)

[Component Name 1] (BREAKING CHANGE:) (az command:) make some customer-facing change.  
[Component Name 2] (BREAKING CHANGE:) (az command:) make some customer-facing change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
