### PR TITLE
{Monitor} pin azure-mgmt-loganalytics to 0.2

### DIFF
--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -93,7 +93,7 @@ DEPENDENCIES = [
     'azure-mgmt-iothubprovisioningservices~=0.2.0',
     'azure-mgmt-keyvault~=2.2.0',
     'azure-mgmt-kusto~=0.3.0',
-    'azure-mgmt-loganalytics~=0.2',
+    'azure-mgmt-loganalytics==0.2',
     'azure-mgmt-managedservices~=1.0',
     'azure-mgmt-managementgroups~=0.1',
     'azure-mgmt-maps~=0.1.0',


### PR DESCRIPTION
**Description<!--Mandatory-->**  
As https://github.com/Azure/azure-cli/pull/12974 shows, azure-mgmt-loganalytics has a breaking change [from 0.3.0 to 0.2.0](https://pypi.org/project/azure-mgmt-loganalytics/0.3.0/) such that it breaks CI.
![image](https://user-images.githubusercontent.com/14357159/79058975-13b17100-7ca7-11ea-845f-3c9ff477589b.png)

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
