### PR TITLE
{Monitor} fix wrong mocking way in test_monitor_general_operations.py

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
@@ -11,7 +11,6 @@ from msrestazure.tools import resource_id
 class MonitorCloneVMScenarios(ScenarioTest):
     @ResourceGroupPreparer(location='eastus')
     def test_monitor_clone_vm_metric_alerts_scenario(self, resource_group):
-        self.test_guid_count = 0
         self.kwargs.update({
             'alert': 'alert1',
             'vm1': 'vm1',
@@ -41,7 +40,7 @@ class MonitorCloneVMScenarios(ScenarioTest):
             self.check('evaluationFrequency', '0:01:00'),
             self.check('length(scopes)', 2)
         ])
-        with mock.patch('azure.cli.command_modules.monitor.util.gen_guid', side_effect=self.create_guid):
+        with mock.patch('azure.cli.command_modules.monitor.operations.monitor_clone_util.gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {vm1_id} --target-resource {vm3_id}', checks=[
                 self.check('metricsAlert[0].description', 'High CPU'),
                 self.check('metricsAlert[0].severity', 2),
@@ -57,7 +56,6 @@ class MonitorCloneStorageAccountScenarios(ScenarioTest):
     @StorageAccountPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_2')
     def test_monitor_clone_storage_metric_alerts_scenario(self, resource_group, storage_account, storage_account_2):
-        self.test_guid_count = 0
         self.kwargs.update({
             'alert': 'alert1',
             'sa': storage_account,
@@ -89,7 +87,7 @@ class MonitorCloneStorageAccountScenarios(ScenarioTest):
             self.check('length(criteria.allOf[1].dimensions)', 1)
         ])
 
-        with mock.patch('azure.cli.command_modules.monitor.util.gen_guid', side_effect=self.create_guid):
+        with mock.patch('azure.cli.command_modules.monitor.operations.monitor_clone_util.gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {sa_id} --target-resource {sa_id_2}', checks=[
                 self.check('metricsAlert[0].description', 'Test'),
                 self.check('metricsAlert[0].severity', 2),
@@ -107,7 +105,6 @@ class MonitorCloneStorageAccountAlwaysScenarios(ScenarioTest):
     @StorageAccountPreparer()
     @StorageAccountPreparer(parameter_name='storage_account_2')
     def test_monitor_clone_storage_metric_alerts_always_scenario(self, resource_group, storage_account, storage_account_2):
-        self.test_guid_count = 0
         self.kwargs.update({
             'alert': 'alert1',
             'sa': storage_account,
@@ -139,7 +136,7 @@ class MonitorCloneStorageAccountAlwaysScenarios(ScenarioTest):
             self.check('length(criteria.allOf[1].dimensions)', 1)
         ])
 
-        with mock.patch('azure.cli.command_modules.monitor.util.gen_guid', side_effect=self.create_guid):
+        with mock.patch('azure.cli.command_modules.monitor.operations.monitor_clone_util.gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {sa_id} --target-resource {sa_id_2} --always-clone', checks=[
                 self.check('metricsAlert[0].description', 'Test'),
                 self.check('metricsAlert[0].severity', 2),
@@ -155,7 +152,6 @@ class MonitorCloneStorageAccountAlwaysScenarios(ScenarioTest):
 class MonitorClonePublicIpScenarios(ScenarioTest):
     @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')
     def test_monitor_clone_public_ip_metric_alerts_scenario(self, resource_group):
-        self.test_guid_count = 0
         self.kwargs.update({
             'alert': 'alert1',
             'alert2': 'alert2',
@@ -190,7 +186,7 @@ class MonitorClonePublicIpScenarios(ScenarioTest):
             self.check('length(scopes)', 1)
         ])
 
-        with mock.patch('azure.cli.command_modules.monitor.util.gen_guid', side_effect=self.create_guid):
+        with mock.patch('azure.cli.command_modules.monitor.operations.monitor_clone_util.gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {ip1_id} --target-resource {ip2_id}', checks=[
                 self.check('length(metricsAlert)', 2),
             ])
@@ -200,7 +196,6 @@ class MonitorCloneStorageAccountAcrossSubsScenarios(ScenarioTest):
     @live_only()
     @ResourceGroupPreparer(name_prefix='cli_test_metric_alert_clone')
     def test_monitor_clone_storage_metric_alerts_across_subs_scenario(self, resource_group):
-        self.test_guid_count = 0
         self.kwargs.update({
             'alert': 'alert1',
             'sa': self.create_random_name('sa', 24),
@@ -234,7 +229,7 @@ class MonitorCloneStorageAccountAcrossSubsScenarios(ScenarioTest):
                      self.check('length(criteria.allOf[1].dimensions)', 1)
                  ])
 
-        with mock.patch('azure.cli.command_modules.monitor.util.gen_guid', side_effect=self.create_guid):
+        with mock.patch('azure.cli.command_modules.monitor.operations.monitor_clone_util.gen_guid', side_effect=self.create_guid):
             self.cmd('monitor clone --source-resource {sa_id} --target-resource {sa_id_2}', checks=[
                 self.check('metricsAlert[0].description', 'Test'),
                 self.check('metricsAlert[0].severity', 2),


### PR DESCRIPTION
**Description<!--Mandatory-->**  
As I migrating test framework from nose to pytest, the test in test_monitor_general_operations.py is strange, it can not pass and the result is running order dependent. :(

For example, it I tested _MonitorCloneStorageAccountScenarios_ then _MonitorCloneStorageAccountAlwaysScenarios_, the tests would fail as the second test _MonitorCloneStorageAccountAlwaysScenarios_ re-used the MagicMock generated in the first test _MonitorCloneStorageAccountScenarios_, So, the counter `test_guid_count` in the mocked method from ScenarioTest is unset, it kept growing, that's why it failed.

with the wrong mocking way, the mock instance comes with `mock.path` is 

**Testing Guide**  
Still using the tests above,

before test against this PR, try to print out the `self` in `create_guid` of _ScenarioTest_, it will show the two output `self` are the same: `test_monitor_clone_storage_metric_alerts_scenario (azure.cli.command_modules.monitor.tests.latest.test_monitor_general_operations.MonitorCloneStorageAccountScenarios)`, the test will fail.

Test against this PR, and still print out the `self` in `create_guid` of _ScenarioTest_, will see the self is different and they are correct. The first one belongs to `test_monitor_clone_storage_metric_alerts_scenario (azure.cli.command_modules.monitor.tests.latest.test_monitor_general_operations.MonitorCloneStorageAccountScenarios)` and the second one belongs to `test_monitor_clone_storage_metric_alerts_always_scenario (azure.cli.command_modules.monitor.tests.latest.test_monitor_general_operations.MonitorCloneStorageAccountAlwaysScenarios)`.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
