### PR TITLE
[Service Fabric] Fix #12891: az sf application update --application-parameters removes old parameters that are not in the request

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/servicefabric/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/_params.py
@@ -147,7 +147,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('application_type_name', options_list=['--name', '--application-type-name'], help='Specify the application type name.')
 
     # application-type version
-    with self.argument_context('sf application-type version create') as c:
+    with self.argument_context('sf application-type version') as c:
         c.argument('version', arg_type=application_type_version)
         c.argument('package_url', arg_type=package_url)
 

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/operations/applications.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/operations/applications.py
@@ -87,7 +87,7 @@ def update_app(client,
         if application_type_version:
             appResource.type_version = application_type_version
         if application_parameters:
-            appResource.parameters = application_parameters
+            appResource.parameters.update(application_parameters)
         if minimum_nodes is not None:
             appResource.minimum_nodes = minimum_nodes
         if maximum_nodes is not None:

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/recordings/test_application.yaml
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/recordings/test_application.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"3307ff37-85af-4550-bc6a-d1e02672cb7c","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":["2f442157-a11c-46b9-ae5b-6e39ff4e5849","c4801e8a-cb58-4c35-aca6-f2dcc106f287","0898bdbb-73b0-471a-81e5-20f1fe4dd66e","617b097b-4b93-4ede-83de-5f075bb5fb2f","33c4f319-9bdd-48d6-9c4d-410b750a4a5a","8e0c0a52-6a6c-4d40-8370-dd62790dcd70","4828c8ec-dc2e-4779-b502-87ac9ce28ab7","3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"],"skuId":"c7df2760-2c81-4ef7-b578-5b5392b571df"},{"disabledPlans":[],"skuId":"412ce1a7-a499-41b3-8eb6-b38f2bbc5c3f"},{"disabledPlans":["39b5c996-467e-4e60-bd62-46066f572726"],"skuId":"90d8b3f8-712e-4f7b-aa1e-62e7ae6cbe96"},{"disabledPlans":["e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72"],"skuId":"09015f9f-377f-4538-bbb5-f75ceb09358a"},{"disabledPlans":[],"skuId":"f30db892-07e9-47e9-837c-80727f46fd3d"},{"disabledPlans":[],"skuId":"26a18e8f-4d14-46f8-835a-ed3ba424a961"},{"disabledPlans":[],"skuId":"488ba24a-39a9-4473-8ee5-19291e71b002"},{"disabledPlans":[],"skuId":"b05e124f-c7cc-45a0-a6aa-8cf78c946968"},{"disabledPlans":[],"skuId":"c5928f49-12ba-48f7-ada3-0d743a3601d5"},{"disabledPlans":["0b03f40b-c404-40c3-8651-2aceb74365fa","b650d915-9886-424b-a08d-633cede56f57","e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72","fe71d6c3-a2ea-4499-9778-da042bf08063","fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"],"skuId":"ea126fc5-a19e-42e2-a731-da9d437bffcf"}],"assignedPlans":[{"assignedTimestamp":"2019-11-25T07:19:11Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2019-11-25T07:19:11Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2019-11-25T07:19:11Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2019-11-25T07:19:11Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2019-11-25T07:19:11Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2019-11-25T07:19:11Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2019-11-25T07:19:11Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"},{"assignedTimestamp":"2019-11-04T20:47:57Z","capabilityStatus":"Enabled","service":"WhiteboardServices","servicePlanId":"4a51bca5-1eff-43f5-878c-177680f191af"},{"assignedTimestamp":"2019-10-15T05:20:41Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"5136a095-5cf0-4aff-bec3-e84448b38ea5"},{"assignedTimestamp":"2019-10-15T05:20:41Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb0351d-3b08-4503-993d-383af8de41e3"},{"assignedTimestamp":"2019-10-09T16:03:10Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"ca4be917-fbce-4b52-839e-6647467a1668"},{"assignedTimestamp":"2019-08-08T19:38:25Z","capabilityStatus":"Enabled","service":"MicrosoftFormsProTest","servicePlanId":"97f29a83-1a20-44ff-bf48-5e4ad11f3e51"},{"assignedTimestamp":"2019-05-24T07:32:57Z","capabilityStatus":"Enabled","service":"DYN365AISERVICEINSIGHTS","servicePlanId":"1412cdc1-d593-4ad1-9050-40c30ad0b023"},{"assignedTimestamp":"2019-05-10T06:44:54Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"199a5c09-e0ca-4e37-8f7c-b05d533e1ea2"},{"assignedTimestamp":"2019-04-04T13:35:12Z","capabilityStatus":"Enabled","service":"ProjectProgramsAndPortfolios","servicePlanId":"818523f5-016b-4355-9be8-ed6944946ea7"},{"assignedTimestamp":"2019-04-04T13:35:12Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"fa200448-008c-4acb-abd4-ea106ed2199d"},{"assignedTimestamp":"2019-04-04T13:35:12Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"50554c47-71d9-49fd-bc54-42a2765c555c"},{"assignedTimestamp":"2018-11-19T20:20:28Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"50e68c76-46c6-4674-81f9-75456511b170"},{"assignedTimestamp":"2018-11-19T20:20:28Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"17ab22cd-a0b3-4536-910a-cb6eb12696c0"},{"assignedTimestamp":"2018-09-24T18:57:55Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"018fb91e-cee3-418c-9063-d7562978bdaf"},{"assignedTimestamp":"2018-09-24T18:57:54Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"b1188c4c-1b36-4018-b48b-ee07604f6feb"},{"assignedTimestamp":"2018-09-07T09:50:28Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"e212cbc7-0961-4c40-9825-01117710dcb1"},{"assignedTimestamp":"2018-08-30T22:33:16Z","capabilityStatus":"Enabled","service":"Sway","servicePlanId":"a23b959c-7ce8-4e57-9140-b90eb88a9e97"},{"assignedTimestamp":"2018-08-30T22:33:16Z","capabilityStatus":"Deleted","service":"OfficeForms","servicePlanId":"159f4cd6-e380-449f-a816-af1a9ef76344"},{"assignedTimestamp":"2018-08-17T09:23:58Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"bea4c11e-220a-4e6d-8eb8-8ea15d019f90"},{"assignedTimestamp":"2018-08-17T09:23:58Z","capabilityStatus":"Enabled","service":"Deskless","servicePlanId":"8c7d2df8-86f0-4902-b2ed-a0458298f3b3"},{"assignedTimestamp":"2018-08-17T09:23:58Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"6c57d4b6-3b23-47a5-9bc9-69f17b4947b3"},{"assignedTimestamp":"2018-08-17T09:23:58Z","capabilityStatus":"Enabled","service":"To-Do","servicePlanId":"3fb82609-8c27-4f7b-bd51-30634711ee67"},{"assignedTimestamp":"2018-04-24T12:46:30Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2018-04-24T12:46:30Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2018-03-24T01:46:21Z","capabilityStatus":"Deleted","service":"MicrosoftStream","servicePlanId":"acffdce6-c30f-4dc2-81c0-372e33c515ec"},{"assignedTimestamp":"2018-03-17T19:56:04Z","capabilityStatus":"Enabled","service":"WindowsDefenderATP","servicePlanId":"871d91ec-ec1a-452b-a83f-bd76c7d770ef"},{"assignedTimestamp":"2018-03-17T19:56:04Z","capabilityStatus":"Enabled","service":"AzureAdvancedThreatAnalytics","servicePlanId":"14ab5db5-e6c4-4b20-b4bc-13e36fd2227f"},{"assignedTimestamp":"2018-03-17T19:56:04Z","capabilityStatus":"Enabled","service":"Windows","servicePlanId":"e7c91390-7625-45be-94e0-e16907e03118"},{"assignedTimestamp":"2018-01-09T13:10:07Z","capabilityStatus":"Enabled","service":"ProjectWorkManagement","servicePlanId":"b737dad2-2f6c-4c65-90e3-ca563267e8b9"},{"assignedTimestamp":"2018-01-01T06:42:49Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"41781fb2-bc02-4b7c-bd55-b576c07bb09d"},{"assignedTimestamp":"2018-01-01T06:42:49Z","capabilityStatus":"Enabled","service":"MultiFactorService","servicePlanId":"8a256a2b-b617-496d-b51b-e76466e88db0"},{"assignedTimestamp":"2017-12-31T19:37:55Z","capabilityStatus":"Deleted","service":"Adallom","servicePlanId":"932ad362-64a8-4783-9106-97849a1a30b9"},{"assignedTimestamp":"2017-12-14T02:47:10Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"5689bec4-755d-4753-8b61-40975025187c"},{"assignedTimestamp":"2017-12-14T02:47:10Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"2e2ddb96-6af9-4b1d-a3f0-d6ecfd22edb2"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"8c098270-9dd4-4350-9b30-ba4703f3b36b"},{"assignedTimestamp":"2017-11-07T01:40:04Z","capabilityStatus":"Enabled","service":"MicrosoftStream","servicePlanId":"6c6042f5-6f01-4d67-b8c1-eb99d36eed3e"},{"assignedTimestamp":"2017-11-07T01:40:04Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2017-11-07T01:40:04Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2017-10-13T17:26:10Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"9f431833-0334-42de-a7dc-70aa40db46db"},{"assignedTimestamp":"2017-10-13T17:26:10Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb87545-963c-4e0d-99df-69c6916d9eb0"},{"assignedTimestamp":"2017-10-13T17:26:10Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"34c0d7a0-a70f-4668-9238-47f9fc208882"},{"assignedTimestamp":"2017-10-13T07:21:19Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"eec0eb4f-6444-4f95-aba0-50c24d67f998"},{"assignedTimestamp":"2017-10-13T07:21:19Z","capabilityStatus":"Enabled","service":"SCO","servicePlanId":"c1ec4a95-1f05-45b3-a911-aa3fa01094f5"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"0feaeb32-d00e-4d66-bd5a-43b5b83db82c"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"07699545-9485-468e-95b6-2fca3738be01"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"PowerBI","servicePlanId":"70d33638-9c74-4d01-bfd3-562de28bd4ba"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"4de31727-a228-4ec3-a5bf-8e45b5ca48cc"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"663a804f-1c30-4ff0-9915-9db84f0d1cea"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"TeamspaceAPI","servicePlanId":"57ff2da0-773e-42df-b2af-ffb7a2317929"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"9c0dab89-a30c-4117-86e7-97bda240acd2"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"YammerEnterprise","servicePlanId":"7547a3fe-08ee-4ccb-b430-5077c5041653"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"43de0ff5-c92c-492b-9116-175376d08c38"},{"assignedTimestamp":"2017-10-12T21:41:33Z","capabilityStatus":"Enabled","service":"Netbreeze","servicePlanId":"03acaee3-9492-4f40-aed4-bcb6b32981b6"},{"assignedTimestamp":"2017-10-12T21:41:33Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"d56f3deb-50d8-465a-bedb-f079817ccac1"}],"city":"REDMOND","companyName":"MICROSOFT","consentProvidedForMinor":null,"country":null,"createdDateTime":null,"creationType":null,"department":"SFS","dirSyncEnabled":true,"displayName":"Alfredo
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"3307ff37-85af-4550-bc6a-d1e02672cb7c","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":["65cc641f-cccd-4643-97e0-a17e3045e541","e26c2fcc-ab91-4a61-b35c-03cdc8dddf66","46129a58-a698-46f0-aa5b-17f6586297d9","6db1f1db-2b46-403f-be40-e39395f08dbb","6dc145d6-95dd-4191-b9c3-185575ee6f6b","41fcdd7d-4733-4863-9cf4-c65b83ce2df4","2f442157-a11c-46b9-ae5b-6e39ff4e5849","c4801e8a-cb58-4c35-aca6-f2dcc106f287","0898bdbb-73b0-471a-81e5-20f1fe4dd66e","617b097b-4b93-4ede-83de-5f075bb5fb2f","33c4f319-9bdd-48d6-9c4d-410b750a4a5a","8e0c0a52-6a6c-4d40-8370-dd62790dcd70","4828c8ec-dc2e-4779-b502-87ac9ce28ab7","3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"],"skuId":"c7df2760-2c81-4ef7-b578-5b5392b571df"},{"disabledPlans":[],"skuId":"412ce1a7-a499-41b3-8eb6-b38f2bbc5c3f"},{"disabledPlans":["39b5c996-467e-4e60-bd62-46066f572726"],"skuId":"90d8b3f8-712e-4f7b-aa1e-62e7ae6cbe96"},{"disabledPlans":["e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72"],"skuId":"09015f9f-377f-4538-bbb5-f75ceb09358a"},{"disabledPlans":[],"skuId":"f30db892-07e9-47e9-837c-80727f46fd3d"},{"disabledPlans":[],"skuId":"26a18e8f-4d14-46f8-835a-ed3ba424a961"},{"disabledPlans":[],"skuId":"488ba24a-39a9-4473-8ee5-19291e71b002"},{"disabledPlans":[],"skuId":"b05e124f-c7cc-45a0-a6aa-8cf78c946968"},{"disabledPlans":[],"skuId":"c5928f49-12ba-48f7-ada3-0d743a3601d5"},{"disabledPlans":["0b03f40b-c404-40c3-8651-2aceb74365fa","b650d915-9886-424b-a08d-633cede56f57","e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72","fe71d6c3-a2ea-4499-9778-da042bf08063","fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"],"skuId":"ea126fc5-a19e-42e2-a731-da9d437bffcf"}],"assignedPlans":[{"assignedTimestamp":"2020-03-12T00:41:44Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2020-03-12T00:41:44Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2020-03-12T00:41:44Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2020-03-12T00:41:44Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"},{"assignedTimestamp":"2019-11-25T07:19:11Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2019-11-25T07:19:11Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2019-11-25T07:19:11Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2019-11-04T20:47:57Z","capabilityStatus":"Enabled","service":"WhiteboardServices","servicePlanId":"4a51bca5-1eff-43f5-878c-177680f191af"},{"assignedTimestamp":"2019-10-15T05:20:41Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"5136a095-5cf0-4aff-bec3-e84448b38ea5"},{"assignedTimestamp":"2019-10-15T05:20:41Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb0351d-3b08-4503-993d-383af8de41e3"},{"assignedTimestamp":"2019-10-09T16:03:10Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"ca4be917-fbce-4b52-839e-6647467a1668"},{"assignedTimestamp":"2019-08-08T19:38:25Z","capabilityStatus":"Enabled","service":"MicrosoftFormsProTest","servicePlanId":"97f29a83-1a20-44ff-bf48-5e4ad11f3e51"},{"assignedTimestamp":"2019-05-24T07:32:57Z","capabilityStatus":"Enabled","service":"DYN365AISERVICEINSIGHTS","servicePlanId":"1412cdc1-d593-4ad1-9050-40c30ad0b023"},{"assignedTimestamp":"2019-05-10T06:44:54Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"199a5c09-e0ca-4e37-8f7c-b05d533e1ea2"},{"assignedTimestamp":"2019-04-04T13:35:12Z","capabilityStatus":"Enabled","service":"ProjectProgramsAndPortfolios","servicePlanId":"818523f5-016b-4355-9be8-ed6944946ea7"},{"assignedTimestamp":"2019-04-04T13:35:12Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"fa200448-008c-4acb-abd4-ea106ed2199d"},{"assignedTimestamp":"2019-04-04T13:35:12Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"50554c47-71d9-49fd-bc54-42a2765c555c"},{"assignedTimestamp":"2018-11-19T20:20:28Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"50e68c76-46c6-4674-81f9-75456511b170"},{"assignedTimestamp":"2018-11-19T20:20:28Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"17ab22cd-a0b3-4536-910a-cb6eb12696c0"},{"assignedTimestamp":"2018-09-24T18:57:55Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"018fb91e-cee3-418c-9063-d7562978bdaf"},{"assignedTimestamp":"2018-09-24T18:57:54Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"b1188c4c-1b36-4018-b48b-ee07604f6feb"},{"assignedTimestamp":"2018-09-07T09:50:28Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"e212cbc7-0961-4c40-9825-01117710dcb1"},{"assignedTimestamp":"2018-08-30T22:33:16Z","capabilityStatus":"Enabled","service":"Sway","servicePlanId":"a23b959c-7ce8-4e57-9140-b90eb88a9e97"},{"assignedTimestamp":"2018-08-30T22:33:16Z","capabilityStatus":"Deleted","service":"OfficeForms","servicePlanId":"159f4cd6-e380-449f-a816-af1a9ef76344"},{"assignedTimestamp":"2018-08-17T09:23:58Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"bea4c11e-220a-4e6d-8eb8-8ea15d019f90"},{"assignedTimestamp":"2018-08-17T09:23:58Z","capabilityStatus":"Enabled","service":"Deskless","servicePlanId":"8c7d2df8-86f0-4902-b2ed-a0458298f3b3"},{"assignedTimestamp":"2018-08-17T09:23:58Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"6c57d4b6-3b23-47a5-9bc9-69f17b4947b3"},{"assignedTimestamp":"2018-08-17T09:23:58Z","capabilityStatus":"Enabled","service":"To-Do","servicePlanId":"3fb82609-8c27-4f7b-bd51-30634711ee67"},{"assignedTimestamp":"2018-04-24T12:46:30Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2018-04-24T12:46:30Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2018-03-24T01:46:21Z","capabilityStatus":"Deleted","service":"MicrosoftStream","servicePlanId":"acffdce6-c30f-4dc2-81c0-372e33c515ec"},{"assignedTimestamp":"2018-03-17T19:56:04Z","capabilityStatus":"Enabled","service":"WindowsDefenderATP","servicePlanId":"871d91ec-ec1a-452b-a83f-bd76c7d770ef"},{"assignedTimestamp":"2018-03-17T19:56:04Z","capabilityStatus":"Enabled","service":"AzureAdvancedThreatAnalytics","servicePlanId":"14ab5db5-e6c4-4b20-b4bc-13e36fd2227f"},{"assignedTimestamp":"2018-03-17T19:56:04Z","capabilityStatus":"Enabled","service":"Windows","servicePlanId":"e7c91390-7625-45be-94e0-e16907e03118"},{"assignedTimestamp":"2018-01-09T13:10:07Z","capabilityStatus":"Enabled","service":"ProjectWorkManagement","servicePlanId":"b737dad2-2f6c-4c65-90e3-ca563267e8b9"},{"assignedTimestamp":"2018-01-01T06:42:49Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"41781fb2-bc02-4b7c-bd55-b576c07bb09d"},{"assignedTimestamp":"2018-01-01T06:42:49Z","capabilityStatus":"Enabled","service":"MultiFactorService","servicePlanId":"8a256a2b-b617-496d-b51b-e76466e88db0"},{"assignedTimestamp":"2017-12-31T19:37:55Z","capabilityStatus":"Deleted","service":"Adallom","servicePlanId":"932ad362-64a8-4783-9106-97849a1a30b9"},{"assignedTimestamp":"2017-12-14T02:47:10Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"5689bec4-755d-4753-8b61-40975025187c"},{"assignedTimestamp":"2017-12-14T02:47:10Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"2e2ddb96-6af9-4b1d-a3f0-d6ecfd22edb2"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"8c098270-9dd4-4350-9b30-ba4703f3b36b"},{"assignedTimestamp":"2017-11-07T01:40:04Z","capabilityStatus":"Enabled","service":"MicrosoftStream","servicePlanId":"6c6042f5-6f01-4d67-b8c1-eb99d36eed3e"},{"assignedTimestamp":"2017-11-07T01:40:04Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2017-11-07T01:40:04Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2017-10-13T17:26:10Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"9f431833-0334-42de-a7dc-70aa40db46db"},{"assignedTimestamp":"2017-10-13T17:26:10Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb87545-963c-4e0d-99df-69c6916d9eb0"},{"assignedTimestamp":"2017-10-13T17:26:10Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"34c0d7a0-a70f-4668-9238-47f9fc208882"},{"assignedTimestamp":"2017-10-13T07:21:19Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"eec0eb4f-6444-4f95-aba0-50c24d67f998"},{"assignedTimestamp":"2017-10-13T07:21:19Z","capabilityStatus":"Enabled","service":"SCO","servicePlanId":"c1ec4a95-1f05-45b3-a911-aa3fa01094f5"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"0feaeb32-d00e-4d66-bd5a-43b5b83db82c"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"07699545-9485-468e-95b6-2fca3738be01"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"PowerBI","servicePlanId":"70d33638-9c74-4d01-bfd3-562de28bd4ba"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"4de31727-a228-4ec3-a5bf-8e45b5ca48cc"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"663a804f-1c30-4ff0-9915-9db84f0d1cea"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"TeamspaceAPI","servicePlanId":"57ff2da0-773e-42df-b2af-ffb7a2317929"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"9c0dab89-a30c-4117-86e7-97bda240acd2"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"YammerEnterprise","servicePlanId":"7547a3fe-08ee-4ccb-b430-5077c5041653"},{"assignedTimestamp":"2017-10-13T02:23:16Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"43de0ff5-c92c-492b-9116-175376d08c38"},{"assignedTimestamp":"2017-10-12T21:41:33Z","capabilityStatus":"Enabled","service":"Netbreeze","servicePlanId":"03acaee3-9492-4f40-aed4-bcb6b32981b6"},{"assignedTimestamp":"2017-10-12T21:41:33Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"d56f3deb-50d8-465a-bedb-f079817ccac1"}],"city":"REDMOND","companyName":"MICROSOFT","consentProvidedForMinor":null,"country":null,"createdDateTime":null,"creationType":null,"department":"SFS","dirSyncEnabled":true,"displayName":"Alfredo
         Santamaria Gomez","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Alfredo","immutableId":"1252188","isCompromised":null,"jobTitle":"SOFTWARE
-        ENGINEER","lastDirSyncTime":"2020-01-20T08:38:51Z","legalAgeGroupClassification":null,"mail":"Alfredo.Santamaria@microsoft.com","mailNickname":"alsantam","mobile":null,"onPremisesDistinguishedName":"CN=Alfredo
+        ENGINEER","lastDirSyncTime":"2020-01-28T07:40:58Z","legalAgeGroupClassification":null,"mail":"Alfredo.Santamaria@microsoft.com","mailNickname":"alsantam","mobile":null,"onPremisesDistinguishedName":"CN=Alfredo
         Santamaria Gomez,OU=UserAccounts,DC=northamerica,DC=corp,DC=microsoft,DC=com","onPremisesSecurityIdentifier":"S-1-5-21-124525095-708259637-1543119021-1768146","otherMails":[],"passwordPolicies":"DisablePasswordExpiration","passwordProfile":null,"physicalDeliveryOfficeName":"41/1H00","postalCode":null,"preferredLanguage":null,"provisionedPlans":[{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Netbreeze"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"}],"provisioningErrors":[],"proxyAddresses":["X500:/o=microsoft/ou=Exchange
         Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=4c4fde36ef8e4419b7a8683d77d0ea0e-Alfredo
         Santam","x500:/o=ExchangeLabs/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=5b9326560aba4548b3f55813552a1d62-Alfredo
@@ -27,7 +27,7 @@ interactions:
         Santa3c6c65b","smtp:alsantam@microsoft.onmicrosoft.com","smtp:alsantam@service.microsoft.com","smtp:alsantam@microsoft.com","X500:/o=microsoft/ou=Exchange
         Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=1fe043b7a56b425097310ee390e87535-Alfredo
         Santam","SMTP:Alfredo.Santamaria@microsoft.com"],"refreshTokensValidFromDateTime":"2019-11-20T18:48:41Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":"alsantam@microsoft.com","state":null,"streetAddress":null,"surname":"Santamaria
-        Gomez","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/3307ff37-85af-4550-bc6a-d1e02672cb7c/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":"US","userIdentities":[],"userPrincipalName":"alsantam@microsoft.com","userState":null,"userStateChangedOn":null,"userType":"Member","extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10200871","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10200871","extension_18e31482d3fb4a8ea958aa96b662f508_ZipCode":"98052","extension_18e31482d3fb4a8ea958aa96b662f508_StateProvinceCode":"WA","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"91710758","extension_18e31482d3fb4a8ea958aa96b662f508_LocationAreaCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_CountryShortCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1010","extension_18e31482d3fb4a8ea958aa96b662f508_CityName":"REDMOND","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"41","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"309","extension_18e31482d3fb4a8ea958aa96b662f508_AddressLine1":"1
+        Gomez","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/3307ff37-85af-4550-bc6a-d1e02672cb7c/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":"CA","userIdentities":[],"userPrincipalName":"alsantam@microsoft.com","userState":null,"userStateChangedOn":null,"userType":"Member","extension_18e31482d3fb4a8ea958aa96b662f508_SupervisorInd":"N","extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10200871","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10200871","extension_18e31482d3fb4a8ea958aa96b662f508_ZipCode":"98052","extension_18e31482d3fb4a8ea958aa96b662f508_StateProvinceCode":"WA","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"91710758","extension_18e31482d3fb4a8ea958aa96b662f508_LocationAreaCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_CountryShortCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1010","extension_18e31482d3fb4a8ea958aa96b662f508_CityName":"REDMOND","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"41","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"309","extension_18e31482d3fb4a8ea958aa96b662f508_AddressLine1":"1
         Microsoft Way","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToPersonnelNbr":"10806","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToFullName":"Basu,
         Tassaduq H.","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToEmailName":"TASSB","extension_18e31482d3fb4a8ea958aa96b662f508_PersonnelNumber":"1252188"}'
     headers:
@@ -36,25 +36,25 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '16355'
+      - '16652'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Wed, 22 Jan 2020 01:55:26 GMT
+      - Tue, 07 Apr 2020 02:40:13 GMT
       duration:
-      - '1404796'
+      - '1551725'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - hwn6uEtjHiiLa1+/G29HvIs5WOJFHYFOq64UHyjuGvY=
+      - NVEeIRUodQUDtAt9juaPceg3Yv9ILjs4AVN6PJSP83c=
       ocp-aad-session-key:
-      - 8YO9OwziYwVdFfJb6WzU_8RqD6wI8tjS9gGK5uCg1xN27li8Q6vHbJ-PGK_WJGMz72E_SQbLXnaF5--hGSv1opcJGMzeFKO1BEG2cPHjmS-GliU-NH87wDinbV2wBmec.HfqNyWkG17Lp7npeW04KGeKRu3IKoLyXk-hy-l41c70
+      - cQ1KWd1OJg3KfYBw1bgEVdKnMebqKZrw7sAVSLU1-lAiHCchNYa2OjzBa11Qunm1gun0LrtxUPbzneFj6SmUlOm5JBlRPdba52Ef3feqli_aYjJ8qiOrXc8vziEBTswD.pC6Z9XuBJv_w85tiPoVW5CYlpV_pgSYZCxBVfzXh_XY
       pragma:
       - no-cache
       request-id:
-      - febe17bc-67b2-4557-ad5d-b98185d24a51
+      - 18427a3a-f2a3-4f39-93a6-096470aeb703
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -76,7 +76,9 @@ interactions:
       "import", "update", "managecontacts", "getissuers", "listissuers", "setissuers",
       "deleteissuers", "manageissuers", "recover"], "storage": ["get", "list", "delete",
       "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}}],
-      "enabledForDeployment": true, "enabledForTemplateDeployment": true}}'
+      "enabledForDeployment": true, "enabledForTemplateDeployment": true, "softDeleteRetentionInDays":
+      90, "enableRbacAuthorization": false, "networkAcls": {"bypass": "AzureServices",
+      "defaultAction": "Allow", "ipRules": [], "virtualNetworkRules": []}}}'
     headers:
       Accept:
       - application/json
@@ -87,30 +89,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '814'
+      - '993'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --resource-group -n -l --enabled-for-deployment --enabled-for-template-deployment
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-keyvault/1.1.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002","name":"sfrp-cli-kv-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"3307ff37-85af-4550-bc6a-d1e02672cb7c","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://sfrp-cli-kv-000002.vault.azure.net","provisioningState":"RegisteringDns"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002","name":"sfrp-cli-kv-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"3307ff37-85af-4550-bc6a-d1e02672cb7c","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://sfrp-cli-kv-000002.vault.azure.net","provisioningState":"RegisteringDns"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1141'
+      - '1228'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:55:28 GMT
+      - Tue, 07 Apr 2020 02:40:15 GMT
       expires:
       - '-1'
       pragma:
@@ -128,7 +130,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.0.269
+      - 1.1.0.276
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-powered-by:
@@ -151,21 +153,21 @@ interactions:
       - --resource-group -n -l --enabled-for-deployment --enabled-for-template-deployment
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-keyvault/1.1.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002","name":"sfrp-cli-kv-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"3307ff37-85af-4550-bc6a-d1e02672cb7c","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://sfrp-cli-kv-000002.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002","name":"sfrp-cli-kv-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"3307ff37-85af-4550-bc6a-d1e02672cb7c","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://sfrp-cli-kv-000002.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1137'
+      - '1224'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:55:58 GMT
+      - Tue, 07 Apr 2020 02:40:46 GMT
       expires:
       - '-1'
       pragma:
@@ -183,7 +185,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.0.269
+      - 1.1.0.276
       x-powered-by:
       - ASP.NET
     status:
@@ -221,7 +223,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:00 GMT
+      - Tue, 07 Apr 2020 02:40:47 GMT
       expires:
       - '-1'
       pragma:
@@ -238,11 +240,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.159.235;act_addr_fam=InterNetwork;
+      - addr=131.107.160.208;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.898
       x-powered-by:
       - ASP.NET
     status:
@@ -276,9 +278,9 @@ interactions:
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/create?api-version=7.0
   response:
     body:
-      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK7xSwFy6dhghqlp8y96D2xdfK7Ur+XueQoO5HB3YGwHU3MS5Nv4PUE7FC6vu44FjHtoRT3/uXmgVjL9yNiOaLLUkJ2r7P54VqoUO1s1yaLDLmark5rijA90x0I3i26+RtJKNFWKY5i/279OsR+zOy6GC1l3Py6TyVmi2JYvojuofcXHtsYkn9z+GrB9CMrs5XuYFuslw7vvPXJZIBVdgXFcd1yvAATEX2J/jN49TqKe2MkHmeIifnarhnn6XjqloJyoVy38x6A0CQmDxVuhXTP6AzMuqXW+e5jlxdV/Nx/42uclZDDtn0ffTMa3h0F/S4wv+8hDyuaqIYGpFHwDXfUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAheGdsd+qkWTjb1KWrxTkcKtmvZm74EqjCOM37pgjT0vy9hDjd9EReXCp1Jq+R0mTANQMPC3GCishpQNXVe8BIgFi/hVyaXbeDW6Bbtba2HkPw4Ks19pidq+KEl+zuFKasPjSeafGa9lnlc6vJJb4EQBCyEJ1alCsTXHB//KYlIK4HQ484wTGR3u6Lrlu5h9rDeoDNNNYEuOWCqFoinI8XtvyXrCMnnvWyIQI+JYWHbEigTh25A4vysrH78BSPdJpt0PqHgSRC/2QGZWbeI/0QnntO48Ob0Bv0gEikXB+BgXUBWTuds6SJPvKTQddhMVNEYeum8TI8KEx8Xly5fVzY","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMt/U4KYYWcSNhe8izx2pgDz0PUDobrxQqRYsMXei0Ol58hRsMHKpZW/k8B+xy+EtUsOgg8bkNA2EObwtiui5blokelT67e8vlUV6831AJkUtILk18++k4OEquMPtJgAvFP/a1CoFNqsqhkVyfFsQ6e9EsRySuPG+dyNc05lxSfXK4SXEw3lk0QX7PQRFcO1YXWBKg3Rbodb4vp3Cfmm75JQyGMdWSvOg18CqqSOk9D4pBL9zoQu0sGV4Nc9M+8ODg0fBrZYSTY4F7QAxYn7obq1XPq7GhyFMRHqNjdRlSeO9qqCq5A42LbSpiBIdNchVkmn98giVrKTY4M+lxMv1LsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQDKFlbgCq8ULrhpNmd8kZ4X8KSUHb2F9wbjAK8VMy8tuEMWhO4fWg6pE+1yEDva2zdaBRNPCVFJQjPhWS5OJ2TO/sHGYAdu9OnS1WrhpLIsXIFM9l2rxBKTy/KJIDFpdamoXjiVKAe5t4YPQkANPRknG1aW1xxiIkqyWnN+xJq8TN8hWu3mX1hasthgXGK0X01P7Th5Vn7a8SwSpS2ZD4lCDOvOFQVTE6DNTCDqgxW9mVQJVqlYhKYyshSdGzKdSXaYZgmKu9d6jGqA1I9lw/uKKFQsg5J5MVDby77Ihy9WPNz1tMB9zKl/cV1oyrzqv09GMUM/0nlQiuzqcQhgj8pe","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"377780c915fc47279384e96aba0d234f"}'
+        time based on the issuer provider. Please check again later.","request_id":"9032459f89a64416803f1f92fe6873d2"}'
     headers:
       cache-control:
       - no-cache
@@ -287,11 +289,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:03 GMT
+      - Tue, 07 Apr 2020 02:40:50 GMT
       expires:
       - '-1'
       location:
-      - https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending?api-version=7.0&request_id=377780c915fc47279384e96aba0d234f
+      - https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending?api-version=7.0&request_id=9032459f89a64416803f1f92fe6873d2
       pragma:
       - no-cache
       server:
@@ -303,11 +305,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.159.235;act_addr_fam=InterNetwork;
+      - addr=131.107.160.208;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.898
       x-powered-by:
       - ASP.NET
     status:
@@ -333,9 +335,9 @@ interactions:
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK7xSwFy6dhghqlp8y96D2xdfK7Ur+XueQoO5HB3YGwHU3MS5Nv4PUE7FC6vu44FjHtoRT3/uXmgVjL9yNiOaLLUkJ2r7P54VqoUO1s1yaLDLmark5rijA90x0I3i26+RtJKNFWKY5i/279OsR+zOy6GC1l3Py6TyVmi2JYvojuofcXHtsYkn9z+GrB9CMrs5XuYFuslw7vvPXJZIBVdgXFcd1yvAATEX2J/jN49TqKe2MkHmeIifnarhnn6XjqloJyoVy38x6A0CQmDxVuhXTP6AzMuqXW+e5jlxdV/Nx/42uclZDDtn0ffTMa3h0F/S4wv+8hDyuaqIYGpFHwDXfUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAheGdsd+qkWTjb1KWrxTkcKtmvZm74EqjCOM37pgjT0vy9hDjd9EReXCp1Jq+R0mTANQMPC3GCishpQNXVe8BIgFi/hVyaXbeDW6Bbtba2HkPw4Ks19pidq+KEl+zuFKasPjSeafGa9lnlc6vJJb4EQBCyEJ1alCsTXHB//KYlIK4HQ484wTGR3u6Lrlu5h9rDeoDNNNYEuOWCqFoinI8XtvyXrCMnnvWyIQI+JYWHbEigTh25A4vysrH78BSPdJpt0PqHgSRC/2QGZWbeI/0QnntO48Ob0Bv0gEikXB+BgXUBWTuds6SJPvKTQddhMVNEYeum8TI8KEx8Xly5fVzY","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMt/U4KYYWcSNhe8izx2pgDz0PUDobrxQqRYsMXei0Ol58hRsMHKpZW/k8B+xy+EtUsOgg8bkNA2EObwtiui5blokelT67e8vlUV6831AJkUtILk18++k4OEquMPtJgAvFP/a1CoFNqsqhkVyfFsQ6e9EsRySuPG+dyNc05lxSfXK4SXEw3lk0QX7PQRFcO1YXWBKg3Rbodb4vp3Cfmm75JQyGMdWSvOg18CqqSOk9D4pBL9zoQu0sGV4Nc9M+8ODg0fBrZYSTY4F7QAxYn7obq1XPq7GhyFMRHqNjdRlSeO9qqCq5A42LbSpiBIdNchVkmn98giVrKTY4M+lxMv1LsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQDKFlbgCq8ULrhpNmd8kZ4X8KSUHb2F9wbjAK8VMy8tuEMWhO4fWg6pE+1yEDva2zdaBRNPCVFJQjPhWS5OJ2TO/sHGYAdu9OnS1WrhpLIsXIFM9l2rxBKTy/KJIDFpdamoXjiVKAe5t4YPQkANPRknG1aW1xxiIkqyWnN+xJq8TN8hWu3mX1hasthgXGK0X01P7Th5Vn7a8SwSpS2ZD4lCDOvOFQVTE6DNTCDqgxW9mVQJVqlYhKYyshSdGzKdSXaYZgmKu9d6jGqA1I9lw/uKKFQsg5J5MVDby77Ihy9WPNz1tMB9zKl/cV1oyrzqv09GMUM/0nlQiuzqcQhgj8pe","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"377780c915fc47279384e96aba0d234f"}'
+        time based on the issuer provider. Please check again later.","request_id":"9032459f89a64416803f1f92fe6873d2"}'
     headers:
       cache-control:
       - no-cache
@@ -344,7 +346,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:02 GMT
+      - Tue, 07 Apr 2020 02:40:50 GMT
       expires:
       - '-1'
       pragma:
@@ -358,11 +360,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.159.235;act_addr_fam=InterNetwork;
+      - addr=131.107.160.208;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.898
       x-powered-by:
       - ASP.NET
     status:
@@ -388,9 +390,9 @@ interactions:
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK7xSwFy6dhghqlp8y96D2xdfK7Ur+XueQoO5HB3YGwHU3MS5Nv4PUE7FC6vu44FjHtoRT3/uXmgVjL9yNiOaLLUkJ2r7P54VqoUO1s1yaLDLmark5rijA90x0I3i26+RtJKNFWKY5i/279OsR+zOy6GC1l3Py6TyVmi2JYvojuofcXHtsYkn9z+GrB9CMrs5XuYFuslw7vvPXJZIBVdgXFcd1yvAATEX2J/jN49TqKe2MkHmeIifnarhnn6XjqloJyoVy38x6A0CQmDxVuhXTP6AzMuqXW+e5jlxdV/Nx/42uclZDDtn0ffTMa3h0F/S4wv+8hDyuaqIYGpFHwDXfUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAheGdsd+qkWTjb1KWrxTkcKtmvZm74EqjCOM37pgjT0vy9hDjd9EReXCp1Jq+R0mTANQMPC3GCishpQNXVe8BIgFi/hVyaXbeDW6Bbtba2HkPw4Ks19pidq+KEl+zuFKasPjSeafGa9lnlc6vJJb4EQBCyEJ1alCsTXHB//KYlIK4HQ484wTGR3u6Lrlu5h9rDeoDNNNYEuOWCqFoinI8XtvyXrCMnnvWyIQI+JYWHbEigTh25A4vysrH78BSPdJpt0PqHgSRC/2QGZWbeI/0QnntO48Ob0Bv0gEikXB+BgXUBWTuds6SJPvKTQddhMVNEYeum8TI8KEx8Xly5fVzY","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMt/U4KYYWcSNhe8izx2pgDz0PUDobrxQqRYsMXei0Ol58hRsMHKpZW/k8B+xy+EtUsOgg8bkNA2EObwtiui5blokelT67e8vlUV6831AJkUtILk18++k4OEquMPtJgAvFP/a1CoFNqsqhkVyfFsQ6e9EsRySuPG+dyNc05lxSfXK4SXEw3lk0QX7PQRFcO1YXWBKg3Rbodb4vp3Cfmm75JQyGMdWSvOg18CqqSOk9D4pBL9zoQu0sGV4Nc9M+8ODg0fBrZYSTY4F7QAxYn7obq1XPq7GhyFMRHqNjdRlSeO9qqCq5A42LbSpiBIdNchVkmn98giVrKTY4M+lxMv1LsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQDKFlbgCq8ULrhpNmd8kZ4X8KSUHb2F9wbjAK8VMy8tuEMWhO4fWg6pE+1yEDva2zdaBRNPCVFJQjPhWS5OJ2TO/sHGYAdu9OnS1WrhpLIsXIFM9l2rxBKTy/KJIDFpdamoXjiVKAe5t4YPQkANPRknG1aW1xxiIkqyWnN+xJq8TN8hWu3mX1hasthgXGK0X01P7Th5Vn7a8SwSpS2ZD4lCDOvOFQVTE6DNTCDqgxW9mVQJVqlYhKYyshSdGzKdSXaYZgmKu9d6jGqA1I9lw/uKKFQsg5J5MVDby77Ihy9WPNz1tMB9zKl/cV1oyrzqv09GMUM/0nlQiuzqcQhgj8pe","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"377780c915fc47279384e96aba0d234f"}'
+        time based on the issuer provider. Please check again later.","request_id":"9032459f89a64416803f1f92fe6873d2"}'
     headers:
       cache-control:
       - no-cache
@@ -399,7 +401,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:13 GMT
+      - Tue, 07 Apr 2020 02:41:01 GMT
       expires:
       - '-1'
       pragma:
@@ -413,11 +415,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.159.235;act_addr_fam=InterNetwork;
+      - addr=131.107.160.208;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.898
       x-powered-by:
       - ASP.NET
     status:
@@ -443,7 +445,172 @@ interactions:
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending?api-version=7.0
   response:
     body:
-      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK7xSwFy6dhghqlp8y96D2xdfK7Ur+XueQoO5HB3YGwHU3MS5Nv4PUE7FC6vu44FjHtoRT3/uXmgVjL9yNiOaLLUkJ2r7P54VqoUO1s1yaLDLmark5rijA90x0I3i26+RtJKNFWKY5i/279OsR+zOy6GC1l3Py6TyVmi2JYvojuofcXHtsYkn9z+GrB9CMrs5XuYFuslw7vvPXJZIBVdgXFcd1yvAATEX2J/jN49TqKe2MkHmeIifnarhnn6XjqloJyoVy38x6A0CQmDxVuhXTP6AzMuqXW+e5jlxdV/Nx/42uclZDDtn0ffTMa3h0F/S4wv+8hDyuaqIYGpFHwDXfUCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAheGdsd+qkWTjb1KWrxTkcKtmvZm74EqjCOM37pgjT0vy9hDjd9EReXCp1Jq+R0mTANQMPC3GCishpQNXVe8BIgFi/hVyaXbeDW6Bbtba2HkPw4Ks19pidq+KEl+zuFKasPjSeafGa9lnlc6vJJb4EQBCyEJ1alCsTXHB//KYlIK4HQ484wTGR3u6Lrlu5h9rDeoDNNNYEuOWCqFoinI8XtvyXrCMnnvWyIQI+JYWHbEigTh25A4vysrH78BSPdJpt0PqHgSRC/2QGZWbeI/0QnntO48Ob0Bv0gEikXB+BgXUBWTuds6SJPvKTQddhMVNEYeum8TI8KEx8Xly5fVzY","cancellation_requested":false,"status":"completed","target":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003","request_id":"377780c915fc47279384e96aba0d234f"}'
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMt/U4KYYWcSNhe8izx2pgDz0PUDobrxQqRYsMXei0Ol58hRsMHKpZW/k8B+xy+EtUsOgg8bkNA2EObwtiui5blokelT67e8vlUV6831AJkUtILk18++k4OEquMPtJgAvFP/a1CoFNqsqhkVyfFsQ6e9EsRySuPG+dyNc05lxSfXK4SXEw3lk0QX7PQRFcO1YXWBKg3Rbodb4vp3Cfmm75JQyGMdWSvOg18CqqSOk9D4pBL9zoQu0sGV4Nc9M+8ODg0fBrZYSTY4F7QAxYn7obq1XPq7GhyFMRHqNjdRlSeO9qqCq5A42LbSpiBIdNchVkmn98giVrKTY4M+lxMv1LsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQDKFlbgCq8ULrhpNmd8kZ4X8KSUHb2F9wbjAK8VMy8tuEMWhO4fWg6pE+1yEDva2zdaBRNPCVFJQjPhWS5OJ2TO/sHGYAdu9OnS1WrhpLIsXIFM9l2rxBKTy/KJIDFpdamoXjiVKAe5t4YPQkANPRknG1aW1xxiIkqyWnN+xJq8TN8hWu3mX1hasthgXGK0X01P7Th5Vn7a8SwSpS2ZD4lCDOvOFQVTE6DNTCDqgxW9mVQJVqlYhKYyshSdGzKdSXaYZgmKu9d6jGqA1I9lw/uKKFQsg5J5MVDby77Ihy9WPNz1tMB9zKl/cV1oyrzqv09GMUM/0nlQiuzqcQhgj8pe","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"9032459f89a64416803f1f92fe6873d2"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1322'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2020 02:41:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=131.107.160.208;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-keyvault/7.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending?api-version=7.0
+  response:
+    body:
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMt/U4KYYWcSNhe8izx2pgDz0PUDobrxQqRYsMXei0Ol58hRsMHKpZW/k8B+xy+EtUsOgg8bkNA2EObwtiui5blokelT67e8vlUV6831AJkUtILk18++k4OEquMPtJgAvFP/a1CoFNqsqhkVyfFsQ6e9EsRySuPG+dyNc05lxSfXK4SXEw3lk0QX7PQRFcO1YXWBKg3Rbodb4vp3Cfmm75JQyGMdWSvOg18CqqSOk9D4pBL9zoQu0sGV4Nc9M+8ODg0fBrZYSTY4F7QAxYn7obq1XPq7GhyFMRHqNjdRlSeO9qqCq5A42LbSpiBIdNchVkmn98giVrKTY4M+lxMv1LsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQDKFlbgCq8ULrhpNmd8kZ4X8KSUHb2F9wbjAK8VMy8tuEMWhO4fWg6pE+1yEDva2zdaBRNPCVFJQjPhWS5OJ2TO/sHGYAdu9OnS1WrhpLIsXIFM9l2rxBKTy/KJIDFpdamoXjiVKAe5t4YPQkANPRknG1aW1xxiIkqyWnN+xJq8TN8hWu3mX1hasthgXGK0X01P7Th5Vn7a8SwSpS2ZD4lCDOvOFQVTE6DNTCDqgxW9mVQJVqlYhKYyshSdGzKdSXaYZgmKu9d6jGqA1I9lw/uKKFQsg5J5MVDby77Ihy9WPNz1tMB9zKl/cV1oyrzqv09GMUM/0nlQiuzqcQhgj8pe","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"9032459f89a64416803f1f92fe6873d2"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1322'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2020 02:41:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=131.107.160.208;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-keyvault/7.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending?api-version=7.0
+  response:
+    body:
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMt/U4KYYWcSNhe8izx2pgDz0PUDobrxQqRYsMXei0Ol58hRsMHKpZW/k8B+xy+EtUsOgg8bkNA2EObwtiui5blokelT67e8vlUV6831AJkUtILk18++k4OEquMPtJgAvFP/a1CoFNqsqhkVyfFsQ6e9EsRySuPG+dyNc05lxSfXK4SXEw3lk0QX7PQRFcO1YXWBKg3Rbodb4vp3Cfmm75JQyGMdWSvOg18CqqSOk9D4pBL9zoQu0sGV4Nc9M+8ODg0fBrZYSTY4F7QAxYn7obq1XPq7GhyFMRHqNjdRlSeO9qqCq5A42LbSpiBIdNchVkmn98giVrKTY4M+lxMv1LsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQDKFlbgCq8ULrhpNmd8kZ4X8KSUHb2F9wbjAK8VMy8tuEMWhO4fWg6pE+1yEDva2zdaBRNPCVFJQjPhWS5OJ2TO/sHGYAdu9OnS1WrhpLIsXIFM9l2rxBKTy/KJIDFpdamoXjiVKAe5t4YPQkANPRknG1aW1xxiIkqyWnN+xJq8TN8hWu3mX1hasthgXGK0X01P7Th5Vn7a8SwSpS2ZD4lCDOvOFQVTE6DNTCDqgxW9mVQJVqlYhKYyshSdGzKdSXaYZgmKu9d6jGqA1I9lw/uKKFQsg5J5MVDby77Ihy9WPNz1tMB9zKl/cV1oyrzqv09GMUM/0nlQiuzqcQhgj8pe","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"9032459f89a64416803f1f92fe6873d2"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1322'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 07 Apr 2020 02:41:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - addr=131.107.160.208;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
+        azure-keyvault/7.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending?api-version=7.0
+  response:
+    body:
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMt/U4KYYWcSNhe8izx2pgDz0PUDobrxQqRYsMXei0Ol58hRsMHKpZW/k8B+xy+EtUsOgg8bkNA2EObwtiui5blokelT67e8vlUV6831AJkUtILk18++k4OEquMPtJgAvFP/a1CoFNqsqhkVyfFsQ6e9EsRySuPG+dyNc05lxSfXK4SXEw3lk0QX7PQRFcO1YXWBKg3Rbodb4vp3Cfmm75JQyGMdWSvOg18CqqSOk9D4pBL9zoQu0sGV4Nc9M+8ODg0fBrZYSTY4F7QAxYn7obq1XPq7GhyFMRHqNjdRlSeO9qqCq5A42LbSpiBIdNchVkmn98giVrKTY4M+lxMv1LsCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQDKFlbgCq8ULrhpNmd8kZ4X8KSUHb2F9wbjAK8VMy8tuEMWhO4fWg6pE+1yEDva2zdaBRNPCVFJQjPhWS5OJ2TO/sHGYAdu9OnS1WrhpLIsXIFM9l2rxBKTy/KJIDFpdamoXjiVKAe5t4YPQkANPRknG1aW1xxiIkqyWnN+xJq8TN8hWu3mX1hasthgXGK0X01P7Th5Vn7a8SwSpS2ZD4lCDOvOFQVTE6DNTCDqgxW9mVQJVqlYhKYyshSdGzKdSXaYZgmKu9d6jGqA1I9lw/uKKFQsg5J5MVDby77Ihy9WPNz1tMB9zKl/cV1oyrzqv09GMUM/0nlQiuzqcQhgj8pe","cancellation_requested":false,"status":"completed","target":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003","request_id":"9032459f89a64416803f1f92fe6873d2"}'
     headers:
       cache-control:
       - no-cache
@@ -452,7 +619,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:24 GMT
+      - Tue, 07 Apr 2020 02:41:44 GMT
       expires:
       - '-1'
       pragma:
@@ -466,11 +633,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.159.235;act_addr_fam=InterNetwork;
+      - addr=131.107.160.208;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.898
       x-powered-by:
       - ASP.NET
     status:
@@ -496,16 +663,16 @@ interactions:
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/?api-version=7.0
   response:
     body:
-      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/712e4ba9347c4bcb88a05b1864fdd4d7","kid":"https://sfrp-cli-kv-000002.vault.azure.net/keys/sfrp-cli-000003/712e4ba9347c4bcb88a05b1864fdd4d7","sid":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/712e4ba9347c4bcb88a05b1864fdd4d7","x5t":"5iDWr0pY8JRdXQZ3jKohXhExEto","cer":"MIIDQjCCAiqgAwIBAgIQIRP1Sfo/Qaiqj83U+9Ok/DANBgkqhkiG9w0BAQsFADAeMRwwGgYDVQQDExNDTElHZXREZWZhdWx0UG9saWN5MB4XDTIwMDEyMjAxNDYyMFoXDTIxMDEyMjAxNTYyMFowHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK7xSwFy6dhghqlp8y96D2xdfK7Ur+XueQoO5HB3YGwHU3MS5Nv4PUE7FC6vu44FjHtoRT3/uXmgVjL9yNiOaLLUkJ2r7P54VqoUO1s1yaLDLmark5rijA90x0I3i26+RtJKNFWKY5i/279OsR+zOy6GC1l3Py6TyVmi2JYvojuofcXHtsYkn9z+GrB9CMrs5XuYFuslw7vvPXJZIBVdgXFcd1yvAATEX2J/jN49TqKe2MkHmeIifnarhnn6XjqloJyoVy38x6A0CQmDxVuhXTP6AzMuqXW+e5jlxdV/Nx/42uclZDDtn0ffTMa3h0F/S4wv+8hDyuaqIYGpFHwDXfUCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgG+MAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFBivxgIP5rw/kks4gXKxAq+OtMQbMB0GA1UdDgQWBBQYr8YCD+a8P5JLOIFysQKvjrTEGzANBgkqhkiG9w0BAQsFAAOCAQEAhiEMFFryP9wg8f/3AcWye0gGT5PJzWfRK4ptYrAQbE5sDKpbYYnAP05GtN8tLZEtupinQh24jz6t222vFkJXEwlS+iQ5jBfgLQIhtaGYHgxEfacsYTLRKUZHK+dcsXxfX4F+kw8tuyl00JWH3sRWvvQ/BH5rghntjGA5IEn/Flc9qZsOlJFdGe4ePSSkgbrxM09VlTRZPhS7LoZuTDOumnw3OoPEhLRu2lO0/R9jyYLEJQiHERChUiiK2YLWZf9kmdLPe1WK5wbf0h4Wd9elqKjCmUn42ESHtUSpVRBssHekgT6+Hjuu7yVXts4xLIhIBCPlSNZ9W29CVww8YMfpzg==","attributes":{"enabled":true,"nbf":1579657580,"exp":1611280580,"created":1579658180,"updated":1579658180,"recoveryLevel":"Purgeable"},"policy":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":true},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=CLIGetDefaultPolicy","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["cRLSign","dataEncipherment","digitalSignature","keyAgreement","keyCertSign","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"days_before_expiry":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1579658162,"updated":1579658162}},"pending":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending"}}'
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/ba42565a892846e19608eaca3790c3f8","kid":"https://sfrp-cli-kv-000002.vault.azure.net/keys/sfrp-cli-000003/ba42565a892846e19608eaca3790c3f8","sid":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/ba42565a892846e19608eaca3790c3f8","x5t":"DKsOX4R5FDYZvNt8ltXg3ClnIGo","cer":"MIIDQjCCAiqgAwIBAgIQEPSkA0zlR+2H/c+wNL4P5DANBgkqhkiG9w0BAQsFADAeMRwwGgYDVQQDExNDTElHZXREZWZhdWx0UG9saWN5MB4XDTIwMDQwNzAyMzEzN1oXDTIxMDQwNzAyNDEzN1owHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMt/U4KYYWcSNhe8izx2pgDz0PUDobrxQqRYsMXei0Ol58hRsMHKpZW/k8B+xy+EtUsOgg8bkNA2EObwtiui5blokelT67e8vlUV6831AJkUtILk18++k4OEquMPtJgAvFP/a1CoFNqsqhkVyfFsQ6e9EsRySuPG+dyNc05lxSfXK4SXEw3lk0QX7PQRFcO1YXWBKg3Rbodb4vp3Cfmm75JQyGMdWSvOg18CqqSOk9D4pBL9zoQu0sGV4Nc9M+8ODg0fBrZYSTY4F7QAxYn7obq1XPq7GhyFMRHqNjdRlSeO9qqCq5A42LbSpiBIdNchVkmn98giVrKTY4M+lxMv1LsCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgG+MAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFMDEd1wTkm7J14cZ1SQeXG9uwOTwMB0GA1UdDgQWBBTAxHdcE5JuydeHGdUkHlxvbsDk8DANBgkqhkiG9w0BAQsFAAOCAQEAGxJf7PBLoUuxG21J8im6/zG2E7RVMMXSwhsmiah5+tDWE+W9HeHNfSqD0+xT+5FAEi56z4vVKjqs7h21ocj4YtLRyyXucV45nKrjHAklhM85/QpmjbKQ/+KsFeoe3bpE6pyA1tClP+2DMoJ4NaqGd5PdWnOJxfoF78d3D0IkeGhts//JTJdwKlks6I1Opxxs3XJKIVlq8EMKaiYz1D1y946McyIwyyJzka54HMaG3cfW5Vf9qvAzfZ+aAMBGXgG8zoTZiNl8AcTMuEtz6quccuewaBc3C/srtC8PCLjIlo6tTMvx+wN3pYiVlJwQXPG8HHmmFd7iS7kgFZABSQoHXw==","attributes":{"enabled":true,"nbf":1586226697,"exp":1617763297,"created":1586227297,"updated":1586227297,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":true},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=CLIGetDefaultPolicy","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["cRLSign","dataEncipherment","digitalSignature","keyAgreement","keyCertSign","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"days_before_expiry":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1586227250,"updated":1586227250}},"pending":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000003/pending"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2482'
+      - '2494'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:24 GMT
+      - Tue, 07 Apr 2020 02:41:45 GMT
       expires:
       - '-1'
       pragma:
@@ -519,11 +686,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.159.235;act_addr_fam=InterNetwork;
+      - addr=131.107.160.208;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.898
       x-powered-by:
       - ASP.NET
     status:
@@ -544,14 +711,14 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-01-22T01:55:23Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-07T02:40:10Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -560,7 +727,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:25 GMT
+      - Tue, 07 Apr 2020 02:41:46 GMT
       expires:
       - '-1'
       pragma:
@@ -589,14 +756,14 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-01-22T01:55:23Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-07T02:40:10Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -605,7 +772,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:25 GMT
+      - Tue, 07 Apr 2020 02:41:46 GMT
       expires:
       - '-1'
       pragma:
@@ -630,30 +797,27 @@ interactions:
       - sf cluster create
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json; charset=utf-8
       ParameterSetName:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-keyvault/1.1.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/alsantamrg4/providers/Microsoft.KeyVault/vaults/alsantamrg4","name":"alsantamrg4","type":"Microsoft.KeyVault/vaults","location":"eastus2","tags":{"clusterName":"alsantamrg4","resourceType":"Service
-        Fabric"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002","name":"sfrp-cli-kv-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/demo-5419170317012020-paasv2/providers/Microsoft.KeyVault/vaults/KeyVault541917031701","name":"KeyVault541917031701","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/demo-6033490122012020-paasv2/providers/Microsoft.KeyVault/vaults/KeyVault603349012201","name":"KeyVault603349012201","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG-Globalization-ARM-Keyvault/providers/Microsoft.KeyVault/vaults/GlobalARMKeyVaultnew","name":"GlobalARMKeyVaultnew","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest10118012443/providers/Microsoft.KeyVault/vaults/rmsfe2etest10118012443","name":"rmsfe2etest10118012443","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest10118155639/providers/Microsoft.KeyVault/vaults/rmsfe2etest10118155639","name":"rmsfe2etest10118155639","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest10119031512/providers/Microsoft.KeyVault/vaults/rmsfe2etest10119031512","name":"rmsfe2etest10119031512","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest10119151827/providers/Microsoft.KeyVault/vaults/rmsfe2etest10119151827","name":"rmsfe2etest10119151827","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest10120041012/providers/Microsoft.KeyVault/vaults/rmsfe2etest10120041012","name":"rmsfe2etest10120041012","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest10120154006/providers/Microsoft.KeyVault/vaults/rmsfe2etest10120154006","name":"rmsfe2etest10120154006","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest10121033606/providers/Microsoft.KeyVault/vaults/rmsfe2etest10121033606","name":"rmsfe2etest10121033606","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest10121172023/providers/Microsoft.KeyVault/vaults/rmsfe2etest10121172023","name":"rmsfe2etest10121172023","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest20118013537/providers/Microsoft.KeyVault/vaults/rmsfe2etest20118013537","name":"rmsfe2etest20118013537","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest20118155645/providers/Microsoft.KeyVault/vaults/rmsfe2etest20118155645","name":"rmsfe2etest20118155645","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest20119033204/providers/Microsoft.KeyVault/vaults/rmsfe2etest20119033204","name":"rmsfe2etest20119033204","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest20119152227/providers/Microsoft.KeyVault/vaults/rmsfe2etest20119152227","name":"rmsfe2etest20119152227","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest20120033244/providers/Microsoft.KeyVault/vaults/rmsfe2etest20120033244","name":"rmsfe2etest20120033244","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest20120153004/providers/Microsoft.KeyVault/vaults/rmsfe2etest20120153004","name":"rmsfe2etest20120153004","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest20121033606/providers/Microsoft.KeyVault/vaults/rmsfe2etest20121033606","name":"rmsfe2etest20121033606","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest20121173702/providers/Microsoft.KeyVault/vaults/rmsfe2etest20121173702","name":"rmsfe2etest20121173702","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest30121034819/providers/Microsoft.KeyVault/vaults/rmsfe2etest30121034819","name":"rmsfe2etest30121034819","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest30121174251/providers/Microsoft.KeyVault/vaults/rmsfe2etest30121174251","name":"rmsfe2etest30121174251","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest40118012950/providers/Microsoft.KeyVault/vaults/rmsfe2etest40118012950","name":"rmsfe2etest40118012950","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest40118174002/providers/Microsoft.KeyVault/vaults/rmsfe2etest40118174002","name":"rmsfe2etest40118174002","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest40119033200/providers/Microsoft.KeyVault/vaults/rmsfe2etest40119033200","name":"rmsfe2etest40119033200","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest40119152610/providers/Microsoft.KeyVault/vaults/rmsfe2etest40119152610","name":"rmsfe2etest40119152610","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest40120033750/providers/Microsoft.KeyVault/vaults/rmsfe2etest40120033750","name":"rmsfe2etest40120033750","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest40120153502/providers/Microsoft.KeyVault/vaults/rmsfe2etest40120153502","name":"rmsfe2etest40120153502","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest40121034215/providers/Microsoft.KeyVault/vaults/rmsfe2etest40121034215","name":"rmsfe2etest40121034215","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest40121174251/providers/Microsoft.KeyVault/vaults/rmsfe2etest40121174251","name":"rmsfe2etest40121174251","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest50118012947/providers/Microsoft.KeyVault/vaults/rmsfe2etest50118012947","name":"rmsfe2etest50118012947","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest50118194141/providers/Microsoft.KeyVault/vaults/rmsfe2etest50118194141","name":"rmsfe2etest50118194141","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest50119031514/providers/Microsoft.KeyVault/vaults/rmsfe2etest50119031514","name":"rmsfe2etest50119031514","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest50119152624/providers/Microsoft.KeyVault/vaults/rmsfe2etest50119152624","name":"rmsfe2etest50119152624","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest50120033244/providers/Microsoft.KeyVault/vaults/rmsfe2etest50120033244","name":"rmsfe2etest50120033244","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest50120153449/providers/Microsoft.KeyVault/vaults/rmsfe2etest50120153449","name":"rmsfe2etest50120153449","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest50121034819/providers/Microsoft.KeyVault/vaults/rmsfe2etest50121034819","name":"rmsfe2etest50121034819","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest50121173712/providers/Microsoft.KeyVault/vaults/rmsfe2etest50121173712","name":"rmsfe2etest50121173712","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest60118012949/providers/Microsoft.KeyVault/vaults/rmsfe2etest60118012949","name":"rmsfe2etest60118012949","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest60118194140/providers/Microsoft.KeyVault/vaults/rmsfe2etest60118194140","name":"rmsfe2etest60118194140","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest60119032205/providers/Microsoft.KeyVault/vaults/rmsfe2etest60119032205","name":"rmsfe2etest60119032205","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest60119152227/providers/Microsoft.KeyVault/vaults/rmsfe2etest60119152227","name":"rmsfe2etest60119152227","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest60120033750/providers/Microsoft.KeyVault/vaults/rmsfe2etest60120033750","name":"rmsfe2etest60120033750","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest60120153007/providers/Microsoft.KeyVault/vaults/rmsfe2etest60120153007","name":"rmsfe2etest60120153007","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest60121033611/providers/Microsoft.KeyVault/vaults/rmsfe2etest60121033611","name":"rmsfe2etest60121033611","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest60121173714/providers/Microsoft.KeyVault/vaults/rmsfe2etest60121173714","name":"rmsfe2etest60121173714","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest70118021914/providers/Microsoft.KeyVault/vaults/rmsfe2etest70118021914","name":"rmsfe2etest70118021914","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest70118163030/providers/Microsoft.KeyVault/vaults/rmsfe2etest70118163030","name":"rmsfe2etest70118163030","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest70119032205/providers/Microsoft.KeyVault/vaults/rmsfe2etest70119032205","name":"rmsfe2etest70119032205","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest70119152610/providers/Microsoft.KeyVault/vaults/rmsfe2etest70119152610","name":"rmsfe2etest70119152610","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest70120033751/providers/Microsoft.KeyVault/vaults/rmsfe2etest70120033751","name":"rmsfe2etest70120033751","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest70120153502/providers/Microsoft.KeyVault/vaults/rmsfe2etest70120153502","name":"rmsfe2etest70120153502","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest70121034831/providers/Microsoft.KeyVault/vaults/rmsfe2etest70121034831","name":"rmsfe2etest70121034831","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest70121171453/providers/Microsoft.KeyVault/vaults/rmsfe2etest70121171453","name":"rmsfe2etest70121171453","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/alsantamclitest/providers/Microsoft.KeyVault/vaults/alsantamclitest","name":"alsantamclitest","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002","name":"sfrp-cli-kv-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RG-Globalization-ARM-Keyvault/providers/Microsoft.KeyVault/vaults/GlobalARMKeyVaultnew","name":"GlobalARMKeyVaultnew","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest20403230949/providers/Microsoft.KeyVault/vaults/rmsfe2etest20403230949","name":"rmsfe2etest20403230949","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest30403172952/providers/Microsoft.KeyVault/vaults/rmsfe2etest30403172952","name":"rmsfe2etest30403172952","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest40403172950/providers/Microsoft.KeyVault/vaults/rmsfe2etest40403172950","name":"rmsfe2etest40403172950","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rmsfe2etest50403173500/providers/Microsoft.KeyVault/vaults/rmsfe2etest50403173500","name":"rmsfe2etest50403173500","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testadm031110/providers/Microsoft.KeyVault/vaults/testadm031110","name":"testadm031110","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testadm040321/providers/Microsoft.KeyVault/vaults/testadm040321","name":"testadm040321","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '14551'
+      - '2347'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:26 GMT
+      - Tue, 07 Apr 2020 02:41:46 GMT
       expires:
       - '-1'
       pragma:
@@ -678,29 +842,27 @@ interactions:
       - sf cluster create
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json; charset=utf-8
       ParameterSetName:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-keyvault/1.1.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002","name":"sfrp-cli-kv-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"3307ff37-85af-4550-bc6a-d1e02672cb7c","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"vaultUri":"https://sfrp-cli-kv-000002.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002","name":"sfrp-cli-kv-000002","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"3307ff37-85af-4550-bc6a-d1e02672cb7c","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://sfrp-cli-kv-000002.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1137'
+      - '1224'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:26 GMT
+      - Tue, 07 Apr 2020 02:41:46 GMT
       expires:
       - '-1'
       pragma:
@@ -718,7 +880,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.0.269
+      - 1.1.0.276
       x-powered-by:
       - ASP.NET
     status:
@@ -741,19 +903,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/712e4ba9347c4bcb88a05b1864fdd4d7?api-version=7.0
+    uri: https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/ba42565a892846e19608eaca3790c3f8?api-version=7.0
   response:
     body:
-      string: '{"value":"MIIKTAIBAzCCCgwGCSqGSIb3DQEHAaCCCf0Eggn5MIIJ9TCCBhYGCSqGSIb3DQEHAaCCBgcEggYDMIIF/zCCBfsGCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAj6XjzuO8aljAICB9AEggTYlJFY1c1G3k6emLWH9lBuwl/yt1KeqvCODxkrh8/Rj1lhONZ2EUYH1ZG02SpTl2sFCrDjA6ihs0CJngzhx3zvX6unRXZebMrKLsOycdPNno2v3locueD2A+GrCiT4M7iUQMJlw18MDmSDJAX6Ce1RSDLvfK9amz7SoerP7ANW1IaxGteyR0p26DGbJRQoKwRM4FVJMxGk1KJI+vsYjWeiOAT2DgcQ3VSfCMCIbK2xjDtcvsDWO00LX+0ZQzcXmiRRAee3hLZijgONZFlyh6fT//PDrlJply8X3k94Y1W4W+Jx/lLW+digrUkzMLIrc4f/jUyEG5Q+JxXurwL7DAv2PqGBCCmp3kIT/o7T3pMRK9mXNkCSmxQWrxunvso5HWwiwVn2lnPRYWnAlm2JvW1NSDlUnE3mzFxT9uL0zC8zox86yo2WqNJVoMt7qIlZYmhnqB6EgjswmkXTarriwyqwNq74Y34HExXS2qee/VMcDYnKIEXcyV9mZxmnCkZGQMTWrQR7YZejmScMXzW9VmlndzyZmkVak0DC3BW2MpG5tAw24Npw2ybiNRBV3y4YLd8KCYxeiy4JAbKsiH2yUJUtdGeRhO0O7PAyW19dOLpE/ZndpjsU2JJtJI5Wsj5fzP43sIPwMYXF9TysF6Rj/zIoYXCg9eP2AlJs8r+ltVaKv/mGSplZxLDg4ejIcRgBPDh/mrNTjfnIxpEeq67OYKjyifjlKmVdVicO7l0RMG07FyjJEAU0UPlYtjV6ZAvwNQnv5hUPUIED+HLgbjqTbWW/5GEmcjdcwD9c6mP8joBkMjivtMRAICrGstNXFGiYcKkO/RrJrnFQAMbs49pP/13oh5Hbmz/R1o1ymgca8dkktpn1MWqqDoP6WYdJWh/Dyb3jMBKFDF6RrCm9kYwmS5LSKpCCVKLB7w9a9zZ4rA5+96hgVHItbKxFWxMW701MS4kuvBrjDMqh881D7KvrmCa1cRRanWq3UIGzlEz7aNON81Iu71ZobLIYOHHH24Ui62ZXsw694xVbmfVKAzXsUpEguJtqpFQN+lOW9tmRVpxpera9QUofD77R/XExgIdsaDZBRgVJW/ryWYHaqMbnYRVqzky2KWRadI/Qcy5pH6oBiKcPcOLCjRl3XYpMpVduUkI4mwvWdqQTc8LSuWIn+yDHCRXjCzwXyyCfCjYzSEcR3vc70nTl6EFICwEa1bwWa3aObRNlS7WrfFhopSZ4MRAQKubD59czDi2D+KbDFhuq1a+DWdEeRMB5MelFwmsGFmcVTWwPDK+DtB+Oe2GK5Pwa79+he/8DBjaaqw/9g6r3VqafHgfQr+1ShBDPxVidBEdVZHUhHU/GIp+fjyUneGosEdjhvxaieqwCUlK6w+0xrhb1zwn8gJ5xzQrMRPeYkRmbKPLfpxiTsnlOW9EYPdduHHPEm/loDuIttVBFn3MVRLjtbc5rqgYNNW/0tDVGATT4a3o+uNxozPa0KYaRJndqSb4eTKEDoqX7Va5mBqStp1vXDBlr5sRfDLtvKT99258x9CAunXdmfxFdPKsWIrzcmQ46GX5Nlb9SnDJjOg9DlqPHm1x2hxy8Noayj7bvLfhHCDqoK2+8ZXp2jHBeC1w8aa7QLIPu/qe/+pTv5YtFLyQ3arbkAE1giTGB6TATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IADUAYgBkADgAMQAyADAAYgAtADMANgA5AGMALQA0ADMANwBiAC0AYQAwAGMANQAtADEAMAA0AGEAZQA0ADgAMgAwADkAYQA1MHkGCSsGAQQBgjcRATFsHmoATQBpAGMAcgBvAHMAbwBmAHQAIABFAG4AaABhAG4AYwBlAGQAIABSAFMAQQAgAGEAbgBkACAAQQBFAFMAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMIID1wYJKoZIhvcNAQcGoIIDyDCCA8QCAQAwggO9BgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBBjAOBAi3qo5xx5MEbQICB9CAggOQKRze8YN0ekOkflggLqr0OVCbFjAIPdV+CHqxP4ThOKQE3uMPty3J9EfkO02rapSGXNIVI4ZslIEo575LKA2xgt70wFSccb7Ys7m2MNH2jLoRO1quYRUWdjyKQ4jNMmCTr+iPesq8P2wvxyi2VmaNHseaRK91neuw/kdCpVqncgVK3UPgew2fquyhX01B/FmFCGc4awJKWQCsY4DfW25OYiBLeMbW7OTSQGaHwxjMzmcGAzZrxGsP1kMg3OUzxuBeqZ5/xoN21TCRZeIhndBZUoMC6mi9UF3TZ7S37V4u2W6xHnbgyag/TSXsMewR1kR0a7c7r4xc9O7CsXNQNaLeRU+c5WLTY8Pt2WYNjTIz7LSXymPajk2sVO7aL4vjoum89DWM08KT2Yivpph0UE5btjigMSPE7h917kadE0wjwtEe8NhQO/W3LDP1isG/+v9ji65e7QKM8cpuM+iXN5AM+QzZ/GMjH2XUSYrmIlVYDgH5e94hAVBqjnJWU4TU2jXl3Daq+KmM8ggxpWza2w9o27xTpVeJG6W8MyVdYSC3FOtxjXAL9O9Ci4UcGcvsDRhuhnLOc8QnwYP641Yb5UaP9XUcrMdCx3DO0UqAFvfl65EV8StUjc4bRV6Wc7zU6sSorj7kfx4xcJaQgmD1GkM4yDyFbwiIEfWG8l0EbI8KxSpWXA7hvzOCUZVgdrIhtuDWcZFTsSXP0nUly77dyAxbp2dRyjjBj2dJxI3x3XR3PuZcxSH8gs4awX4aJpWqtxSP59WJD+cEoN9AjjQFwexYw+O99u6yGtpxJC84rgBrK5GTjfnK2GT0YclD6jcD9Ugp8ukvJmySZrtuUUMiPL2IVi9tboIAKjWMo1mJJbMSXqcY+BiyWC1t92X1s7OGZ/LPPFnJ1u6HB4LBBUmj+v3na8SqHk+RIx0mHcvR4TZYG0Vo8lqydwv1jVMBIOe6VfcOhiClKbk9GL07OAjbfsC5ihRXWeIl7hdHuHmAP0nZhBfQRfUTm7QE5u7al974+Ch5nboKGgX0bx7JzetoO01XIt1WkPjNX277NbSzObqPYSH8UPq3rqD5wSXH3zD9RR+IhLE9NXvlwTAeTqjl36nnCj5RoD3up/hjn7UMe2F8+g7glP226EkBdzGkXWXtYck8++aWHmXPKiSrIAs7RuLsvLvKPHrEEwvbcL3SEY4gugAVQ6o4GLc4zUPUA9nVW7LzMDcwHzAHBgUrDgMCGgQUfu1n/YOVnRDnGnjhY8nhcm41XTMEFJq69x6sHLkDlV/IhouBnAg7wSiG","contentType":"application/x-pkcs12","id":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/712e4ba9347c4bcb88a05b1864fdd4d7","managed":true,"attributes":{"enabled":true,"nbf":1579657580,"exp":1611280580,"created":1579658180,"updated":1579658180,"recoveryLevel":"Purgeable"},"kid":"https://sfrp-cli-kv-000002.vault.azure.net/keys/sfrp-cli-000003/712e4ba9347c4bcb88a05b1864fdd4d7"}'
+      string: '{"value":"MIIKTAIBAzCCCgwGCSqGSIb3DQEHAaCCCf0Eggn5MIIJ9TCCBhYGCSqGSIb3DQEHAaCCBgcEggYDMIIF/zCCBfsGCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAjDzVHO3nhKSgICB9AEggTYLqNEEyaq+3cV+riuu6m38pRg0aB634h2A3MpobITd2bPU26mQCjPCWUJyY8K8ugp6wvJODAofGrruDt5DUZS6zJLvnxA7w6FGsmHUpX/O6BWWE7BZvZ1be+bzmGPYqJ/a3uinVsaUZSkmZu2IoQEHWw6QSpIY/sRML5cTDXCTjusD9GyW7fBdIX8rlBIfJmFD0M/CpETwQj+UiOp2L2X1CFsrtBA1Zehuc6GNdNGBhE0li4b22UZInofwMSk1vuyuTrwM1gvHfwYkr1hh419qpyp8g9/M1LtDU9kEgsaDWLGxRSU9tYf5GZCfUkVDF/DYRrRkwjzdXtrP7AAqNDLPi9rvXEtr5ZCjTGqHEyudKUB0OZKxVxOmDLeSz3mf4f44RNJ9HNEEiaG2RzU7Twp4QoQgJU5M8BQY8o0XBRRH6tjDXd4U82gXHWD2+kvd/LemceX3WulCmS/k7//5z3tod0ji612YgNsfosfgjuy3gT+HPIY32FQu1elZA8HP47EUx2rF66aK+n+XiEW8/a61uBFeTF3nE2trjsRPjdbMN41kk+1kcWG4CdDrxEuuKOPvE1tDS1Bm8gxHRQpLdNc3yvp8nbZQ+t79WmYYbhiCAxZUo4Cg+dKBiNWCFT9/QVwT9+YSq1CVYxeEpYGCogDGZQXyNyYgB1orivG1lDXUju1/gD19xrM472sP27oHymFg6kuXhHHsGQmuXarg+bKsmIg0zINfGd4n50GEwaUkLjBIKJkQCkEf1QfsEymNZlL7/oeCOy37Mg2r/cXltWDh/YFSS5E0UT/kynhvHa+8lV8rNj3vmMfL5QPwlpH3ThsQZmoXpVkrmHUrRftUtgQhnmM6hi9ZDON4dNMwEZdieomfhQjarCjeVqJuObI/bJBkaTc/j1N2OGpjCmORPTuZ26mXLWFHoZ1cvJOpjZQXbVlqRdgwRrfzFqx0AABQwRxofeR2+pgik0RVeJZ49+KrBetVXlgXBMMq4HpJtoFAPZotf1IHG1DPmKemdqG4Y4mX9BZtTBkD/vdErGlyqWLbVGGqheXdguSt/1WycJynXonMZdhxUbqxMWC9iAWSsT2wsw6VZxYZta05ZLP4yio4IRg/zLpz59rlk9ovL+7XsqqphZiG3JIXQvJn7WRXrbdxDr8nf+upcdRKoYSpzED6ZOj33MGQSzWedVjbpsm8+oBU+JckRYocCBm3/L2cqioOBzjkdIYwss+VMZsnho4upabL+vrlOjOuI0yKjNGeQEnL9LT3sFVSow4G4cFZXTk6OaIUaVnjZ8wleVpEIKYqwKdk6Uv1ZNSnhq60R6iwe1oKQuxYrv6CjXubPpSsPtyutTPfkg1X1YNk70V24F0Mksty8ceyKIaeHUKJEe4zYOWddVZegcylV1JWKaPeDkjvdmXVq0R7mEsM0Tx6thHywzo4JQggivDssh9en4VBFxPMLVe0WKBgGCxYn2hBtn8Hk7bjeKm9WWJE53qiwO605ptE8e2jZcXZInILOgBI9HZ4sROBL8nUPZzIVaIftFTf+49yE7wgP92ihZzM20bndkwerxSp2xBrzCtumfVX87ruIXbPoMZrkiAME+2Nuj6WCToUGO4HuPOFj66CLdlyXiopiVc5zMmvtp6iiQafnSKQJMK2bV/TTGB6TATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IADcAOQA1ADIAYQAxAGMAMQAtAGQAZgA3AGIALQA0ADUANwAxAC0AOAAwADIAYgAtADAAMQBiADkAMwA5ADEAOQA5ADcAMAAwMHkGCSsGAQQBgjcRATFsHmoATQBpAGMAcgBvAHMAbwBmAHQAIABFAG4AaABhAG4AYwBlAGQAIABSAFMAQQAgAGEAbgBkACAAQQBFAFMAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMIID1wYJKoZIhvcNAQcGoIIDyDCCA8QCAQAwggO9BgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBBjAOBAhfcLw2aloGOgICB9CAggOQXZeMsiTCxqcGeI8lUNSJOenpDj3Ntt1fven/UF1+slq9Rc+Pinu2Qr7MTnr5QurRdZ1fLMa2v0ssiHJlkg7Fu5v1hv92o7JO8IMFsLS3Xiih54cjv06nxEd5rHtYcU7PjrZQODyyvNyRzBSovE/SF8liS9Ez+/uMYhMSufAxlwqZ5HqKq44uBqgN6DbIXpoOpBpToLIeyNvm5oZvFfyjEfBx/YR4qpjauYqamh48/pXjaGFZU44/chLSPJa/gwbRNsyJg69z5P5zQzylCWZhQCHANqE9JEWQzXSGhbbfdUMW8mpw97CAxq08005mwdZGU4CIKAJWYLioAHm7jfDtbzSwn6TQiGOqNx66itGtQJ0jbMqUPXnZymbjO8lcVOaRp24CeVAcqfe15n3TBFy/B01zUBQcuSe95EpN0QtpAeywDD9goO1DLL0I6t61cYCUz320h8gmkixS5PSrQj2cSaSOO9yif4Ge3EOjEaqgWtJm3q5GPZS8nkiv+s9WORmtzOd4LwKPxwmNszKpzq286nx7XF5cairs0WmXl969e1P9sRj+q49ZQoVwb2U5/oblFQplz1BXNY+ctOShHpvUvIDFLh95ehJGiuZalH5bgtwqkLPvdzeGlRfzVZkJ6OfweAUb3RegN6MylSPc0lEoa2RQWRlgAsWJq1U3qgxdeuUxGJdVoJiSAHp0bfhVyUSUUe3Cf2r5dAJI1sk5ifbwjRU7DKMzDE/Bjzk3DWREYJ4i4gywDJV34EI8T3idMXMvVBsDbOxYTYuJ6+/lPonsaiO0FrUfC+k4P4yAh3ABVQf815WiO+osB/Tw6XgpT6BItRIIuS5n0wb4qpvLbpd00UH/G31hrKQPQdntP9/n9LiPuFZqGECpNFWEkyuvjAFItbe/U8Y4iD4QM11bxbGuIqV1qMT2Y6VAeLaf7IVX/sbQ5huyVP38XpoVy0O6D48QTqY9QUzp3SmJ3rlSxhAAY2JcPxzYI1xRgi81/0q8mP+Djj68oUSmNPOpVG8u2eDMQ452kllBa9fLbN4xmSLYSzebQu+75YOQHVEcnJFFUsfSGtSSJBjkEOPfxB09u2J4he+e5Ri0gIuqDOULTv+fuO8mVukPoncd+l8YOrlrHmZgnaKqZSfvQfp2TXDSKfFJLaVt3yzcMqxx226BZ3yANyEOvnqn4llsByMlnv+qdHd+kbhgWmCX3cnyF+OgHVtTMDcwHzAHBgUrDgMCGgQU3GljWcZeomPm+0fJd8mFFX4o6vEEFLkMpqVhsVkzxkQOS/PVMG7Pom49","contentType":"application/x-pkcs12","id":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/ba42565a892846e19608eaca3790c3f8","managed":true,"attributes":{"enabled":true,"nbf":1586226697,"exp":1617763297,"created":1586227297,"updated":1586227297,"recoveryLevel":"Recoverable+Purgeable"},"kid":"https://sfrp-cli-kv-000002.vault.azure.net/keys/sfrp-cli-000003/ba42565a892846e19608eaca3790c3f8"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3960'
+      - '3972'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:26 GMT
+      - Tue, 07 Apr 2020 02:41:47 GMT
       expires:
       - '-1'
       pragma:
@@ -767,11 +929,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=131.107.159.235;act_addr_fam=InterNetwork;
+      - addr=131.107.160.208;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westus
       x-ms-keyvault-service-version:
-      - 1.1.0.891
+      - 1.1.0.898
       x-powered-by:
       - ASP.NET
     status:
@@ -988,8 +1150,8 @@ interactions:
       "vmImageSku": {"value": "2016-Datacenter"}, "vmImageVersion": {"value": "latest"},
       "loadBalancedAppPort1": {"value": 80}, "loadBalancedAppPort2": {"value": 8081},
       "certificateStorevalue": {"value": "My"}, "certificateThumbprint": {"value":
-      "E620D6AF4A58F0945D5D06778CAA215E113112DA"}, "sourceVaultvalue": {"value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002"},
-      "certificateUrlvalue": {"value": "https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/712e4ba9347c4bcb88a05b1864fdd4d7"},
+      "0CAB0E5F8479143619BCDB7C96D5E0DC2967206A"}, "sourceVaultvalue": {"value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002"},
+      "certificateUrlvalue": {"value": "https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/ba42565a892846e19608eaca3790c3f8"},
       "clusterProtectionLevel": {"value": "EncryptAndSign"}, "storageAccountType":
       {"value": "Standard_LRS"}, "supportLogStorageAccountType": {"value": "Standard_LRS"},
       "applicationDiagnosticsStorageAccountType": {"value": "Standard_LRS"}, "nt0InstanceCount":
@@ -1012,14 +1174,14 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202001211756","name":"AzurePSDeployment-202001211756","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17577236477356496805","parameters":{"clusterLocation":{"type":"String","value":"westus"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"adminUserName":{"type":"String","value":"adminuser"},"durabilityLevel":{"type":"String","value":"Bronze"},"reliabilityLevel":{"type":"String","value":"Bronze"},"adminPassword":{"type":"SecureString"},"vmImagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"vmImageOffer":{"type":"String","value":"WindowsServer"},"vmImageSku":{"type":"String","value":"2016-Datacenter"},"vmSku":{"type":"String","value":"Standard_D2_V2"},"vmImageVersion":{"type":"String","value":"latest"},"loadBalancedAppPort1":{"type":"Int","value":80},"loadBalancedAppPort2":{"type":"Int","value":8081},"certificateStoreValue":{"type":"String","value":"My"},"certificateThumbprint":{"type":"String","value":"E620D6AF4A58F0945D5D06778CAA215E113112DA"},"sourceVaultValue":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002"},"certificateUrlValue":{"type":"String","value":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/712e4ba9347c4bcb88a05b1864fdd4d7"},"clusterProtectionLevel":{"type":"String","value":"EncryptAndSign"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"supportLogStorageAccountType":{"type":"String","value":"Standard_LRS"},"applicationDiagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"nt0InstanceCount":{"type":"Int","value":3}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-01-22T01:56:23.0007199Z","duration":"PT0S","correlationId":"91f4eabd-ebd2-4c7c-8abe-a6f4054b1f88","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]},{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"VNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/a2wjyals4we6e3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"a2wjyals4we6e3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2","actionName":"listKeys","apiVersion":"2015-05-01-preview"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/a2wjyals4we6e3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"a2wjyals4we6e3","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/nt1vm","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2","apiVersion":"2016-01-01"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"}],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/a2wjyals4we6e3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202004061941","name":"AzurePSDeployment-202004061941","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17577236477356496805","parameters":{"clusterLocation":{"type":"String","value":"westus"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"adminUserName":{"type":"String","value":"adminuser"},"durabilityLevel":{"type":"String","value":"Bronze"},"reliabilityLevel":{"type":"String","value":"Bronze"},"adminPassword":{"type":"SecureString"},"vmImagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"vmImageOffer":{"type":"String","value":"WindowsServer"},"vmImageSku":{"type":"String","value":"2016-Datacenter"},"vmSku":{"type":"String","value":"Standard_D2_V2"},"vmImageVersion":{"type":"String","value":"latest"},"loadBalancedAppPort1":{"type":"Int","value":80},"loadBalancedAppPort2":{"type":"Int","value":8081},"certificateStoreValue":{"type":"String","value":"My"},"certificateThumbprint":{"type":"String","value":"0CAB0E5F8479143619BCDB7C96D5E0DC2967206A"},"sourceVaultValue":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002"},"certificateUrlValue":{"type":"String","value":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/ba42565a892846e19608eaca3790c3f8"},"clusterProtectionLevel":{"type":"String","value":"EncryptAndSign"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"supportLogStorageAccountType":{"type":"String","value":"Standard_LRS"},"applicationDiagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"nt0InstanceCount":{"type":"Int","value":3}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-04-07T02:41:48.0162659Z","duration":"PT0S","correlationId":"fc5cd756-d12d-4dd1-82fd-5f189924511a","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]},{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"VNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/uvpemtvelhiye3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"uvpemtvelhiye3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2","actionName":"listKeys","apiVersion":"2015-05-01-preview"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/uvpemtvelhiye3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"uvpemtvelhiye3","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/nt1vm","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2","apiVersion":"2016-01-01"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"}],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/uvpemtvelhiye3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004"}]}}'
     headers:
       cache-control:
       - no-cache
@@ -1028,7 +1190,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:23 GMT
+      - Tue, 07 Apr 2020 02:41:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1257,8 +1419,8 @@ interactions:
       "vmImageSku": {"value": "2016-Datacenter"}, "vmImageVersion": {"value": "latest"},
       "loadBalancedAppPort1": {"value": 80}, "loadBalancedAppPort2": {"value": 8081},
       "certificateStorevalue": {"value": "My"}, "certificateThumbprint": {"value":
-      "E620D6AF4A58F0945D5D06778CAA215E113112DA"}, "sourceVaultvalue": {"value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002"},
-      "certificateUrlvalue": {"value": "https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/712e4ba9347c4bcb88a05b1864fdd4d7"},
+      "0CAB0E5F8479143619BCDB7C96D5E0DC2967206A"}, "sourceVaultvalue": {"value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002"},
+      "certificateUrlvalue": {"value": "https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/ba42565a892846e19608eaca3790c3f8"},
       "clusterProtectionLevel": {"value": "EncryptAndSign"}, "storageAccountType":
       {"value": "Standard_LRS"}, "supportLogStorageAccountType": {"value": "Standard_LRS"},
       "applicationDiagnosticsStorageAccountType": {"value": "Standard_LRS"}, "nt0InstanceCount":
@@ -1281,17 +1443,17 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202001211756","name":"AzurePSDeployment-202001211756","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17577236477356496805","parameters":{"clusterLocation":{"type":"String","value":"westus"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"adminUserName":{"type":"String","value":"adminuser"},"durabilityLevel":{"type":"String","value":"Bronze"},"reliabilityLevel":{"type":"String","value":"Bronze"},"adminPassword":{"type":"SecureString"},"vmImagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"vmImageOffer":{"type":"String","value":"WindowsServer"},"vmImageSku":{"type":"String","value":"2016-Datacenter"},"vmSku":{"type":"String","value":"Standard_D2_V2"},"vmImageVersion":{"type":"String","value":"latest"},"loadBalancedAppPort1":{"type":"Int","value":80},"loadBalancedAppPort2":{"type":"Int","value":8081},"certificateStoreValue":{"type":"String","value":"My"},"certificateThumbprint":{"type":"String","value":"E620D6AF4A58F0945D5D06778CAA215E113112DA"},"sourceVaultValue":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002"},"certificateUrlValue":{"type":"String","value":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/712e4ba9347c4bcb88a05b1864fdd4d7"},"clusterProtectionLevel":{"type":"String","value":"EncryptAndSign"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"supportLogStorageAccountType":{"type":"String","value":"Standard_LRS"},"applicationDiagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"nt0InstanceCount":{"type":"Int","value":3}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-01-22T01:56:29.4068615Z","duration":"PT0.867457S","correlationId":"6f2b4c0c-ce9b-46fb-a457-557b05efb723","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]},{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"VNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/a2wjyals4we6e3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"a2wjyals4we6e3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2","actionName":"listKeys","apiVersion":"2015-05-01-preview"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/a2wjyals4we6e3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"a2wjyals4we6e3","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/nt1vm","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2","apiVersion":"2016-01-01"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202004061941","name":"AzurePSDeployment-202004061941","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17577236477356496805","parameters":{"clusterLocation":{"type":"String","value":"westus"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"adminUserName":{"type":"String","value":"adminuser"},"durabilityLevel":{"type":"String","value":"Bronze"},"reliabilityLevel":{"type":"String","value":"Bronze"},"adminPassword":{"type":"SecureString"},"vmImagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"vmImageOffer":{"type":"String","value":"WindowsServer"},"vmImageSku":{"type":"String","value":"2016-Datacenter"},"vmSku":{"type":"String","value":"Standard_D2_V2"},"vmImageVersion":{"type":"String","value":"latest"},"loadBalancedAppPort1":{"type":"Int","value":80},"loadBalancedAppPort2":{"type":"Int","value":8081},"certificateStoreValue":{"type":"String","value":"My"},"certificateThumbprint":{"type":"String","value":"0CAB0E5F8479143619BCDB7C96D5E0DC2967206A"},"sourceVaultValue":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002"},"certificateUrlValue":{"type":"String","value":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/ba42565a892846e19608eaca3790c3f8"},"clusterProtectionLevel":{"type":"String","value":"EncryptAndSign"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"supportLogStorageAccountType":{"type":"String","value":"Standard_LRS"},"applicationDiagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"nt0InstanceCount":{"type":"Int","value":3}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-04-07T02:41:49.8743318Z","duration":"PT0.622596S","correlationId":"fdf38029-a618-46f9-897e-050180ff0914","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]},{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"VNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/uvpemtvelhiye3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"uvpemtvelhiye3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2","actionName":"listKeys","apiVersion":"2015-05-01-preview"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/uvpemtvelhiye3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"uvpemtvelhiye3","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/nt1vm","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2","apiVersion":"2016-01-01"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202001211756/operationStatuses/08586219486969382848?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202004061941/operationStatuses/08586153795762259479?api-version=2019-07-01
       cache-control:
       - no-cache
       content-length:
@@ -1299,7 +1461,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:29 GMT
+      - Tue, 07 Apr 2020 02:41:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1328,9 +1490,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1342,7 +1504,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:56:58 GMT
+      - Tue, 07 Apr 2020 02:42:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1371,9 +1533,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1385,7 +1547,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:57:28 GMT
+      - Tue, 07 Apr 2020 02:42:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1414,9 +1576,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1428,7 +1590,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:57:59 GMT
+      - Tue, 07 Apr 2020 02:43:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1457,9 +1619,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1471,7 +1633,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:58:29 GMT
+      - Tue, 07 Apr 2020 02:43:50 GMT
       expires:
       - '-1'
       pragma:
@@ -1500,9 +1662,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1514,7 +1676,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:58:59 GMT
+      - Tue, 07 Apr 2020 02:44:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1543,9 +1705,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1557,7 +1719,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:59:29 GMT
+      - Tue, 07 Apr 2020 02:44:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1586,9 +1748,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1600,7 +1762,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 01:59:59 GMT
+      - Tue, 07 Apr 2020 02:45:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1629,9 +1791,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1643,7 +1805,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:00:29 GMT
+      - Tue, 07 Apr 2020 02:45:50 GMT
       expires:
       - '-1'
       pragma:
@@ -1672,9 +1834,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1686,7 +1848,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:00:59 GMT
+      - Tue, 07 Apr 2020 02:46:20 GMT
       expires:
       - '-1'
       pragma:
@@ -1715,9 +1877,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1729,7 +1891,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:01:29 GMT
+      - Tue, 07 Apr 2020 02:46:50 GMT
       expires:
       - '-1'
       pragma:
@@ -1758,9 +1920,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1772,7 +1934,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:01:59 GMT
+      - Tue, 07 Apr 2020 02:47:20 GMT
       expires:
       - '-1'
       pragma:
@@ -1801,9 +1963,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1815,7 +1977,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:02:30 GMT
+      - Tue, 07 Apr 2020 02:47:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1844,9 +2006,9 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219486969382848?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153795762259479?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1858,7 +2020,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:02:59 GMT
+      - Tue, 07 Apr 2020 02:48:20 GMT
       expires:
       - '-1'
       pragma:
@@ -1887,21 +2049,21 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202001211756","name":"AzurePSDeployment-202001211756","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17577236477356496805","parameters":{"clusterLocation":{"type":"String","value":"westus"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"adminUserName":{"type":"String","value":"adminuser"},"durabilityLevel":{"type":"String","value":"Bronze"},"reliabilityLevel":{"type":"String","value":"Bronze"},"adminPassword":{"type":"SecureString"},"vmImagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"vmImageOffer":{"type":"String","value":"WindowsServer"},"vmImageSku":{"type":"String","value":"2016-Datacenter"},"vmSku":{"type":"String","value":"Standard_D2_V2"},"vmImageVersion":{"type":"String","value":"latest"},"loadBalancedAppPort1":{"type":"Int","value":80},"loadBalancedAppPort2":{"type":"Int","value":8081},"certificateStoreValue":{"type":"String","value":"My"},"certificateThumbprint":{"type":"String","value":"E620D6AF4A58F0945D5D06778CAA215E113112DA"},"sourceVaultValue":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002"},"certificateUrlValue":{"type":"String","value":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/712e4ba9347c4bcb88a05b1864fdd4d7"},"clusterProtectionLevel":{"type":"String","value":"EncryptAndSign"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"supportLogStorageAccountType":{"type":"String","value":"Standard_LRS"},"applicationDiagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"nt0InstanceCount":{"type":"Int","value":3}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-01-22T02:02:41.4041743Z","duration":"PT6M12.8647698S","correlationId":"6f2b4c0c-ce9b-46fb-a457-557b05efb723","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]},{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"VNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/a2wjyals4we6e3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"a2wjyals4we6e3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2","actionName":"listKeys","apiVersion":"2015-05-01-preview"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/a2wjyals4we6e3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"a2wjyals4we6e3","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/nt1vm","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsa2wjyals4we6e2","apiVersion":"2016-01-01"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"}],"outputs":{"clusterProperties":{"type":"Object","value":{"provisioningState":"Succeeded","clusterId":"dd19ad06-bd62-4de6-8054-62884e031001","clusterCodeVersion":"6.5.676.9590","clusterState":"WaitingForNodes","managementEndpoint":"https://sfrp-cli-000004.westus.cloudapp.azure.com:19080","clusterEndpoint":"https://westus.servicefabric.azure.com/runtime/clusters/dd19ad06-bd62-4de6-8054-62884e031001","certificate":{"thumbprint":"E620D6AF4A58F0945D5D06778CAA215E113112DA","x509StoreName":"My"},"clientCertificateThumbprints":[],"clientCertificateCommonNames":[],"fabricSettings":[{"name":"Security","parameters":[{"name":"ClusterProtectionLevel","value":"EncryptAndSign"}]}],"vmImage":"Windows","reliabilityLevel":"Bronze","nodeTypes":[{"name":"nt1vm","vmInstanceCount":3,"clientConnectionEndpointPort":19000,"httpGatewayEndpointPort":19080,"applicationPorts":{"startPort":20000,"endPort":30000},"ephemeralPorts":{"startPort":49152,"endPort":65534},"isPrimary":true,"durabilityLevel":"Bronze"}],"diagnosticsStorageAccountConfig":{"storageAccountName":"sflogsa2wjyals4we6e2","primaryAccessKey":"","secondaryAccessKey":"","protectedAccountKeyName":"StorageAccountKey1","blobEndpoint":"https://sflogsa2wjyals4we6e2.blob.core.windows.net/","queueEndpoint":"https://sflogsa2wjyals4we6e2.queue.core.windows.net/","tableEndpoint":"https://sflogsa2wjyals4we6e2.table.core.windows.net/"},"upgradeMode":"Automatic","availableClusterVersions":[{"codeVersion":"6.5.676.9590","supportExpiryUtc":"2020-05-01T00:00:00","environment":"Windows"},{"codeVersion":"7.0.457.9590","supportExpiryUtc":"9999-12-31T23:59:59.9999999","environment":"Windows"}],"addonFeatures":["DnsService"]}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/a2wjyals4we6e3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsa2wjyals4we6e2"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202004061941","name":"AzurePSDeployment-202004061941","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17577236477356496805","parameters":{"clusterLocation":{"type":"String","value":"westus"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"adminUserName":{"type":"String","value":"adminuser"},"durabilityLevel":{"type":"String","value":"Bronze"},"reliabilityLevel":{"type":"String","value":"Bronze"},"adminPassword":{"type":"SecureString"},"vmImagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"vmImageOffer":{"type":"String","value":"WindowsServer"},"vmImageSku":{"type":"String","value":"2016-Datacenter"},"vmSku":{"type":"String","value":"Standard_D2_V2"},"vmImageVersion":{"type":"String","value":"latest"},"loadBalancedAppPort1":{"type":"Int","value":80},"loadBalancedAppPort2":{"type":"Int","value":8081},"certificateStoreValue":{"type":"String","value":"My"},"certificateThumbprint":{"type":"String","value":"0CAB0E5F8479143619BCDB7C96D5E0DC2967206A"},"sourceVaultValue":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002"},"certificateUrlValue":{"type":"String","value":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000003/ba42565a892846e19608eaca3790c3f8"},"clusterProtectionLevel":{"type":"String","value":"EncryptAndSign"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"supportLogStorageAccountType":{"type":"String","value":"Standard_LRS"},"applicationDiagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"nt0InstanceCount":{"type":"Int","value":3}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-04-07T02:48:05.0165304Z","duration":"PT6M15.7647946S","correlationId":"fdf38029-a618-46f9-897e-050180ff0914","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]},{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"VNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm","resourceType":"Microsoft.Network/loadBalancers","resourceName":"LB-sfrp-cli-000004-nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/uvpemtvelhiye3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"uvpemtvelhiye3"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2","actionName":"listKeys","apiVersion":"2015-05-01-preview"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/uvpemtvelhiye3","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"uvpemtvelhiye3","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/nt1vm","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"nt1vm"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"sflogsuvpemtvelhiye2","apiVersion":"2016-01-01"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"PublicIP-LB-FE-0"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004","resourceType":"Microsoft.ServiceFabric/clusters","resourceName":"sfrp-cli-000004"}],"outputs":{"clusterProperties":{"type":"Object","value":{"provisioningState":"Succeeded","clusterId":"138c17d2-0aba-4d57-ba51-f5b26dfcb72b","clusterCodeVersion":"7.0.470.9590","clusterState":"WaitingForNodes","managementEndpoint":"https://sfrp-cli-000004.westus.cloudapp.azure.com:19080","clusterEndpoint":"https://westus.servicefabric.azure.com/runtime/clusters/138c17d2-0aba-4d57-ba51-f5b26dfcb72b","certificate":{"thumbprint":"0CAB0E5F8479143619BCDB7C96D5E0DC2967206A","x509StoreName":"My"},"clientCertificateThumbprints":[],"clientCertificateCommonNames":[],"fabricSettings":[{"name":"Security","parameters":[{"name":"ClusterProtectionLevel","value":"EncryptAndSign"}]}],"vmImage":"Windows","reliabilityLevel":"Bronze","nodeTypes":[{"name":"nt1vm","vmInstanceCount":3,"clientConnectionEndpointPort":19000,"httpGatewayEndpointPort":19080,"applicationPorts":{"startPort":20000,"endPort":30000},"ephemeralPorts":{"startPort":49152,"endPort":65534},"isPrimary":true,"durabilityLevel":"Bronze"}],"diagnosticsStorageAccountConfig":{"storageAccountName":"sflogsuvpemtvelhiye2","primaryAccessKey":"","secondaryAccessKey":"","protectedAccountKeyName":"StorageAccountKey1","blobEndpoint":"https://sflogsuvpemtvelhiye2.blob.core.windows.net/","queueEndpoint":"https://sflogsuvpemtvelhiye2.queue.core.windows.net/","tableEndpoint":"https://sflogsuvpemtvelhiye2.table.core.windows.net/"},"upgradeMode":"Automatic","availableClusterVersions":[{"codeVersion":"7.0.470.9590","supportExpiryUtc":"9999-12-31T23:59:59.9999999","environment":"Windows"}],"addonFeatures":["DnsService"]}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachineScaleSets/nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/loadBalancers/LB-sfrp-cli-000004-nt1vm"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/PublicIP-LB-FE-0"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/VNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/sflogsuvpemtvelhiye2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/uvpemtvelhiye3"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '10394'
+      - '10298'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:02:59 GMT
+      - Tue, 07 Apr 2020 02:48:20 GMT
       expires:
       - '-1'
       pragma:
@@ -1930,7 +2092,7 @@ interactions:
       - -g -c -l --secret-identifier --vm-password --cluster-size
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -1941,12 +2103,12 @@ interactions:
         \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004\",\r\n
         \ \"name\": \"sfrp-cli-000004\",\r\n  \"tags\": {\r\n    \"resourceType\":
         \"Service Fabric\",\r\n    \"clusterName\": \"sfrp-cli-000004\"\r\n  },\r\n
-        \ \"etag\": \"W/\\\"637152550718733498\\\"\",\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"clusterId\": \"dd19ad06-bd62-4de6-8054-62884e031001\",\r\n
-        \   \"clusterCodeVersion\": \"6.5.676.9590\",\r\n    \"clusterState\": \"Deploying\",\r\n
+        \ \"etag\": \"W/\\\"637218241911731092\\\"\",\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"clusterId\": \"138c17d2-0aba-4d57-ba51-f5b26dfcb72b\",\r\n
+        \   \"clusterCodeVersion\": \"7.0.470.9590\",\r\n    \"clusterState\": \"Deploying\",\r\n
         \   \"managementEndpoint\": \"https://sfrp-cli-000004.westus.cloudapp.azure.com:19080\",\r\n
-        \   \"clusterEndpoint\": \"https://westus.servicefabric.azure.com/runtime/clusters/dd19ad06-bd62-4de6-8054-62884e031001\",\r\n
-        \   \"certificate\": {\r\n      \"thumbprint\": \"E620D6AF4A58F0945D5D06778CAA215E113112DA\",\r\n
+        \   \"clusterEndpoint\": \"https://westus.servicefabric.azure.com/runtime/clusters/138c17d2-0aba-4d57-ba51-f5b26dfcb72b\",\r\n
+        \   \"certificate\": {\r\n      \"thumbprint\": \"0CAB0E5F8479143619BCDB7C96D5E0DC2967206A\",\r\n
         \     \"x509StoreName\": \"My\"\r\n    },\r\n    \"clientCertificateThumbprints\":
         [],\r\n    \"clientCertificateCommonNames\": [],\r\n    \"fabricSettings\":
         [\r\n      {\r\n        \"name\": \"Security\",\r\n        \"parameters\":
@@ -1960,27 +2122,25 @@ interactions:
         \       \"ephemeralPorts\": {\r\n          \"startPort\": 49152,\r\n          \"endPort\":
         65534\r\n        },\r\n        \"isPrimary\": true,\r\n        \"durabilityLevel\":
         \"Bronze\"\r\n      }\r\n    ],\r\n    \"diagnosticsStorageAccountConfig\":
-        {\r\n      \"storageAccountName\": \"sflogsa2wjyals4we6e2\",\r\n      \"primaryAccessKey\":
+        {\r\n      \"storageAccountName\": \"sflogsuvpemtvelhiye2\",\r\n      \"primaryAccessKey\":
         \"\",\r\n      \"secondaryAccessKey\": \"\",\r\n      \"protectedAccountKeyName\":
-        \"StorageAccountKey1\",\r\n      \"blobEndpoint\": \"https://sflogsa2wjyals4we6e2.blob.core.windows.net/\",\r\n
-        \     \"queueEndpoint\": \"https://sflogsa2wjyals4we6e2.queue.core.windows.net/\",\r\n
-        \     \"tableEndpoint\": \"https://sflogsa2wjyals4we6e2.table.core.windows.net/\"\r\n
+        \"StorageAccountKey1\",\r\n      \"blobEndpoint\": \"https://sflogsuvpemtvelhiye2.blob.core.windows.net/\",\r\n
+        \     \"queueEndpoint\": \"https://sflogsuvpemtvelhiye2.queue.core.windows.net/\",\r\n
+        \     \"tableEndpoint\": \"https://sflogsuvpemtvelhiye2.table.core.windows.net/\"\r\n
         \   },\r\n    \"upgradeMode\": \"Automatic\",\r\n    \"addonFeatures\": [\r\n
         \     \"DnsService\"\r\n    ],\r\n    \"availableClusterVersions\": [\r\n
-        \     {\r\n        \"codeVersion\": \"6.5.676.9590\",\r\n        \"supportExpiryUtc\":
-        \"2020-05-01T00:00:00\",\r\n        \"environment\": \"Windows\"\r\n      },\r\n
-        \     {\r\n        \"codeVersion\": \"7.0.457.9590\",\r\n        \"supportExpiryUtc\":
+        \     {\r\n        \"codeVersion\": \"7.0.470.9590\",\r\n        \"supportExpiryUtc\":
         \"9999-12-31T23:59:59.9999999\",\r\n        \"environment\": \"Windows\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2736'
+      - '2591'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:01 GMT
+      - Tue, 07 Apr 2020 02:48:21 GMT
       expires:
       - '-1'
       pragma:
@@ -2014,7 +2174,7 @@ interactions:
       - -g -c
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -2025,12 +2185,12 @@ interactions:
         \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004\",\r\n
         \ \"name\": \"sfrp-cli-000004\",\r\n  \"tags\": {\r\n    \"resourceType\":
         \"Service Fabric\",\r\n    \"clusterName\": \"sfrp-cli-000004\"\r\n  },\r\n
-        \ \"etag\": \"W/\\\"637152550718733498\\\"\",\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"clusterId\": \"dd19ad06-bd62-4de6-8054-62884e031001\",\r\n
-        \   \"clusterCodeVersion\": \"6.5.676.9590\",\r\n    \"clusterState\": \"Deploying\",\r\n
+        \ \"etag\": \"W/\\\"637218241911731092\\\"\",\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"clusterId\": \"138c17d2-0aba-4d57-ba51-f5b26dfcb72b\",\r\n
+        \   \"clusterCodeVersion\": \"7.0.470.9590\",\r\n    \"clusterState\": \"Deploying\",\r\n
         \   \"managementEndpoint\": \"https://sfrp-cli-000004.westus.cloudapp.azure.com:19080\",\r\n
-        \   \"clusterEndpoint\": \"https://westus.servicefabric.azure.com/runtime/clusters/dd19ad06-bd62-4de6-8054-62884e031001\",\r\n
-        \   \"certificate\": {\r\n      \"thumbprint\": \"E620D6AF4A58F0945D5D06778CAA215E113112DA\",\r\n
+        \   \"clusterEndpoint\": \"https://westus.servicefabric.azure.com/runtime/clusters/138c17d2-0aba-4d57-ba51-f5b26dfcb72b\",\r\n
+        \   \"certificate\": {\r\n      \"thumbprint\": \"0CAB0E5F8479143619BCDB7C96D5E0DC2967206A\",\r\n
         \     \"x509StoreName\": \"My\"\r\n    },\r\n    \"clientCertificateThumbprints\":
         [],\r\n    \"clientCertificateCommonNames\": [],\r\n    \"fabricSettings\":
         [\r\n      {\r\n        \"name\": \"Security\",\r\n        \"parameters\":
@@ -2044,27 +2204,25 @@ interactions:
         \       \"ephemeralPorts\": {\r\n          \"startPort\": 49152,\r\n          \"endPort\":
         65534\r\n        },\r\n        \"isPrimary\": true,\r\n        \"durabilityLevel\":
         \"Bronze\"\r\n      }\r\n    ],\r\n    \"diagnosticsStorageAccountConfig\":
-        {\r\n      \"storageAccountName\": \"sflogsa2wjyals4we6e2\",\r\n      \"primaryAccessKey\":
+        {\r\n      \"storageAccountName\": \"sflogsuvpemtvelhiye2\",\r\n      \"primaryAccessKey\":
         \"\",\r\n      \"secondaryAccessKey\": \"\",\r\n      \"protectedAccountKeyName\":
-        \"StorageAccountKey1\",\r\n      \"blobEndpoint\": \"https://sflogsa2wjyals4we6e2.blob.core.windows.net/\",\r\n
-        \     \"queueEndpoint\": \"https://sflogsa2wjyals4we6e2.queue.core.windows.net/\",\r\n
-        \     \"tableEndpoint\": \"https://sflogsa2wjyals4we6e2.table.core.windows.net/\"\r\n
+        \"StorageAccountKey1\",\r\n      \"blobEndpoint\": \"https://sflogsuvpemtvelhiye2.blob.core.windows.net/\",\r\n
+        \     \"queueEndpoint\": \"https://sflogsuvpemtvelhiye2.queue.core.windows.net/\",\r\n
+        \     \"tableEndpoint\": \"https://sflogsuvpemtvelhiye2.table.core.windows.net/\"\r\n
         \   },\r\n    \"upgradeMode\": \"Automatic\",\r\n    \"addonFeatures\": [\r\n
         \     \"DnsService\"\r\n    ],\r\n    \"availableClusterVersions\": [\r\n
-        \     {\r\n        \"codeVersion\": \"6.5.676.9590\",\r\n        \"supportExpiryUtc\":
-        \"2020-05-01T00:00:00\",\r\n        \"environment\": \"Windows\"\r\n      },\r\n
-        \     {\r\n        \"codeVersion\": \"7.0.457.9590\",\r\n        \"supportExpiryUtc\":
+        \     {\r\n        \"codeVersion\": \"7.0.470.9590\",\r\n        \"supportExpiryUtc\":
         \"9999-12-31T23:59:59.9999999\",\r\n        \"environment\": \"Windows\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2736'
+      - '2591'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:02 GMT
+      - Tue, 07 Apr 2020 02:48:21 GMT
       expires:
       - '-1'
       pragma:
@@ -2098,7 +2256,7 @@ interactions:
       - -g -c
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -2114,7 +2272,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:02 GMT
+      - Tue, 07 Apr 2020 02:48:21 GMT
       expires:
       - '-1'
       pragma:
@@ -2148,7 +2306,7 @@ interactions:
       - -g -c --application-type-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -2164,7 +2322,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:02 GMT
+      - Tue, 07 Apr 2020 02:48:21 GMT
       expires:
       - '-1'
       pragma:
@@ -2202,7 +2360,7 @@ interactions:
       - -g -c --application-type-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: PUT
@@ -2211,7 +2369,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp\",\r\n
-        \ \"name\": \"CalcServiceApp\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152553833693421\\\"\",\r\n
+        \ \"name\": \"CalcServiceApp\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218245028516650\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}"
     headers:
       cache-control:
@@ -2221,7 +2379,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:02 GMT
+      - Tue, 07 Apr 2020 02:48:22 GMT
       expires:
       - '-1'
       pragma:
@@ -2257,7 +2415,7 @@ interactions:
       - -g -c --application-type-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -2266,7 +2424,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp\",\r\n
-        \ \"name\": \"CalcServiceApp\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152553833693421\\\"\",\r\n
+        \ \"name\": \"CalcServiceApp\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218245028516650\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}"
     headers:
       cache-control:
@@ -2276,7 +2434,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:03 GMT
+      - Tue, 07 Apr 2020 02:48:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2312,7 +2470,7 @@ interactions:
       - -g -c --application-type-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: DELETE
@@ -2324,7 +2482,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 22 Jan 2020 02:03:03 GMT
+      - Tue, 07 Apr 2020 02:48:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2356,7 +2514,7 @@ interactions:
       - -g -c --application-type-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -2364,7 +2522,7 @@ interactions:
   response:
     body:
       string: "{\r\n  \"error\": {\r\n    \"code\": \"NotFound\",\r\n    \"message\":
-        \"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CLITEST.RGRIUQXJRYFGKLK2DBAI3Q3SSHD6DQL5MMVQ4WDAXSBFOHD4LE7ZU73VTNXEH5DRWP2/providers/Microsoft.ServiceFabric/clusters/SFRP-CLI-3IHN3UH2AS35AVW/applicationTypes/CALCSERVICEAPP
+        \"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CLITEST.RGBIDHID7IZ6IK5DRYTYPKOR7IYAML7DOMICJMEVYWMARK7DZAAAJ6C5FQEAPSEZHT6/providers/Microsoft.ServiceFabric/clusters/SFRP-CLI-KKQSDG7HQVKGSDM/applicationTypes/CALCSERVICEAPP
         not found.\",\r\n    \"details\": []\r\n  }\r\n}"
     headers:
       cache-control:
@@ -2374,7 +2532,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:04 GMT
+      - Tue, 07 Apr 2020 02:48:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2404,7 +2562,7 @@ interactions:
       - -g -c --application-type-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -2420,7 +2578,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:05 GMT
+      - Tue, 07 Apr 2020 02:48:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2454,7 +2612,7 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -2470,7 +2628,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:05 GMT
+      - Tue, 07 Apr 2020 02:48:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2508,7 +2666,7 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: PUT
@@ -2517,7 +2675,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp\",\r\n
-        \ \"name\": \"CalcServiceApp\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152553864323626\\\"\",\r\n
+        \ \"name\": \"CalcServiceApp\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218245050704410\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}"
     headers:
       cache-control:
@@ -2527,7 +2685,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:05 GMT
+      - Tue, 07 Apr 2020 02:48:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2563,7 +2721,7 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -2579,7 +2737,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:05 GMT
+      - Tue, 07 Apr 2020 02:48:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2617,7 +2775,7 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: PUT
@@ -2626,13 +2784,13 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.0\",\r\n
-        \ \"name\": \"1.0\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152553867292279\\\"\",\r\n
+        \ \"name\": \"1.0\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218245053516898\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"appPackageUrl\":
         \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.0.sfpkg\",\r\n
         \   \"defaultParameterList\": {}\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b?api-version=2019-03-01
       cache-control:
       - no-cache
       content-length:
@@ -2640,11 +2798,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:03:06 GMT
+      - Tue, 07 Apr 2020 02:48:25 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/14c14348-7434-4e49-98dd-cc820664034b?api-version=2019-03-01
       pragma:
       - no-cache
       server:
@@ -2674,14 +2832,14 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b\",\r\n
+        \ \"name\": \"14c14348-7434-4e49-98dd-cc820664034b\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T02:48:25.3516898Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -2691,7 +2849,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:04:06 GMT
+      - Tue, 07 Apr 2020 02:49:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2725,14 +2883,14 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b\",\r\n
+        \ \"name\": \"14c14348-7434-4e49-98dd-cc820664034b\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T02:48:25.3516898Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -2742,7 +2900,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:04:36 GMT
+      - Tue, 07 Apr 2020 02:49:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2776,14 +2934,14 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b\",\r\n
+        \ \"name\": \"14c14348-7434-4e49-98dd-cc820664034b\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T02:48:25.3516898Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -2793,7 +2951,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:05:06 GMT
+      - Tue, 07 Apr 2020 02:50:25 GMT
       expires:
       - '-1'
       pragma:
@@ -2827,14 +2985,14 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b\",\r\n
+        \ \"name\": \"14c14348-7434-4e49-98dd-cc820664034b\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T02:48:25.3516898Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -2844,7 +3002,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:05:37 GMT
+      - Tue, 07 Apr 2020 02:50:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2878,14 +3036,14 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b\",\r\n
+        \ \"name\": \"14c14348-7434-4e49-98dd-cc820664034b\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T02:48:25.3516898Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -2895,7 +3053,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:06:07 GMT
+      - Tue, 07 Apr 2020 02:51:25 GMT
       expires:
       - '-1'
       pragma:
@@ -2929,474 +3087,15 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 0.0\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '353'
-      content-type:
-      - application/json
-      date:
-      - Wed, 22 Jan 2020 02:06:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf application-type version create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c --application-type-name --version --package-url
-      User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 0.0\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '353'
-      content-type:
-      - application/json
-      date:
-      - Wed, 22 Jan 2020 02:07:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf application-type version create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c --application-type-name --version --package-url
-      User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 0.0\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '353'
-      content-type:
-      - application/json
-      date:
-      - Wed, 22 Jan 2020 02:07:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf application-type version create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c --application-type-name --version --package-url
-      User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 0.0\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '353'
-      content-type:
-      - application/json
-      date:
-      - Wed, 22 Jan 2020 02:08:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf application-type version create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c --application-type-name --version --package-url
-      User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 0.0\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '353'
-      content-type:
-      - application/json
-      date:
-      - Wed, 22 Jan 2020 02:08:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf application-type version create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c --application-type-name --version --package-url
-      User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 0.0\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '353'
-      content-type:
-      - application/json
-      date:
-      - Wed, 22 Jan 2020 02:09:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf application-type version create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c --application-type-name --version --package-url
-      User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 0.0\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '353'
-      content-type:
-      - application/json
-      date:
-      - Wed, 22 Jan 2020 02:09:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf application-type version create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c --application-type-name --version --package-url
-      User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 0.0\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '353'
-      content-type:
-      - application/json
-      date:
-      - Wed, 22 Jan 2020 02:10:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf application-type version create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c --application-type-name --version --package-url
-      User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 0.0\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '353'
-      content-type:
-      - application/json
-      date:
-      - Wed, 22 Jan 2020 02:10:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf application-type version create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c --application-type-name --version --package-url
-      User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b\",\r\n
+        \ \"name\": \"14c14348-7434-4e49-98dd-cc820664034b\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"Details\\\": \\\"Running Image Builder process ...\\\"\\r\\n}\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"startTime\": \"2020-04-07T02:48:25.3516898Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -3406,7 +3105,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:11:07 GMT
+      - Tue, 07 Apr 2020 02:51:55 GMT
       expires:
       - '-1'
       pragma:
@@ -3440,15 +3139,15 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b\",\r\n
+        \ \"name\": \"14c14348-7434-4e49-98dd-cc820664034b\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"Details\\\": \\\"Running Image Builder process ...\\\"\\r\\n}\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"startTime\": \"2020-04-07T02:48:25.3516898Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -3458,7 +3157,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:11:38 GMT
+      - Tue, 07 Apr 2020 02:52:26 GMT
       expires:
       - '-1'
       pragma:
@@ -3492,66 +3191,14 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"InProgress:{\\r\\n
-        \ \\\"Details\\\": \\\"Running Image Builder process ...\\\"\\r\\n}\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 0.0\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '419'
-      content-type:
-      - application/json
-      date:
-      - Wed, 22 Jan 2020 02:12:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf application-type version create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c --application-type-name --version --package-url
-      User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c?api-version=2019-03-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n
-        \ \"name\": \"784b6585-5a27-4c3f-95dc-5170f92b364c\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"startTime\": \"2020-01-22T02:03:06.7292279Z\",\r\n  \"endTime\": \"2020-01-22T02:12:34.5099165Z\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/14c14348-7434-4e49-98dd-cc820664034b\",\r\n
+        \ \"name\": \"14c14348-7434-4e49-98dd-cc820664034b\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"startTime\": \"2020-04-07T02:48:25.3516898Z\",\r\n  \"endTime\": \"2020-04-07T02:52:42.0358401Z\",\r\n
         \ \"percentComplete\": 100.0\r\n}"
     headers:
       cache-control:
@@ -3561,7 +3208,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:12:38 GMT
+      - Tue, 07 Apr 2020 02:52:55 GMT
       expires:
       - '-1'
       pragma:
@@ -3595,14 +3242,14 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.0?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.0\",\r\n
-        \ \"name\": \"1.0\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152553867292279\\\"\",\r\n
+        \ \"name\": \"1.0\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218245053516898\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"appPackageUrl\":
         \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.0.sfpkg\",\r\n
         \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\"\r\n    }\r\n
@@ -3615,7 +3262,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:12:38 GMT
+      - Tue, 07 Apr 2020 02:52:55 GMT
       expires:
       - '-1'
       pragma:
@@ -3649,7 +3296,7 @@ interactions:
       - -g -c --application-type-name --version
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -3658,7 +3305,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.0\",\r\n
-        \ \"name\": \"1.0\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152553867292279\\\"\",\r\n
+        \ \"name\": \"1.0\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218245053516898\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"appPackageUrl\":
         \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.0.sfpkg\",\r\n
         \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\"\r\n    }\r\n
@@ -3671,7 +3318,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:12:38 GMT
+      - Tue, 07 Apr 2020 02:52:56 GMT
       expires:
       - '-1'
       pragma:
@@ -3707,7 +3354,7 @@ interactions:
       - -g -c --application-type-name --version
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: DELETE
@@ -3717,17 +3364,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/6b761482-f393-4bb7-a15e-c172a638b2cd?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/94937a5f-c955-48b8-bf9a-1b7b166172e2?api-version=2019-03-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 22 Jan 2020 02:12:39 GMT
+      - Tue, 07 Apr 2020 02:52:56 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/6b761482-f393-4bb7-a15e-c172a638b2cd?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/94937a5f-c955-48b8-bf9a-1b7b166172e2?api-version=2019-03-01
       pragma:
       - no-cache
       server:
@@ -3757,14 +3404,14 @@ interactions:
       - -g -c --application-type-name --version
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/6b761482-f393-4bb7-a15e-c172a638b2cd?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/94937a5f-c955-48b8-bf9a-1b7b166172e2?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/6b761482-f393-4bb7-a15e-c172a638b2cd\",\r\n
-        \ \"name\": \"6b761482-f393-4bb7-a15e-c172a638b2cd\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:12:39.6082772Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/94937a5f-c955-48b8-bf9a-1b7b166172e2\",\r\n
+        \ \"name\": \"94937a5f-c955-48b8-bf9a-1b7b166172e2\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T02:52:57.2078609Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -3774,7 +3421,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:13:39 GMT
+      - Tue, 07 Apr 2020 02:53:57 GMT
       expires:
       - '-1'
       pragma:
@@ -3808,14 +3455,14 @@ interactions:
       - -g -c --application-type-name --version
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/6b761482-f393-4bb7-a15e-c172a638b2cd?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/94937a5f-c955-48b8-bf9a-1b7b166172e2?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/6b761482-f393-4bb7-a15e-c172a638b2cd\",\r\n
-        \ \"name\": \"6b761482-f393-4bb7-a15e-c172a638b2cd\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:12:39.6082772Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/94937a5f-c955-48b8-bf9a-1b7b166172e2\",\r\n
+        \ \"name\": \"94937a5f-c955-48b8-bf9a-1b7b166172e2\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T02:52:57.2078609Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -3825,7 +3472,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:14:09 GMT
+      - Tue, 07 Apr 2020 02:54:26 GMT
       expires:
       - '-1'
       pragma:
@@ -3859,14 +3506,14 @@ interactions:
       - -g -c --application-type-name --version
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/6b761482-f393-4bb7-a15e-c172a638b2cd?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/94937a5f-c955-48b8-bf9a-1b7b166172e2?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/6b761482-f393-4bb7-a15e-c172a638b2cd\",\r\n
-        \ \"name\": \"6b761482-f393-4bb7-a15e-c172a638b2cd\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"startTime\": \"2020-01-22T02:12:39.6082772Z\",\r\n  \"endTime\": \"2020-01-22T02:14:34.5105409Z\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/94937a5f-c955-48b8-bf9a-1b7b166172e2\",\r\n
+        \ \"name\": \"94937a5f-c955-48b8-bf9a-1b7b166172e2\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"startTime\": \"2020-04-07T02:52:57.2078609Z\",\r\n  \"endTime\": \"2020-04-07T02:54:42.0572629Z\",\r\n
         \ \"percentComplete\": 100.0\r\n}"
     headers:
       cache-control:
@@ -3876,7 +3523,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:14:39 GMT
+      - Tue, 07 Apr 2020 02:54:56 GMT
       expires:
       - '-1'
       pragma:
@@ -3910,7 +3557,7 @@ interactions:
       - -g -c --application-type-name --version
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -3918,7 +3565,7 @@ interactions:
   response:
     body:
       string: "{\r\n  \"error\": {\r\n    \"code\": \"NotFound\",\r\n    \"message\":
-        \"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CLITEST.RGRIUQXJRYFGKLK2DBAI3Q3SSHD6DQL5MMVQ4WDAXSBFOHD4LE7ZU73VTNXEH5DRWP2/providers/Microsoft.ServiceFabric/clusters/SFRP-CLI-3IHN3UH2AS35AVW/applicationTypes/CALCSERVICEAPP/versions/1.0
+        \"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CLITEST.RGBIDHID7IZ6IK5DRYTYPKOR7IYAML7DOMICJMEVYWMARK7DZAAAJ6C5FQEAPSEZHT6/providers/Microsoft.ServiceFabric/clusters/SFRP-CLI-KKQSDG7HQVKGSDM/applicationTypes/CALCSERVICEAPP/versions/1.0
         not found.\",\r\n    \"details\": []\r\n  }\r\n}"
     headers:
       cache-control:
@@ -3928,7 +3575,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:14:41 GMT
+      - Tue, 07 Apr 2020 02:54:58 GMT
       expires:
       - '-1'
       pragma:
@@ -3958,7 +3605,7 @@ interactions:
       - -g -c
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -3974,7 +3621,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:14:41 GMT
+      - Tue, 07 Apr 2020 02:54:58 GMT
       expires:
       - '-1'
       pragma:
@@ -4009,7 +3656,7 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -4019,7 +3666,7 @@ interactions:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes\",\r\n
         \     \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp\",\r\n
         \     \"name\": \"CalcServiceApp\",\r\n      \"tags\": {},\r\n      \"etag\":
-        \"W/\\\"637152553864323626\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\":
+        \"W/\\\"637218245050704410\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\":
         \"Succeeded\"\r\n      }\r\n    }\r\n  ]\r\n}"
     headers:
       cache-control:
@@ -4029,7 +3676,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:14:41 GMT
+      - Tue, 07 Apr 2020 02:54:59 GMT
       expires:
       - '-1'
       pragma:
@@ -4064,7 +3711,7 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -4080,7 +3727,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:14:41 GMT
+      - Tue, 07 Apr 2020 02:54:59 GMT
       expires:
       - '-1'
       pragma:
@@ -4119,7 +3766,7 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: PUT
@@ -4128,13 +3775,13 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.0\",\r\n
-        \ \"name\": \"1.0\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152560825111817\\\"\",\r\n
+        \ \"name\": \"1.0\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218248998542530\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"appPackageUrl\":
         \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.0.sfpkg\",\r\n
         \   \"defaultParameterList\": {}\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7cc567b4-0bda-441a-843c-f57d7d29c822?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/9f80a9a1-f804-4219-8e6f-a479973c20ad?api-version=2019-03-01
       cache-control:
       - no-cache
       content-length:
@@ -4142,11 +3789,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:14:41 GMT
+      - Tue, 07 Apr 2020 02:54:59 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/7cc567b4-0bda-441a-843c-f57d7d29c822?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/9f80a9a1-f804-4219-8e6f-a479973c20ad?api-version=2019-03-01
       pragma:
       - no-cache
       server:
@@ -4177,24 +3824,24 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7cc567b4-0bda-441a-843c-f57d7d29c822?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/9f80a9a1-f804-4219-8e6f-a479973c20ad?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7cc567b4-0bda-441a-843c-f57d7d29c822\",\r\n
-        \ \"name\": \"7cc567b4-0bda-441a-843c-f57d7d29c822\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:14:42.5111817Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/9f80a9a1-f804-4219-8e6f-a479973c20ad\",\r\n
+        \ \"name\": \"9f80a9a1-f804-4219-8e6f-a479973c20ad\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T02:54:59.854253Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '353'
+      - '352'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:15:41 GMT
+      - Tue, 07 Apr 2020 02:55:59 GMT
       expires:
       - '-1'
       pragma:
@@ -4229,24 +3876,24 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7cc567b4-0bda-441a-843c-f57d7d29c822?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/9f80a9a1-f804-4219-8e6f-a479973c20ad?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7cc567b4-0bda-441a-843c-f57d7d29c822\",\r\n
-        \ \"name\": \"7cc567b4-0bda-441a-843c-f57d7d29c822\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:14:42.5111817Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/9f80a9a1-f804-4219-8e6f-a479973c20ad\",\r\n
+        \ \"name\": \"9f80a9a1-f804-4219-8e6f-a479973c20ad\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T02:54:59.854253Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '353'
+      - '352'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:16:12 GMT
+      - Tue, 07 Apr 2020 02:56:29 GMT
       expires:
       - '-1'
       pragma:
@@ -4281,25 +3928,25 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7cc567b4-0bda-441a-843c-f57d7d29c822?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/9f80a9a1-f804-4219-8e6f-a479973c20ad?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7cc567b4-0bda-441a-843c-f57d7d29c822\",\r\n
-        \ \"name\": \"7cc567b4-0bda-441a-843c-f57d7d29c822\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/9f80a9a1-f804-4219-8e6f-a479973c20ad\",\r\n
+        \ \"name\": \"9f80a9a1-f804-4219-8e6f-a479973c20ad\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"Details\\\": \\\"Running Image Builder process ...\\\"\\r\\n}\",\r\n
-        \ \"startTime\": \"2020-01-22T02:14:42.5111817Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"startTime\": \"2020-04-07T02:54:59.854253Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '419'
+      - '418'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:16:42 GMT
+      - Tue, 07 Apr 2020 02:56:59 GMT
       expires:
       - '-1'
       pragma:
@@ -4334,25 +3981,25 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7cc567b4-0bda-441a-843c-f57d7d29c822?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/9f80a9a1-f804-4219-8e6f-a479973c20ad?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7cc567b4-0bda-441a-843c-f57d7d29c822\",\r\n
-        \ \"name\": \"7cc567b4-0bda-441a-843c-f57d7d29c822\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/9f80a9a1-f804-4219-8e6f-a479973c20ad\",\r\n
+        \ \"name\": \"9f80a9a1-f804-4219-8e6f-a479973c20ad\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"Details\\\": \\\"Running Image Builder process ...\\\"\\r\\n}\",\r\n
-        \ \"startTime\": \"2020-01-22T02:14:42.5111817Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"startTime\": \"2020-04-07T02:54:59.854253Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '419'
+      - '418'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:17:13 GMT
+      - Tue, 07 Apr 2020 02:57:30 GMT
       expires:
       - '-1'
       pragma:
@@ -4387,14 +4034,14 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7cc567b4-0bda-441a-843c-f57d7d29c822?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/9f80a9a1-f804-4219-8e6f-a479973c20ad?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7cc567b4-0bda-441a-843c-f57d7d29c822\",\r\n
-        \ \"name\": \"7cc567b4-0bda-441a-843c-f57d7d29c822\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"startTime\": \"2020-01-22T02:14:42.5111817Z\",\r\n  \"endTime\": \"2020-01-22T02:17:34.665885Z\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/9f80a9a1-f804-4219-8e6f-a479973c20ad\",\r\n
+        \ \"name\": \"9f80a9a1-f804-4219-8e6f-a479973c20ad\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"startTime\": \"2020-04-07T02:54:59.854253Z\",\r\n  \"endTime\": \"2020-04-07T02:57:42.1038819Z\",\r\n
         \ \"percentComplete\": 100.0\r\n}"
     headers:
       cache-control:
@@ -4404,7 +4051,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:17:42 GMT
+      - Tue, 07 Apr 2020 02:57:59 GMT
       expires:
       - '-1'
       pragma:
@@ -4439,14 +4086,14 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.0?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.0\",\r\n
-        \ \"name\": \"1.0\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152560825111817\\\"\",\r\n
+        \ \"name\": \"1.0\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218248998542530\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"appPackageUrl\":
         \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.0.sfpkg\",\r\n
         \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\"\r\n    }\r\n
@@ -4459,7 +4106,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:17:42 GMT
+      - Tue, 07 Apr 2020 02:58:00 GMT
       expires:
       - '-1'
       pragma:
@@ -4494,7 +4141,7 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -4510,7 +4157,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:17:42 GMT
+      - Tue, 07 Apr 2020 02:58:00 GMT
       expires:
       - '-1'
       pragma:
@@ -4550,7 +4197,7 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: PUT
@@ -4559,14 +4206,14 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330824\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321491\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"typeName\":
         \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.0\",\r\n    \"parameters\":
         {\r\n      \"Mode\": \"binary\"\r\n    },\r\n    \"removeApplicationCapacity\":
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7e4ebf65-502b-4417-b831-c443f47aeb94?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d74060eb-a652-46f5-831e-889cf85070c1?api-version=2019-03-01
       cache-control:
       - no-cache
       content-length:
@@ -4574,11 +4221,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:17:43 GMT
+      - Tue, 07 Apr 2020 02:58:01 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/7e4ebf65-502b-4417-b831-c443f47aeb94?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/d74060eb-a652-46f5-831e-889cf85070c1?api-version=2019-03-01
       pragma:
       - no-cache
       server:
@@ -4589,7 +4236,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 202
       message: Accepted
@@ -4609,14 +4256,14 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7e4ebf65-502b-4417-b831-c443f47aeb94?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d74060eb-a652-46f5-831e-889cf85070c1?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7e4ebf65-502b-4417-b831-c443f47aeb94\",\r\n
-        \ \"name\": \"7e4ebf65-502b-4417-b831-c443f47aeb94\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:17:43.7330824Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d74060eb-a652-46f5-831e-889cf85070c1\",\r\n
+        \ \"name\": \"d74060eb-a652-46f5-831e-889cf85070c1\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T02:58:00.9321491Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -4626,7 +4273,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:18:43 GMT
+      - Tue, 07 Apr 2020 02:59:00 GMT
       expires:
       - '-1'
       pragma:
@@ -4661,14 +4308,14 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7e4ebf65-502b-4417-b831-c443f47aeb94?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d74060eb-a652-46f5-831e-889cf85070c1?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7e4ebf65-502b-4417-b831-c443f47aeb94\",\r\n
-        \ \"name\": \"7e4ebf65-502b-4417-b831-c443f47aeb94\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:17:43.7330824Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d74060eb-a652-46f5-831e-889cf85070c1\",\r\n
+        \ \"name\": \"d74060eb-a652-46f5-831e-889cf85070c1\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T02:58:00.9321491Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -4678,7 +4325,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:19:13 GMT
+      - Tue, 07 Apr 2020 02:59:31 GMT
       expires:
       - '-1'
       pragma:
@@ -4713,14 +4360,14 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7e4ebf65-502b-4417-b831-c443f47aeb94?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d74060eb-a652-46f5-831e-889cf85070c1?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/7e4ebf65-502b-4417-b831-c443f47aeb94\",\r\n
-        \ \"name\": \"7e4ebf65-502b-4417-b831-c443f47aeb94\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"startTime\": \"2020-01-22T02:17:43.7330824Z\",\r\n  \"endTime\": \"2020-01-22T02:19:34.6942236Z\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d74060eb-a652-46f5-831e-889cf85070c1\",\r\n
+        \ \"name\": \"d74060eb-a652-46f5-831e-889cf85070c1\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"startTime\": \"2020-04-07T02:58:00.9321491Z\",\r\n  \"endTime\": \"2020-04-07T02:59:42.1284241Z\",\r\n
         \ \"percentComplete\": 100.0\r\n}"
     headers:
       cache-control:
@@ -4730,7 +4377,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:19:43 GMT
+      - Tue, 07 Apr 2020 03:00:01 GMT
       expires:
       - '-1'
       pragma:
@@ -4765,14 +4412,14 @@ interactions:
         --package-url --application-parameters
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330824\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321491\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
         \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.0\",\r\n    \"parameters\":
         {\r\n      \"Mode\": \"binary\"\r\n    },\r\n    \"removeApplicationCapacity\":
@@ -4785,7 +4432,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:19:43 GMT
+      - Tue, 07 Apr 2020 03:00:01 GMT
       expires:
       - '-1'
       pragma:
@@ -4819,7 +4466,7 @@ interactions:
       - -g -c --application-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -4828,7 +4475,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330824\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321491\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
         \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.0\",\r\n    \"parameters\":
         {\r\n      \"Mode\": \"binary\"\r\n    },\r\n    \"removeApplicationCapacity\":
@@ -4841,7 +4488,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:19:43 GMT
+      - Tue, 07 Apr 2020 03:00:01 GMT
       expires:
       - '-1'
       pragma:
@@ -4902,14 +4549,14 @@ interactions:
         --partition-scheme
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202001211819","name":"AzurePSDeployment-202001211819","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17171238564262146892","parameters":{"applicationName":{"type":"String","value":"testApp000006"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"serviceKind":{"type":"String","value":"Stateless"},"serviceName":{"type":"String","value":"testApp000006~testService"},"serviceTypeName":{"type":"String","value":"CalcServiceType"},"partitionScheme":{"type":"String","value":"Singleton"},"partitionDescription":{"type":"Object","value":{"partitionScheme":"Singleton"}},"instanceCount":{"type":"Int","value":-1}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-01-22T02:19:45.2040098Z","duration":"PT0S","correlationId":"69ad273f-b215-4151-87a0-f73aca38bc93","providers":[{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters/applications/services","locations":[null]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006/services/testApp000006~testService"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202004062000","name":"AzurePSDeployment-202004062000","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17171238564262146892","parameters":{"applicationName":{"type":"String","value":"testApp000006"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"serviceKind":{"type":"String","value":"Stateless"},"serviceName":{"type":"String","value":"testApp000006~testService"},"serviceTypeName":{"type":"String","value":"CalcServiceType"},"partitionScheme":{"type":"String","value":"Singleton"},"partitionDescription":{"type":"Object","value":{"partitionScheme":"Singleton"}},"instanceCount":{"type":"Int","value":-1}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-04-07T03:00:02.4275033Z","duration":"PT0S","correlationId":"d7d08fba-7f4c-4b29-a783-c6d0c6fa65a5","providers":[{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters/applications/services","locations":[null]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006/services/testApp000006~testService"}]}}'
     headers:
       cache-control:
       - no-cache
@@ -4918,7 +4565,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:19:44 GMT
+      - Tue, 07 Apr 2020 03:00:02 GMT
       expires:
       - '-1'
       pragma:
@@ -4978,25 +4625,25 @@ interactions:
         --partition-scheme
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202001211819","name":"AzurePSDeployment-202001211819","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17171238564262146892","parameters":{"applicationName":{"type":"String","value":"testApp000006"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"serviceKind":{"type":"String","value":"Stateless"},"serviceName":{"type":"String","value":"testApp000006~testService"},"serviceTypeName":{"type":"String","value":"CalcServiceType"},"partitionScheme":{"type":"String","value":"Singleton"},"partitionDescription":{"type":"Object","value":{"partitionScheme":"Singleton"}},"instanceCount":{"type":"Int","value":-1}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-01-22T02:19:46.0725603Z","duration":"PT0.3388849S","correlationId":"8d4bd1a6-27ea-4564-bd69-fb972df46f8f","providers":[{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters/applications/services","locations":[null]}]}],"dependencies":[]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202004062000","name":"AzurePSDeployment-202004062000","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17171238564262146892","parameters":{"applicationName":{"type":"String","value":"testApp000006"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"serviceKind":{"type":"String","value":"Stateless"},"serviceName":{"type":"String","value":"testApp000006~testService"},"serviceTypeName":{"type":"String","value":"CalcServiceType"},"partitionScheme":{"type":"String","value":"Singleton"},"partitionDescription":{"type":"Object","value":{"partitionScheme":"Singleton"}},"instanceCount":{"type":"Int","value":-1}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-04-07T03:00:03.0427038Z","duration":"PT0.188439S","correlationId":"7ecc262a-4a57-41fc-96c7-8e052fa9cfd1","providers":[{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters/applications/services","locations":[null]}]}],"dependencies":[]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202001211819/operationStatuses/08586219472997439467?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202004062000/operationStatuses/08586153784826233548?api-version=2019-07-01
       cache-control:
       - no-cache
       content-length:
-      - '1192'
+      - '1191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:19:45 GMT
+      - Tue, 07 Apr 2020 03:00:02 GMT
       expires:
       - '-1'
       pragma:
@@ -5006,7 +4653,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1196'
     status:
       code: 201
       message: Created
@@ -5026,9 +4673,9 @@ interactions:
         --partition-scheme
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219472997439467?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153784826233548?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -5040,7 +4687,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:20:16 GMT
+      - Tue, 07 Apr 2020 03:00:33 GMT
       expires:
       - '-1'
       pragma:
@@ -5070,9 +4717,9 @@ interactions:
         --partition-scheme
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219472997439467?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153784826233548?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -5084,7 +4731,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:20:45 GMT
+      - Tue, 07 Apr 2020 03:01:02 GMT
       expires:
       - '-1'
       pragma:
@@ -5114,9 +4761,9 @@ interactions:
         --partition-scheme
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219472997439467?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153784826233548?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -5128,7 +4775,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:21:15 GMT
+      - Tue, 07 Apr 2020 03:01:32 GMT
       expires:
       - '-1'
       pragma:
@@ -5158,9 +4805,9 @@ interactions:
         --partition-scheme
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219472997439467?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153784826233548?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -5172,7 +4819,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:21:46 GMT
+      - Tue, 07 Apr 2020 03:02:03 GMT
       expires:
       - '-1'
       pragma:
@@ -5202,9 +4849,9 @@ interactions:
         --partition-scheme
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586219472997439467?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586153784826233548?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -5216,7 +4863,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:22:16 GMT
+      - Tue, 07 Apr 2020 03:02:33 GMT
       expires:
       - '-1'
       pragma:
@@ -5246,21 +4893,21 @@ interactions:
         --partition-scheme
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202001211819","name":"AzurePSDeployment-202001211819","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17171238564262146892","parameters":{"applicationName":{"type":"String","value":"testApp000006"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"serviceKind":{"type":"String","value":"Stateless"},"serviceName":{"type":"String","value":"testApp000006~testService"},"serviceTypeName":{"type":"String","value":"CalcServiceType"},"partitionScheme":{"type":"String","value":"Singleton"},"partitionDescription":{"type":"Object","value":{"partitionScheme":"Singleton"}},"instanceCount":{"type":"Int","value":-1}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-01-22T02:22:01.4144975Z","duration":"PT2M15.6808221S","correlationId":"8d4bd1a6-27ea-4564-bd69-fb972df46f8f","providers":[{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters/applications/services","locations":[null]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006/services/testApp000006~testService"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/AzurePSDeployment-202004062000","name":"AzurePSDeployment-202004062000","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17171238564262146892","parameters":{"applicationName":{"type":"String","value":"testApp000006"},"clusterName":{"type":"String","value":"sfrp-cli-000004"},"serviceKind":{"type":"String","value":"Stateless"},"serviceName":{"type":"String","value":"testApp000006~testService"},"serviceTypeName":{"type":"String","value":"CalcServiceType"},"partitionScheme":{"type":"String","value":"Singleton"},"partitionDescription":{"type":"Object","value":{"partitionScheme":"Singleton"}},"instanceCount":{"type":"Int","value":-1}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-04-07T03:02:03.8410914Z","duration":"PT2M0.9868266S","correlationId":"7ecc262a-4a57-41fc-96c7-8e052fa9cfd1","providers":[{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters/applications/services","locations":[null]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006/services/testApp000006~testService"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1494'
+      - '1493'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Jan 2020 02:22:16 GMT
+      - Tue, 07 Apr 2020 03:02:33 GMT
       expires:
       - '-1'
       pragma:
@@ -5290,17 +4937,17 @@ interactions:
         --partition-scheme
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006/services/testApp000006~testService?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"type\": \"services\",\r\n  \"location\": \"westus\",\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006/services/testApp000006~testService\",\r\n
+      string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications/services\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006/services/testApp000006~testService\",\r\n
         \ \"name\": \"testApp000006~testService\",\r\n  \"tags\": {},\r\n  \"etag\":
-        \"W/\\\"637152564005849085\\\"\",\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"W/\\\"637218252114759269\\\"\",\r\n  \"properties\": {\r\n    \"provisioningState\":
         \"Succeeded\",\r\n    \"serviceKind\": \"Stateless\",\r\n    \"placementConstraints\":
         \"\",\r\n    \"serviceTypeName\": \"CalcServiceType\",\r\n    \"partitionDescription\":
         {\r\n      \"partitionScheme\": \"Singleton\"\r\n    },\r\n    \"serviceLoadMetrics\":
@@ -5310,11 +4957,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '767'
+      - '813'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:22:16 GMT
+      - Tue, 07 Apr 2020 03:02:34 GMT
       expires:
       - '-1'
       pragma:
@@ -5348,17 +4995,17 @@ interactions:
       - -g -c --application-name --service-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006/services/testApp000006~testService?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"type\": \"services\",\r\n  \"location\": \"westus\",\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006/services/testApp000006~testService\",\r\n
+      string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications/services\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006/services/testApp000006~testService\",\r\n
         \ \"name\": \"testApp000006~testService\",\r\n  \"tags\": {},\r\n  \"etag\":
-        \"W/\\\"637152564005849085\\\"\",\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"W/\\\"637218252114759269\\\"\",\r\n  \"properties\": {\r\n    \"provisioningState\":
         \"Succeeded\",\r\n    \"serviceKind\": \"Stateless\",\r\n    \"placementConstraints\":
         \"\",\r\n    \"serviceTypeName\": \"CalcServiceType\",\r\n    \"partitionDescription\":
         {\r\n      \"partitionScheme\": \"Singleton\"\r\n    },\r\n    \"serviceLoadMetrics\":
@@ -5368,11 +5015,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '767'
+      - '813'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:22:17 GMT
+      - Tue, 07 Apr 2020 03:02:33 GMT
       expires:
       - '-1'
       pragma:
@@ -5406,7 +5053,7 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -5416,7 +5063,7 @@ interactions:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes\",\r\n
         \     \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp\",\r\n
         \     \"name\": \"CalcServiceApp\",\r\n      \"tags\": {},\r\n      \"etag\":
-        \"W/\\\"637152553864323626\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\":
+        \"W/\\\"637218245050704410\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\":
         \"Succeeded\"\r\n      }\r\n    }\r\n  ]\r\n}"
     headers:
       cache-control:
@@ -5426,7 +5073,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:22:17 GMT
+      - Tue, 07 Apr 2020 03:02:34 GMT
       expires:
       - '-1'
       pragma:
@@ -5460,7 +5107,7 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -5469,7 +5116,7 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
         \     \"location\": \"westus\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.0\",\r\n
-        \     \"name\": \"1.0\",\r\n      \"tags\": {},\r\n      \"etag\": \"W/\\\"637152560825111817\\\"\",\r\n
+        \     \"name\": \"1.0\",\r\n      \"tags\": {},\r\n      \"etag\": \"W/\\\"637218248998542530\\\"\",\r\n
         \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"appPackageUrl\": \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.0.sfpkg\",\r\n
         \       \"defaultParameterList\": {\r\n          \"mode\": \"decimal\"\r\n
@@ -5482,7 +5129,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:22:17 GMT
+      - Tue, 07 Apr 2020 03:02:34 GMT
       expires:
       - '-1'
       pragma:
@@ -5502,7 +5149,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"appPackageUrl": "https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.1.sfpkg"}}'
+    body: '{"properties": {"appPackageUrl": "https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.2.sfpkg"}}'
     headers:
       Accept:
       - application/json
@@ -5520,22 +5167,22 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
-        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1\",\r\n
-        \ \"name\": \"1.1\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152565385860098\\\"\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2\",\r\n
+        \ \"name\": \"1.2\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218253554152456\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"appPackageUrl\":
-        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.1.sfpkg\",\r\n
+        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.2.sfpkg\",\r\n
         \   \"defaultParameterList\": {}\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/632f3cd6-f629-4200-8f45-acc07d8f3263?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c3e52ba-83cf-4d54-953e-ad8cfd236d6c?api-version=2019-03-01
       cache-control:
       - no-cache
       content-length:
@@ -5543,11 +5190,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:22:18 GMT
+      - Tue, 07 Apr 2020 03:02:34 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/632f3cd6-f629-4200-8f45-acc07d8f3263?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/5c3e52ba-83cf-4d54-953e-ad8cfd236d6c?api-version=2019-03-01
       pragma:
       - no-cache
       server:
@@ -5577,14 +5224,14 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/632f3cd6-f629-4200-8f45-acc07d8f3263?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c3e52ba-83cf-4d54-953e-ad8cfd236d6c?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/632f3cd6-f629-4200-8f45-acc07d8f3263\",\r\n
-        \ \"name\": \"632f3cd6-f629-4200-8f45-acc07d8f3263\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:22:18.5860098Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c3e52ba-83cf-4d54-953e-ad8cfd236d6c\",\r\n
+        \ \"name\": \"5c3e52ba-83cf-4d54-953e-ad8cfd236d6c\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T03:02:35.4152456Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -5594,7 +5241,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:23:18 GMT
+      - Tue, 07 Apr 2020 03:03:35 GMT
       expires:
       - '-1'
       pragma:
@@ -5628,15 +5275,15 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/632f3cd6-f629-4200-8f45-acc07d8f3263?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c3e52ba-83cf-4d54-953e-ad8cfd236d6c?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/632f3cd6-f629-4200-8f45-acc07d8f3263\",\r\n
-        \ \"name\": \"632f3cd6-f629-4200-8f45-acc07d8f3263\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c3e52ba-83cf-4d54-953e-ad8cfd236d6c\",\r\n
+        \ \"name\": \"5c3e52ba-83cf-4d54-953e-ad8cfd236d6c\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"Details\\\": \\\"Running Image Builder process ...\\\"\\r\\n}\",\r\n
-        \ \"startTime\": \"2020-01-22T02:22:18.5860098Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"startTime\": \"2020-04-07T03:02:35.4152456Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -5646,7 +5293,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:23:48 GMT
+      - Tue, 07 Apr 2020 03:04:05 GMT
       expires:
       - '-1'
       pragma:
@@ -5680,15 +5327,15 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/632f3cd6-f629-4200-8f45-acc07d8f3263?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c3e52ba-83cf-4d54-953e-ad8cfd236d6c?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/632f3cd6-f629-4200-8f45-acc07d8f3263\",\r\n
-        \ \"name\": \"632f3cd6-f629-4200-8f45-acc07d8f3263\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c3e52ba-83cf-4d54-953e-ad8cfd236d6c\",\r\n
+        \ \"name\": \"5c3e52ba-83cf-4d54-953e-ad8cfd236d6c\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"Details\\\": \\\"Running Image Builder process ...\\\"\\r\\n}\",\r\n
-        \ \"startTime\": \"2020-01-22T02:22:18.5860098Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"startTime\": \"2020-04-07T03:02:35.4152456Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -5698,7 +5345,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:18 GMT
+      - Tue, 07 Apr 2020 03:04:35 GMT
       expires:
       - '-1'
       pragma:
@@ -5732,14 +5379,14 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/632f3cd6-f629-4200-8f45-acc07d8f3263?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c3e52ba-83cf-4d54-953e-ad8cfd236d6c?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/632f3cd6-f629-4200-8f45-acc07d8f3263\",\r\n
-        \ \"name\": \"632f3cd6-f629-4200-8f45-acc07d8f3263\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"startTime\": \"2020-01-22T02:22:18.5860098Z\",\r\n  \"endTime\": \"2020-01-22T02:24:34.7333125Z\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c3e52ba-83cf-4d54-953e-ad8cfd236d6c\",\r\n
+        \ \"name\": \"5c3e52ba-83cf-4d54-953e-ad8cfd236d6c\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"startTime\": \"2020-04-07T03:02:35.4152456Z\",\r\n  \"endTime\": \"2020-04-07T03:04:42.1560378Z\",\r\n
         \ \"percentComplete\": 100.0\r\n}"
     headers:
       cache-control:
@@ -5749,7 +5396,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:49 GMT
+      - Tue, 07 Apr 2020 03:05:05 GMT
       expires:
       - '-1'
       pragma:
@@ -5783,27 +5430,27 @@ interactions:
       - -g -c --application-type-name --version --package-url
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
-        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1\",\r\n
-        \ \"name\": \"1.1\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152565385860098\\\"\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2\",\r\n
+        \ \"name\": \"1.2\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218253554152456\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"appPackageUrl\":
-        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.1.sfpkg\",\r\n
-        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\"\r\n    }\r\n
-        \ }\r\n}"
+        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.2.sfpkg\",\r\n
+        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\",\r\n      \"precision\":
+        \"4\"\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '676'
+      - '701'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:49 GMT
+      - Tue, 07 Apr 2020 03:05:05 GMT
       expires:
       - '-1'
       pragma:
@@ -5840,7 +5487,7 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -5849,7 +5496,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330824\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321491\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
         \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.0\",\r\n    \"parameters\":
         {\r\n      \"Mode\": \"binary\"\r\n    },\r\n    \"removeApplicationCapacity\":
@@ -5862,7 +5509,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:49 GMT
+      - Tue, 07 Apr 2020 03:05:06 GMT
       expires:
       - '-1'
       pragma:
@@ -5899,29 +5546,29 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
-        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1\",\r\n
-        \ \"name\": \"1.1\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152565385860098\\\"\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2\",\r\n
+        \ \"name\": \"1.2\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218253554152456\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"appPackageUrl\":
-        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.1.sfpkg\",\r\n
-        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\"\r\n    }\r\n
-        \ }\r\n}"
+        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.2.sfpkg\",\r\n
+        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\",\r\n      \"precision\":
+        \"4\"\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '676'
+      - '701'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:49 GMT
+      - Tue, 07 Apr 2020 03:05:06 GMT
       expires:
       - '-1'
       pragma:
@@ -5958,7 +5605,7 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -5967,7 +5614,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330824\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321491\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
         \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.0\",\r\n    \"parameters\":
         {\r\n      \"Mode\": \"binary\"\r\n    },\r\n    \"removeApplicationCapacity\":
@@ -5980,7 +5627,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:49 GMT
+      - Tue, 07 Apr 2020 03:05:06 GMT
       expires:
       - '-1'
       pragma:
@@ -6017,29 +5664,29 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
-        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1\",\r\n
-        \ \"name\": \"1.1\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152565385860098\\\"\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2\",\r\n
+        \ \"name\": \"1.2\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218253554152456\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"appPackageUrl\":
-        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.1.sfpkg\",\r\n
-        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\"\r\n    }\r\n
-        \ }\r\n}"
+        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.2.sfpkg\",\r\n
+        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\",\r\n      \"precision\":
+        \"4\"\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '676'
+      - '701'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:50 GMT
+      - Tue, 07 Apr 2020 03:05:06 GMT
       expires:
       - '-1'
       pragma:
@@ -6076,7 +5723,7 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -6085,7 +5732,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330824\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321491\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
         \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.0\",\r\n    \"parameters\":
         {\r\n      \"Mode\": \"binary\"\r\n    },\r\n    \"removeApplicationCapacity\":
@@ -6098,7 +5745,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:50 GMT
+      - Tue, 07 Apr 2020 03:05:06 GMT
       expires:
       - '-1'
       pragma:
@@ -6135,29 +5782,29 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
-        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1\",\r\n
-        \ \"name\": \"1.1\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152565385860098\\\"\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2\",\r\n
+        \ \"name\": \"1.2\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218253554152456\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"appPackageUrl\":
-        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.1.sfpkg\",\r\n
-        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\"\r\n    }\r\n
-        \ }\r\n}"
+        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.2.sfpkg\",\r\n
+        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\",\r\n      \"precision\":
+        \"4\"\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '676'
+      - '701'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:50 GMT
+      - Tue, 07 Apr 2020 03:05:06 GMT
       expires:
       - '-1'
       pragma:
@@ -6194,7 +5841,7 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -6203,7 +5850,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330824\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321491\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
         \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.0\",\r\n    \"parameters\":
         {\r\n      \"Mode\": \"binary\"\r\n    },\r\n    \"removeApplicationCapacity\":
@@ -6216,7 +5863,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:50 GMT
+      - Tue, 07 Apr 2020 03:05:07 GMT
       expires:
       - '-1'
       pragma:
@@ -6253,29 +5900,29 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
-        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1\",\r\n
-        \ \"name\": \"1.1\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152565385860098\\\"\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2\",\r\n
+        \ \"name\": \"1.2\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218253554152456\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"appPackageUrl\":
-        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.1.sfpkg\",\r\n
-        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\"\r\n    }\r\n
-        \ }\r\n}"
+        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.2.sfpkg\",\r\n
+        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\",\r\n      \"precision\":
+        \"4\"\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '676'
+      - '701'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:50 GMT
+      - Tue, 07 Apr 2020 03:05:07 GMT
       expires:
       - '-1'
       pragma:
@@ -6312,7 +5959,7 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -6321,7 +5968,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330824\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321491\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
         \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.0\",\r\n    \"parameters\":
         {\r\n      \"Mode\": \"binary\"\r\n    },\r\n    \"removeApplicationCapacity\":
@@ -6334,7 +5981,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:50 GMT
+      - Tue, 07 Apr 2020 03:05:07 GMT
       expires:
       - '-1'
       pragma:
@@ -6371,29 +6018,29 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
-        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1\",\r\n
-        \ \"name\": \"1.1\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152565385860098\\\"\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2\",\r\n
+        \ \"name\": \"1.2\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218253554152456\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"appPackageUrl\":
-        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.1.sfpkg\",\r\n
-        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\"\r\n    }\r\n
-        \ }\r\n}"
+        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.2.sfpkg\",\r\n
+        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\",\r\n      \"precision\":
+        \"4\"\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '676'
+      - '701'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:50 GMT
+      - Tue, 07 Apr 2020 03:05:07 GMT
       expires:
       - '-1'
       pragma:
@@ -6430,7 +6077,7 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -6439,7 +6086,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330824\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321491\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
         \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.0\",\r\n    \"parameters\":
         {\r\n      \"Mode\": \"binary\"\r\n    },\r\n    \"removeApplicationCapacity\":
@@ -6452,7 +6099,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:51 GMT
+      - Tue, 07 Apr 2020 03:05:07 GMT
       expires:
       - '-1'
       pragma:
@@ -6489,29 +6136,29 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applicationTypes/versions\",\r\n
-        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.1\",\r\n
-        \ \"name\": \"1.1\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152565385860098\\\"\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applicationTypes/CalcServiceApp/versions/1.2\",\r\n
+        \ \"name\": \"1.2\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218253554152456\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"appPackageUrl\":
-        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.1.sfpkg\",\r\n
-        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\"\r\n    }\r\n
-        \ }\r\n}"
+        \"https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.2.sfpkg\",\r\n
+        \   \"defaultParameterList\": {\r\n      \"mode\": \"decimal\",\r\n      \"precision\":
+        \"4\"\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '676'
+      - '701'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:51 GMT
+      - Tue, 07 Apr 2020 03:05:07 GMT
       expires:
       - '-1'
       pragma:
@@ -6548,7 +6195,7 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -6557,7 +6204,7 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330824\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321491\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
         \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.0\",\r\n    \"parameters\":
         {\r\n      \"Mode\": \"binary\"\r\n    },\r\n    \"removeApplicationCapacity\":
@@ -6570,7 +6217,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:51 GMT
+      - Tue, 07 Apr 2020 03:05:07 GMT
       expires:
       - '-1'
       pragma:
@@ -6590,8 +6237,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": "westus", "tags": {}, "properties": {"typeVersion": "1.1",
-      "parameters": {"Mode": "decimal"}, "upgradePolicy": {"upgradeReplicaSetCheckTimeout":
+    body: '{"location": "westus", "tags": {}, "properties": {"typeVersion": "1.2",
+      "parameters": {"Mode": "binary", "Precision": "3"}, "upgradePolicy": {"upgradeReplicaSetCheckTimeout":
       "00:05:00", "forceRestart": true, "rollingUpgradeMonitoringPolicy": {"failureAction":
       "Rollback", "healthCheckWaitDuration": "00:00:00", "healthCheckStableDuration":
       "00:00:00", "healthCheckRetryTimeout": "00:00:00", "upgradeTimeout": "01:56:40",
@@ -6608,7 +6255,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '655'
+      - '672'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -6618,7 +6265,7 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: PUT
@@ -6627,35 +6274,36 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330825\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321492\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"removeApplicationCapacity\":
-        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
-        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
-        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
-        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
-        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
-        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
-        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
-        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"removeApplicationCapacity\": false,\r\n    \"upgradePolicy\": {\r\n
+        \     \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
+        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
+        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
+        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
+        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
+        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
+        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
+        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
       cache-control:
       - no-cache
       content-length:
-      - '1424'
+      - '1448'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:24:51 GMT
+      - Tue, 07 Apr 2020 03:05:08 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
       pragma:
       - no-cache
       server:
@@ -6666,7 +6314,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -6688,14 +6336,14 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n
-        \ \"name\": \"768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:24:51.9546716Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n
+        \ \"name\": \"696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T03:05:08.5645853Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -6705,7 +6353,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:25:51 GMT
+      - Tue, 07 Apr 2020 03:06:08 GMT
       expires:
       - '-1'
       pragma:
@@ -6742,14 +6390,14 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n
-        \ \"name\": \"768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:24:51.9546716Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n
+        \ \"name\": \"696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T03:05:08.5645853Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -6759,7 +6407,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:26:22 GMT
+      - Tue, 07 Apr 2020 03:06:38 GMT
       expires:
       - '-1'
       pragma:
@@ -6796,26 +6444,27 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n
-        \ \"name\": \"768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n
+        \ \"name\": \"696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"AppUpgradeState\\\": \\\"RollingForwardInProgress\\\",\\r\\n  \\\"UpgradeDomainProgress\\\":
         {\\r\\n    \\\"UpgradeDomainName\\\": \\\"\\\",\\r\\n    \\\"NodeProgressList\\\":
-        []\\r\\n  }\\r\\n}\",\r\n  \"startTime\": \"2020-01-22T02:24:51.9546716Z\",\r\n
-        \ \"endTime\": \"0001-01-01T00:00:00\",\r\n  \"percentComplete\": 0.0\r\n}"
+        []\\r\\n  },\\r\\n  \\\"NextUpgradeDomain\\\": null\\r\\n}\",\r\n  \"startTime\":
+        \"2020-04-07T03:05:08.5645853Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '528'
+      - '562'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:26:52 GMT
+      - Tue, 07 Apr 2020 03:07:08 GMT
       expires:
       - '-1'
       pragma:
@@ -6852,26 +6501,27 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n
-        \ \"name\": \"768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n
+        \ \"name\": \"696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"AppUpgradeState\\\": \\\"RollingForwardInProgress\\\",\\r\\n  \\\"UpgradeDomainProgress\\\":
         {\\r\\n    \\\"UpgradeDomainName\\\": \\\"\\\",\\r\\n    \\\"NodeProgressList\\\":
-        []\\r\\n  }\\r\\n}\",\r\n  \"startTime\": \"2020-01-22T02:24:51.9546716Z\",\r\n
-        \ \"endTime\": \"0001-01-01T00:00:00\",\r\n  \"percentComplete\": 0.0\r\n}"
+        []\\r\\n  },\\r\\n  \\\"NextUpgradeDomain\\\": null\\r\\n}\",\r\n  \"startTime\":
+        \"2020-04-07T03:05:08.5645853Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '528'
+      - '562'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:27:21 GMT
+      - Tue, 07 Apr 2020 03:07:38 GMT
       expires:
       - '-1'
       pragma:
@@ -6908,26 +6558,27 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n
-        \ \"name\": \"768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n
+        \ \"name\": \"696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"AppUpgradeState\\\": \\\"RollingForwardInProgress\\\",\\r\\n  \\\"UpgradeDomainProgress\\\":
         {\\r\\n    \\\"UpgradeDomainName\\\": \\\"0\\\",\\r\\n    \\\"NodeProgressList\\\":
-        []\\r\\n  }\\r\\n}\",\r\n  \"startTime\": \"2020-01-22T02:24:51.9546716Z\",\r\n
-        \ \"endTime\": \"0001-01-01T00:00:00\",\r\n  \"percentComplete\": 0.0\r\n}"
+        []\\r\\n  },\\r\\n  \\\"NextUpgradeDomain\\\": \\\"1\\\"\\r\\n}\",\r\n  \"startTime\":
+        \"2020-04-07T03:05:08.5645853Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '529'
+      - '564'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:27:52 GMT
+      - Tue, 07 Apr 2020 03:08:09 GMT
       expires:
       - '-1'
       pragma:
@@ -6964,26 +6615,27 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n
-        \ \"name\": \"768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n
+        \ \"name\": \"696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"AppUpgradeState\\\": \\\"RollingForwardInProgress\\\",\\r\\n  \\\"UpgradeDomainProgress\\\":
         {\\r\\n    \\\"UpgradeDomainName\\\": \\\"0\\\",\\r\\n    \\\"NodeProgressList\\\":
-        []\\r\\n  }\\r\\n}\",\r\n  \"startTime\": \"2020-01-22T02:24:51.9546716Z\",\r\n
-        \ \"endTime\": \"0001-01-01T00:00:00\",\r\n  \"percentComplete\": 0.0\r\n}"
+        []\\r\\n  },\\r\\n  \\\"NextUpgradeDomain\\\": \\\"1\\\"\\r\\n}\",\r\n  \"startTime\":
+        \"2020-04-07T03:05:08.5645853Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '529'
+      - '564'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:28:22 GMT
+      - Tue, 07 Apr 2020 03:08:38 GMT
       expires:
       - '-1'
       pragma:
@@ -7020,26 +6672,27 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n
-        \ \"name\": \"768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n
+        \ \"name\": \"696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"AppUpgradeState\\\": \\\"RollingForwardInProgress\\\",\\r\\n  \\\"UpgradeDomainProgress\\\":
         {\\r\\n    \\\"UpgradeDomainName\\\": \\\"1\\\",\\r\\n    \\\"NodeProgressList\\\":
-        []\\r\\n  }\\r\\n}\",\r\n  \"startTime\": \"2020-01-22T02:24:51.9546716Z\",\r\n
-        \ \"endTime\": \"0001-01-01T00:00:00\",\r\n  \"percentComplete\": 0.0\r\n}"
+        []\\r\\n  },\\r\\n  \\\"NextUpgradeDomain\\\": \\\"2\\\"\\r\\n}\",\r\n  \"startTime\":
+        \"2020-04-07T03:05:08.5645853Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '529'
+      - '564'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:28:51 GMT
+      - Tue, 07 Apr 2020 03:09:08 GMT
       expires:
       - '-1'
       pragma:
@@ -7076,26 +6729,27 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n
-        \ \"name\": \"768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n
+        \ \"name\": \"696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"AppUpgradeState\\\": \\\"RollingForwardInProgress\\\",\\r\\n  \\\"UpgradeDomainProgress\\\":
         {\\r\\n    \\\"UpgradeDomainName\\\": \\\"1\\\",\\r\\n    \\\"NodeProgressList\\\":
-        []\\r\\n  }\\r\\n}\",\r\n  \"startTime\": \"2020-01-22T02:24:51.9546716Z\",\r\n
-        \ \"endTime\": \"0001-01-01T00:00:00\",\r\n  \"percentComplete\": 0.0\r\n}"
+        []\\r\\n  },\\r\\n  \\\"NextUpgradeDomain\\\": \\\"2\\\"\\r\\n}\",\r\n  \"startTime\":
+        \"2020-04-07T03:05:08.5645853Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '529'
+      - '564'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:29:22 GMT
+      - Tue, 07 Apr 2020 03:09:38 GMT
       expires:
       - '-1'
       pragma:
@@ -7132,26 +6786,27 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n
-        \ \"name\": \"768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n
+        \ \"name\": \"696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"AppUpgradeState\\\": \\\"RollingForwardInProgress\\\",\\r\\n  \\\"UpgradeDomainProgress\\\":
         {\\r\\n    \\\"UpgradeDomainName\\\": \\\"2\\\",\\r\\n    \\\"NodeProgressList\\\":
-        []\\r\\n  }\\r\\n}\",\r\n  \"startTime\": \"2020-01-22T02:24:51.9546716Z\",\r\n
-        \ \"endTime\": \"0001-01-01T00:00:00\",\r\n  \"percentComplete\": 0.0\r\n}"
+        []\\r\\n  },\\r\\n  \\\"NextUpgradeDomain\\\": null\\r\\n}\",\r\n  \"startTime\":
+        \"2020-04-07T03:05:08.5645853Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '529'
+      - '563'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:29:52 GMT
+      - Tue, 07 Apr 2020 03:10:09 GMT
       expires:
       - '-1'
       pragma:
@@ -7188,26 +6843,27 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n
-        \ \"name\": \"768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n  \"status\": \"InProgress:{\\r\\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n
+        \ \"name\": \"696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n  \"status\": \"InProgress:{\\r\\n
         \ \\\"AppUpgradeState\\\": \\\"RollingForwardInProgress\\\",\\r\\n  \\\"UpgradeDomainProgress\\\":
         {\\r\\n    \\\"UpgradeDomainName\\\": \\\"2\\\",\\r\\n    \\\"NodeProgressList\\\":
-        []\\r\\n  }\\r\\n}\",\r\n  \"startTime\": \"2020-01-22T02:24:51.9546716Z\",\r\n
-        \ \"endTime\": \"0001-01-01T00:00:00\",\r\n  \"percentComplete\": 0.0\r\n}"
+        []\\r\\n  },\\r\\n  \\\"NextUpgradeDomain\\\": null\\r\\n}\",\r\n  \"startTime\":
+        \"2020-04-07T03:05:08.5645853Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '529'
+      - '563'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:30:23 GMT
+      - Tue, 07 Apr 2020 03:10:39 GMT
       expires:
       - '-1'
       pragma:
@@ -7244,14 +6900,14 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n
-        \ \"name\": \"768cce30-e49a-4927-8e07-cdde6d709e17\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"startTime\": \"2020-01-22T02:24:51.9546716Z\",\r\n  \"endTime\": \"2020-01-22T02:30:34.8120136Z\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n
+        \ \"name\": \"696f4b70-dabc-48c9-9aad-0c8d6bac26e7\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"startTime\": \"2020-04-07T03:05:08.5645853Z\",\r\n  \"endTime\": \"2020-04-07T03:10:42.2226538Z\",\r\n
         \ \"percentComplete\": 100.0\r\n}"
     headers:
       cache-control:
@@ -7261,7 +6917,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:30:52 GMT
+      - Tue, 07 Apr 2020 03:11:09 GMT
       expires:
       - '-1'
       pragma:
@@ -7298,36 +6954,37 @@ interactions:
         --force-restart
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330825\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321492\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"removeApplicationCapacity\":
-        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
-        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
-        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
-        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
-        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
-        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
-        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
-        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"removeApplicationCapacity\": false,\r\n    \"upgradePolicy\": {\r\n
+        \     \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
+        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
+        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
+        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
+        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
+        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
+        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
+        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1425'
+      - '1449'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:30:52 GMT
+      - Tue, 07 Apr 2020 03:11:09 GMT
       expires:
       - '-1'
       pragma:
@@ -7361,7 +7018,7 @@ interactions:
       - -g -c --application-name --minimum-nodes --maximum-nodes
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -7370,29 +7027,30 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330825\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321492\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"removeApplicationCapacity\":
-        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
-        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
-        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
-        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
-        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
-        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
-        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
-        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"removeApplicationCapacity\": false,\r\n    \"upgradePolicy\": {\r\n
+        \     \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
+        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
+        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
+        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
+        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
+        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
+        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
+        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1425'
+      - '1449'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:30:53 GMT
+      - Tue, 07 Apr 2020 03:11:09 GMT
       expires:
       - '-1'
       pragma:
@@ -7426,7 +7084,7 @@ interactions:
       - -g -c --application-name --minimum-nodes --maximum-nodes
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -7435,29 +7093,30 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330825\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321492\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"removeApplicationCapacity\":
-        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
-        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
-        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
-        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
-        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
-        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
-        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
-        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"removeApplicationCapacity\": false,\r\n    \"upgradePolicy\": {\r\n
+        \     \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
+        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
+        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
+        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
+        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
+        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
+        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
+        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1425'
+      - '1449'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:30:54 GMT
+      - Tue, 07 Apr 2020 03:11:10 GMT
       expires:
       - '-1'
       pragma:
@@ -7491,7 +7150,7 @@ interactions:
       - -g -c --application-name --minimum-nodes --maximum-nodes
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -7500,29 +7159,30 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330825\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321492\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"removeApplicationCapacity\":
-        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
-        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
-        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
-        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
-        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
-        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
-        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
-        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"removeApplicationCapacity\": false,\r\n    \"upgradePolicy\": {\r\n
+        \     \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
+        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
+        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
+        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
+        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
+        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
+        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
+        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1425'
+      - '1449'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:30:53 GMT
+      - Tue, 07 Apr 2020 03:11:10 GMT
       expires:
       - '-1'
       pragma:
@@ -7556,7 +7216,7 @@ interactions:
       - -g -c --application-name --minimum-nodes --maximum-nodes
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -7565,29 +7225,30 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330825\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321492\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"removeApplicationCapacity\":
-        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
-        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
-        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
-        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
-        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
-        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
-        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
-        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"removeApplicationCapacity\": false,\r\n    \"upgradePolicy\": {\r\n
+        \     \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
+        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
+        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
+        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
+        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
+        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
+        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
+        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1425'
+      - '1449'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:30:54 GMT
+      - Tue, 07 Apr 2020 03:11:10 GMT
       expires:
       - '-1'
       pragma:
@@ -7621,7 +7282,7 @@ interactions:
       - -g -c --application-name --minimum-nodes --maximum-nodes
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -7630,29 +7291,30 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330825\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321492\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"removeApplicationCapacity\":
-        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
-        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
-        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
-        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
-        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
-        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
-        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
-        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"removeApplicationCapacity\": false,\r\n    \"upgradePolicy\": {\r\n
+        \     \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
+        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
+        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
+        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
+        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
+        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
+        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
+        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1425'
+      - '1449'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:30:54 GMT
+      - Tue, 07 Apr 2020 03:11:10 GMT
       expires:
       - '-1'
       pragma:
@@ -7686,7 +7348,7 @@ interactions:
       - -g -c --application-name --minimum-nodes --maximum-nodes
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -7695,29 +7357,30 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330825\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321492\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"removeApplicationCapacity\":
-        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
-        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
-        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
-        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
-        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
-        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
-        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
-        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"removeApplicationCapacity\": false,\r\n    \"upgradePolicy\": {\r\n
+        \     \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
+        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
+        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
+        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
+        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
+        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
+        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
+        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1425'
+      - '1449'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:30:55 GMT
+      - Tue, 07 Apr 2020 03:11:10 GMT
       expires:
       - '-1'
       pragma:
@@ -7751,7 +7414,7 @@ interactions:
       - -g -c --application-name --minimum-nodes --maximum-nodes
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -7760,29 +7423,30 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330825\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321492\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"removeApplicationCapacity\":
-        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
-        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
-        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
-        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
-        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
-        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
-        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
-        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"removeApplicationCapacity\": false,\r\n    \"upgradePolicy\": {\r\n
+        \     \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
+        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
+        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
+        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
+        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
+        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
+        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
+        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1425'
+      - '1449'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:30:54 GMT
+      - Tue, 07 Apr 2020 03:11:11 GMT
       expires:
       - '-1'
       pragma:
@@ -7802,8 +7466,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": "westus", "tags": {}, "properties": {"typeVersion": "1.1",
-      "parameters": {"Mode": "decimal"}, "upgradePolicy": {"upgradeReplicaSetCheckTimeout":
+    body: '{"location": "westus", "tags": {}, "properties": {"typeVersion": "1.2",
+      "parameters": {"Mode": "binary", "Precision": "3"}, "upgradePolicy": {"upgradeReplicaSetCheckTimeout":
       "00:05:00", "forceRestart": true, "rollingUpgradeMonitoringPolicy": {"failureAction":
       "Rollback", "healthCheckWaitDuration": "00:00:00", "healthCheckStableDuration":
       "00:00:00", "healthCheckRetryTimeout": "00:00:00", "upgradeTimeout": "01:56:40",
@@ -7822,14 +7486,14 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '817'
+      - '834'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g -c --application-name --minimum-nodes --maximum-nodes
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: PUT
@@ -7838,36 +7502,36 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330826\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321493\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"maximumNodes\": 3,\r\n
-        \   \"minimumNodes\": 1,\r\n    \"removeApplicationCapacity\": false,\r\n
-        \   \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
-        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
-        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
-        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
-        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
-        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
-        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
-        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"maximumNodes\": 3,\r\n    \"minimumNodes\": 1,\r\n    \"removeApplicationCapacity\":
+        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
+        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
+        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
+        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
+        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
+        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
+        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
+        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d212bc04-9ecb-4099-9038-99963e5b35b8?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c43bedd-c29a-4e5c-95ba-3122f1744c34?api-version=2019-03-01
       cache-control:
       - no-cache
       content-length:
-      - '1472'
+      - '1496'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:30:55 GMT
+      - Tue, 07 Apr 2020 03:11:11 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/d212bc04-9ecb-4099-9038-99963e5b35b8?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/5c43bedd-c29a-4e5c-95ba-3122f1744c34?api-version=2019-03-01
       pragma:
       - no-cache
       server:
@@ -7878,7 +7542,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -7897,14 +7561,14 @@ interactions:
       - -g -c --application-name --minimum-nodes --maximum-nodes
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d212bc04-9ecb-4099-9038-99963e5b35b8?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c43bedd-c29a-4e5c-95ba-3122f1744c34?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d212bc04-9ecb-4099-9038-99963e5b35b8\",\r\n
-        \ \"name\": \"d212bc04-9ecb-4099-9038-99963e5b35b8\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:30:55.9649432Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c43bedd-c29a-4e5c-95ba-3122f1744c34\",\r\n
+        \ \"name\": \"5c43bedd-c29a-4e5c-95ba-3122f1744c34\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T03:11:11.9114327Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -7914,7 +7578,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:31:55 GMT
+      - Tue, 07 Apr 2020 03:12:11 GMT
       expires:
       - '-1'
       pragma:
@@ -7948,65 +7612,14 @@ interactions:
       - -g -c --application-name --minimum-nodes --maximum-nodes
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d212bc04-9ecb-4099-9038-99963e5b35b8?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c43bedd-c29a-4e5c-95ba-3122f1744c34?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d212bc04-9ecb-4099-9038-99963e5b35b8\",\r\n
-        \ \"name\": \"d212bc04-9ecb-4099-9038-99963e5b35b8\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:30:55.9649432Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 0.0\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '353'
-      content-type:
-      - application/json
-      date:
-      - Wed, 22 Jan 2020 02:32:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf application update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c --application-name --minimum-nodes --maximum-nodes
-      User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d212bc04-9ecb-4099-9038-99963e5b35b8?api-version=2019-03-01
-  response:
-    body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/d212bc04-9ecb-4099-9038-99963e5b35b8\",\r\n
-        \ \"name\": \"d212bc04-9ecb-4099-9038-99963e5b35b8\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"startTime\": \"2020-01-22T02:30:55.9649432Z\",\r\n  \"endTime\": \"2020-01-22T02:32:34.8415033Z\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/5c43bedd-c29a-4e5c-95ba-3122f1744c34\",\r\n
+        \ \"name\": \"5c43bedd-c29a-4e5c-95ba-3122f1744c34\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"startTime\": \"2020-04-07T03:11:11.9114327Z\",\r\n  \"endTime\": \"2020-04-07T03:12:42.2620112Z\",\r\n
         \ \"percentComplete\": 100.0\r\n}"
     headers:
       cache-control:
@@ -8016,7 +7629,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:32:56 GMT
+      - Tue, 07 Apr 2020 03:12:41 GMT
       expires:
       - '-1'
       pragma:
@@ -8050,37 +7663,37 @@ interactions:
       - -g -c --application-name --minimum-nodes --maximum-nodes
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006?api-version=2019-03-01
   response:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330826\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321493\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"maximumNodes\": 3,\r\n
-        \   \"minimumNodes\": 1,\r\n    \"removeApplicationCapacity\": false,\r\n
-        \   \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
-        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
-        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
-        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
-        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
-        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
-        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
-        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"maximumNodes\": 3,\r\n    \"minimumNodes\": 1,\r\n    \"removeApplicationCapacity\":
+        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
+        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
+        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
+        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
+        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
+        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
+        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
+        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1473'
+      - '1497'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:32:56 GMT
+      - Tue, 07 Apr 2020 03:12:41 GMT
       expires:
       - '-1'
       pragma:
@@ -8114,7 +7727,7 @@ interactions:
       - -g -c --application-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -8123,30 +7736,30 @@ interactions:
     body:
       string: "{\r\n  \"type\": \"Microsoft.ServiceFabric/clusters/applications\",\r\n
         \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/clusters/sfrp-cli-000004/applications/testApp000006\",\r\n
-        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637152562637330826\\\"\",\r\n
+        \ \"name\": \"testApp000006\",\r\n  \"tags\": {},\r\n  \"etag\": \"W/\\\"637218250809321493\\\"\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"typeName\":
-        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.1\",\r\n    \"parameters\":
-        {\r\n      \"Mode\": \"decimal\"\r\n    },\r\n    \"maximumNodes\": 3,\r\n
-        \   \"minimumNodes\": 1,\r\n    \"removeApplicationCapacity\": false,\r\n
-        \   \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n        \"considerWarningAsError\":
-        false,\r\n        \"maxPercentUnhealthyDeployedApplications\": 0,\r\n        \"defaultServiceTypeHealthPolicy\":
-        {\r\n          \"maxPercentUnhealthyServices\": 0,\r\n          \"maxPercentUnhealthyPartitionsPerService\":
-        0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\": 0\r\n        }\r\n
-        \     },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n        \"failureAction\":
-        \"Rollback\",\r\n        \"healthCheckRetryTimeout\": \"00:00:00\",\r\n        \"healthCheckWaitDuration\":
-        \"00:00:00\",\r\n        \"healthCheckStableDuration\": \"00:00:00\",\r\n
-        \       \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
+        \"CalcServiceApp\",\r\n    \"typeVersion\": \"1.2\",\r\n    \"parameters\":
+        {\r\n      \"Mode\": \"binary\",\r\n      \"Precision\": \"3\"\r\n    },\r\n
+        \   \"maximumNodes\": 3,\r\n    \"minimumNodes\": 1,\r\n    \"removeApplicationCapacity\":
+        false,\r\n    \"upgradePolicy\": {\r\n      \"applicationHealthPolicy\": {\r\n
+        \       \"considerWarningAsError\": false,\r\n        \"maxPercentUnhealthyDeployedApplications\":
+        0,\r\n        \"defaultServiceTypeHealthPolicy\": {\r\n          \"maxPercentUnhealthyServices\":
+        0,\r\n          \"maxPercentUnhealthyPartitionsPerService\": 0,\r\n          \"maxPercentUnhealthyReplicasPerPartition\":
+        0\r\n        }\r\n      },\r\n      \"rollingUpgradeMonitoringPolicy\": {\r\n
+        \       \"failureAction\": \"Rollback\",\r\n        \"healthCheckRetryTimeout\":
+        \"00:00:00\",\r\n        \"healthCheckWaitDuration\": \"00:00:00\",\r\n        \"healthCheckStableDuration\":
+        \"00:00:00\",\r\n        \"upgradeDomainTimeout\": \"01:23:20\",\r\n        \"upgradeTimeout\":
         \"01:56:40\"\r\n      },\r\n      \"upgradeReplicaSetCheckTimeout\": \"00:05:00\",\r\n
         \     \"forceRestart\": true\r\n    }\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1473'
+      - '1497'
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:32:57 GMT
+      - Tue, 07 Apr 2020 03:12:42 GMT
       expires:
       - '-1'
       pragma:
@@ -8182,7 +7795,7 @@ interactions:
       - -g -c --application-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: DELETE
@@ -8192,17 +7805,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/1441ab3b-45b5-49a0-9b50-4dba327d3eab?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/daa6e1d0-2ff8-4538-8d38-0c1ef56b94c1?api-version=2019-03-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 22 Jan 2020 02:32:57 GMT
+      - Tue, 07 Apr 2020 03:12:43 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/1441ab3b-45b5-49a0-9b50-4dba327d3eab?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/daa6e1d0-2ff8-4538-8d38-0c1ef56b94c1?api-version=2019-03-01
       pragma:
       - no-cache
       server:
@@ -8232,14 +7845,14 @@ interactions:
       - -g -c --application-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/1441ab3b-45b5-49a0-9b50-4dba327d3eab?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/daa6e1d0-2ff8-4538-8d38-0c1ef56b94c1?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/1441ab3b-45b5-49a0-9b50-4dba327d3eab\",\r\n
-        \ \"name\": \"1441ab3b-45b5-49a0-9b50-4dba327d3eab\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:32:57.6298881Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/daa6e1d0-2ff8-4538-8d38-0c1ef56b94c1\",\r\n
+        \ \"name\": \"daa6e1d0-2ff8-4538-8d38-0c1ef56b94c1\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T03:12:43.4184729Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -8249,7 +7862,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:33:57 GMT
+      - Tue, 07 Apr 2020 03:13:43 GMT
       expires:
       - '-1'
       pragma:
@@ -8283,14 +7896,14 @@ interactions:
       - -g -c --application-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/1441ab3b-45b5-49a0-9b50-4dba327d3eab?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/daa6e1d0-2ff8-4538-8d38-0c1ef56b94c1?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/1441ab3b-45b5-49a0-9b50-4dba327d3eab\",\r\n
-        \ \"name\": \"1441ab3b-45b5-49a0-9b50-4dba327d3eab\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:32:57.6298881Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/daa6e1d0-2ff8-4538-8d38-0c1ef56b94c1\",\r\n
+        \ \"name\": \"daa6e1d0-2ff8-4538-8d38-0c1ef56b94c1\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T03:12:43.4184729Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -8300,7 +7913,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:34:27 GMT
+      - Tue, 07 Apr 2020 03:14:13 GMT
       expires:
       - '-1'
       pragma:
@@ -8334,14 +7947,14 @@ interactions:
       - -g -c --application-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/1441ab3b-45b5-49a0-9b50-4dba327d3eab?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/daa6e1d0-2ff8-4538-8d38-0c1ef56b94c1?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/1441ab3b-45b5-49a0-9b50-4dba327d3eab\",\r\n
-        \ \"name\": \"1441ab3b-45b5-49a0-9b50-4dba327d3eab\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"startTime\": \"2020-01-22T02:32:57.6298881Z\",\r\n  \"endTime\": \"2020-01-22T02:34:34.8555136Z\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/daa6e1d0-2ff8-4538-8d38-0c1ef56b94c1\",\r\n
+        \ \"name\": \"daa6e1d0-2ff8-4538-8d38-0c1ef56b94c1\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"startTime\": \"2020-04-07T03:12:43.4184729Z\",\r\n  \"endTime\": \"2020-04-07T03:14:42.2774988Z\",\r\n
         \ \"percentComplete\": 100.0\r\n}"
     headers:
       cache-control:
@@ -8351,7 +7964,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:34:58 GMT
+      - Tue, 07 Apr 2020 03:14:43 GMT
       expires:
       - '-1'
       pragma:
@@ -8387,7 +8000,7 @@ interactions:
       - -g -c --application-type-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: DELETE
@@ -8397,17 +8010,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/3ae1a026-a84f-4079-9631-3de70c23a467?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/e85e8c65-3b3c-44db-bb51-203e33b07946?api-version=2019-03-01
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Wed, 22 Jan 2020 02:34:59 GMT
+      - Tue, 07 Apr 2020 03:14:44 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/3ae1a026-a84f-4079-9631-3de70c23a467?api-version=2019-03-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operationResults/e85e8c65-3b3c-44db-bb51-203e33b07946?api-version=2019-03-01
       pragma:
       - no-cache
       server:
@@ -8437,14 +8050,14 @@ interactions:
       - -g -c --application-type-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/3ae1a026-a84f-4079-9631-3de70c23a467?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/e85e8c65-3b3c-44db-bb51-203e33b07946?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/3ae1a026-a84f-4079-9631-3de70c23a467\",\r\n
-        \ \"name\": \"3ae1a026-a84f-4079-9631-3de70c23a467\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:34:59.1846221Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/e85e8c65-3b3c-44db-bb51-203e33b07946\",\r\n
+        \ \"name\": \"e85e8c65-3b3c-44db-bb51-203e33b07946\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T03:14:45.0431409Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -8454,7 +8067,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:35:59 GMT
+      - Tue, 07 Apr 2020 03:15:44 GMT
       expires:
       - '-1'
       pragma:
@@ -8488,14 +8101,14 @@ interactions:
       - -g -c --application-type-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/3ae1a026-a84f-4079-9631-3de70c23a467?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/e85e8c65-3b3c-44db-bb51-203e33b07946?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/3ae1a026-a84f-4079-9631-3de70c23a467\",\r\n
-        \ \"name\": \"3ae1a026-a84f-4079-9631-3de70c23a467\",\r\n  \"status\": \"Created\",\r\n
-        \ \"startTime\": \"2020-01-22T02:34:59.1846221Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/e85e8c65-3b3c-44db-bb51-203e33b07946\",\r\n
+        \ \"name\": \"e85e8c65-3b3c-44db-bb51-203e33b07946\",\r\n  \"status\": \"Created\",\r\n
+        \ \"startTime\": \"2020-04-07T03:14:45.0431409Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0\r\n}"
     headers:
       cache-control:
@@ -8505,7 +8118,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:36:28 GMT
+      - Tue, 07 Apr 2020 03:16:14 GMT
       expires:
       - '-1'
       pragma:
@@ -8539,14 +8152,14 @@ interactions:
       - -g -c --application-type-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/3ae1a026-a84f-4079-9631-3de70c23a467?api-version=2019-03-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/e85e8c65-3b3c-44db-bb51-203e33b07946?api-version=2019-03-01
   response:
     body:
-      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/3ae1a026-a84f-4079-9631-3de70c23a467\",\r\n
-        \ \"name\": \"3ae1a026-a84f-4079-9631-3de70c23a467\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"startTime\": \"2020-01-22T02:34:59.1846221Z\",\r\n  \"endTime\": \"2020-01-22T02:36:34.9110231Z\",\r\n
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/westus/operations/e85e8c65-3b3c-44db-bb51-203e33b07946\",\r\n
+        \ \"name\": \"e85e8c65-3b3c-44db-bb51-203e33b07946\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"startTime\": \"2020-04-07T03:14:45.0431409Z\",\r\n  \"endTime\": \"2020-04-07T03:16:42.3446021Z\",\r\n
         \ \"percentComplete\": 100.0\r\n}"
     headers:
       cache-control:
@@ -8556,7 +8169,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:36:59 GMT
+      - Tue, 07 Apr 2020 03:16:45 GMT
       expires:
       - '-1'
       pragma:
@@ -8590,7 +8203,7 @@ interactions:
       - -g -c --application-name
       User-Agent:
       - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.0.78
+        azure-mgmt-servicefabric/0.4.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
@@ -8598,7 +8211,7 @@ interactions:
   response:
     body:
       string: "{\r\n  \"error\": {\r\n    \"code\": \"NotFound\",\r\n    \"message\":
-        \"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CLITEST.RGRIUQXJRYFGKLK2DBAI3Q3SSHD6DQL5MMVQ4WDAXSBFOHD4LE7ZU73VTNXEH5DRWP2/providers/Microsoft.ServiceFabric/clusters/SFRP-CLI-3IHN3UH2AS35AVW/applications/TESTAPP2W5T
+        \"Resource /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/CLITEST.RGBIDHID7IZ6IK5DRYTYPKOR7IYAML7DOMICJMEVYWMARK7DZAAAJ6C5FQEAPSEZHT6/providers/Microsoft.ServiceFabric/clusters/SFRP-CLI-KKQSDG7HQVKGSDM/applications/TESTAPPCCB6
         not found.\",\r\n    \"details\": []\r\n  }\r\n}"
     headers:
       cache-control:
@@ -8608,7 +8221,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 22 Jan 2020 02:37:00 GMT
+      - Tue, 07 Apr 2020 03:16:46 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/test_sf_application.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/test_sf_application.py
@@ -58,11 +58,12 @@ class ServiceFabricApplicationTests(ScenarioTest):
                  checks=[self.check('provisioningState', 'Succeeded')])
 
         self.cmd('az sf application update -g {rg} -c {cluster_name} --application-name {app_name} --application-type-version {v2} '
-                 '--application-parameters Mode=decimal --health-check-stable-duration 0 --health-check-wait-duration 0 --health-check-retry-timeout 0 '
+                 '--application-parameters Precision=3 --health-check-stable-duration 0 --health-check-wait-duration 0 --health-check-retry-timeout 0 '
                  '--upgrade-domain-timeout 5000 --upgrade-timeout 7000 --failure-action Rollback --upgrade-replica-set-check-timeout 300 --force-restart',
                  checks=[self.check('provisioningState', 'Succeeded'),
                          self.check('typeVersion', '{v2}'),
-                         self.check('parameters.Mode', 'decimal'),
+                         self.check('parameters.Mode', 'binary'),
+                         self.check('parameters.Precision', '3'),
                          self.check('upgradePolicy.forceRestart', True),
                          self.check('upgradePolicy.upgradeReplicaSetCheckTimeout', '00:05:00'),
                          self.check('upgradePolicy.rollingUpgradeMonitoringPolicy.healthCheckRetryTimeout', '00:00:00'),
@@ -97,8 +98,8 @@ class ServiceFabricApplicationTests(ScenarioTest):
             'app_type_name': 'CalcServiceApp',
             'v1': '1.0',
             'app_package_v1': 'https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.0.sfpkg',
-            'v2': '1.1',
-            'app_package_v2': 'https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.1.sfpkg',
+            'v2': '1.2',
+            'app_package_v2': 'https://sfrpserviceclienttesting.blob.core.windows.net/test-apps/CalcApp_1.2.sfpkg',
             'app_name': self.create_random_name('testApp', 11),
             'service_type': 'CalcServiceType'
         })


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Update application using --application-parameters replaces all the current parameters with the ones provided in the command instead of adding and updating them, so it will remove previous parameters that are not passed in the command. Merging new parameters with old ones to fix it and modify the tests to try this scenario.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
