### PR TITLE
{Misc} az version: GA

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/commands.py
@@ -389,4 +389,4 @@ def load_command_table(self, _):
         g.custom_command('rest', 'rest_call')
 
     with self.command_group('') as g:
-        g.custom_command('version', 'show_version', is_preview=True)
+        g.custom_command('version', 'show_version')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Make `az version` from #11680 GA. Otherwise the preview warning breaks the terminal color when calling

```pwsh
Measure-Command {az version}
```

![image](https://user-images.githubusercontent.com/4003950/79211886-63e02d00-7e79-11ea-9d95-b1bc490d06eb.png)

We need to run/demo this line for performance baseline evaluation. 

Besides, the command is already stable. 

**Testing Guide**  
```pwsh
> az version
{
  "azure-cli": "2.3.1",
  "azure-cli-command-modules-nspkg": "2.0.3",
  "azure-cli-core": "2.3.1",
  "azure-cli-nspkg": "3.0.4",
  "azure-cli-telemetry": "1.0.4",
  "azure-cli-testsdk": "0.2.4",
  "extensions": {
    "interactive": "0.4.4",
    "support": "0.1.1",
    "timeseriesinsights": "0.1.0"
  }
}

> Measure-Command {az version}

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 2
Milliseconds      : 80
Ticks             : 20807594
TotalDays         : 2.40828634259259E-05
TotalHours        : 0.000577988722222222
TotalMinutes      : 0.0346793233333333
TotalSeconds      : 2.0807594
TotalMilliseconds : 2080.7594
```
