### PR TITLE
[Packaging] Drop support for Ubuntu/Disco package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -841,37 +841,6 @@ jobs:
       TargetPath: $(Build.ArtifactStagingDirectory)
       ArtifactName: ubuntu-bionic
 
-- job: BuildUbuntuDisco
-  displayName: Build Ubuntu Disco Package
-
-  dependsOn: BuildPythonWheel
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-    - task: DownloadPipelineArtifact@1
-      displayName: 'Download Build Artifacts'
-      inputs:
-        TargetPath: '$(Build.ArtifactStagingDirectory)/pypi'
-        artifactName: pypi
-
-
-    - task: Bash@3
-      displayName: 'Build Ubuntu Disco Package'
-      inputs:
-        targetType: 'filePath'
-        filePath: scripts/release/debian/pipeline.sh
-      env:
-        DISTRO: disco
-        DISTRO_BASE_IMAGE: ubuntu:disco
-
-
-    - task: PublishPipelineArtifact@0
-      displayName: 'Publish Artifact: debian'
-      inputs:
-        TargetPath: $(Build.ArtifactStagingDirectory)
-        ArtifactName: ubuntu-disco
-
 - job: BuildUbuntuEoan
   displayName: Build Ubuntu Eoan Package
 
@@ -996,7 +965,6 @@ jobs:
    - BuildUbuntuBionic
    - BuildDebianJessie
    - BuildDebianStretch
-   - BuildUbuntuDisco
    - BuildUbuntuEoan
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
   pool:
@@ -1032,13 +1000,6 @@ jobs:
     inputs:
       TargetPath: '$(Build.ArtifactStagingDirectory)/debian'
       artifactName: ubuntu-bionic
-
-
-  - task: DownloadPipelineArtifact@1
-    displayName: 'Download Ubuntu:Disco Builds'
-    inputs:
-      TargetPath: '$(Build.ArtifactStagingDirectory)/debian'
-      artifactName: ubuntu-disco
 
 
   - task: DownloadPipelineArtifact@1
@@ -1082,8 +1043,8 @@ jobs:
        done
 
        # Distros that do require libssl1.1
-       DISTROS=(bionic disco eoan buster)
-       BASE_IMAGES=(ubuntu:bionic ubuntu:disco ubuntu:eoan debian:buster)
+       DISTROS=(bionic eoan buster)
+       BASE_IMAGES=(ubuntu:bionic ubuntu:eoan debian:buster)
 
        for i in ${!DISTROS[@]}; do
            echo "== Test debian package on ${DISTROS[$i]} =="


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Ubuntu Disco has reached end-of-life since January 23, 2020. And now Ubuntu repo no longer provides the release file for Disco. See https://wiki.ubuntu.com/Releases

Will update corresponding ADO tasks as well.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
