### PR TITLE
[Survey] Add switch to turn off survey link

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -89,7 +89,8 @@ class AzCli(CLI):
 
     def show_version(self):
         from azure.cli.core.util import get_az_version_string
-        from azure.cli.core.commands.constants import SURVEY_PROMPT, SURVEY_PROMPT_COLOR
+        from azure.cli.core.commands.constants import (SURVEY_PROMPT, SURVEY_PROMPT_COLOR,
+                                                       UX_SURVEY_PROMPT, UX_SURVEY_PROMPT_COLOR)
 
         ver_string, updates_available = get_az_version_string()
         print(ver_string)
@@ -101,8 +102,10 @@ class AzCli(CLI):
                            updates_available)
         else:
             print('Your CLI is up-to-date.')
-
-        print('\n' + (SURVEY_PROMPT_COLOR if self.enable_color else SURVEY_PROMPT))
+        show_link = self.config.getboolean('output', 'show_survey_link', True)
+        if show_link:
+            print('\n' + (SURVEY_PROMPT_COLOR if self.enable_color else SURVEY_PROMPT))
+            print(UX_SURVEY_PROMPT_COLOR if self.enable_color else UX_SURVEY_PROMPT)
 
     def exception_handler(self, ex):  # pylint: disable=no-self-use
         from azure.cli.core.util import handle_exception

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -7,7 +7,8 @@ from __future__ import print_function
 import argparse
 
 from azure.cli.core.commands import ExtensionCommandSource
-from azure.cli.core.commands.constants import SURVEY_PROMPT, SURVEY_PROMPT_COLOR
+from azure.cli.core.commands.constants import (SURVEY_PROMPT, SURVEY_PROMPT_COLOR,
+                                               UX_SURVEY_PROMPT, UX_SURVEY_PROMPT_COLOR)
 
 from knack.help import (HelpFile as KnackHelpFile, CommandHelpFile as KnackCommandHelpFile,
                         GroupHelpFile as KnackGroupHelpFile, ArgumentGroupRegistry as KnackArgumentGroupRegistry,
@@ -172,8 +173,11 @@ class AzCliHelp(CLIPrintMixin, CLIHelp):
         else:
             AzCliHelp.update_examples(help_file)
         self._print_detailed_help(cli_name, help_file)
-
-        print(SURVEY_PROMPT_COLOR if self.cli_ctx.enable_color else SURVEY_PROMPT)
+        show_link = self.cli_ctx.config.getboolean('output', 'show_survey_link', True)
+        if show_link:
+            print(SURVEY_PROMPT_COLOR if self.cli_ctx.enable_color else SURVEY_PROMPT)
+            if not nouns:
+                print(UX_SURVEY_PROMPT_COLOR if self.cli_ctx.enable_color else UX_SURVEY_PROMPT)
 
     def _register_help_loaders(self):
         import azure.cli.core._help_loaders as help_loaders

--- a/src/azure-cli-core/azure/cli/core/commands/constants.py
+++ b/src/azure-cli-core/azure/cli/core/commands/constants.py
@@ -35,3 +35,6 @@ BLACKLISTED_MODS = ['context', 'shell', 'documentdb', 'component']
 SURVEY_PROMPT = 'Please let us know how we are doing: https://aka.ms/clihats'
 SURVEY_PROMPT_COLOR = Fore.YELLOW + Style.BRIGHT + 'Please let us know how we are doing: ' + Fore.BLUE + \
     'https://aka.ms/clihats' + Style.RESET_ALL
+UX_SURVEY_PROMPT = 'Mobile developer using Azure CLI? Come try our newest feature: https://aka.ms/CLIUXstudy'
+UX_SURVEY_PROMPT_COLOR = Fore.YELLOW + Style.BRIGHT + 'Mobile developer using Azure CLI? Come try our newest feature: '\
+    + Fore.BLUE + 'https://aka.ms/CLIUXstudy' + Style.RESET_ALL

--- a/src/azure-cli-core/azure/cli/core/commands/constants.py
+++ b/src/azure-cli-core/azure/cli/core/commands/constants.py
@@ -35,6 +35,7 @@ BLACKLISTED_MODS = ['context', 'shell', 'documentdb', 'component']
 SURVEY_PROMPT = 'Please let us know how we are doing: https://aka.ms/clihats'
 SURVEY_PROMPT_COLOR = Fore.YELLOW + Style.BRIGHT + 'Please let us know how we are doing: ' + Fore.BLUE + \
     'https://aka.ms/clihats' + Style.RESET_ALL
-UX_SURVEY_PROMPT = 'Mobile developer using Azure CLI? Come try our newest feature: https://aka.ms/CLIUXstudy'
-UX_SURVEY_PROMPT_COLOR = Fore.YELLOW + Style.BRIGHT + 'Mobile developer using Azure CLI? Come try our newest feature: '\
+UX_SURVEY_PROMPT = 'And let us know if you\'re interested in trying out our newest features: https://aka.ms/CLIUXstudy'
+UX_SURVEY_PROMPT_COLOR = Fore.YELLOW + Style.BRIGHT + \
+    'And let us know if you\'re interested in trying out our newest features: ' \
     + Fore.BLUE + 'https://aka.ms/CLIUXstudy' + Style.RESET_ALL

--- a/src/azure-cli-core/azure/cli/core/commands/constants.py
+++ b/src/azure-cli-core/azure/cli/core/commands/constants.py
@@ -35,7 +35,7 @@ BLACKLISTED_MODS = ['context', 'shell', 'documentdb', 'component']
 SURVEY_PROMPT = 'Please let us know how we are doing: https://aka.ms/clihats'
 SURVEY_PROMPT_COLOR = Fore.YELLOW + Style.BRIGHT + 'Please let us know how we are doing: ' + Fore.BLUE + \
     'https://aka.ms/clihats' + Style.RESET_ALL
-UX_SURVEY_PROMPT = 'And let us know if you\'re interested in trying out our newest features: https://aka.ms/CLIUXstudy'
+UX_SURVEY_PROMPT = 'and let us know if you\'re interested in trying out our newest features: https://aka.ms/CLIUXstudy'
 UX_SURVEY_PROMPT_COLOR = Fore.YELLOW + Style.BRIGHT + \
-    'And let us know if you\'re interested in trying out our newest features: ' \
+    'and let us know if you\'re interested in trying out our newest features: ' \
     + Fore.BLUE + 'https://aka.ms/CLIUXstudy' + Style.RESET_ALL


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
1. The survey link now can be turned off by setting environment variable `AZURE_OUTPUT_SHOW_SURVEY_LINK=no` or add the following in `~/.azure/config`:
```
[output]
show_survey_link = no
```
The environment variable has higher priority.

2. Added a UX study survey link in `az --version` and `az --help` (but not in `az some-command --help`).
The output looks like this in `az --version` :
![image](https://user-images.githubusercontent.com/55177366/79424469-c27ce680-7ff2-11ea-9be1-f05831a40b81.png)


**Testing Guide**  
<!--Example commands with explanations.-->
```
az --version
az --help
export AZURE_OUTPUT_SHOW_SURVEY_LINK=no
az --version
az --help
az vm --help
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
