### PR TITLE
{Core} Fix bug in core test test_parser that will affect exception stack while existing if argument parse raise Exception

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -49,7 +49,7 @@ class TestParser(unittest.TestCase):
         args = parser.parse_args('sub-command the-second-name'.split())
         self.assertIs(args.func, command2)
 
-        with mock.patch('azure.cli.core.parser.AzCliCommandParser.error', side_effect=VerifyError(self)):
+        with mock.patch('azure.cli.core.parser.AzCliCommandParser.error', new=VerifyError(self)):
             parser.parse_args('sub-command'.split())
             self.assertTrue(AzCliCommandParser.error.called)
 
@@ -72,7 +72,7 @@ class TestParser(unittest.TestCase):
         args = parser.parse_args('test command --req yep'.split())
         self.assertIs(args.func, command)
 
-        with mock.patch('azure.cli.core.parser.AzCliCommandParser.error', side_effect=VerifyError(self)):
+        with mock.patch('azure.cli.core.parser.AzCliCommandParser.error', new=VerifyError(self)):
             parser.parse_args('test command'.split())
             self.assertTrue(AzCliCommandParser.error.called)
 
@@ -95,7 +95,7 @@ class TestParser(unittest.TestCase):
         args = parser.parse_args('test command --req yep nope'.split())
         self.assertIs(args.func, command)
 
-        with mock.patch('azure.cli.core.parser.AzCliCommandParser.error', side_effect=VerifyError(self)):
+        with mock.patch('azure.cli.core.parser.AzCliCommandParser.error', new=VerifyError(self)):
             parser.parse_args('test command -req yep'.split())
             self.assertTrue(AzCliCommandParser.error.called)
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -49,9 +49,9 @@ class TestParser(unittest.TestCase):
         args = parser.parse_args('sub-command the-second-name'.split())
         self.assertIs(args.func, command2)
 
-        AzCliCommandParser.error = VerifyError(self,)
-        parser.parse_args('sub-command'.split())
-        self.assertTrue(AzCliCommandParser.error.called)
+        with mock.patch('azure.cli.core.parser.AzCliCommandParser.error', side_effect=VerifyError(self)):
+            parser.parse_args('sub-command'.split())
+            self.assertTrue(AzCliCommandParser.error.called)
 
     def test_required_parameter(self):
         def test_handler(args):  # pylint: disable=unused-argument
@@ -72,9 +72,9 @@ class TestParser(unittest.TestCase):
         args = parser.parse_args('test command --req yep'.split())
         self.assertIs(args.func, command)
 
-        AzCliCommandParser.error = VerifyError(self)
-        parser.parse_args('test command'.split())
-        self.assertTrue(AzCliCommandParser.error.called)
+        with mock.patch('azure.cli.core.parser.AzCliCommandParser.error', side_effect=VerifyError(self)):
+            parser.parse_args('test command'.split())
+            self.assertTrue(AzCliCommandParser.error.called)
 
     def test_nargs_parameter(self):
         def test_handler():
@@ -95,9 +95,9 @@ class TestParser(unittest.TestCase):
         args = parser.parse_args('test command --req yep nope'.split())
         self.assertIs(args.func, command)
 
-        AzCliCommandParser.error = VerifyError(self)
-        parser.parse_args('test command -req yep'.split())
-        self.assertTrue(AzCliCommandParser.error.called)
+        with mock.patch('azure.cli.core.parser.AzCliCommandParser.error', side_effect=VerifyError(self)):
+            parser.parse_args('test command -req yep'.split())
+            self.assertTrue(AzCliCommandParser.error.called)
 
     def test_case_insensitive_enum_choices(self):
         from enum import Enum


### PR DESCRIPTION
**Description<!--Mandatory-->**  
The overwrited way in `src/azure-cli-core/azure/cli/core/tests/test_parser.py`:
https://github.com/Azure/azure-cli/blob/8b7f3f6ef29b48be610ede323a10b9f41360708a/src/azure-cli-core/azure/cli/core/tests/test_parser.py#L49-L54

makes global impact while running tests **in serial**. 
With the way it overwrites, all tests in CLI after running with those tests, the instance method `error` of `AzCliCommandParser` will be replaced by `<azure.cli.core.tests.test_parser.VerifyError object at 0x7ff5efebbc88>` if you print it out in your test method.

**Background**:
```Python
# argparse.py (ArgumentParser)
# =====================================
# Command line argument parsing methods
# =====================================
def parse_args(self, args=None, namespace=None):
    args, argv = self.parse_known_args(args, namespace)
    if argv:
        msg = _('unrecognized arguments: %s')
        self.error(msg % ' '.join(argv))
    return args
```
https://github.com/Azure/azure-cli/blob/34f9033b96e6ea31f82626a9f2b152c1a061300e/src/azure-cli-core/azure/cli/core/parser.py#L138-L144

1. The origial way while an error is raised after an command is parsed is to call `self.error` method, so before calling, the top of exception stack would be any instacne of class/sub-calss of the built-in Exception/BaseException/Error.
2. Then `argparse` will call `self.error`, who will raise `SyetemExit`, so the top of exception stack would be `SytemExit`.

What will the original way impact?
the overwrited `error` method didn't re-raise `SystemExit` as `AzCliCommandParser` and `argparse.ArgumentParser` do:
https://github.com/Azure/azure-cli/blob/8b7f3f6ef29b48be610ede323a10b9f41360708a/src/azure-cli-core/azure/cli/core/tests/test_parser.py#L252-L262

So, after those tests run, the top of StackException would never be `SystemExit`.

So, If running tests in serial via `pytest`, the context will remain and affecting the rest of tests. Like test `src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_account_scenarios.py::StorageAccountTests::test_show_usage_no_location`, which will fail because it try to catch an SystemExit:
```Python
def test_show_usage_no_location(self):
    with self.assertRaises(SystemExit):
        self.cmd('storage account show-usage')
```

**Testing Guide**  
Before fix,
running 
https://github.com/Azure/azure-cli/blob/06a03627aae86c0870341cd974edf97ea2812b72/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_account_scenarios.py#L283-L285

this test will fail.
After fix, the command will pass


**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
