### PR TITLE
{Docs} Quote code in help messages with backticks

### DIFF
--- a/doc/authoring_help.md
+++ b/doc/authoring_help.md
@@ -79,7 +79,7 @@ examples:
 - Make sure the doc contains all the details that someone unfamiliar with the API needs to use the command.
 - Examples are worth a thousand words. Provide examples that cover common use cases.
 - Don't use "etc". Sometimes it makes sense to spell out a list completely. Sometimes it works to say "like ..." instead of "..., etc".
-- Use active voice. For example, say "Update web app configurations" instead of "Updates web app congfigurations" or "Updating web app configurations".
+- Use active voice. For example, say "Update web app configurations" instead of "Updates web app configurations" or "Updating web app configurations".
 - Don't use highly formal language. If you imagine that another dev sat down with you and you were telling him what he needs to know to use the command, that's exactly what you need to write, in those words.
 - If the help message contains **angle brackets**, like `<name>`, it will be parsed as an HTML tag during document rendering. To bypass that, quote the content with backticks `` `<name>` `` to tell the document renderer to parse it as **code**. 
 

--- a/doc/authoring_help.md
+++ b/doc/authoring_help.md
@@ -1,8 +1,8 @@
-# Azure CLI Help System #
+# Azure CLI Help System
 
 Help authoring for commands is done in a number of places, all of which are contained in the Az code base.  Some help text comes from product code, but it can be overridden using a YAML-based help authoring system.  The YAML-based system is the recommended way to update command and group help text.
 
-## YAML Help Authoring ##
+## YAML Help Authoring
 
 If you're not familiar with YAML, see the [YAML specification](http://www.yaml.org/spec/1.2/spec.html).
 
@@ -26,7 +26,7 @@ To override help for a given command:
 >  2. The Help Authoring System now supports **help.yaml** files. Eventually, **_help.py** files will be replaced by **help.yaml**.
 
 
-### Example YAML help file, _help.py ###
+### Example YAML help file, _help.py
 
 ```py
 #---------------------------------------------------------------------------------------------
@@ -83,19 +83,19 @@ examples:
 - Don't use highly formal language. If you imagine that another dev sat down with you and you were telling him what he needs to know to use the command, that's exactly what you need to write, in those words.
 - If the help message contains **angle brackets**, like `<name>`, it will be parsed as an HTML tag during document rendering. To bypass that, quote the content with backticks `` `<name>` `` to tell the document renderer to parse it as **code**. 
 
-# Testing Authored Help #
+# Testing Authored Help
 
 To verify the YAML help is correctly formatted, the command/group's help command must be executed at runtime.  For example, to verify "az account clear", run the command "az account clear -h" and verify the text.  
 
 Runtime is also when help authoring errors will be reported, such as documenting a parameter that doesn't exist.  Errors will only show when the CLI help is executed, so verifying the CLI help is required to ensure your authoring is correct.   
 
-# Other Help Authoring #
+# Other Help Authoring
 
 Commands without YAML usually still have help text.  Where does it come from?  These sections briefly outline where Az help text comes from.
 
 Authoring note: it is not recommended to use the product code to author command/group help--YAML is the recommended way (see above).  This information is provided for completeness and may be useful for fixing small typos in existing help text.
 
-## Help Layers ##
+## Help Layers
 
 Command help starts with its raw SDK docstring text, if available.  Non-SDK commands may have their own docstring.  Code can specify values that replace the SDK/docstring contents.  YAML is the final override for help content and is the recommended way for authoring command and group help.  Note that group help can only be authored via YAML.  
 
@@ -108,11 +108,11 @@ Here are the layers of Project Az help, with each layer overriding the layer bel
 | Docstring                     |
 | SDK Text                      |
 
-## Page titles for command groups ##
+## Page titles for command groups
 
 Page titles for your command groups as generated from the source are simply the command syntax, "az vm", but we use friendly titles on the published pages - "Virtual machines - az vm". To do that, ee add the friendly part of the page title to [titlemapping.json](https://github.com/Azure/azure-docs-cli/blob/master/titleMapping.json) in the azure-docs-cli repo. When you add a new command group, make sure to update the mapping.
 
-## Profile specific help ##
+## Profile specific help
 
 The CLI supports multiple profiles. Help can be authored to take advantage of this.  
 Commands available, arguments, descriptions and examples all change dynamically based on the profile in use.
@@ -167,7 +167,7 @@ Examples
         Standard_LRS
 ```
 
-## Online Reference Documentation ##
+## Online Reference Documentation
 
 The help that you author above will be available online as reference documentation.
 

--- a/doc/authoring_help.md
+++ b/doc/authoring_help.md
@@ -26,7 +26,7 @@ To override help for a given command:
 >  2. The Help Authoring System now supports **help.yaml** files. Eventually, **_help.py** files will be replaced by **help.yaml**.
 
 
-### Example YAML help file, _help.py
+### Example YAML help file, \_help.py
 
 ```py
 #---------------------------------------------------------------------------------------------

--- a/doc/authoring_help.md
+++ b/doc/authoring_help.md
@@ -28,7 +28,7 @@ To override help for a given command:
 
 ### Example YAML help file, _help.py ###
 
-<pre>
+```py
 #---------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
@@ -39,40 +39,40 @@ from knack.help_files import helps
 #pylint: disable=line-too-long
 
 helps['account clear'] = """
-            type: command
-            short-summary: Clear account
-            long-summary: Longer summary of clearing account
-            parameters: 
-                - name: --account-name -n
-                  type: string
-                  short-summary: 'Account name'
-                  long-summary: |
-                      Longer summary with newlines preserved.  Preserving newlines is helpful for paragraph breaks.
-                  populator-commands: 
-                    - az account list
-                - name: --another-parameter
-                  short-summary: These parameter names must match what is shown in the command's CLI help output, including abbreviation.
-            examples:
-                - name: Collapse whitespace in YAML
-                  text: >
-                    The > character collapses multiple lines into a single line, which is good for on-screen wrapping.
-            """
-</pre>
+type: command
+short-summary: Clear account
+long-summary: Longer summary of clearing account
+parameters: 
+    - name: --account-name -n
+      type: string
+      short-summary: 'Account name'
+      long-summary: |
+          Longer summary with newlines preserved.  Preserving newlines is helpful for paragraph breaks.
+      populator-commands: 
+        - az account list
+    - name: --another-parameter
+      short-summary: These parameter names must match what is shown in the command's CLI help output, including abbreviation.
+examples:
+    - name: Collapse whitespace in YAML
+      text: >
+        The > character collapses multiple lines into a single line, which is good for on-screen wrapping.
+"""
+```
 
 You can also document groups using the same format.
 
-<pre>
+```py
 helps['account'] = """
-            type: group
-            short-summary: The account group
-            long-summary: Longer summary of account            
-            examples:
-                - name: Clear an account 
-                  text: Description
-                - name: Choose your current account
-                  text: az account set...
-            """
-</pre>
+type: group
+short-summary: The account group
+long-summary: Longer summary of account            
+examples:
+    - name: Clear an account 
+      text: Description
+    - name: Choose your current account
+      text: az account set...
+"""
+```
 
 # Tips to write effective help for your command
 
@@ -81,6 +81,7 @@ helps['account'] = """
 - Don't use "etc". Sometimes it makes sense to spell out a list completely. Sometimes it works to say "like ..." instead of "..., etc".
 - Use active voice. For example, say "Update web app configurations" instead of "Updates web app congfigurations" or "Updating web app configurations".
 - Don't use highly formal language. If you imagine that another dev sat down with you and you were telling him what he needs to know to use the command, that's exactly what you need to write, in those words.
+- If the help message contains **angle brackets**, like `<name>`, it will be parsed as an HTML tag during document rendering. To bypass that, quote the content with backticks `` `<name>` `` to tell the document renderer to parse it as **code**. 
 
 # Testing Authored Help #
 

--- a/doc/authoring_help.md
+++ b/doc/authoring_help.md
@@ -133,7 +133,7 @@ For command examples, you can optionally specify the profile the example is for 
 Here's a demonstration for `storage account create`:
 The first example is only supported on the `latest` and `2018-03-01-hybrid` profiles whilst the second example is only supported on `2017-03-09-profile`.
 
-### _help.py
+### \_help.py
 
 ```
     examples:

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -140,7 +140,7 @@ def load_arguments(self, _):
         c.argument('restore_content_only', action='store_true', help='restore only deleted files without web app settings')
 
     with self.argument_context('webapp traffic-routing') as c:
-        c.argument('distribution', options_list=['--distribution', '-d'], nargs='+', help='space-separated slot routings in a format of <slot-name>=<percentage> e.g. staging=50. Unused traffic percentage will go to the Production slot')
+        c.argument('distribution', options_list=['--distribution', '-d'], nargs='+', help='space-separated slot routings in a format of `<slot-name>=<percentage>` e.g. staging=50. Unused traffic percentage will go to the Production slot')
 
     with self.argument_context('webapp update') as c:
         c.argument('client_affinity_enabled', help="Enables sending session affinity cookies.", arg_type=get_three_state_flag(return_label=True))
@@ -182,7 +182,7 @@ def load_arguments(self, _):
         with self.argument_context(scope + ' config ssl') as c:
             c.argument('certificate_thumbprint', help='The ssl cert thumbprint')
         with self.argument_context(scope + ' config appsettings') as c:
-            c.argument('settings', nargs='+', help="space-separated app settings in a format of <name>=<value>")
+            c.argument('settings', nargs='+', help="space-separated app settings in a format of `<name>=<value>`")
             c.argument('setting_names', nargs='+', help="space-separated app setting names")
         with self.argument_context(scope + ' config ssl import') as c:
             c.argument('key_vault', help='The name or resource ID of the Key Vault')
@@ -205,7 +205,7 @@ def load_arguments(self, _):
             c.argument('nodejs_task_runner', arg_group='VSTS CD Provider', help='Task runner for nodejs. Default is None', arg_type=get_enum_type(['None', 'Gulp', 'Grunt']))
             c.argument('python_framework', arg_group='VSTS CD Provider', help='Framework used for Python application. Default is Django', arg_type=get_enum_type(['Bottle', 'Django', 'Flask']))
             c.argument('python_version', arg_group='VSTS CD Provider', help='Python version used for application. Default is Python 3.5.3 x86', arg_type=get_enum_type(['Python 2.7.12 x64', 'Python 2.7.12 x86', 'Python 2.7.13 x64', 'Python 2.7.13 x86', 'Python 3.5.3 x64', 'Python 3.5.3 x86', 'Python 3.6.0 x64', 'Python 3.6.0 x86', 'Python 3.6.2 x64', 'Python 3.6.1 x86']))
-            c.argument('cd_project_url', arg_group='VSTS CD Provider', help='URL of the Visual Studio Team Services (VSTS) project to use for continuous delivery. URL should be in format https://<accountname>.visualstudio.com/<projectname>')
+            c.argument('cd_project_url', arg_group='VSTS CD Provider', help='URL of the Visual Studio Team Services (VSTS) project to use for continuous delivery. URL should be in format `https://<accountname>.visualstudio.com/<projectname>`')
             c.argument('cd_account_create', arg_group='VSTS CD Provider', help="To create a new Visual Studio Team Services (VSTS) account if it doesn't exist already", action='store_true')
             c.argument('test', arg_group='VSTS CD Provider', help='Name of the web app to be used for load testing. If web app is not available, it will be created. Default: Disable')
             c.argument('slot_swap', arg_group='VSTS CD Provider', help='Name of the slot to be used for deployment and later promote to production. If slot is not available, it will be created. Default: Not configured')
@@ -254,7 +254,7 @@ def load_arguments(self, _):
             c.argument('app_command_line', options_list=['--startup-file'], help="The startup file for linux hosted web apps, e.g. 'process.json' for Node.js web")
             c.argument('ftps_state', help="Set the Ftps state value for an app. Default value is 'AllAllowed'.", arg_type=get_enum_type(FTPS_STATE_TYPES))
             c.argument('generic_configurations', nargs='+',
-                       help='provide site configuration list in a format of either "key=value" pair or "@<json_file>"')
+                       help='provide site configuration list in a format of either `key=value` pair or `@<json_file>`')
 
         with self.argument_context(scope + ' config container') as c:
             c.argument('docker_registry_server_url', options_list=['--docker-registry-server-url', '-r'],
@@ -316,8 +316,8 @@ def load_arguments(self, _):
 
     for scope in ['appsettings', 'connection-string']:
         with self.argument_context('webapp config ' + scope) as c:
-            c.argument('settings', nargs='+', help="space-separated {} in a format of <name>=<value>".format(scope))
-            c.argument('slot_settings', nargs='+', help="space-separated slot {} in a format of either <name>=<value> or @<json_file>".format(scope))
+            c.argument('settings', nargs='+', help="space-separated {} in a format of `<name>=<value>`".format(scope))
+            c.argument('slot_settings', nargs='+', help="space-separated slot {} in a format of either `<name>=<value>` or `@<json_file>`".format(scope))
             c.argument('setting_names', nargs='+', help="space-separated {} names".format(scope))
 
     with self.argument_context('webapp config connection-string') as c:
@@ -487,7 +487,7 @@ def load_arguments(self, _):
     with self.argument_context('functionapp show') as c:
         c.argument('name', arg_type=name_arg_type)
     with self.argument_context('functionapp config appsettings') as c:
-        c.argument('slot_settings', nargs='+', help="space-separated slot app settings in a format of <name>=<value>")
+        c.argument('slot_settings', nargs='+', help="space-separated slot app settings in a format of `<name>=<value>`")
 
     with self.argument_context('functionapp plan') as c:
         c.argument('name', arg_type=name_arg_type, help='The name of the app service plan',

--- a/src/azure-cli/azure/cli/command_modules/batch/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_params.py
@@ -124,7 +124,7 @@ def load_arguments(self, _):
         c.argument('auto_scale_formula', help='A formula for the desired number of compute nodes in the pool. The formula is checked for validity before the pool is created. If the formula is not valid, the Batch service rejects the request with detailed error information. For more information about specifying this formula, see https://azure.microsoft.com/documentation/articles/batch-automatic-scaling/.')
         c.extra('disk_encryption_targets',
                 arg_group="Pool: Virtual Machine Configuration",
-                help='A space seperated list of DiskEncryptionTargets. current possible values include OsDisk and TemporaryDisk.', type=disk_encryption_configuration_format)
+                help='A space separated list of DiskEncryptionTargets. current possible values include OsDisk and TemporaryDisk.', type=disk_encryption_configuration_format)
         c.extra('image', completer=load_supported_images, arg_group="Pool: Virtual Machine Configuration",
                 help="OS image reference. This can be either 'publisher:offer:sku[:version]' format, or a fully qualified ARM image id of the form '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/images/{imageName}'. If 'publisher:offer:sku[:version]' format, version is optional and if omitted latest will be used. Valid values can be retrieved via 'az batch pool supported-images list'. For example: 'MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:latest'")
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -93,7 +93,7 @@ def load_arguments(self, _):
     with self.argument_context('keyvault create', arg_group='Network Rule') as c:
         c.argument('network_acls', type=validate_file_or_dict,
                    help='Network ACLs. It accepts a JSON filename or a JSON string. JSON format: '
-                        '{\\"ip\\":[<ip1>, <ip2>...],\\"vnet\\":[<vnet_name_1>/<subnet_name_1>,<subnet_id2>...]}')
+                        '`{\\"ip\\":[<ip1>, <ip2>...],\\"vnet\\":[<vnet_name_1>/<subnet_name_1>,<subnet_id2>...]}`')
         c.argument('network_acls_ips', nargs='*', help='Network ACLs IP rules. Space-separated list of IP addresses.')
         c.argument('network_acls_vnets', nargs='*', help='Network ACLS VNet rules. Space-separated list of '
                                                          'Vnet/subnet pairs or subnet resource ids.')

--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -1460,7 +1460,7 @@ def load_arguments(self, _):
 
     with self.argument_context('network public-ip prefix') as c:
         c.argument('public_ip_prefix_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/publicIPPrefixes'), id_part='name', help='The name of the public IP prefix.')
-        c.argument('prefix_length', options_list='--length', help='Length of the prefix (i.e. XX.XX.XX.XX/<Length>)')
+        c.argument('prefix_length', options_list='--length', help='Length of the prefix (i.e. `XX.XX.XX.XX/<Length>`)')
         c.argument('zone', zone_type)
 
     with self.argument_context('network public-ip prefix create') as c:

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -391,7 +391,7 @@ def load_arguments(self, _):
 
     with self.argument_context('managedapp definition create') as c:
         c.argument('lock_level', arg_type=get_enum_type(ApplicationLockLevel), help='The type of lock restriction.')
-        c.argument('authorizations', options_list=['--authorizations', '-a'], nargs='+', help="space-separated authorization pairs in a format of <principalId>:<roleDefinitionId>")
+        c.argument('authorizations', options_list=['--authorizations', '-a'], nargs='+', help="space-separated authorization pairs in a format of `<principalId>:<roleDefinitionId>`")
         c.argument('createUiDefinition', options_list=['--create-ui-definition', '-c'], help='JSON formatted string or a path to a file with such content', type=file_type)
         c.argument('mainTemplate', options_list=['--main-template', '-t'], help='JSON formatted string or a path to a file with such content', type=file_type)
 

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -58,7 +58,7 @@ def load_arguments(self, _):
         c.argument('identifier', options_list=['--id'], help='identifier uri, application id, or object id of the application')
 
     with self.argument_context('ad app permission') as c:
-        c.argument('api_permissions', nargs='+', help='space seperated list of <resource-access-id>=<type>')
+        c.argument('api_permissions', nargs='+', help='space separated list of `<resource-access-id>=<type>`')
         c.argument('expires', help='Expiry date for the permissions in years. e.g. 1, 2 or "never"')
         c.argument('scope', help='Specifies the value of the scope claim that the resource application should expect in the OAuth 2.0 access token, e.g. User.Read')
         c.argument('api', help='the target API to access')

--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -541,7 +541,7 @@ def load_arguments(self, _):
 
     with self.argument_context('vmss create', min_api='2017-03-30', arg_group='Network') as c:
         c.argument('public_ip_per_vm', action='store_true', help="Each VM instance will have a public ip. For security, you can use '--nsg' to apply appropriate rules")
-        c.argument('vm_domain_name', help="domain name of VM instances, once configured, the FQDN is 'vm<vm-index>.<vm-domain-name>.<..rest..>'")
+        c.argument('vm_domain_name', help="domain name of VM instances, once configured, the FQDN is `vm<vm-index>.<vm-domain-name>.<..rest..>`")
         c.argument('dns_servers', nargs='+', help="space-separated IP addresses of DNS servers, e.g. 10.0.0.5 10.0.0.6")
         c.argument('accelerated_networking', arg_type=get_three_state_flag(),
                    help="enable accelerated networking. Unless specified, CLI will enable it based on machine image and size")
@@ -687,7 +687,7 @@ def load_arguments(self, _):
             c.ignore('disk_info', 'storage_account_type', 'public_ip_address_type', 'nsg_type', 'nic_type', 'vnet_type', 'load_balancer_type', 'app_gateway_type')
             c.argument('os_caching', options_list=[self.deprecate(target='--storage-caching', redirect='--os-disk-caching', hide=True), '--os-disk-caching'], help='Storage caching type for the VM OS disk. Default: ReadWrite', arg_type=get_enum_type(CachingTypes))
             c.argument('data_caching', options_list=['--data-disk-caching'], nargs='+',
-                       help="storage caching type for data disk(s), including 'None', 'ReadOnly', 'ReadWrite', etc. Use a singular value to apply on all disks, or use '<lun>=<vaule1> <lun>=<value2>' to configure individual disk")
+                       help="storage caching type for data disk(s), including 'None', 'ReadOnly', 'ReadWrite', etc. Use a singular value to apply on all disks, or use `<lun>=<vaule1> <lun>=<value2>` to configure individual disk")
             c.argument('ultra_ssd_enabled', ultra_ssd_enabled_type)
             c.argument('ephemeral_os_disk', arg_type=get_three_state_flag(), min_api='2018-06-01',
                        help='Allows you to create an OS disk directly on the host node, providing local disk performance and faster VM/VMSS reimage time.', is_preview=True)
@@ -835,7 +835,7 @@ def load_arguments(self, _):
 
     with self.argument_context('sig image-version create') as c:
         c.argument('gallery_image_version', options_list=['--gallery-image-version', '-e'],
-                   help='Gallery image version in semantic version pattern. The allowed characters are digit and period. Digits must be within the range of a 32-bit integer, e.g. <MajorVersion>.<MinorVersion>.<Patch>')
+                   help='Gallery image version in semantic version pattern. The allowed characters are digit and period. Digits must be within the range of a 32-bit integer, e.g. `<MajorVersion>.<MinorVersion>.<Patch>`')
         c.argument('description', help='the description of the gallery image version')
         c.argument('managed_image', help='image name(if in the same resource group) or resource id')
         c.argument('os_snapshot', help='Name or ID of OS disk snapshot')
@@ -853,7 +853,7 @@ def load_arguments(self, _):
     for scope in ['sig image-version create', 'sig image-version update']:
         with self.argument_context(scope) as c:
             c.argument('target_regions', nargs='*', validator=process_gallery_image_version_namespace,
-                       help='Space-separated list of regions and their replica counts. Use "<region>[=<replica count>][=<storage account type>]" to optionally set the replica count and/or storage account type for each region. '
+                       help='Space-separated list of regions and their replica counts. Use `<region>[=<replica count>][=<storage account type>]` to optionally set the replica count and/or storage account type for each region. '
                             'If a replica count is not specified, the default replica count will be used. If a storage account type is not specified, the default storage account type will be used')
             c.argument('replica_count', help='The default number of replicas to be created per region. To set regional replication counts, use --target-regions', type=int)
     # endregion


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Fix https://github.com/Azure/azure-cli/issues/10698: `az ad app permission add` description not understandable

## Symptom

The doc for `az ad app permission add` is not rendered correctly, with the value of `--api-permissions` missing. 

https://docs.microsoft.com/en-us/cli/azure/ad/app/permission

![image](https://user-images.githubusercontent.com/4003950/79529962-91f38600-80a0-11ea-9068-1f9fed693146.png)

## Root Cause

The reason is that the doc generator parses `<resource-access-id>` and `<type>` as a possible HTML entities:

https://github.com/Azure/azure-cli/blob/1f34245e83fbb68777c26a764f9cb5e8b86c0051/src/azure-cli/azure/cli/command_modules/role/_params.py#L61

but they don't match up with any entities on the [Docs HTML Whitelist](https://review.docs.microsoft.com/en-us/help/onboard/admin/html-whitelist?branch=master), and the content is discarded. 

**This happens not only to this command but all over the place, including VM, Network and more commands.** 

##  Solution

This PR quotes the text with backticks `` ` `` like what `azure-cli-core` does for `--resource-group`: https://github.com/Azure/azure-cli/blob/c4e91c00b7266efb7fb05dcd75870ea2dde713cc/src/azure-cli-core/azure/cli/core/commands/parameters.py#L241

In this way, the doc is rendered correctly (even better with highlighting due to backtick (`` ` ``) being interpreted as `code` in markdown), such as 

https://docs.microsoft.com/en-us/cli/azure/acs

![image](https://user-images.githubusercontent.com/4003950/79529915-6b354f80-80a0-11ea-938d-10d4689b5467.png)

⚠ But the disadvantage is the `--help` message may look verbose. 

## Remarks

I searched the occurrence of `<>` with regex `<.+?>` (`?` stands for non-greedy match) and added backticks manually. 

