### PR TITLE
{Role} fix test fail when running in serial due to buggy way to swtich tempory folder back

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -348,7 +348,8 @@ class RoleAssignmentScenarioTest(RoleScenarioTest):
             self.cmd('ad user create --display-name tester123 --password Test123456789 --user-principal-name {upn}')
             time.sleep(15)  # By-design, it takes some time for RBAC system propagated with graph object change
 
-            base_dir = os.curdir
+            base_dir = os.path.abspath(os.curdir)
+
             try:
                 temp_dir = self.create_temp_dir()
                 os.chdir(temp_dir)
@@ -368,7 +369,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTest):
                 self.cmd('role assignment list --assignee {upn} --role reader --scope ' + rg_id, checks=self.check('length([])', 0))
             finally:
                 self.cmd('configure --default group="" --scope local')
-                os.chdir(os.path.basename(base_dir))
+                os.chdir(base_dir)
                 self.cmd('ad user delete --upn-or-object-id {upn}')
 
     @ResourceGroupPreparer(name_prefix='cli_role_assign')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
When running these 2 tests in serial:
1. test_role.py::RoleAssignmentScenarioTest::test_role_assignment_handle_conflicted_assignments
2. test_role.py::RoleAssignmentScenarioTest::test_role_assignment_mgmt_grp
The second one will fail on Linux but succeed on Windows.

**Why failed on Linux**?
At the beginning, the 1st test would chdir to a temporary dir.
https://github.com/Azure/azure-cli/blob/280692d3b080685846c9b9a71dbe5c10dbd0ce94/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py#L351-L354

and at the end the of test, it would try to switch back but actually it didn't because the `basr_dir` is a relative path. So, the original directory is lost and the test procedure would stay at the temporary directory.

https://github.com/Azure/azure-cli/blob/280692d3b080685846c9b9a71dbe5c10dbd0ce94/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py#L369-L372

However, during the creation of tempory directory, it will register a callback to clean this folder away after the test is done.
```Python
    # IntegrationTestBase from base.py (azure_devtools)
    def create_temp_dir(self):
        """
        Create a temporary directory for testing. The test harness will delete the directory during tearing down.
        """
        temp_dir = tempfile.mkdtemp()
        self.addCleanup(lambda: shutil.rmtree(temp_dir, ignore_errors=True))

        return temp_dir
```
So, when the second test starts, it's in a non-existing directory, and the intialization of CLI instannce would fail due to LocalContext object require reading a file from current dir:
```
======================================================================================================================================== ERRORS ========================================================================================================================================
______________________________________________________________________________________________________ ERROR at setup of RoleAssignmentScenarioTest.test_role_assignment_mgmt_grp ______________________________________________________________________________________________________

self = <[AttributeError("'RoleAssignmentScenarioTest' object has no attribute '_testMethodName'",) raised in repr()] RoleAssignmentScenarioTest object at 0x7fa0ac645f60>, method_name = 'test_role_assignment_mgmt_grp', config_file = None, recording_name = None
recording_processors = None, replay_processors = None, recording_patches = None, replay_patches = None

    def __init__(self, method_name, config_file=None, recording_name=None,
                 recording_processors=None, replay_processors=None, recording_patches=None, replay_patches=None):
>       self.cli_ctx = get_dummy_cli()

/home/harold/Microsoft/azure-cli/src/azure-cli-testsdk/azure/cli/testsdk/base.py:82: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/harold/Microsoft/azure-cli/src/azure-cli-testsdk/azure/cli/testsdk/reverse_dependency.py:14: in get_dummy_cli
    return getattr(mod, 'DummyCli')(*args, **kwargs)
/home/harold/Microsoft/azure-cli/src/azure-cli-core/azure/cli/core/mock.py:34: in __init__
    invocation_cls=AzCliCommandInvoker)
/home/harold/Microsoft/azure-cli/src/azure-cli-core/azure/cli/core/__init__.py:73: in __init__
    dir_name=os.path.basename(self.config.config_dir), file_name='local_context'
/home/harold/Microsoft/azure-cli/src/azure-cli-core/azure/cli/core/local_context.py:27: in __init__
    self._load_local_context_file()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <azure.cli.core.local_context.AzCLILocalContext object at 0x7fa0ad3ad198>

    def _load_local_context_file(self):
>       current_dir = os.getcwd()
E       FileNotFoundError: [Errno 2] No such file or directory

/home/harold/Microsoft/azure-cli/src/azure-cli-core/azure/cli/core/local_context.py:30: FileNotFoundError
```

**Why succeeded on Windows**
The removal temporary dir is ignoring the permission error
```Python
shutil.rmtree(temp_dir, ignore_errors=True)
```
![image](https://user-images.githubusercontent.com/14357159/79532518-f534e680-80a7-11ea-9fee-6bcdb74ed133.png)

So, the deletion wouldn't succeed and the second test would stuck in that temporary folder and succeed just lucky.

**Testing Guide**  
Before fix, run via
```Shell
pytest -x -v -p no:warnings --log-level=WARN \
src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py::RoleAssignmentScenarioTest::test_role_assignment_handle_conflicted_assignments \
src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py::RoleAssignmentScenarioTest::test_role_assignment_mgmt_grp
```

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
