### PR TITLE
[Privatedns] Add feature in private DNS zone to import export zone file

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/privatedns/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/_help.py
@@ -692,3 +692,21 @@ examples:
   - name: Pause executing next line of CLI script until the Private DNS zone is successfully provisioned.
     text: az network private-dns zone wait -g MyResourceGroup -n www.mysite.com --created
 """
+
+helps['network private-dns zone export'] = """
+type: command
+short-summary: Export a Private DNS zone as a DNS zone file.
+examples:
+  - name: Export a Private DNS zone as a DNS zone file.
+    text: >
+        az network private-dns zone export -g MyResourceGroup -n www.mysite.com -f mysite_com_zone.txt
+"""
+
+helps['network private-dns zone import'] = """
+type: command
+short-summary: Create a Private DNS zone using a DNS zone file.
+examples:
+  - name: Import a local zone file into a Private DNS zone resource.
+    text: >
+        az network private-dns zone import -g MyResourceGroup -n MyZone -f /path/to/zone/file
+"""

--- a/src/azure-cli/azure/cli/command_modules/privatedns/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/_params.py
@@ -5,8 +5,9 @@
 
 # pylint: disable=line-too-long
 # pylint: disable=too-many-statements
+from argcomplete.completers import FilesCompleter
 from knack.arguments import CLIArgumentType, ignore_type
-from azure.cli.core.commands.parameters import (get_three_state_flag, tags_type)
+from azure.cli.core.commands.parameters import (get_three_state_flag, tags_type, file_type)
 from azure.cli.command_modules.privatedns._validators import (
     privatedns_zone_name_type, get_vnet_validator, validate_privatedns_metadata, validate_privatedns_record_type)
 
@@ -83,3 +84,9 @@ def load_arguments(self, _):
 
     with self.argument_context('network private-dns record-set txt') as c:
         c.argument('value', options_list=('--value', '-v'), nargs='+', help='Space-separated list of text values which will be concatenated together.')
+
+    with self.argument_context('network private-dns zone import') as c:
+        c.argument('file_name', options_list=['--file-name', '-f'], type=file_type, completer=FilesCompleter(), help='Path to the Private DNS zone file to import')
+
+    with self.argument_context('network private-dns zone export') as c:
+        c.argument('file_name', options_list=['--file-name', '-f'], type=file_type, completer=FilesCompleter(), help='Path to the Private DNS zone file to save')

--- a/src/azure-cli/azure/cli/command_modules/privatedns/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/commands.py
@@ -35,6 +35,8 @@ def load_command_table(self, _):
         g.command('delete', 'delete', confirmation=True, supports_no_wait=True)
         g.show_command('show', 'get', table_transformer=transform_privatedns_zone_table_output)
         g.custom_command('list', 'list_privatedns_zones', client_factory=cf_privatedns_mgmt_zones, table_transformer=transform_privatedns_zone_table_output)
+        g.custom_command('import', 'import_zone')
+        g.custom_command('export', 'export_zone')
         g.custom_command('create', 'create_privatedns_zone', client_factory=cf_privatedns_mgmt_zones, supports_no_wait=True)
         g.generic_update_command('update', setter_name='update', custom_func_name='update_privatedns_zone', supports_no_wait=True)
         g.wait_command('wait')

--- a/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
@@ -14,7 +14,6 @@ from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.command_modules.network.zone_file.make_zone_file import make_zone_file
 from azure.cli.command_modules.network.zone_file.parse_zone_file import parse_zone_file
-import time
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
@@ -5,12 +5,15 @@
 
 # pylint: disable=line-too-long
 from __future__ import print_function
-from collections import Counter
+from collections import Counter, OrderedDict
 from knack.log import get_logger
 from msrestazure.azure_exceptions import CloudError
 from msrestazure.tools import parse_resource_id
 from azure.cli.core.util import CLIError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
+from azure.cli.command_modules.network.zone_file.make_zone_file import make_zone_file
+from azure.cli.command_modules.network.zone_file.parse_zone_file import parse_zone_file
+import time
 
 logger = get_logger(__name__)
 
@@ -22,6 +25,231 @@ def list_privatedns_zones(cmd, resource_group_name=None):
     if resource_group_name:
         return client.list_by_resource_group(resource_group_name)
     return client.list()
+
+
+# pylint: disable=too-many-statements, too-many-locals
+def import_zone(cmd, resource_group_name, private_zone_name, file_name):
+    from azure.cli.core.util import read_file_content
+    import sys
+    from azure.mgmt.privatedns.models import RecordSet
+
+    file_text = read_file_content(file_name)
+    zone_obj = parse_zone_file(file_text, private_zone_name)
+    origin = private_zone_name
+    record_sets = {}
+
+    for record_set_name in zone_obj:
+        for record_set_type in zone_obj[record_set_name]:
+            record_set_obj = zone_obj[record_set_name][record_set_type]
+
+            if record_set_type == 'soa':
+                origin = record_set_name.rstrip('.')
+
+            if not isinstance(record_set_obj, list):
+                record_set_obj = [record_set_obj]
+
+            for entry in record_set_obj:
+
+                record_set_ttl = entry['ttl']
+                record_set_key = '{}{}'.format(record_set_name.lower(), record_set_type)
+
+                record = _build_record(cmd, entry)
+                if not record:
+                    logger.warning('Cannot import %s. RecordType is not found. Skipping...', entry['delim'].lower())
+                    continue
+
+                record_set = record_sets.get(record_set_key, None)
+                if not record_set:
+
+                    # Workaround for issue #2824
+                    relative_record_set_name = record_set_name.rstrip('.')
+                    if not relative_record_set_name.endswith(origin):
+                        logger.warning(
+                            'Cannot import %s. Only records relative to origin may be '
+                            'imported at this time. Skipping...', relative_record_set_name)
+                        continue
+
+                    record_set = RecordSet(ttl=record_set_ttl)
+                    record_sets[record_set_key] = record_set
+                _privatedns_add_record(record_set, record, record_set_type, is_list=record_set_type.lower() not in ['soa', 'cname'])
+
+    total_records = 0
+    for key, rs in record_sets.items():
+        rs_name, rs_type = key.lower().rsplit('.', 1)
+        rs_name = rs_name[:-(len(origin) + 1)] if rs_name != origin else '@'
+        try:
+            record_count = len(getattr(rs, _privatedns_type_to_property_name(rs_type)))
+        except TypeError:
+            record_count = 1
+        total_records += record_count
+    cum_records = 0
+
+    from azure.mgmt.privatedns import PrivateDnsManagementClient
+    from azure.mgmt.privatedns.models import PrivateZone
+    client = get_mgmt_service_client(cmd.cli_ctx, PrivateDnsManagementClient)
+
+    print('== BEGINNING ZONE IMPORT: {} ==\n'.format(private_zone_name), file=sys.stderr)
+
+    if private_zone_name.endswith(".local"):
+        logger.warning(("Please be aware that DNS names ending with .local are reserved for use with multicast DNS "
+                        "and may not work as expected with some operating systems. For details refer to your operating systems documentation."))
+    zone = PrivateZone(location='global')
+    client.private_zones.create_or_update(resource_group_name, private_zone_name, zone)
+
+    for key, rs in record_sets.items():
+
+        rs_name, rs_type = key.lower().rsplit('.', 1)
+        rs_name = '@' if rs_name == origin else rs_name
+        if rs_name.endswith(origin):
+            rs_name = rs_name[:-(len(origin) + 1)]
+
+        try:
+            record_count = len(getattr(rs, _privatedns_type_to_property_name(rs_type)))
+        except TypeError:
+            record_count = 1
+        if rs_name == '@' and rs_type == 'soa':
+            # 30 second sleep in case zone is getting created. else follwoing get soa record-set call fails
+            time.sleep(30)
+            root_soa = client.record_sets.get(resource_group_name, private_zone_name, 'soa', '@')
+            rs.soa_record.host = root_soa.soa_record.host
+            rs_name = '@'
+        try:
+            client.record_sets.create_or_update(
+                resource_group_name, private_zone_name, rs_type, rs_name, rs)
+            cum_records += record_count
+            print("({}/{}) Imported {} records of type '{}' and name '{}'"
+                  .format(cum_records, total_records, record_count, rs_type, rs_name), file=sys.stderr)
+        except CloudError as ex:
+            logger.error(ex)
+    print("\n== {}/{} RECORDS IMPORTED SUCCESSFULLY: '{}' =="
+          .format(cum_records, total_records, private_zone_name), file=sys.stderr)
+
+
+# pylint: disable=too-many-branches
+def export_zone(cmd, resource_group_name, private_zone_name, file_name=None):
+    from azure.mgmt.privatedns import PrivateDnsManagementClient
+    from time import localtime, strftime
+    client = get_mgmt_service_client(cmd.cli_ctx, PrivateDnsManagementClient).record_sets
+    record_sets_soa = client.list_by_type(resource_group_name, private_zone_name, "soa")
+    record_sets_all = client.list(resource_group_name, private_zone_name)
+    zone_obj = OrderedDict({
+        '$origin': private_zone_name.rstrip('.') + '.',
+        'resource-group': resource_group_name,
+        'zone-name': private_zone_name.rstrip('.'),
+        'datetime': strftime('%a, %d %b %Y %X %z', localtime())
+    })
+
+    for record_set in record_sets_soa:
+        record_type = record_set.type.rsplit('/', 1)[1].lower()
+        if record_type == 'soa':
+            record_set_name = record_set.name
+            record_data = getattr(record_set, _privatedns_type_to_property_name(record_type), None)
+
+            if not isinstance(record_data, list):
+                record_data = [record_data]
+
+            for record in record_data:
+
+                record_obj = {'ttl': record_set.ttl}
+
+                if record_type == 'soa':
+                    zone_obj[record_set_name] = OrderedDict()
+                    zone_obj[record_set_name][record_type] = []
+                    record_obj.update({
+                        'mname': record.host.rstrip('.') + '.',
+                        'rname': record.email.rstrip('.') + '.',
+                        'serial': int(record.serial_number), 'refresh': record.refresh_time,
+                        'retry': record.retry_time, 'expire': record.expire_time,
+                        'minimum': record.minimum_ttl
+                    })
+                    zone_obj['$ttl'] = record.minimum_ttl
+                    zone_obj[record_set_name][record_type].append(record_obj)
+
+    for record_set in record_sets_all:
+        record_type = record_set.type.rsplit('/', 1)[1].lower()
+        record_set_name = record_set.name
+        record_data = getattr(record_set, _privatedns_type_to_property_name(record_type), None)
+
+        # ignore empty record sets
+        if not record_data:
+            continue
+
+        if not isinstance(record_data, list):
+            record_data = [record_data]
+
+        if record_set_name not in zone_obj:
+            zone_obj[record_set_name] = OrderedDict()
+
+        for record in record_data:
+
+            record_obj = {'ttl': record_set.ttl}
+
+            if record_type not in zone_obj[record_set_name]:
+                zone_obj[record_set_name][record_type] = []
+
+            if record_type == 'aaaa':
+                record_obj.update({'ip': record.ipv6_address})
+            elif record_type == 'a':
+                record_obj.update({'ip': record.ipv4_address})
+            elif record_type == 'caa':
+                record_obj.update({'val': record.value, 'tag': record.tag, 'flags': record.flags})
+            elif record_type == 'cname':
+                record_obj.update({'alias': record.cname.rstrip('.') + '.'})
+            elif record_type == 'mx':
+                record_obj.update({'preference': record.preference, 'host': record.exchange})
+            elif record_type == 'ns':
+                record_obj.update({'host': record.nsdname})
+            elif record_type == 'ptr':
+                record_obj.update({'host': record.ptrdname})
+            elif record_type == 'soa':
+                continue
+            elif record_type == 'srv':
+                record_obj.update({'priority': record.priority, 'weight': record.weight,
+                                   'port': record.port, 'target': record.target})
+            elif record_type == 'txt':
+                record_obj.update({'txt': ''.join(record.value)})
+
+            zone_obj[record_set_name][record_type].append(record_obj)
+
+    zone_file_content = make_zone_file(zone_obj)
+    print(zone_file_content)
+    if file_name:
+        try:
+            with open(file_name, 'w') as f:
+                f.write(zone_file_content)
+        except IOError:
+            raise CLIError('Unable to export to file: {}'.format(file_name))
+
+
+# pylint: disable=too-many-return-statements, inconsistent-return-statements, unused-argument
+def _build_record(cmd, data):
+    from azure.mgmt.privatedns.models import AaaaRecord, ARecord, CnameRecord, MxRecord, PtrRecord, SoaRecord, SrvRecord, TxtRecord
+    record_type = data['delim'].lower()
+    try:
+        if record_type == 'aaaa':
+            return AaaaRecord(ipv6_address=data['ip'])
+        if record_type == 'a':
+            return ARecord(ipv4_address=data['ip'])
+        if record_type == 'cname':
+            return CnameRecord(cname=data['alias'])
+        if record_type == 'mx':
+            return MxRecord(preference=data['preference'], exchange=data['host'])
+        if record_type == 'ptr':
+            return PtrRecord(ptrdname=data['host'])
+        if record_type == 'soa':
+            return SoaRecord(host=data['host'], email=data['email'], serial_number=data['serial'],
+                             refresh_time=data['refresh'], retry_time=data['retry'], expire_time=data['expire'],
+                             minimum_ttl=data['minimum'])
+        if record_type == 'srv':
+            return SrvRecord(
+                priority=int(data['priority']), weight=int(data['weight']), port=int(data['port']),
+                target=data['target'])
+        if record_type in ['txt', 'spf']:
+            text_data = data['txt']
+            return TxtRecord(value=text_data) if isinstance(text_data, list) else TxtRecord(value=[text_data])
+    except KeyError as ke:
+        raise CLIError("The {} record '{}' is missing a property.  {}"
+                       .format(record_type, data['name'], ke))
 
 
 def create_privatedns_zone(cmd, resource_group_name, private_zone_name, tags=None):
@@ -331,6 +559,7 @@ def dict_matches_filter(d, filter_dict):
                or lists_match(filter_dict[key], d.get(key, [])) for key in filter_dict)  # noqa
 
 
+# pylint: disable=too-many-function-args
 def lists_match(l1, l2):
     try:
         return Counter(l1) == Counter(l2)

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/README.md
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/README.md
@@ -1,0 +1,9 @@
+zone1.com - Check import for sample zone file with all record type in it.
+zone2.com - Check import for preserving TXT record space preservation, long text record. SPF record to be imported as TXT and default TTL for record
+zone3.com – Check import for zone file with Missing name in record set to reuse previous name, Missing class, Multi line record
+zone4.com – Check TTL calculation to take lowest for record, Check for conflicting TTLs on records with the same name
+zone5.com - checks fqdn with different $ORIGIN, checks different $ORIGIN are picked up and Check $ORIGIN from outside zone is permitted (but not for record names), Also check that $ORIGIN without '.' terminator has one added (and a warning)
+zone6.com - Check @ A record import
+zone7.com - Check @ TXT record import
+zone8.com – Check * A record import
+zone.local – Check for the warning while creating private DNS zones with .local at end.

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone1_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone1_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsxNzNjOGY3NS1iZmY3LTQwYzAtODI5Ny00MWYyYTg0YTc2ODM=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlMmI4MzBiOC0xZjU4LTQ1ZjgtODE3Ny1lOGJiYWQ4MDA3MjQ=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:10 GMT
+      - Wed, 22 Apr 2020 08:32:00 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsxNzNjOGY3NS1iZmY3LTQwYzAtODI5Ny00MWYyYTg0YTc2ODM=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlMmI4MzBiOC0xZjU4LTQ1ZjgtODE3Ny1lOGJiYWQ4MDA3MjQ=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -71,7 +71,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsxNzNjOGY3NS1iZmY3LTQwYzAtODI5Ny00MWYyYTg0YTc2ODM=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlMmI4MzBiOC0xZjU4LTQ1ZjgtODE3Ny1lOGJiYWQ4MDA3MjQ=?api-version=2018-09-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -83,7 +83,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:41 GMT
+      - Wed, 22 Apr 2020 08:32:30 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -123,7 +123,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"d3ae408c-d07b-407c-8978-a0aef5505f1e","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"91d521b2-cb16-4e6c-934f-0ed4717f7281","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -132,9 +132,62 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:42 GMT
+      - Wed, 22 Apr 2020 08:32:31 GMT
       etag:
-      - d3ae408c-d07b-407c-8978-a0aef5505f1e
+      - 91d521b2-cb16-4e6c-934f-0ed4717f7281
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '495'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"35a11c2e-e90f-4f02-8b34-2737cfe3385e","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:32:31 GMT
+      etag:
+      - 35a11c2e-e90f-4f02-8b34-2737cfe3385e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -182,7 +235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16acf3e4-2a68-4469-9a44-3667449f02b3","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16dcece1-d26a-4035-8050-e0a69ecf3b5f","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -191,9 +244,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:42 GMT
+      - Wed, 22 Apr 2020 08:32:32 GMT
       etag:
-      - 16acf3e4-2a68-4469-9a44-3667449f02b3
+      - 16dcece1-d26a-4035-8050-e0a69ecf3b5f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -207,7 +260,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -240,7 +293,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/MX/mymx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"f75e249d-93cc-4a2c-93cd-5729b5c2cb98","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"c3a450f7-71af-48c4-a2eb-07a2e6570e78","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -249,9 +302,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:43 GMT
+      - Wed, 22 Apr 2020 08:32:33 GMT
       etag:
-      - f75e249d-93cc-4a2c-93cd-5729b5c2cb98
+      - c3a450f7-71af-48c4-a2eb-07a2e6570e78
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -261,7 +314,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -293,7 +346,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/manuala?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dd4b71e9-6a4e-4ce4-89a6-6a3c4cfbb846","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"edb63e4e-0ebd-4000-a92b-6d8431abadb9","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -302,9 +355,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:44 GMT
+      - Wed, 22 Apr 2020 08:32:35 GMT
       etag:
-      - dd4b71e9-6a4e-4ce4-89a6-6a3c4cfbb846
+      - edb63e4e-0ebd-4000-a92b-6d8431abadb9
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -314,7 +367,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -347,7 +400,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/mya?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8ccc39de-f5ec-4499-9b65-9fcdb40a4b0b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"eff5595f-4944-4c11-8c5c-31ae7b42d49b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -356,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:46 GMT
+      - Wed, 22 Apr 2020 08:32:36 GMT
       etag:
-      - 8ccc39de-f5ec-4499-9b65-9fcdb40a4b0b
+      - eff5595f-4944-4c11-8c5c-31ae7b42d49b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -368,7 +421,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -400,7 +453,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/AAAA/myaaaa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"ee179e4e-b635-4ce1-a792-b6c4ab07c9f5","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"d1191185-05c4-4a62-8698-245acefdb039","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -409,9 +462,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:47 GMT
+      - Wed, 22 Apr 2020 08:32:36 GMT
       etag:
-      - ee179e4e-b635-4ce1-a792-b6c4ab07c9f5
+      - d1191185-05c4-4a62-8698-245acefdb039
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -453,7 +506,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/CNAME/mycname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"728359c1-98d9-458d-9ea5-cb60092ff199","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"24d7b510-6a6b-4e98-a118-1068d92a4252","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -462,9 +515,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:48 GMT
+      - Wed, 22 Apr 2020 08:32:38 GMT
       etag:
-      - 728359c1-98d9-458d-9ea5-cb60092ff199
+      - 24d7b510-6a6b-4e98-a118-1068d92a4252
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -506,7 +559,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e3999ef5-3abc-4408-9a7c-55439cf67ca6","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8983963f-1970-4cd7-8809-43b529dfc24d","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -515,9 +568,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:49 GMT
+      - Wed, 22 Apr 2020 08:32:39 GMT
       etag:
-      - e3999ef5-3abc-4408-9a7c-55439cf67ca6
+      - 8983963f-1970-4cd7-8809-43b529dfc24d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -527,7 +580,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -559,7 +612,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myptr?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a7a8e8c2-44a3-4d3c-8722-5e2e6ade3e87","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"df509397-34be-476b-ad65-a7ab2bb4bd02","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -568,9 +621,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:50 GMT
+      - Wed, 22 Apr 2020 08:32:40 GMT
       etag:
-      - a7a8e8c2-44a3-4d3c-8722-5e2e6ade3e87
+      - df509397-34be-476b-ad65-a7ab2bb4bd02
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -580,7 +633,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -612,7 +665,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/myname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0449bfac-517d-4019-8d7d-9349f3162d4c","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"07a1dda0-067f-42a0-9f36-e3e574dd3c27","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -621,9 +674,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:51 GMT
+      - Wed, 22 Apr 2020 08:32:41 GMT
       etag:
-      - 0449bfac-517d-4019-8d7d-9349f3162d4c
+      - 07a1dda0-067f-42a0-9f36-e3e574dd3c27
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -633,7 +686,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -666,7 +719,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"46c84cee-fb3b-4247-8790-60e1f626bd83","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b1934e14-e6d8-42ca-a227-412c8aecc1d8","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
         def"]},{"value":["foo bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -676,9 +729,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:52 GMT
+      - Wed, 22 Apr 2020 08:32:43 GMT
       etag:
-      - 46c84cee-fb3b-4247-8790-60e1f626bd83
+      - b1934e14-e6d8-42ca-a227-412c8aecc1d8
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -688,7 +741,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -720,7 +773,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxtrs?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"efb4ef27-7b6b-4a43-a579-6d9fab6876ef","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a0c1742-4918-47d2-93f3-307718c97e67","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -729,9 +782,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:53 GMT
+      - Wed, 22 Apr 2020 08:32:43 GMT
       etag:
-      - efb4ef27-7b6b-4a43-a579-6d9fab6876ef
+      - 6a0c1742-4918-47d2-93f3-307718c97e67
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -741,7 +794,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -774,7 +827,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/mysrv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"db7a485f-9dfb-49c1-ac3c-61f62a0deac6","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"70b6a37c-dfd9-43ca-bed7-87fcdfbb4a64","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -783,9 +836,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:54 GMT
+      - Wed, 22 Apr 2020 08:32:45 GMT
       etag:
-      - db7a485f-9dfb-49c1-ac3c-61f62a0deac6
+      - 70b6a37c-dfd9-43ca-bed7-87fcdfbb4a64
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -795,7 +848,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -828,7 +881,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/_sip._tls?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"dd285c45-d3c4-4452-a874-4ea76e21812a","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ffc71334-ec96-417c-9edd-99678214d5bd","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -837,9 +890,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:56 GMT
+      - Wed, 22 Apr 2020 08:32:46 GMT
       etag:
-      - dd285c45-d3c4-4452-a874-4ea76e21812a
+      - ffc71334-ec96-417c-9edd-99678214d5bd
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -849,7 +902,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -877,8 +930,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16acf3e4-2a68-4469-9a44-3667449f02b3","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"dd285c45-d3c4-4452-a874-4ea76e21812a","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dd4b71e9-6a4e-4ce4-89a6-6a3c4cfbb846","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8ccc39de-f5ec-4499-9b65-9fcdb40a4b0b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"ee179e4e-b635-4ce1-a792-b6c4ab07c9f5","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"728359c1-98d9-458d-9ea5-cb60092ff199","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"f75e249d-93cc-4a2c-93cd-5729b5c2cb98","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e3999ef5-3abc-4408-9a7c-55439cf67ca6","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0449bfac-517d-4019-8d7d-9349f3162d4c","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a7a8e8c2-44a3-4d3c-8722-5e2e6ade3e87","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"db7a485f-9dfb-49c1-ac3c-61f62a0deac6","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"46c84cee-fb3b-4247-8790-60e1f626bd83","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
-        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"efb4ef27-7b6b-4a43-a579-6d9fab6876ef","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16dcece1-d26a-4035-8050-e0a69ecf3b5f","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ffc71334-ec96-417c-9edd-99678214d5bd","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"edb63e4e-0ebd-4000-a92b-6d8431abadb9","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"eff5595f-4944-4c11-8c5c-31ae7b42d49b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"d1191185-05c4-4a62-8698-245acefdb039","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"24d7b510-6a6b-4e98-a118-1068d92a4252","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"c3a450f7-71af-48c4-a2eb-07a2e6570e78","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8983963f-1970-4cd7-8809-43b529dfc24d","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"07a1dda0-067f-42a0-9f36-e3e574dd3c27","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"df509397-34be-476b-ad65-a7ab2bb4bd02","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"70b6a37c-dfd9-43ca-bed7-87fcdfbb4a64","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b1934e14-e6d8-42ca-a227-412c8aecc1d8","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a0c1742-4918-47d2-93f3-307718c97e67","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -887,7 +940,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:56 GMT
+      - Wed, 22 Apr 2020 08:32:46 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -931,7 +984,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16acf3e4-2a68-4469-9a44-3667449f02b3","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16dcece1-d26a-4035-8050-e0a69ecf3b5f","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -940,7 +993,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:57 GMT
+      - Wed, 22 Apr 2020 08:32:47 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -984,8 +1037,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16acf3e4-2a68-4469-9a44-3667449f02b3","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"dd285c45-d3c4-4452-a874-4ea76e21812a","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dd4b71e9-6a4e-4ce4-89a6-6a3c4cfbb846","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8ccc39de-f5ec-4499-9b65-9fcdb40a4b0b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"ee179e4e-b635-4ce1-a792-b6c4ab07c9f5","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"728359c1-98d9-458d-9ea5-cb60092ff199","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"f75e249d-93cc-4a2c-93cd-5729b5c2cb98","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e3999ef5-3abc-4408-9a7c-55439cf67ca6","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0449bfac-517d-4019-8d7d-9349f3162d4c","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a7a8e8c2-44a3-4d3c-8722-5e2e6ade3e87","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"db7a485f-9dfb-49c1-ac3c-61f62a0deac6","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"46c84cee-fb3b-4247-8790-60e1f626bd83","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
-        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"efb4ef27-7b6b-4a43-a579-6d9fab6876ef","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16dcece1-d26a-4035-8050-e0a69ecf3b5f","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ffc71334-ec96-417c-9edd-99678214d5bd","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"edb63e4e-0ebd-4000-a92b-6d8431abadb9","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"eff5595f-4944-4c11-8c5c-31ae7b42d49b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"d1191185-05c4-4a62-8698-245acefdb039","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"24d7b510-6a6b-4e98-a118-1068d92a4252","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"c3a450f7-71af-48c4-a2eb-07a2e6570e78","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8983963f-1970-4cd7-8809-43b529dfc24d","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"07a1dda0-067f-42a0-9f36-e3e574dd3c27","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"df509397-34be-476b-ad65-a7ab2bb4bd02","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"70b6a37c-dfd9-43ca-bed7-87fcdfbb4a64","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b1934e14-e6d8-42ca-a227-412c8aecc1d8","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a0c1742-4918-47d2-93f3-307718c97e67","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -994,7 +1047,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:14:57 GMT
+      - Wed, 22 Apr 2020 08:32:48 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1009,6 +1062,106 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59987'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3OWIzNTlhNS0wM2I2LTQ3YzUtYjA4ZS05NmE1OTNhZjIwMjg=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Wed, 22 Apr 2020 08:33:04 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3OWIzNTlhNS0wM2I2LTQ3YzUtYjA4ZS05NmE1OTNhZjIwMjg=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3OWIzNTlhNS0wM2I2LTQ3YzUtYjA4ZS05NmE1OTNhZjIwMjg=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:33:34 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:
@@ -1045,7 +1198,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYmM1YWRlYi1kYmY2LTQ4ZWEtOWExZi03ZjAxNmNlNTE4YmQ=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyMGIyZDllNy1jZWViLTQ4NjYtODA3YS1hN2FjYWQxNzhmYTA=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -1053,9 +1206,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:15:00 GMT
+      - Wed, 22 Apr 2020 08:33:44 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYmM1YWRlYi1kYmY2LTQ4ZWEtOWExZi03ZjAxNmNlNTE4YmQ=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyMGIyZDllNy1jZWViLTQ4NjYtODA3YS1hN2FjYWQxNzhmYTA=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1065,7 +1218,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -1087,24 +1240,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyMGIyZDllNy1jZWViLTQ4NjYtODA3YS1hN2FjYWQxNzhmYTA=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16acf3e4-2a68-4469-9a44-3667449f02b3","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:15:30 GMT
-      etag:
-      - 16acf3e4-2a68-4469-9a44-3667449f02b3
+      - Wed, 22 Apr 2020 08:34:14 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1118,7 +1267,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -1141,19 +1290,74 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYmM1YWRlYi1kYmY2LTQ4ZWEtOWExZi03ZjAxNmNlNTE4YmQ=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
   response:
     body:
-      string: '{"status":"Succeeded"}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"2415c8fd-e1e2-4c51-b506-e9f7db8f28aa","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '22'
+      - '613'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:15:31 GMT
+      - Wed, 22 Apr 2020 08:34:15 GMT
+      etag:
+      - 2415c8fd-e1e2-4c51-b506-e9f7db8f28aa
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '489'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4a73770b-7249-41af-8560-8cc7d7746a9a","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:15 GMT
+      etag:
+      - 4a73770b-7249-41af-8560-8cc7d7746a9a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1168,6 +1372,761 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "azuredns-hostmaster.microsoft.com.", "serialNumber": 1, "refreshTime":
+      3600, "retryTime": 300, "expireTime": 2419200, "minimumTtl": 300}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"931b2d99-321e-4c6b-806c-c0ff0b8d31c8","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:17 GMT
+      etag:
+      - 931b2d99-321e-4c6b-806c-c0ff0b8d31c8
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 100, "weight":
+      1, "port": 443, "target": "target.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/_sip._tls?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"a6620efa-5096-4e86-bdde-4df0a7673348","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '509'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:17 GMT
+      etag:
+      - a6620efa-5096-4e86-bdde-4df0a7673348
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.0.0.10"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/manuala?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a8cfb0ee-9bea-4338-a5ab-4ac38c6a308f","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '455'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:19 GMT
+      etag:
+      - a8cfb0ee-9bea-4338-a5ab-4ac38c6a308f
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 0, "aRecords": [{"ipv4Address": "10.0.1.0"}, {"ipv4Address":
+      "10.0.1.1"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/mya?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffd6de70-7890-4e02-ba3f-886857c14084","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:20 GMT
+      etag:
+      - ffd6de70-7890-4e02-ba3f-886857c14084
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/AAAA/myaaaa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"f756ddc8-8ee7-4cc7-a50e-cb20535b6e3e","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '487'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:21 GMT
+      etag:
+      - f756ddc8-8ee7-4cc7-a50e-cb20535b6e3e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "contoso.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/CNAME/mycname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c8d340b2-5d1b-45eb-82b4-068dc07ea301","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '461'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:22 GMT
+      etag:
+      - c8d340b2-5d1b-45eb-82b4-068dc07ea301
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 1, "exchange":
+      "mail.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/MX/mymx?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a271ab08-5727-45f5-a5ca-a2a581bcfb27","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '469'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:24 GMT
+      etag:
+      - a271ab08-5727-45f5-a5ca-a2a581bcfb27
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "myptrdname"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"db4c8488-2f4c-4973-b51f-b1d14d2cc430","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '456'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:25 GMT
+      etag:
+      - db4c8488-2f4c-4973-b51f-b1d14d2cc430
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["manualtxt"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/myname2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5fb1b29d-0837-439b-b287-604ebfb78b82","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '457'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:26 GMT
+      etag:
+      - 5fb1b29d-0837-439b-b287-604ebfb78b82
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "contoso.com"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myptr?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"fa5a3059-cfe9-4321-b70c-1848f99a85cc","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:27 GMT
+      etag:
+      - fa5a3059-cfe9-4321-b70c-1848f99a85cc
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
+      "port": 1234, "target": "target.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/mysrv?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"e6102be8-a529-4eaa-a83e-f6e3094efe4d","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '496'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:29 GMT
+      etag:
+      - e6102be8-a529-4eaa-a83e-f6e3094efe4d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 7200, "txtRecords": [{"value": ["abc def"]}, {"value":
+      ["foo bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"958b83ab-de7c-40eb-9180-a58d71b0feb7","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '474'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:30 GMT
+      etag:
+      - 958b83ab-de7c-40eb-9180-a58d71b0feb7
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["hi"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '64'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxtrs?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a2bf1a74-7971-469f-8381-340f1a6ff6a0","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:30 GMT
+      etag:
+      - a2bf1a74-7971-469f-8381-340f1a6ff6a0
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"931b2d99-321e-4c6b-806c-c0ff0b8d31c8","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"a6620efa-5096-4e86-bdde-4df0a7673348","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a8cfb0ee-9bea-4338-a5ab-4ac38c6a308f","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffd6de70-7890-4e02-ba3f-886857c14084","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"f756ddc8-8ee7-4cc7-a50e-cb20535b6e3e","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c8d340b2-5d1b-45eb-82b4-068dc07ea301","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a271ab08-5727-45f5-a5ca-a2a581bcfb27","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"db4c8488-2f4c-4973-b51f-b1d14d2cc430","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5fb1b29d-0837-439b-b287-604ebfb78b82","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"fa5a3059-cfe9-4321-b70c-1848f99a85cc","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"e6102be8-a529-4eaa-a83e-f6e3094efe4d","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"958b83ab-de7c-40eb-9180-a58d71b0feb7","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a2bf1a74-7971-469f-8381-340f1a6ff6a0","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '6252'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 08:34:31 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59974'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone1_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone1_Import.yaml
@@ -1,0 +1,1978 @@
+interactions:
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiYWJhMTAyYy1kNDZiLTQ0MTEtOGNlYi0wNWM1Y2EyZWU4NWQ=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:16 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiYWJhMTAyYy1kNDZiLTQ0MTEtOGNlYi0wNWM1Y2EyZWU4NWQ=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"af115114-46fc-4a2c-9c45-707678660a3d","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:46 GMT
+      etag:
+      - af115114-46fc-4a2c-9c45-707678660a3d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"dadc400a-d174-4a88-9bf4-36b3ea22d8cd","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:47 GMT
+      etag:
+      - dadc400a-d174-4a88-9bf4-36b3ea22d8cd
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '497'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "azuredns-hostmaster.microsoft.com.", "serialNumber": 1, "refreshTime":
+      3600, "retryTime": 300, "expireTime": 2419200, "minimumTtl": 300}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4e30d32c-0d13-4260-bd04-cc693aab81e4","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:48 GMT
+      etag:
+      - 4e30d32c-0d13-4260-bd04-cc693aab81e4
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 1, "exchange":
+      "mail.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/MX/mymx?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"181c5486-e435-44f6-aa92-515e5d0f07e7","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '469'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:49 GMT
+      etag:
+      - 181c5486-e435-44f6-aa92-515e5d0f07e7
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.0.0.10"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/manuala?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3b040e5c-5308-4e45-95f8-c821eb80e7d6","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '455'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:50 GMT
+      etag:
+      - 3b040e5c-5308-4e45-95f8-c821eb80e7d6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 0, "aRecords": [{"ipv4Address": "10.0.1.0"}, {"ipv4Address":
+      "10.0.1.1"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/mya?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"593a0809-3c42-42bf-b2f8-881fd9a3cc17","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:52 GMT
+      etag:
+      - 593a0809-3c42-42bf-b2f8-881fd9a3cc17
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/AAAA/myaaaa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"671553e3-d8c3-44d0-8b25-3ec256a3eed1","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '487'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:53 GMT
+      etag:
+      - 671553e3-d8c3-44d0-8b25-3ec256a3eed1
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "contoso.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/CNAME/mycname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"afba46ac-b2dc-4263-87f4-fe3bed314076","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '461'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:54 GMT
+      etag:
+      - afba46ac-b2dc-4263-87f4-fe3bed314076
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "myptrdname"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c3235246-1fbd-4a17-841f-27eaf141b0c3","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '456'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:55 GMT
+      etag:
+      - c3235246-1fbd-4a17-841f-27eaf141b0c3
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "contoso.com"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myptr?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"27a3347b-956f-47f2-8afe-dfaf3c0e94d5","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:56 GMT
+      etag:
+      - 27a3347b-956f-47f2-8afe-dfaf3c0e94d5
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["manualtxt"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/myname2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3ba6e2d2-8954-4c2a-941b-29c37ab91ff7","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '457'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:57 GMT
+      etag:
+      - 3ba6e2d2-8954-4c2a-941b-29c37ab91ff7
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 7200, "txtRecords": [{"value": ["abc def"]}, {"value":
+      ["foo bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a1d8c00c-2f97-4a98-aa0f-37c02d380d2c","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '474'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:58 GMT
+      etag:
+      - a1d8c00c-2f97-4a98-aa0f-37c02d380d2c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["hi"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '64'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxtrs?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c68c0806-e995-4100-a28c-bc2d23e6e96c","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:26:59 GMT
+      etag:
+      - c68c0806-e995-4100-a28c-bc2d23e6e96c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
+      "port": 1234, "target": "target.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/mysrv?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"2af84352-0309-43e6-a2a9-093077df8d90","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '496'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:27:00 GMT
+      etag:
+      - 2af84352-0309-43e6-a2a9-093077df8d90
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 100, "weight":
+      1, "port": 443, "target": "target.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/_sip._tls?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"f5adf947-9e24-4a7e-9574-bba92ac555cc","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '509'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:27:01 GMT
+      etag:
+      - f5adf947-9e24-4a7e-9574-bba92ac555cc
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4e30d32c-0d13-4260-bd04-cc693aab81e4","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"f5adf947-9e24-4a7e-9574-bba92ac555cc","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3b040e5c-5308-4e45-95f8-c821eb80e7d6","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"593a0809-3c42-42bf-b2f8-881fd9a3cc17","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"671553e3-d8c3-44d0-8b25-3ec256a3eed1","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"afba46ac-b2dc-4263-87f4-fe3bed314076","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"181c5486-e435-44f6-aa92-515e5d0f07e7","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c3235246-1fbd-4a17-841f-27eaf141b0c3","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3ba6e2d2-8954-4c2a-941b-29c37ab91ff7","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"27a3347b-956f-47f2-8afe-dfaf3c0e94d5","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"2af84352-0309-43e6-a2a9-093077df8d90","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a1d8c00c-2f97-4a98-aa0f-37c02d380d2c","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c68c0806-e995-4100-a28c-bc2d23e6e96c","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '6252'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:27:02 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59987'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4e30d32c-0d13-4260-bd04-cc693aab81e4","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '606'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:27:03 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4e30d32c-0d13-4260-bd04-cc693aab81e4","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"f5adf947-9e24-4a7e-9574-bba92ac555cc","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3b040e5c-5308-4e45-95f8-c821eb80e7d6","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"593a0809-3c42-42bf-b2f8-881fd9a3cc17","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"671553e3-d8c3-44d0-8b25-3ec256a3eed1","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"afba46ac-b2dc-4263-87f4-fe3bed314076","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"181c5486-e435-44f6-aa92-515e5d0f07e7","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c3235246-1fbd-4a17-841f-27eaf141b0c3","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3ba6e2d2-8954-4c2a-941b-29c37ab91ff7","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"27a3347b-956f-47f2-8afe-dfaf3c0e94d5","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"2af84352-0309-43e6-a2a9-093077df8d90","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a1d8c00c-2f97-4a98-aa0f-37c02d380d2c","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c68c0806-e995-4100-a28c-bc2d23e6e96c","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '6252'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:27:03 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59974'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3Zjg4OTBhNi00NjViLTQ4MzUtOTY1Yy0yZmJiMjhlMTdiODI=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Thu, 16 Apr 2020 14:27:06 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3Zjg4OTBhNi00NjViLTQ4MzUtOTY1Yy0yZmJiMjhlMTdiODI=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3Zjg4OTBhNi00NjViLTQ4MzUtOTY1Yy0yZmJiMjhlMTdiODI=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:27:37 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTswOWQ2OTZjNy01N2E1LTQ0OTMtYWViNy05OTEzZDc5MTU0MjY=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:04 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTswOWQ2OTZjNy01N2E1LTQ0OTMtYWViNy05OTEzZDc5MTU0MjY=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f0b0d216-194e-43bf-a1d7-8df73416508c","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:34 GMT
+      etag:
+      - f0b0d216-194e-43bf-a1d7-8df73416508c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"dd0b2bac-afec-48e4-be1b-fe264d89dc50","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:35 GMT
+      etag:
+      - dd0b2bac-afec-48e4-be1b-fe264d89dc50
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 100, "weight":
+      1, "port": 443, "target": "target.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/_sip._tls?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"d740bcd0-0d50-4587-9870-890d6292d704","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '509'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:36 GMT
+      etag:
+      - d740bcd0-0d50-4587-9870-890d6292d704
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.0.0.10"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/manuala?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"33cb0b1f-f1a2-448b-9c16-8c817d3e4275","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '455'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:38 GMT
+      etag:
+      - 33cb0b1f-f1a2-448b-9c16-8c817d3e4275
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 0, "aRecords": [{"ipv4Address": "10.0.1.0"}, {"ipv4Address":
+      "10.0.1.1"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/mya?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0dfb4bfa-b63f-4901-a6e2-c2082e1cacee","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:39 GMT
+      etag:
+      - 0dfb4bfa-b63f-4901-a6e2-c2082e1cacee
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/AAAA/myaaaa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"0e24ac37-36b0-445a-92a6-6cd7cbba4a5e","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '487'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:41 GMT
+      etag:
+      - 0e24ac37-36b0-445a-92a6-6cd7cbba4a5e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "contoso.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/CNAME/mycname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"dc7b232b-cbac-45fb-a91d-83e6ae933711","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '461'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:41 GMT
+      etag:
+      - dc7b232b-cbac-45fb-a91d-83e6ae933711
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 1, "exchange":
+      "mail.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/MX/mymx?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"9f841027-3208-4aa3-aa32-8ebb0a392c3b","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '469'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:42 GMT
+      etag:
+      - 9f841027-3208-4aa3-aa32-8ebb0a392c3b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "myptrdname"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c542f81a-c739-4db4-9b75-d46a63428d93","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '456'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:43 GMT
+      etag:
+      - c542f81a-c739-4db4-9b75-d46a63428d93
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["manualtxt"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/myname2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9cfc397c-cc02-4add-8b66-074356ec8b86","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '457'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:44 GMT
+      etag:
+      - 9cfc397c-cc02-4add-8b66-074356ec8b86
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "contoso.com"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myptr?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"d51ffcb5-8ddb-470b-8744-a261b9f4ea7b","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:46 GMT
+      etag:
+      - d51ffcb5-8ddb-470b-8744-a261b9f4ea7b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
+      "port": 1234, "target": "target.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/mysrv?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"48863b66-6bf1-4b64-8360-0ccb2d7273dc","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '496'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:47 GMT
+      etag:
+      - 48863b66-6bf1-4b64-8360-0ccb2d7273dc
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 7200, "txtRecords": [{"value": ["abc def"]}, {"value":
+      ["foo bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9db215a1-3d4f-4e74-9696-dcdfba4fd51e","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '474'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:48 GMT
+      etag:
+      - 9db215a1-3d4f-4e74-9696-dcdfba4fd51e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["hi"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '64'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxtrs?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b5f0e2a3-8411-458f-b022-31b3973629b9","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:50 GMT
+      etag:
+      - b5f0e2a3-8411-458f-b022-31b3973629b9
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"dbfd9223-40fa-4cf8-b14c-b74a317da21d","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"d740bcd0-0d50-4587-9870-890d6292d704","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"33cb0b1f-f1a2-448b-9c16-8c817d3e4275","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0dfb4bfa-b63f-4901-a6e2-c2082e1cacee","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"0e24ac37-36b0-445a-92a6-6cd7cbba4a5e","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"dc7b232b-cbac-45fb-a91d-83e6ae933711","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"9f841027-3208-4aa3-aa32-8ebb0a392c3b","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c542f81a-c739-4db4-9b75-d46a63428d93","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9cfc397c-cc02-4add-8b66-074356ec8b86","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"d51ffcb5-8ddb-470b-8744-a261b9f4ea7b","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"48863b66-6bf1-4b64-8360-0ccb2d7273dc","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9db215a1-3d4f-4e74-9696-dcdfba4fd51e","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b5f0e2a3-8411-458f-b022-31b3973629b9","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '6252'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:28:50 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59974'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone1_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone1_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlMmI4MzBiOC0xZjU4LTQ1ZjgtODE3Ny1lOGJiYWQ4MDA3MjQ=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlY2RiMDRmOS03YjFkLTQ4YzktOTFjYy0yZTkxYWYyYmQ0MTE=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:00 GMT
+      - Wed, 22 Apr 2020 12:03:16 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlMmI4MzBiOC0xZjU4LTQ1ZjgtODE3Ny1lOGJiYWQ4MDA3MjQ=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlY2RiMDRmOS03YjFkLTQ4YzktOTFjYy0yZTkxYWYyYmQ0MTE=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -48,7 +48,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -71,7 +71,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlMmI4MzBiOC0xZjU4LTQ1ZjgtODE3Ny1lOGJiYWQ4MDA3MjQ=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlY2RiMDRmOS03YjFkLTQ4YzktOTFjYy0yZTkxYWYyYmQ0MTE=?api-version=2018-09-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -83,7 +83,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:30 GMT
+      - Wed, 22 Apr 2020 12:03:46 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -123,7 +123,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"91d521b2-cb16-4e6c-934f-0ed4717f7281","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"ba561373-956d-4054-b07f-db6acc34826d","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -132,9 +132,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:31 GMT
+      - Wed, 22 Apr 2020 12:03:46 GMT
       etag:
-      - 91d521b2-cb16-4e6c-934f-0ed4717f7281
+      - ba561373-956d-4054-b07f-db6acc34826d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -148,7 +148,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '495'
+      - '493'
       x-powered-by:
       - ASP.NET
     status:
@@ -176,7 +176,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"35a11c2e-e90f-4f02-8b34-2737cfe3385e","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"03c49dae-0d78-46a0-ba4f-920102363556","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -185,9 +185,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:31 GMT
+      - Wed, 22 Apr 2020 12:03:48 GMT
       etag:
-      - 35a11c2e-e90f-4f02-8b34-2737cfe3385e
+      - 03c49dae-0d78-46a0-ba4f-920102363556
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -201,7 +201,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -235,7 +235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16dcece1-d26a-4035-8050-e0a69ecf3b5f","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"0efef4d4-6f71-4fdd-a356-0898f738a463","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -244,9 +244,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:32 GMT
+      - Wed, 22 Apr 2020 12:03:49 GMT
       etag:
-      - 16dcece1-d26a-4035-8050-e0a69ecf3b5f
+      - 0efef4d4-6f71-4fdd-a356-0898f738a463
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -293,7 +293,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/MX/mymx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"c3a450f7-71af-48c4-a2eb-07a2e6570e78","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"1a4664b1-87b8-4a60-8d89-6fc16eca3466","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -302,9 +302,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:33 GMT
+      - Wed, 22 Apr 2020 12:03:50 GMT
       etag:
-      - c3a450f7-71af-48c4-a2eb-07a2e6570e78
+      - 1a4664b1-87b8-4a60-8d89-6fc16eca3466
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -314,7 +314,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -346,7 +346,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/manuala?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"edb63e4e-0ebd-4000-a92b-6d8431abadb9","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cc55dfa7-98ae-44ec-9970-ba36b1138870","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -355,9 +355,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:35 GMT
+      - Wed, 22 Apr 2020 12:03:52 GMT
       etag:
-      - edb63e4e-0ebd-4000-a92b-6d8431abadb9
+      - cc55dfa7-98ae-44ec-9970-ba36b1138870
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -367,7 +367,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -400,7 +400,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/mya?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"eff5595f-4944-4c11-8c5c-31ae7b42d49b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e68cd83f-1e59-4675-bf71-5c9aef1e3d46","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -409,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:36 GMT
+      - Wed, 22 Apr 2020 12:03:52 GMT
       etag:
-      - eff5595f-4944-4c11-8c5c-31ae7b42d49b
+      - e68cd83f-1e59-4675-bf71-5c9aef1e3d46
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -421,7 +421,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -453,7 +453,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/AAAA/myaaaa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"d1191185-05c4-4a62-8698-245acefdb039","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"d7c86691-0504-4205-ae75-42253605a7da","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -462,9 +462,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:36 GMT
+      - Wed, 22 Apr 2020 12:03:53 GMT
       etag:
-      - d1191185-05c4-4a62-8698-245acefdb039
+      - d7c86691-0504-4205-ae75-42253605a7da
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -474,7 +474,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -506,7 +506,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/CNAME/mycname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"24d7b510-6a6b-4e98-a118-1068d92a4252","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c752242a-4324-445b-a174-e090179d576a","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -515,9 +515,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:38 GMT
+      - Wed, 22 Apr 2020 12:03:55 GMT
       etag:
-      - 24d7b510-6a6b-4e98-a118-1068d92a4252
+      - c752242a-4324-445b-a174-e090179d576a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -527,7 +527,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -559,7 +559,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8983963f-1970-4cd7-8809-43b529dfc24d","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"bf25b6c9-61ed-4487-887b-2fa4f6de7a11","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -568,9 +568,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:39 GMT
+      - Wed, 22 Apr 2020 12:03:56 GMT
       etag:
-      - 8983963f-1970-4cd7-8809-43b529dfc24d
+      - bf25b6c9-61ed-4487-887b-2fa4f6de7a11
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -612,7 +612,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myptr?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"df509397-34be-476b-ad65-a7ab2bb4bd02","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e71904fa-9464-4cef-8b6f-85ae030e4b38","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -621,9 +621,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:40 GMT
+      - Wed, 22 Apr 2020 12:03:57 GMT
       etag:
-      - df509397-34be-476b-ad65-a7ab2bb4bd02
+      - e71904fa-9464-4cef-8b6f-85ae030e4b38
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -633,7 +633,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -665,7 +665,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/myname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"07a1dda0-067f-42a0-9f36-e3e574dd3c27","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7b90b5da-4644-4235-911b-f086a43cf835","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -674,9 +674,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:41 GMT
+      - Wed, 22 Apr 2020 12:03:58 GMT
       etag:
-      - 07a1dda0-067f-42a0-9f36-e3e574dd3c27
+      - 7b90b5da-4644-4235-911b-f086a43cf835
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -686,7 +686,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -719,7 +719,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b1934e14-e6d8-42ca-a227-412c8aecc1d8","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"aca290c2-99d8-4384-9f83-6cde4604c8b2","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
         def"]},{"value":["foo bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -729,9 +729,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:43 GMT
+      - Wed, 22 Apr 2020 12:03:59 GMT
       etag:
-      - b1934e14-e6d8-42ca-a227-412c8aecc1d8
+      - aca290c2-99d8-4384-9f83-6cde4604c8b2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -741,7 +741,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -773,7 +773,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxtrs?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a0c1742-4918-47d2-93f3-307718c97e67","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4fc98983-5511-4cf2-b0d8-98c54fc60ee4","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -782,9 +782,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:43 GMT
+      - Wed, 22 Apr 2020 12:04:01 GMT
       etag:
-      - 6a0c1742-4918-47d2-93f3-307718c97e67
+      - 4fc98983-5511-4cf2-b0d8-98c54fc60ee4
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -794,7 +794,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -827,7 +827,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/mysrv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"70b6a37c-dfd9-43ca-bed7-87fcdfbb4a64","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"29746c5f-0221-4e11-af94-aec8d6a29e47","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -836,9 +836,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:45 GMT
+      - Wed, 22 Apr 2020 12:04:02 GMT
       etag:
-      - 70b6a37c-dfd9-43ca-bed7-87fcdfbb4a64
+      - 29746c5f-0221-4e11-af94-aec8d6a29e47
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -881,7 +881,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/_sip._tls?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ffc71334-ec96-417c-9edd-99678214d5bd","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"702de406-76dd-494d-8705-cafdefd4a82f","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -890,9 +890,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:46 GMT
+      - Wed, 22 Apr 2020 12:04:03 GMT
       etag:
-      - ffc71334-ec96-417c-9edd-99678214d5bd
+      - 702de406-76dd-494d-8705-cafdefd4a82f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -930,8 +930,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16dcece1-d26a-4035-8050-e0a69ecf3b5f","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ffc71334-ec96-417c-9edd-99678214d5bd","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"edb63e4e-0ebd-4000-a92b-6d8431abadb9","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"eff5595f-4944-4c11-8c5c-31ae7b42d49b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"d1191185-05c4-4a62-8698-245acefdb039","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"24d7b510-6a6b-4e98-a118-1068d92a4252","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"c3a450f7-71af-48c4-a2eb-07a2e6570e78","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8983963f-1970-4cd7-8809-43b529dfc24d","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"07a1dda0-067f-42a0-9f36-e3e574dd3c27","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"df509397-34be-476b-ad65-a7ab2bb4bd02","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"70b6a37c-dfd9-43ca-bed7-87fcdfbb4a64","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b1934e14-e6d8-42ca-a227-412c8aecc1d8","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
-        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a0c1742-4918-47d2-93f3-307718c97e67","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"0efef4d4-6f71-4fdd-a356-0898f738a463","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"702de406-76dd-494d-8705-cafdefd4a82f","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cc55dfa7-98ae-44ec-9970-ba36b1138870","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e68cd83f-1e59-4675-bf71-5c9aef1e3d46","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"d7c86691-0504-4205-ae75-42253605a7da","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c752242a-4324-445b-a174-e090179d576a","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"1a4664b1-87b8-4a60-8d89-6fc16eca3466","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"bf25b6c9-61ed-4487-887b-2fa4f6de7a11","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7b90b5da-4644-4235-911b-f086a43cf835","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e71904fa-9464-4cef-8b6f-85ae030e4b38","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"29746c5f-0221-4e11-af94-aec8d6a29e47","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"aca290c2-99d8-4384-9f83-6cde4604c8b2","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4fc98983-5511-4cf2-b0d8-98c54fc60ee4","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -940,7 +940,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:46 GMT
+      - Wed, 22 Apr 2020 12:04:04 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -984,7 +984,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16dcece1-d26a-4035-8050-e0a69ecf3b5f","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"0efef4d4-6f71-4fdd-a356-0898f738a463","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -993,7 +993,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:47 GMT
+      - Wed, 22 Apr 2020 12:04:04 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1037,8 +1037,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16dcece1-d26a-4035-8050-e0a69ecf3b5f","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ffc71334-ec96-417c-9edd-99678214d5bd","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"edb63e4e-0ebd-4000-a92b-6d8431abadb9","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"eff5595f-4944-4c11-8c5c-31ae7b42d49b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"d1191185-05c4-4a62-8698-245acefdb039","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"24d7b510-6a6b-4e98-a118-1068d92a4252","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"c3a450f7-71af-48c4-a2eb-07a2e6570e78","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8983963f-1970-4cd7-8809-43b529dfc24d","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"07a1dda0-067f-42a0-9f36-e3e574dd3c27","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"df509397-34be-476b-ad65-a7ab2bb4bd02","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"70b6a37c-dfd9-43ca-bed7-87fcdfbb4a64","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b1934e14-e6d8-42ca-a227-412c8aecc1d8","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
-        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a0c1742-4918-47d2-93f3-307718c97e67","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"0efef4d4-6f71-4fdd-a356-0898f738a463","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"702de406-76dd-494d-8705-cafdefd4a82f","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cc55dfa7-98ae-44ec-9970-ba36b1138870","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e68cd83f-1e59-4675-bf71-5c9aef1e3d46","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"d7c86691-0504-4205-ae75-42253605a7da","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c752242a-4324-445b-a174-e090179d576a","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"1a4664b1-87b8-4a60-8d89-6fc16eca3466","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"bf25b6c9-61ed-4487-887b-2fa4f6de7a11","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7b90b5da-4644-4235-911b-f086a43cf835","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e71904fa-9464-4cef-8b6f-85ae030e4b38","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"29746c5f-0221-4e11-af94-aec8d6a29e47","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"aca290c2-99d8-4384-9f83-6cde4604c8b2","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4fc98983-5511-4cf2-b0d8-98c54fc60ee4","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1047,7 +1047,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:32:48 GMT
+      - Wed, 22 Apr 2020 12:04:05 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1096,15 +1096,15 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3OWIzNTlhNS0wM2I2LTQ3YzUtYjA4ZS05NmE1OTNhZjIwMjg=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTswODAzZjdlMC0yYjdkLTQ3YWEtYTNmMS01NWFmNmNmZTU1MTc=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
       - '0'
       date:
-      - Wed, 22 Apr 2020 08:33:04 GMT
+      - Wed, 22 Apr 2020 12:04:07 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3OWIzNTlhNS0wM2I2LTQ3YzUtYjA4ZS05NmE1OTNhZjIwMjg=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTswODAzZjdlMC0yYjdkLTQ3YWEtYTNmMS01NWFmNmNmZTU1MTc=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1137,7 +1137,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3OWIzNTlhNS0wM2I2LTQ3YzUtYjA4ZS05NmE1OTNhZjIwMjg=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTswODAzZjdlMC0yYjdkLTQ3YWEtYTNmMS01NWFmNmNmZTU1MTc=?api-version=2018-09-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1149,7 +1149,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:33:34 GMT
+      - Wed, 22 Apr 2020 12:04:38 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1198,7 +1198,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyMGIyZDllNy1jZWViLTQ4NjYtODA3YS1hN2FjYWQxNzhmYTA=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5OGRiYzkyMi1hNTZiLTRmZGEtYTgwZi1mY2ZmNTE5NDIxNDc=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -1206,9 +1206,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:33:44 GMT
+      - Wed, 22 Apr 2020 12:04:57 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyMGIyZDllNy1jZWViLTQ4NjYtODA3YS1hN2FjYWQxNzhmYTA=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5OGRiYzkyMi1hNTZiLTRmZGEtYTgwZi1mY2ZmNTE5NDIxNDc=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1241,7 +1241,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyMGIyZDllNy1jZWViLTQ4NjYtODA3YS1hN2FjYWQxNzhmYTA=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5OGRiYzkyMi1hNTZiLTRmZGEtYTgwZi1mY2ZmNTE5NDIxNDc=?api-version=2018-09-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1253,7 +1253,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:14 GMT
+      - Wed, 22 Apr 2020 12:05:28 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1293,7 +1293,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"2415c8fd-e1e2-4c51-b506-e9f7db8f28aa","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"5e18c8e6-5f61-4a4e-8737-e1555eadb9a4","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -1302,9 +1302,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:15 GMT
+      - Wed, 22 Apr 2020 12:05:28 GMT
       etag:
-      - 2415c8fd-e1e2-4c51-b506-e9f7db8f28aa
+      - 5e18c8e6-5f61-4a4e-8737-e1555eadb9a4
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1318,7 +1318,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '489'
+      - '495'
       x-powered-by:
       - ASP.NET
     status:
@@ -1346,7 +1346,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4a73770b-7249-41af-8560-8cc7d7746a9a","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"85b72e69-ca05-40b2-919a-436cc0b060a8","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1355,9 +1355,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:15 GMT
+      - Wed, 22 Apr 2020 12:05:29 GMT
       etag:
-      - 4a73770b-7249-41af-8560-8cc7d7746a9a
+      - 85b72e69-ca05-40b2-919a-436cc0b060a8
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1405,7 +1405,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"931b2d99-321e-4c6b-806c-c0ff0b8d31c8","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"69bf91b1-505c-4713-a1fb-1d865d40cbcb","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1414,9 +1414,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:17 GMT
+      - Wed, 22 Apr 2020 12:05:30 GMT
       etag:
-      - 931b2d99-321e-4c6b-806c-c0ff0b8d31c8
+      - 69bf91b1-505c-4713-a1fb-1d865d40cbcb
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1463,7 +1463,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/_sip._tls?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"a6620efa-5096-4e86-bdde-4df0a7673348","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"5398da30-4eb2-4aa4-9214-339c0e047472","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1472,9 +1472,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:17 GMT
+      - Wed, 22 Apr 2020 12:05:31 GMT
       etag:
-      - a6620efa-5096-4e86-bdde-4df0a7673348
+      - 5398da30-4eb2-4aa4-9214-339c0e047472
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1484,7 +1484,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -1516,7 +1516,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/manuala?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a8cfb0ee-9bea-4338-a5ab-4ac38c6a308f","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"82b1f1b0-f774-45f3-8433-5fb359758c77","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1525,9 +1525,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:19 GMT
+      - Wed, 22 Apr 2020 12:05:32 GMT
       etag:
-      - a8cfb0ee-9bea-4338-a5ab-4ac38c6a308f
+      - 82b1f1b0-f774-45f3-8433-5fb359758c77
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1537,7 +1537,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -1570,7 +1570,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/mya?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffd6de70-7890-4e02-ba3f-886857c14084","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4124356-8e27-4111-b7b2-7c7d04c5b16f","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1579,9 +1579,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:20 GMT
+      - Wed, 22 Apr 2020 12:05:34 GMT
       etag:
-      - ffd6de70-7890-4e02-ba3f-886857c14084
+      - f4124356-8e27-4111-b7b2-7c7d04c5b16f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1591,7 +1591,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -1623,7 +1623,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/AAAA/myaaaa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"f756ddc8-8ee7-4cc7-a50e-cb20535b6e3e","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"8cf79379-4b97-4469-b8ac-2ff0a39cc1a2","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1632,9 +1632,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:21 GMT
+      - Wed, 22 Apr 2020 12:05:35 GMT
       etag:
-      - f756ddc8-8ee7-4cc7-a50e-cb20535b6e3e
+      - 8cf79379-4b97-4469-b8ac-2ff0a39cc1a2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1644,7 +1644,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -1676,7 +1676,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/CNAME/mycname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c8d340b2-5d1b-45eb-82b4-068dc07ea301","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"93dbc05b-3073-43d9-b5c4-f0e95e82f971","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1685,9 +1685,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:22 GMT
+      - Wed, 22 Apr 2020 12:05:36 GMT
       etag:
-      - c8d340b2-5d1b-45eb-82b4-068dc07ea301
+      - 93dbc05b-3073-43d9-b5c4-f0e95e82f971
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1697,7 +1697,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -1730,7 +1730,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/MX/mymx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a271ab08-5727-45f5-a5ca-a2a581bcfb27","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"131b94b8-4e5b-491b-993b-1dfce7d223db","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1739,9 +1739,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:24 GMT
+      - Wed, 22 Apr 2020 12:05:37 GMT
       etag:
-      - a271ab08-5727-45f5-a5ca-a2a581bcfb27
+      - 131b94b8-4e5b-491b-993b-1dfce7d223db
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1751,7 +1751,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -1783,7 +1783,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"db4c8488-2f4c-4973-b51f-b1d14d2cc430","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"d2ddc5c3-4a71-4577-babc-8c9d63d443d9","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1792,9 +1792,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:25 GMT
+      - Wed, 22 Apr 2020 12:05:39 GMT
       etag:
-      - db4c8488-2f4c-4973-b51f-b1d14d2cc430
+      - d2ddc5c3-4a71-4577-babc-8c9d63d443d9
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1836,7 +1836,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/myname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5fb1b29d-0837-439b-b287-604ebfb78b82","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ef675790-5688-40fc-800a-ed65a1853076","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1845,9 +1845,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:26 GMT
+      - Wed, 22 Apr 2020 12:05:40 GMT
       etag:
-      - 5fb1b29d-0837-439b-b287-604ebfb78b82
+      - ef675790-5688-40fc-800a-ed65a1853076
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1857,7 +1857,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -1889,7 +1889,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myptr?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"fa5a3059-cfe9-4321-b70c-1848f99a85cc","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"0dcf7ecb-28c2-4b24-b1d6-f75216b7fcd9","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1898,9 +1898,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:27 GMT
+      - Wed, 22 Apr 2020 12:05:41 GMT
       etag:
-      - fa5a3059-cfe9-4321-b70c-1848f99a85cc
+      - 0dcf7ecb-28c2-4b24-b1d6-f75216b7fcd9
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1943,7 +1943,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/mysrv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"e6102be8-a529-4eaa-a83e-f6e3094efe4d","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"265bc52e-9c0d-4a83-bf2b-3c6f5b70cd5b","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1952,9 +1952,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:29 GMT
+      - Wed, 22 Apr 2020 12:05:42 GMT
       etag:
-      - e6102be8-a529-4eaa-a83e-f6e3094efe4d
+      - 265bc52e-9c0d-4a83-bf2b-3c6f5b70cd5b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1997,7 +1997,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"958b83ab-de7c-40eb-9180-a58d71b0feb7","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0f1ec53f-b8e4-43f1-b483-ec25f80e5eee","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
         def"]},{"value":["foo bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -2007,9 +2007,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:30 GMT
+      - Wed, 22 Apr 2020 12:05:43 GMT
       etag:
-      - 958b83ab-de7c-40eb-9180-a58d71b0feb7
+      - 0f1ec53f-b8e4-43f1-b483-ec25f80e5eee
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2019,7 +2019,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -2051,7 +2051,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxtrs?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a2bf1a74-7971-469f-8381-340f1a6ff6a0","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7aa7d5c7-77fb-4a50-8ede-2c2cdf4688f4","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2060,9 +2060,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:30 GMT
+      - Wed, 22 Apr 2020 12:05:44 GMT
       etag:
-      - a2bf1a74-7971-469f-8381-340f1a6ff6a0
+      - 7aa7d5c7-77fb-4a50-8ede-2c2cdf4688f4
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2072,7 +2072,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -2100,8 +2100,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"931b2d99-321e-4c6b-806c-c0ff0b8d31c8","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"a6620efa-5096-4e86-bdde-4df0a7673348","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a8cfb0ee-9bea-4338-a5ab-4ac38c6a308f","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffd6de70-7890-4e02-ba3f-886857c14084","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"f756ddc8-8ee7-4cc7-a50e-cb20535b6e3e","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c8d340b2-5d1b-45eb-82b4-068dc07ea301","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a271ab08-5727-45f5-a5ca-a2a581bcfb27","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"db4c8488-2f4c-4973-b51f-b1d14d2cc430","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5fb1b29d-0837-439b-b287-604ebfb78b82","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"fa5a3059-cfe9-4321-b70c-1848f99a85cc","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"e6102be8-a529-4eaa-a83e-f6e3094efe4d","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"958b83ab-de7c-40eb-9180-a58d71b0feb7","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
-        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a2bf1a74-7971-469f-8381-340f1a6ff6a0","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"69bf91b1-505c-4713-a1fb-1d865d40cbcb","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"5398da30-4eb2-4aa4-9214-339c0e047472","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"82b1f1b0-f774-45f3-8433-5fb359758c77","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4124356-8e27-4111-b7b2-7c7d04c5b16f","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"8cf79379-4b97-4469-b8ac-2ff0a39cc1a2","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"93dbc05b-3073-43d9-b5c4-f0e95e82f971","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"131b94b8-4e5b-491b-993b-1dfce7d223db","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"d2ddc5c3-4a71-4577-babc-8c9d63d443d9","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ef675790-5688-40fc-800a-ed65a1853076","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"0dcf7ecb-28c2-4b24-b1d6-f75216b7fcd9","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"265bc52e-9c0d-4a83-bf2b-3c6f5b70cd5b","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0f1ec53f-b8e4-43f1-b483-ec25f80e5eee","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7aa7d5c7-77fb-4a50-8ede-2c2cdf4688f4","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -2110,7 +2110,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 08:34:31 GMT
+      - Wed, 22 Apr 2020 12:05:45 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone1_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone1_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiYWJhMTAyYy1kNDZiLTQ0MTEtOGNlYi0wNWM1Y2EyZWU4NWQ=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsxNzNjOGY3NS1iZmY3LTQwYzAtODI5Ny00MWYyYTg0YTc2ODM=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:16 GMT
+      - Tue, 21 Apr 2020 05:14:10 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiYWJhMTAyYy1kNDZiLTQ0MTEtOGNlYi0wNWM1Y2EyZWU4NWQ=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsxNzNjOGY3NS1iZmY3LTQwYzAtODI5Ny00MWYyYTg0YTc2ODM=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -48,7 +48,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -70,24 +70,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsxNzNjOGY3NS1iZmY3LTQwYzAtODI5Ny00MWYyYTg0YTc2ODM=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"af115114-46fc-4a2c-9c45-707678660a3d","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:46 GMT
-      etag:
-      - af115114-46fc-4a2c-9c45-707678660a3d
+      - Tue, 21 Apr 2020 05:14:41 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -127,7 +123,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"dadc400a-d174-4a88-9bf4-36b3ea22d8cd","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"d3ae408c-d07b-407c-8978-a0aef5505f1e","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -136,9 +132,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:47 GMT
+      - Tue, 21 Apr 2020 05:14:42 GMT
       etag:
-      - dadc400a-d174-4a88-9bf4-36b3ea22d8cd
+      - d3ae408c-d07b-407c-8978-a0aef5505f1e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -152,7 +148,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '497'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -186,7 +182,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4e30d32c-0d13-4260-bd04-cc693aab81e4","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16acf3e4-2a68-4469-9a44-3667449f02b3","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -195,9 +191,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:48 GMT
+      - Tue, 21 Apr 2020 05:14:42 GMT
       etag:
-      - 4e30d32c-0d13-4260-bd04-cc693aab81e4
+      - 16acf3e4-2a68-4469-9a44-3667449f02b3
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -244,7 +240,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/MX/mymx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"181c5486-e435-44f6-aa92-515e5d0f07e7","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"f75e249d-93cc-4a2c-93cd-5729b5c2cb98","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -253,9 +249,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:49 GMT
+      - Tue, 21 Apr 2020 05:14:43 GMT
       etag:
-      - 181c5486-e435-44f6-aa92-515e5d0f07e7
+      - f75e249d-93cc-4a2c-93cd-5729b5c2cb98
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -265,7 +261,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -297,7 +293,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/manuala?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3b040e5c-5308-4e45-95f8-c821eb80e7d6","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dd4b71e9-6a4e-4ce4-89a6-6a3c4cfbb846","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -306,9 +302,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:50 GMT
+      - Tue, 21 Apr 2020 05:14:44 GMT
       etag:
-      - 3b040e5c-5308-4e45-95f8-c821eb80e7d6
+      - dd4b71e9-6a4e-4ce4-89a6-6a3c4cfbb846
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -318,7 +314,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -351,7 +347,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/mya?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"593a0809-3c42-42bf-b2f8-881fd9a3cc17","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8ccc39de-f5ec-4499-9b65-9fcdb40a4b0b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -360,9 +356,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:52 GMT
+      - Tue, 21 Apr 2020 05:14:46 GMT
       etag:
-      - 593a0809-3c42-42bf-b2f8-881fd9a3cc17
+      - 8ccc39de-f5ec-4499-9b65-9fcdb40a4b0b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -372,7 +368,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
@@ -404,7 +400,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/AAAA/myaaaa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"671553e3-d8c3-44d0-8b25-3ec256a3eed1","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"ee179e4e-b635-4ce1-a792-b6c4ab07c9f5","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -413,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:53 GMT
+      - Tue, 21 Apr 2020 05:14:47 GMT
       etag:
-      - 671553e3-d8c3-44d0-8b25-3ec256a3eed1
+      - ee179e4e-b635-4ce1-a792-b6c4ab07c9f5
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -457,7 +453,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/CNAME/mycname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"afba46ac-b2dc-4263-87f4-fe3bed314076","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"728359c1-98d9-458d-9ea5-cb60092ff199","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -466,9 +462,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:54 GMT
+      - Tue, 21 Apr 2020 05:14:48 GMT
       etag:
-      - afba46ac-b2dc-4263-87f4-fe3bed314076
+      - 728359c1-98d9-458d-9ea5-cb60092ff199
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -510,7 +506,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c3235246-1fbd-4a17-841f-27eaf141b0c3","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e3999ef5-3abc-4408-9a7c-55439cf67ca6","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -519,9 +515,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:55 GMT
+      - Tue, 21 Apr 2020 05:14:49 GMT
       etag:
-      - c3235246-1fbd-4a17-841f-27eaf141b0c3
+      - e3999ef5-3abc-4408-9a7c-55439cf67ca6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -531,7 +527,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -563,7 +559,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myptr?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"27a3347b-956f-47f2-8afe-dfaf3c0e94d5","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a7a8e8c2-44a3-4d3c-8722-5e2e6ade3e87","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -572,9 +568,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:56 GMT
+      - Tue, 21 Apr 2020 05:14:50 GMT
       etag:
-      - 27a3347b-956f-47f2-8afe-dfaf3c0e94d5
+      - a7a8e8c2-44a3-4d3c-8722-5e2e6ade3e87
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -584,7 +580,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -616,7 +612,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/myname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3ba6e2d2-8954-4c2a-941b-29c37ab91ff7","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0449bfac-517d-4019-8d7d-9349f3162d4c","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -625,9 +621,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:57 GMT
+      - Tue, 21 Apr 2020 05:14:51 GMT
       etag:
-      - 3ba6e2d2-8954-4c2a-941b-29c37ab91ff7
+      - 0449bfac-517d-4019-8d7d-9349f3162d4c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -637,7 +633,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -670,7 +666,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a1d8c00c-2f97-4a98-aa0f-37c02d380d2c","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"46c84cee-fb3b-4247-8790-60e1f626bd83","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
         def"]},{"value":["foo bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -680,9 +676,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:58 GMT
+      - Tue, 21 Apr 2020 05:14:52 GMT
       etag:
-      - a1d8c00c-2f97-4a98-aa0f-37c02d380d2c
+      - 46c84cee-fb3b-4247-8790-60e1f626bd83
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -692,7 +688,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -724,7 +720,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxtrs?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c68c0806-e995-4100-a28c-bc2d23e6e96c","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"efb4ef27-7b6b-4a43-a579-6d9fab6876ef","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -733,9 +729,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:26:59 GMT
+      - Tue, 21 Apr 2020 05:14:53 GMT
       etag:
-      - c68c0806-e995-4100-a28c-bc2d23e6e96c
+      - efb4ef27-7b6b-4a43-a579-6d9fab6876ef
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -745,7 +741,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -778,7 +774,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/mysrv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"2af84352-0309-43e6-a2a9-093077df8d90","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"db7a485f-9dfb-49c1-ac3c-61f62a0deac6","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -787,9 +783,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:27:00 GMT
+      - Tue, 21 Apr 2020 05:14:54 GMT
       etag:
-      - 2af84352-0309-43e6-a2a9-093077df8d90
+      - db7a485f-9dfb-49c1-ac3c-61f62a0deac6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -799,7 +795,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -832,7 +828,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/_sip._tls?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"f5adf947-9e24-4a7e-9574-bba92ac555cc","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"dd285c45-d3c4-4452-a874-4ea76e21812a","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -841,9 +837,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:27:01 GMT
+      - Tue, 21 Apr 2020 05:14:56 GMT
       etag:
-      - f5adf947-9e24-4a7e-9574-bba92ac555cc
+      - dd285c45-d3c4-4452-a874-4ea76e21812a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -853,7 +849,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -881,8 +877,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4e30d32c-0d13-4260-bd04-cc693aab81e4","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"f5adf947-9e24-4a7e-9574-bba92ac555cc","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3b040e5c-5308-4e45-95f8-c821eb80e7d6","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"593a0809-3c42-42bf-b2f8-881fd9a3cc17","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"671553e3-d8c3-44d0-8b25-3ec256a3eed1","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"afba46ac-b2dc-4263-87f4-fe3bed314076","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"181c5486-e435-44f6-aa92-515e5d0f07e7","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c3235246-1fbd-4a17-841f-27eaf141b0c3","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3ba6e2d2-8954-4c2a-941b-29c37ab91ff7","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"27a3347b-956f-47f2-8afe-dfaf3c0e94d5","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"2af84352-0309-43e6-a2a9-093077df8d90","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a1d8c00c-2f97-4a98-aa0f-37c02d380d2c","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
-        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c68c0806-e995-4100-a28c-bc2d23e6e96c","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16acf3e4-2a68-4469-9a44-3667449f02b3","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"dd285c45-d3c4-4452-a874-4ea76e21812a","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dd4b71e9-6a4e-4ce4-89a6-6a3c4cfbb846","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8ccc39de-f5ec-4499-9b65-9fcdb40a4b0b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"ee179e4e-b635-4ce1-a792-b6c4ab07c9f5","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"728359c1-98d9-458d-9ea5-cb60092ff199","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"f75e249d-93cc-4a2c-93cd-5729b5c2cb98","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e3999ef5-3abc-4408-9a7c-55439cf67ca6","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0449bfac-517d-4019-8d7d-9349f3162d4c","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a7a8e8c2-44a3-4d3c-8722-5e2e6ade3e87","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"db7a485f-9dfb-49c1-ac3c-61f62a0deac6","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"46c84cee-fb3b-4247-8790-60e1f626bd83","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"efb4ef27-7b6b-4a43-a579-6d9fab6876ef","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -891,7 +887,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:27:02 GMT
+      - Tue, 21 Apr 2020 05:14:56 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -935,7 +931,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4e30d32c-0d13-4260-bd04-cc693aab81e4","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16acf3e4-2a68-4469-9a44-3667449f02b3","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -944,7 +940,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:27:03 GMT
+      - Tue, 21 Apr 2020 05:14:57 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -960,7 +956,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59999'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -988,8 +984,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4e30d32c-0d13-4260-bd04-cc693aab81e4","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"f5adf947-9e24-4a7e-9574-bba92ac555cc","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3b040e5c-5308-4e45-95f8-c821eb80e7d6","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"593a0809-3c42-42bf-b2f8-881fd9a3cc17","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"671553e3-d8c3-44d0-8b25-3ec256a3eed1","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"afba46ac-b2dc-4263-87f4-fe3bed314076","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"181c5486-e435-44f6-aa92-515e5d0f07e7","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c3235246-1fbd-4a17-841f-27eaf141b0c3","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3ba6e2d2-8954-4c2a-941b-29c37ab91ff7","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"27a3347b-956f-47f2-8afe-dfaf3c0e94d5","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"2af84352-0309-43e6-a2a9-093077df8d90","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a1d8c00c-2f97-4a98-aa0f-37c02d380d2c","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
-        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c68c0806-e995-4100-a28c-bc2d23e6e96c","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16acf3e4-2a68-4469-9a44-3667449f02b3","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"dd285c45-d3c4-4452-a874-4ea76e21812a","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dd4b71e9-6a4e-4ce4-89a6-6a3c4cfbb846","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8ccc39de-f5ec-4499-9b65-9fcdb40a4b0b","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"ee179e4e-b635-4ce1-a792-b6c4ab07c9f5","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"728359c1-98d9-458d-9ea5-cb60092ff199","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"f75e249d-93cc-4a2c-93cd-5729b5c2cb98","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e3999ef5-3abc-4408-9a7c-55439cf67ca6","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0449bfac-517d-4019-8d7d-9349f3162d4c","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a7a8e8c2-44a3-4d3c-8722-5e2e6ade3e87","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"db7a485f-9dfb-49c1-ac3c-61f62a0deac6","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"46c84cee-fb3b-4247-8790-60e1f626bd83","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"efb4ef27-7b6b-4a43-a579-6d9fab6876ef","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -998,7 +994,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:27:03 GMT
+      - Tue, 21 Apr 2020 05:14:57 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1012,107 +1008,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59974'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3Zjg4OTBhNi00NjViLTQ4MzUtOTY1Yy0yZmJiMjhlMTdiODI=?api-version=2018-09-01
-      cache-control:
-      - private
-      content-length:
-      - '0'
-      date:
-      - Thu, 16 Apr 2020 14:27:06 GMT
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3Zjg4OTBhNi00NjViLTQ4MzUtOTY1Yy0yZmJiMjhlMTdiODI=?api-version=2018-09-01
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3Zjg4OTBhNi00NjViLTQ4MzUtOTY1Yy0yZmJiMjhlMTdiODI=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"Succeeded"}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '22'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:27:37 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
+      - '59987'
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:
@@ -1149,7 +1045,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTswOWQ2OTZjNy01N2E1LTQ0OTMtYWViNy05OTEzZDc5MTU0MjY=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYmM1YWRlYi1kYmY2LTQ4ZWEtOWExZi03ZjAxNmNlNTE4YmQ=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -1157,9 +1053,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:28:04 GMT
+      - Tue, 21 Apr 2020 05:15:00 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTswOWQ2OTZjNy01N2E1LTQ0OTMtYWViNy05OTEzZDc5MTU0MjY=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYmM1YWRlYi1kYmY2LTQ4ZWEtOWExZi03ZjAxNmNlNTE4YmQ=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1169,7 +1065,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -1197,7 +1093,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f0b0d216-194e-43bf-a1d7-8df73416508c","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"16acf3e4-2a68-4469-9a44-3667449f02b3","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1206,9 +1102,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:28:34 GMT
+      - Tue, 21 Apr 2020 05:15:30 GMT
       etag:
-      - f0b0d216-194e-43bf-a1d7-8df73416508c
+      - 16acf3e4-2a68-4469-9a44-3667449f02b3
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1245,21 +1141,19 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYmM1YWRlYi1kYmY2LTQ4ZWEtOWExZi03ZjAxNmNlNTE4YmQ=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com","name":"zone1.com","type":"Microsoft.Network\/privateDnsZones","etag":"dd0b2bac-afec-48e4-be1b-fe264d89dc50","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '613'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:28:35 GMT
-      etag:
-      - dd0b2bac-afec-48e4-be1b-fe264d89dc50
+      - Tue, 21 Apr 2020 05:15:31 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1273,703 +1167,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 100, "weight":
-      1, "port": 443, "target": "target.contoso.com."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '123'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/_sip._tls?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"d740bcd0-0d50-4587-9870-890d6292d704","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '509'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:36 GMT
-      etag:
-      - d740bcd0-0d50-4587-9870-890d6292d704
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.0.0.10"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '73'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/manuala?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"33cb0b1f-f1a2-448b-9c16-8c817d3e4275","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '455'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:38 GMT
-      etag:
-      - 33cb0b1f-f1a2-448b-9c16-8c817d3e4275
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 0, "aRecords": [{"ipv4Address": "10.0.1.0"}, {"ipv4Address":
-      "10.0.1.1"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '98'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/A/mya?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0dfb4bfa-b63f-4901-a6e2-c2082e1cacee","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '466'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:39 GMT
-      etag:
-      - 0dfb4bfa-b63f-4901-a6e2-c2082e1cacee
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '102'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/AAAA/myaaaa?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"0e24ac37-36b0-445a-92a6-6cd7cbba4a5e","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '487'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:41 GMT
-      etag:
-      - 0e24ac37-36b0-445a-92a6-6cd7cbba4a5e
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "contoso.com."}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '71'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/CNAME/mycname?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"dc7b232b-cbac-45fb-a91d-83e6ae933711","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '461'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:41 GMT
-      etag:
-      - dc7b232b-cbac-45fb-a91d-83e6ae933711
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 1, "exchange":
-      "mail.contoso.com."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '96'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/MX/mymx?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"9f841027-3208-4aa3-aa32-8ebb0a392c3b","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '469'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:42 GMT
-      etag:
-      - 9f841027-3208-4aa3-aa32-8ebb0a392c3b
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "myptrdname"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '73'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myname?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c542f81a-c739-4db4-9b75-d46a63428d93","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '456'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:43 GMT
-      etag:
-      - c542f81a-c739-4db4-9b75-d46a63428d93
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["manualtxt"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '71'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/myname2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9cfc397c-cc02-4add-8b66-074356ec8b86","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '457'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:44 GMT
-      etag:
-      - 9cfc397c-cc02-4add-8b66-074356ec8b86
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "contoso.com"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '74'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/PTR/myptr?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"d51ffcb5-8ddb-470b-8744-a261b9f4ea7b","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '454'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:46 GMT
-      etag:
-      - d51ffcb5-8ddb-470b-8744-a261b9f4ea7b
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
-      "port": 1234, "target": "target.contoso.com."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '122'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/SRV/mysrv?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"48863b66-6bf1-4b64-8360-0ccb2d7273dc","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '496'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:47 GMT
-      etag:
-      - 48863b66-6bf1-4b64-8360-0ccb2d7273dc
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 7200, "txtRecords": [{"value": ["abc def"]}, {"value":
-      ["foo bar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '93'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxt2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9db215a1-3d4f-4e74-9696-dcdfba4fd51e","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
-        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '474'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:48 GMT
-      etag:
-      - 9db215a1-3d4f-4e74-9696-dcdfba4fd51e
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["hi"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '64'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/TXT/mytxtrs?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b5f0e2a3-8411-458f-b022-31b3973629b9","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '450'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:50 GMT
-      etag:
-      - b5f0e2a3-8411-458f-b022-31b3973629b9
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns record-set list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -z
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone1_import000001/providers/Microsoft.Network/privateDnsZones/zone1.com/ALL?api-version=2018-09-01
-  response:
-    body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"dbfd9223-40fa-4cf8-b14c-b74a317da21d","properties":{"fqdn":"zone1.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"d740bcd0-0d50-4587-9870-890d6292d704","properties":{"fqdn":"_sip._tls.zone1.com.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"33cb0b1f-f1a2-448b-9c16-8c817d3e4275","properties":{"fqdn":"manuala.zone1.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0dfb4bfa-b63f-4901-a6e2-c2082e1cacee","properties":{"fqdn":"mya.zone1.com.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"0e24ac37-36b0-445a-92a6-6cd7cbba4a5e","properties":{"fqdn":"myaaaa.zone1.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"dc7b232b-cbac-45fb-a91d-83e6ae933711","properties":{"fqdn":"mycname.zone1.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"9f841027-3208-4aa3-aa32-8ebb0a392c3b","properties":{"fqdn":"mymx.zone1.com.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c542f81a-c739-4db4-9b75-d46a63428d93","properties":{"fqdn":"myname.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9cfc397c-cc02-4add-8b66-074356ec8b86","properties":{"fqdn":"myname2.zone1.com.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"d51ffcb5-8ddb-470b-8744-a261b9f4ea7b","properties":{"fqdn":"myptr.zone1.com.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"48863b66-6bf1-4b64-8360-0ccb2d7273dc","properties":{"fqdn":"mysrv.zone1.com.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9db215a1-3d4f-4e74-9696-dcdfba4fd51e","properties":{"fqdn":"mytxt2.zone1.com.","ttl":7200,"txtRecords":[{"value":["abc
-        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone1_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone1.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b5f0e2a3-8411-458f-b022-31b3973629b9","properties":{"fqdn":"mytxtrs.zone1.com.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '6252'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:28:50 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59974'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone2_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone2_Import.yaml
@@ -1,0 +1,4627 @@
+interactions:
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiMjYyYTQ2MC03YzNmLTQxOGQtODYxOS1lYzZlYTlhZTQ2YmQ=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:29:30 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiMjYyYTQ2MC03YzNmLTQxOGQtODYxOS1lYzZlYTlhZTQ2YmQ=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"060de239-695d-48f9-a983-c0e58cfd7788","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:01 GMT
+      etag:
+      - 060de239-695d-48f9-a983-c0e58cfd7788
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"2683ad9c-e3f3-4f9e-aabd-9095a3efcc26","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:02 GMT
+      etag:
+      - 2683ad9c-e3f3-4f9e-aabd-9095a3efcc26
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "hostmaster.", "serialNumber": 10, "refreshTime": 900, "retryTime":
+      600, "expireTime": 86400, "minimumTtl": 3600}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '198'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4fd70fe4-9a79-45d3-9692-2be8fd07262c","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '569'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:02 GMT
+      etag:
+      - 4fd70fe4-9a79-45d3-9692-2be8fd07262c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 200, "txtRecords": [{"value": ["this is another
+      SPF, this time as TXT"]}, {"value": ["v=spf1 mx ip4:14.14.22.0/23 a:mail.trum.ch
+      mx:mese.ch include:spf.mapp.com ?all"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '194'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"aef4eb2f-fa16-452d-a3c5-25cbe37b0e4a","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '559'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:03 GMT
+      etag:
+      - aef4eb2f-fa16-452d-a3c5-25cbe37b0e4a
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["  a  "]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/spaces?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"92bdcf87-b753-4306-a516-2c3a33c36ace","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:04 GMT
+      etag:
+      - 92bdcf87-b753-4306-a516-2c3a33c36ace
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}, {"ipv4Address":
+      "2.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/a2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4e772834-2fee-407a-b9a5-b0d179e5eac7","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:06 GMT
+      etag:
+      - 4e772834-2fee-407a-b9a5-b0d179e5eac7
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:cafe:130::100"},
+      {"ipv6Address": "2001:cafe:130::101"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '124'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/AAAA/aaaa2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"93e29ab0-db00-4a11-9bf4-0b1814be309e","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '504'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:07 GMT
+      etag:
+      - 93e29ab0-db00-4a11-9bf4-0b1814be309e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '170'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/doozie?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3d859368-14ab-4cb5-8ce2-4fc56da9d8b6","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:07 GMT
+      etag:
+      - 3d859368-14ab-4cb5-8ce2-4fc56da9d8b6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "bar.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/CNAME/fee2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"6cfdbff6-706f-4464-bccd-a13786880682","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '448'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:09 GMT
+      etag:
+      - 6cfdbff6-706f-4464-bccd-a13786880682
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "mail1.mymail.com."}, {"preference": 11, "exchange": "flooble."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '141'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/mail?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"29712271-125f-4ff1-bbdd-028a2d89da6c","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '510'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:10 GMT
+      etag:
+      - 29712271-125f-4ff1-bbdd-028a2d89da6c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 10, "weight":
+      20, "port": 30, "target": "foobar."}, {"priority": 55, "weight": 66, "port":
+      77, "target": "zoo."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SRV/sip.tcp?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"42fcfe8a-ab97-41d6-b7e1-be13a5cfbe2f","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '544'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:11 GMT
+      etag:
+      - 42fcfe8a-ab97-41d6-b7e1-be13a5cfbe2f
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1"]}, {"value":
+      ["string 2"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '95'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/test-txt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8bca831c-3c34-43f6-8330-138e8119bf38","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '485'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:12 GMT
+      etag:
+      - 8bca831c-3c34-43f6-8330-138e8119bf38
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "4.5.6.7"}, {"ipv4Address":
+      "6.7.8.9"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/aa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"810e7944-67a1-42f7-9f8a-5e1364aa1719","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:14 GMT
+      etag:
+      - 810e7944-67a1-42f7-9f8a-5e1364aa1719
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 300, "mxRecords": [{"preference": 1, "exchange":
+      "foo.com.zone2.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/aa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7dab57ff-ca55-442e-91a0-5b59cb396ad2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:15 GMT
+      etag:
+      - 7dab57ff-ca55-442e-91a0-5b59cb396ad2
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "7.8.9.0"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/200?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f62518fe-c966-4649-b401-63db9be908dc","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '441'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:16 GMT
+      etag:
+      - f62518fe-c966-4649-b401-63db9be908dc
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 999, "txtRecords": [{"value": ["this is a super
+      long txt record...wow, it is really really long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer....this is a super lon",
+      "g txt record...wow, it is really really long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer....this is a super long
+      txt record...wow,", " it is really really long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer....this is a super long
+      txt record...wow, it is really reall", "y long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer...."]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1017'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1da925ca-2159-43ef-9304-28ab3027561e","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        is a super long txt record...wow, it is really really long!  And I even used
+        copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super lon","g txt record...wow, it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow,"," it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow, it is really reall","y long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1400'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:17 GMT
+      etag:
+      - 1da925ca-2159-43ef-9304-28ab3027561e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "txtRecords": [{"value": ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
+      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '565'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f46dc6e-f3ad-4465-b8c3-83010f526653","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '953'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:18 GMT
+      etag:
+      - 7f46dc6e-f3ad-4465-b8c3-83010f526653
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "txtRecords": [{"value": ["this is an SPF record!
+      Convert to TXT on import"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '108'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/myspf?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7720c774-25d5-432c-ba1e-dfeb3e876baf","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '488'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:18 GMT
+      etag:
+      - 7720c774-25d5-432c-ba1e-dfeb3e876baf
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"1cb66c76-af79-4dca-9bc4-06bcfb64b7df","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '451'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:20 GMT
+      etag:
+      - 1cb66c76-af79-4dca-9bc4-06bcfb64b7df
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foobar.com."},
+      {"ptrdname": "bar.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8cfadc2b-e8b0-4595-944f-1a78d77be1cc","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '478'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:20 GMT
+      etag:
+      - 8cfadc2b-e8b0-4595-944f-1a78d77be1cc
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}, {"ptrdname":
+      "bar.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '97'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.3?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a793fb80-82bd-4a69-9771-4e0cb3c6f5bd","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:22 GMT
+      etag:
+      - a793fb80-82bd-4a69-9771-4e0cb3c6f5bd
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9de19b41-c45f-41e8-a806-e7972e553f75","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:23 GMT
+      etag:
+      - 9de19b41-c45f-41e8-a806-e7972e553f75
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ec953705-1885-419e-8e3d-d0854b387cde","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:24 GMT
+      etag:
+      - ec953705-1885-419e-8e3d-d0854b387cde
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t3?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6ed6d751-2196-47ba-8913-fa436fe8e7aa","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:25 GMT
+      etag:
+      - 6ed6d751-2196-47ba-8913-fa436fe8e7aa
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo;bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t4?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8be42881-e2ef-4ad9-884c-aebb0f8b47f2","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '440'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:26 GMT
+      etag:
+      - 8be42881-e2ef-4ad9-884c-aebb0f8b47f2
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t5?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f0e689c-8222-41a2-88b7-2c805d9210d7","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '442'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:27 GMT
+      etag:
+      - 7f0e689c-8222-41a2-88b7-2c805d9210d7
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t6?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01eb0016-f3bc-4bb6-a1de-63a2bde3d42b","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '442'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:28 GMT
+      etag:
+      - 01eb0016-f3bc-4bb6-a1de-63a2bde3d42b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["\\\"quoted string\\\""]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t7?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ffc18716-409d-4a95-91d9-70035113bc3c","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:29 GMT
+      etag:
+      - ffc18716-409d-4a95-91d9-70035113bc3c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t8?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c00bd9fb-8037-4be7-9858-4705bc722f20","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:30 GMT
+      etag:
+      - c00bd9fb-8037-4be7-9858-4705bc722f20
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobarr"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t9?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bcebbaf5-0707-4b84-bf44-39627869af7d","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '440'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:31 GMT
+      etag:
+      - bcebbaf5-0707-4b84-bf44-39627869af7d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t10?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"51a9f359-fe01-41f0-b3a4-561c68deb280","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '443'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:32 GMT
+      etag:
+      - 51a9f359-fe01-41f0-b3a4-561c68deb280
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t11?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1912e602-ad13-42f3-9aed-5d2ca458d1f7","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '442'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:33 GMT
+      etag:
+      - 1912e602-ad13-42f3-9aed-5d2ca458d1f7
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9ee155dc-3c39-42b4-8eae-f1f5c1959504","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:34 GMT
+      etag:
+      - 9ee155dc-3c39-42b4-8eae-f1f5c1959504
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "be.xpiler.de."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"38314aa9-644c-4a57-92d2-3bf5a423779f","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:35 GMT
+      etag:
+      - 38314aa9-644c-4a57-92d2-3bf5a423779f
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xcaign.de
+      include:_spf6.xcaign.de -all"]}, {"value": ["spf2.0/mfrom,pra mx ip4:15.19.14.0/24
+      ip4:8.8.11.4/27 ip4:9.16.20.19/26 -all"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '217'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"21ee6543-46ca-4e0a-a2bf-cc79d5ca6b5c","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '596'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:37 GMT
+      etag:
+      - 21ee6543-46ca-4e0a-a2bf-cc79d5ca6b5c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cb7dcd07-3c59-440f-866a-96f1c6f6e70e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:38 GMT
+      etag:
+      - cb7dcd07-3c59-440f-866a-96f1c6f6e70e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "be.xpiler.de."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"6c8af5d2-130c-4059-bfd3-497ddb3ad0ac","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:39 GMT
+      etag:
+      - 6c8af5d2-130c-4059-bfd3-497ddb3ad0ac
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xgn.de
+      include:_spf6.xgn.de -all"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"458c397b-172f-458e-8762-bba3d1a78152","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '495'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:41 GMT
+      etag:
+      - 458c397b-172f-458e-8762-bba3d1a78152
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11993'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"1cb66c76-af79-4dca-9bc4-06bcfb64b7df","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8cfadc2b-e8b0-4595-944f-1a78d77be1cc","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f62518fe-c966-4649-b401-63db9be908dc","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a793fb80-82bd-4a69-9771-4e0cb3c6f5bd","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4fd70fe4-9a79-45d3-9692-2be8fd07262c","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"aef4eb2f-fa16-452d-a3c5-25cbe37b0e4a","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4e772834-2fee-407a-b9a5-b0d179e5eac7","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"810e7944-67a1-42f7-9f8a-5e1364aa1719","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7dab57ff-ca55-442e-91a0-5b59cb396ad2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"93e29ab0-db00-4a11-9bf4-0b1814be309e","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9ee155dc-3c39-42b4-8eae-f1f5c1959504","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"38314aa9-644c-4a57-92d2-3bf5a423779f","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"21ee6543-46ca-4e0a-a2bf-cc79d5ca6b5c","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3d859368-14ab-4cb5-8ce2-4fc56da9d8b6","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cb7dcd07-3c59-440f-866a-96f1c6f6e70e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"6c8af5d2-130c-4059-bfd3-497ddb3ad0ac","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"458c397b-172f-458e-8762-bba3d1a78152","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"6cfdbff6-706f-4464-bccd-a13786880682","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1da925ca-2159-43ef-9304-28ab3027561e","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        is a super long txt record...wow, it is really really long!  And I even used
+        copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super lon","g txt record...wow, it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow,"," it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow, it is really reall","y long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f46dc6e-f3ad-4465-b8c3-83010f526653","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"29712271-125f-4ff1-bbdd-028a2d89da6c","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7720c774-25d5-432c-ba1e-dfeb3e876baf","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"92bdcf87-b753-4306-a516-2c3a33c36ace","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9de19b41-c45f-41e8-a806-e7972e553f75","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"51a9f359-fe01-41f0-b3a4-561c68deb280","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1912e602-ad13-42f3-9aed-5d2ca458d1f7","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ec953705-1885-419e-8e3d-d0854b387cde","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6ed6d751-2196-47ba-8913-fa436fe8e7aa","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8be42881-e2ef-4ad9-884c-aebb0f8b47f2","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f0e689c-8222-41a2-88b7-2c805d9210d7","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01eb0016-f3bc-4bb6-a1de-63a2bde3d42b","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ffc18716-409d-4a95-91d9-70035113bc3c","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c00bd9fb-8037-4be7-9858-4705bc722f20","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bcebbaf5-0707-4b84-bf44-39627869af7d","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"42fcfe8a-ab97-41d6-b7e1-be13a5cfbe2f","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8bca831c-3c34-43f6-8330-138e8119bf38","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '18531'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:41 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59951'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4fd70fe4-9a79-45d3-9692-2be8fd07262c","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '581'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:42 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"1cb66c76-af79-4dca-9bc4-06bcfb64b7df","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8cfadc2b-e8b0-4595-944f-1a78d77be1cc","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f62518fe-c966-4649-b401-63db9be908dc","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a793fb80-82bd-4a69-9771-4e0cb3c6f5bd","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4fd70fe4-9a79-45d3-9692-2be8fd07262c","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"aef4eb2f-fa16-452d-a3c5-25cbe37b0e4a","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4e772834-2fee-407a-b9a5-b0d179e5eac7","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"810e7944-67a1-42f7-9f8a-5e1364aa1719","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7dab57ff-ca55-442e-91a0-5b59cb396ad2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"93e29ab0-db00-4a11-9bf4-0b1814be309e","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9ee155dc-3c39-42b4-8eae-f1f5c1959504","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"38314aa9-644c-4a57-92d2-3bf5a423779f","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"21ee6543-46ca-4e0a-a2bf-cc79d5ca6b5c","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3d859368-14ab-4cb5-8ce2-4fc56da9d8b6","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cb7dcd07-3c59-440f-866a-96f1c6f6e70e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"6c8af5d2-130c-4059-bfd3-497ddb3ad0ac","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"458c397b-172f-458e-8762-bba3d1a78152","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"6cfdbff6-706f-4464-bccd-a13786880682","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1da925ca-2159-43ef-9304-28ab3027561e","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        is a super long txt record...wow, it is really really long!  And I even used
+        copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super lon","g txt record...wow, it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow,"," it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow, it is really reall","y long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f46dc6e-f3ad-4465-b8c3-83010f526653","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"29712271-125f-4ff1-bbdd-028a2d89da6c","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7720c774-25d5-432c-ba1e-dfeb3e876baf","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"92bdcf87-b753-4306-a516-2c3a33c36ace","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9de19b41-c45f-41e8-a806-e7972e553f75","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"51a9f359-fe01-41f0-b3a4-561c68deb280","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1912e602-ad13-42f3-9aed-5d2ca458d1f7","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ec953705-1885-419e-8e3d-d0854b387cde","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6ed6d751-2196-47ba-8913-fa436fe8e7aa","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8be42881-e2ef-4ad9-884c-aebb0f8b47f2","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f0e689c-8222-41a2-88b7-2c805d9210d7","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01eb0016-f3bc-4bb6-a1de-63a2bde3d42b","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ffc18716-409d-4a95-91d9-70035113bc3c","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c00bd9fb-8037-4be7-9858-4705bc722f20","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bcebbaf5-0707-4b84-bf44-39627869af7d","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"42fcfe8a-ab97-41d6-b7e1-be13a5cfbe2f","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8bca831c-3c34-43f6-8330-138e8119bf38","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '18531'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:30:43 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59964'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZjRlY2E4OC1iOGUyLTQ1YjYtOGU0Zi1iY2I1ZGVlNjUyZDc=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Thu, 16 Apr 2020 14:30:45 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZjRlY2E4OC1iOGUyLTQ1YjYtOGU0Zi1iY2I1ZGVlNjUyZDc=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZjRlY2E4OC1iOGUyLTQ1YjYtOGU0Zi1iY2I1ZGVlNjUyZDc=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:31:15 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmM2VmYzhiZS1hNTgzLTQ2ODctOTljMy0xNWQyN2VkNDJkOTQ=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:31:43 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmM2VmYzhiZS1hNTgzLTQ2ODctOTljMy0xNWQyN2VkNDJkOTQ=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1ec3988a-61df-4de6-bf0a-99145facc308","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:14 GMT
+      etag:
+      - 1ec3988a-61df-4de6-bf0a-99145facc308
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"f22064df-82cf-4174-85c4-484d0e634395","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:14 GMT
+      etag:
+      - f22064df-82cf-4174-85c4-484d0e634395
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "hostmaster.", "serialNumber": 1, "refreshTime": 900, "retryTime":
+      600, "expireTime": 86400, "minimumTtl": 3600}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '197'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4c12002b-8acf-48a4-ac74-2b184d1dc1a9","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '569'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:14 GMT
+      etag:
+      - 4c12002b-8acf-48a4-ac74-2b184d1dc1a9
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 200, "txtRecords": [{"value": ["this is another
+      SPF, this time as TXT"]}, {"value": ["v=spf1 mx ip4:14.14.22.0/23 a:mail.trum.ch
+      mx:mese.ch include:spf.mapp.com ?all"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '194'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f57c447c-4a79-474e-8746-7e67f5068674","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '559'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:15 GMT
+      etag:
+      - f57c447c-4a79-474e-8746-7e67f5068674
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e4bdb93d-2b33-4071-8116-7121e517ad25","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '451'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:16 GMT
+      etag:
+      - e4bdb93d-2b33-4071-8116-7121e517ad25
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foobar.com."},
+      {"ptrdname": "bar.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a27544f5-0a82-4813-81e4-9fee9d15ec68","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '478'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:17 GMT
+      etag:
+      - a27544f5-0a82-4813-81e4-9fee9d15ec68
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "7.8.9.0"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/200?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"81dd8c2d-7f39-40f7-a3b3-bd55e9b1018c","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '441'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:19 GMT
+      etag:
+      - 81dd8c2d-7f39-40f7-a3b3-bd55e9b1018c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}, {"ptrdname":
+      "bar.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '97'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.3?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"b0a3448a-56a6-48ce-9a36-9d2041fc191c","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:20 GMT
+      etag:
+      - b0a3448a-56a6-48ce-9a36-9d2041fc191c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}, {"ipv4Address":
+      "2.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/a2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"22dece0b-3a43-4b39-9c1a-667f1adfa442","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:21 GMT
+      etag:
+      - 22dece0b-3a43-4b39-9c1a-667f1adfa442
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "4.5.6.7"}, {"ipv4Address":
+      "6.7.8.9"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/aa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"72e4248a-7749-4168-b20d-639fcadc9a2f","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:22 GMT
+      etag:
+      - 72e4248a-7749-4168-b20d-639fcadc9a2f
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 300, "mxRecords": [{"preference": 1, "exchange":
+      "foo.com.zone2.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/aa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"71f33003-b9b7-429c-9907-6641c928ed62","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:24 GMT
+      etag:
+      - 71f33003-b9b7-429c-9907-6641c928ed62
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:cafe:130::100"},
+      {"ipv6Address": "2001:cafe:130::101"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '124'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/AAAA/aaaa2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"b1deb492-3046-49d9-8e91-81f6c67d0108","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '504'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:25 GMT
+      etag:
+      - b1deb492-3046-49d9-8e91-81f6c67d0108
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"42f5ad03-8382-4b1d-8e70-00ad446b80de","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:26 GMT
+      etag:
+      - 42f5ad03-8382-4b1d-8e70-00ad446b80de
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "be.xpiler.de."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b8774030-e1b3-4a06-9e22-96375dc1041e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:27 GMT
+      etag:
+      - b8774030-e1b3-4a06-9e22-96375dc1041e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xcaign.de
+      include:_spf6.xcaign.de -all"]}, {"value": ["spf2.0/mfrom,pra mx ip4:15.19.14.0/24
+      ip4:8.8.11.4/27 ip4:9.16.20.19/26 -all"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '217'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a9f7f18b-38ee-4dc6-bf46-2e9d92fce724","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '596'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:28 GMT
+      etag:
+      - a9f7f18b-38ee-4dc6-bf46-2e9d92fce724
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '170'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/doozie?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d1449f9f-0bc7-4785-a4bb-779ffd572e8e","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:30 GMT
+      etag:
+      - d1449f9f-0bc7-4785-a4bb-779ffd572e8e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"03a38819-4eeb-4883-9a45-49fb3a1382f9","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:31 GMT
+      etag:
+      - 03a38819-4eeb-4883-9a45-49fb3a1382f9
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "be.xpiler.de."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"fa770551-25cc-40b8-8fb0-019e263603c0","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:32 GMT
+      etag:
+      - fa770551-25cc-40b8-8fb0-019e263603c0
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xgn.de
+      include:_spf6.xgn.de -all"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7d8cf5fc-7976-4dba-b938-4c34c02d7401","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '495'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:33 GMT
+      etag:
+      - 7d8cf5fc-7976-4dba-b938-4c34c02d7401
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11992'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "bar.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/CNAME/fee2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"da83925f-b2f4-4f19-b241-5828a2052bae","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '448'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:34 GMT
+      etag:
+      - da83925f-b2f4-4f19-b241-5828a2052bae
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 999, "txtRecords": [{"value": ["this is a super
+      long txt record...wow, it is really really long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer....this is a super lon",
+      "g txt record...wow, it is really really long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer....this is a super long
+      txt record...wow,", " it is really really long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer....this is a super long
+      txt record...wow, it is really reall", "y long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer...."]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1017'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9cbfe400-043c-4c0f-ac39-4d19e989ecd2","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        is a super long txt record...wow, it is really really long!  And I even used
+        copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super lon","g txt record...wow, it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow,"," it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow, it is really reall","y long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1400'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:35 GMT
+      etag:
+      - 9cbfe400-043c-4c0f-ac39-4d19e989ecd2
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "txtRecords": [{"value": ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
+      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '565'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"31438c09-4dcd-4360-9c7f-891e59a42397","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '953'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:37 GMT
+      etag:
+      - 31438c09-4dcd-4360-9c7f-891e59a42397
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "mail1.mymail.com."}, {"preference": 11, "exchange": "flooble."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '141'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/mail?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"e0420400-061b-4bf9-8a4a-732bc21a5fda","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '510'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:37 GMT
+      etag:
+      - e0420400-061b-4bf9-8a4a-732bc21a5fda
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "txtRecords": [{"value": ["this is an SPF record!
+      Convert to TXT on import"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '108'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/myspf?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9bd75f9c-ece0-43ae-8ff1-df038a48d4d3","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '488'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:38 GMT
+      etag:
+      - 9bd75f9c-ece0-43ae-8ff1-df038a48d4d3
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["  a  "]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/spaces?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"eb6fa9aa-61ab-49cd-879e-9a3d82ca2e64","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:39 GMT
+      etag:
+      - eb6fa9aa-61ab-49cd-879e-9a3d82ca2e64
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"31123e41-25c1-4838-b06a-64be257cf1db","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:40 GMT
+      etag:
+      - 31123e41-25c1-4838-b06a-64be257cf1db
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t10?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0c4f2cee-d737-4ee5-bcea-b031a1ebddf2","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '443'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:41 GMT
+      etag:
+      - 0c4f2cee-d737-4ee5-bcea-b031a1ebddf2
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t11?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d7b05e3c-8e3c-4a22-9880-f0c2f124ca52","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '442'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:42 GMT
+      etag:
+      - d7b05e3c-8e3c-4a22-9880-f0c2f124ca52
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"566dd78d-1bff-4fc1-96df-dbacdcd3d0ae","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:43 GMT
+      etag:
+      - 566dd78d-1bff-4fc1-96df-dbacdcd3d0ae
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t3?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7afcd5ce-8ca2-49bd-99aa-4e2d3c406747","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:45 GMT
+      etag:
+      - 7afcd5ce-8ca2-49bd-99aa-4e2d3c406747
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo;bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t4?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"27f4fec0-df82-435b-8145-48e31c5df431","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '440'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:46 GMT
+      etag:
+      - 27f4fec0-df82-435b-8145-48e31c5df431
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t5?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"266d8635-e855-408c-bcc4-aae8ed441866","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '442'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:47 GMT
+      etag:
+      - 266d8635-e855-408c-bcc4-aae8ed441866
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t6?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4c3ad0ed-14e2-4cb8-b635-8a6ea7f7399a","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '442'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:48 GMT
+      etag:
+      - 4c3ad0ed-14e2-4cb8-b635-8a6ea7f7399a
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["\\\"quoted string\\\""]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t7?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c1b84b1e-9acd-47bf-a475-b56ddfcea363","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:49 GMT
+      etag:
+      - c1b84b1e-9acd-47bf-a475-b56ddfcea363
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t8?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8de813eb-ec91-4dbd-850f-4ab9ec33ef99","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:50 GMT
+      etag:
+      - 8de813eb-ec91-4dbd-850f-4ab9ec33ef99
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobarr"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t9?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"522d3d2f-9129-40cb-bb39-a691c380a814","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '440'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:51 GMT
+      etag:
+      - 522d3d2f-9129-40cb-bb39-a691c380a814
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 10, "weight":
+      20, "port": 30, "target": "foobar."}, {"priority": 55, "weight": 66, "port":
+      77, "target": "zoo."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SRV/sip.tcp?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"43fdc37f-c45e-4606-9960-8e94f00dd72b","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '544'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:53 GMT
+      etag:
+      - 43fdc37f-c45e-4606-9960-8e94f00dd72b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1"]}, {"value":
+      ["string 2"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '95'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/test-txt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"84f9a199-ae8a-44a6-87dc-5f04f14bbf56","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '485'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:54 GMT
+      etag:
+      - 84f9a199-ae8a-44a6-87dc-5f04f14bbf56
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e4bdb93d-2b33-4071-8116-7121e517ad25","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a27544f5-0a82-4813-81e4-9fee9d15ec68","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"81dd8c2d-7f39-40f7-a3b3-bd55e9b1018c","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"b0a3448a-56a6-48ce-9a36-9d2041fc191c","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4c12002b-8acf-48a4-ac74-2b184d1dc1a9","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f57c447c-4a79-474e-8746-7e67f5068674","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"22dece0b-3a43-4b39-9c1a-667f1adfa442","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"72e4248a-7749-4168-b20d-639fcadc9a2f","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"71f33003-b9b7-429c-9907-6641c928ed62","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"b1deb492-3046-49d9-8e91-81f6c67d0108","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"42f5ad03-8382-4b1d-8e70-00ad446b80de","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b8774030-e1b3-4a06-9e22-96375dc1041e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a9f7f18b-38ee-4dc6-bf46-2e9d92fce724","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d1449f9f-0bc7-4785-a4bb-779ffd572e8e","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"03a38819-4eeb-4883-9a45-49fb3a1382f9","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"fa770551-25cc-40b8-8fb0-019e263603c0","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7d8cf5fc-7976-4dba-b938-4c34c02d7401","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"da83925f-b2f4-4f19-b241-5828a2052bae","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9cbfe400-043c-4c0f-ac39-4d19e989ecd2","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        is a super long txt record...wow, it is really really long!  And I even used
+        copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super lon","g txt record...wow, it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow,"," it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow, it is really reall","y long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"31438c09-4dcd-4360-9c7f-891e59a42397","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"e0420400-061b-4bf9-8a4a-732bc21a5fda","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9bd75f9c-ece0-43ae-8ff1-df038a48d4d3","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"eb6fa9aa-61ab-49cd-879e-9a3d82ca2e64","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"31123e41-25c1-4838-b06a-64be257cf1db","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0c4f2cee-d737-4ee5-bcea-b031a1ebddf2","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d7b05e3c-8e3c-4a22-9880-f0c2f124ca52","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"566dd78d-1bff-4fc1-96df-dbacdcd3d0ae","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7afcd5ce-8ca2-49bd-99aa-4e2d3c406747","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"27f4fec0-df82-435b-8145-48e31c5df431","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"266d8635-e855-408c-bcc4-aae8ed441866","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4c3ad0ed-14e2-4cb8-b635-8a6ea7f7399a","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c1b84b1e-9acd-47bf-a475-b56ddfcea363","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8de813eb-ec91-4dbd-850f-4ab9ec33ef99","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"522d3d2f-9129-40cb-bb39-a691c380a814","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"43fdc37f-c45e-4606-9960-8e94f00dd72b","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"84f9a199-ae8a-44a6-87dc-5f04f14bbf56","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '18531'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:32:54 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59964'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone2_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone2_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzM5OWRhNC05NWRiLTQxMGUtYTg0Mi1lOGNkM2IyZDgzMGE=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:16 GMT
+      - Wed, 22 Apr 2020 09:01:40 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzM5OWRhNC05NWRiLTQxMGUtYTg0Mi1lOGNkM2IyZDgzMGE=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -48,7 +48,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -71,7 +71,56 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzM5OWRhNC05NWRiLTQxMGUtYTg0Mi1lOGNkM2IyZDgzMGE=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"InProgress"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '23'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 09:02:10 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -83,7 +132,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:46 GMT
+      - Wed, 22 Apr 2020 09:02:41 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -97,7 +146,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -123,7 +172,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"c52cb37f-6cf0-4872-9ced-6437215aa44e","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"42beae59-a297-4250-aa97-e98310f3fb3f","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -132,9 +181,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:46 GMT
+      - Wed, 22 Apr 2020 09:02:42 GMT
       etag:
-      - c52cb37f-6cf0-4872-9ced-6437215aa44e
+      - 42beae59-a297-4250-aa97-e98310f3fb3f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -148,7 +197,60 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '495'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"544f9071-d492-4dbb-8d79-05617395857b","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 09:02:42 GMT
+      etag:
+      - 544f9071-d492-4dbb-8d79-05617395857b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -182,7 +284,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d8dc08bc-da53-4944-886f-363531cd85fa","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5e89f385-9cb1-4f51-bff1-37dd4dc7f330","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -191,9 +293,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:47 GMT
+      - Wed, 22 Apr 2020 09:02:43 GMT
       etag:
-      - d8dc08bc-da53-4944-886f-363531cd85fa
+      - 5e89f385-9cb1-4f51-bff1-37dd4dc7f330
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -207,7 +309,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -241,7 +343,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"379f3e65-bd47-4ef4-a8d8-d5aa92d3b3a6","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"84c01b4f-eff1-49e0-9ed8-c39a7b9fbba7","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
         is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
         a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}}'
     headers:
@@ -252,9 +354,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:48 GMT
+      - Wed, 22 Apr 2020 09:02:45 GMT
       etag:
-      - 379f3e65-bd47-4ef4-a8d8-d5aa92d3b3a6
+      - 84c01b4f-eff1-49e0-9ed8-c39a7b9fbba7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -264,7 +366,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -296,7 +398,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/spaces?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a5b34796-183e-4b5a-909c-aacb27909188","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9c0fb31f-bf4e-41b0-9a1b-0370279137ac","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -305,9 +407,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:48 GMT
+      - Wed, 22 Apr 2020 09:02:46 GMT
       etag:
-      - a5b34796-183e-4b5a-909c-aacb27909188
+      - 9c0fb31f-bf4e-41b0-9a1b-0370279137ac
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -317,7 +419,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
@@ -350,7 +452,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/a2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"de60001d-667e-434c-9388-187e19d65e42","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1542e877-d4e5-4033-846e-458a5d2d3f2c","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -359,9 +461,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:50 GMT
+      - Wed, 22 Apr 2020 09:02:47 GMT
       etag:
-      - de60001d-667e-434c-9388-187e19d65e42
+      - 1542e877-d4e5-4033-846e-458a5d2d3f2c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -371,7 +473,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11991'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -404,7 +506,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/AAAA/aaaa2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"cad2dc0b-46ce-4f89-b3e1-0d169c9518ee","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"7eb8c34e-4fa2-4786-bdf0-e40f312c04ec","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -413,9 +515,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:51 GMT
+      - Wed, 22 Apr 2020 09:02:48 GMT
       etag:
-      - cad2dc0b-46ce-4f89-b3e1-0d169c9518ee
+      - 7eb8c34e-4fa2-4786-bdf0-e40f312c04ec
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -457,7 +559,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/doozie?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"018e3128-b5e9-403f-8ba4-9bd2c4996a3f","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c451e862-8d1b-4427-9c82-9344d185236d","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -466,9 +568,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:52 GMT
+      - Wed, 22 Apr 2020 09:02:50 GMT
       etag:
-      - 018e3128-b5e9-403f-8ba4-9bd2c4996a3f
+      - c451e862-8d1b-4427-9c82-9344d185236d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -478,7 +580,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -510,7 +612,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/CNAME/fee2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"76f533ae-e680-45dc-961f-afda36cdfeb2","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"ae703705-0cd2-43eb-ab84-3d0d1a2c80d8","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -519,9 +621,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:53 GMT
+      - Wed, 22 Apr 2020 09:02:51 GMT
       etag:
-      - 76f533ae-e680-45dc-961f-afda36cdfeb2
+      - ae703705-0cd2-43eb-ab84-3d0d1a2c80d8
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -531,7 +633,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -564,7 +666,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/mail?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"170f8c73-377c-47ab-98f0-a903a2548cf7","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"3656fa8c-4eba-498e-9bcb-e2cf60fa1fa1","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -573,9 +675,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:54 GMT
+      - Wed, 22 Apr 2020 09:02:52 GMT
       etag:
-      - 170f8c73-377c-47ab-98f0-a903a2548cf7
+      - 3656fa8c-4eba-498e-9bcb-e2cf60fa1fa1
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -585,7 +687,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -619,7 +721,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SRV/sip.tcp?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"9935bd96-adb8-4a44-8c57-59f73099cb0b","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"24cbfe41-46df-4eda-a1a7-9589b230da1c","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -628,9 +730,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:55 GMT
+      - Wed, 22 Apr 2020 09:02:53 GMT
       etag:
-      - 9935bd96-adb8-4a44-8c57-59f73099cb0b
+      - 24cbfe41-46df-4eda-a1a7-9589b230da1c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -640,7 +742,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -673,7 +775,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/test-txt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"247bfaf5-3fb8-48bb-b04d-738061465551","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"200f0f71-bc80-4a29-b0a7-d65a8d1f38f0","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]},{"value":["string 2"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -683,9 +785,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:56 GMT
+      - Wed, 22 Apr 2020 09:02:54 GMT
       etag:
-      - 247bfaf5-3fb8-48bb-b04d-738061465551
+      - 200f0f71-bc80-4a29-b0a7-d65a8d1f38f0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -695,7 +797,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -728,7 +830,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/aa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b1c1a584-2b9d-4244-9e97-09bbb856a2ab","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8acb290f-4208-48d9-acc8-fb9fa7d9b35f","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -737,9 +839,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:57 GMT
+      - Wed, 22 Apr 2020 09:02:56 GMT
       etag:
-      - b1c1a584-2b9d-4244-9e97-09bbb856a2ab
+      - 8acb290f-4208-48d9-acc8-fb9fa7d9b35f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -749,7 +851,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -782,7 +884,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/aa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5d8f0863-f321-4eaa-9ecd-69c5e1da2a0e","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"83d861b1-0a55-45b0-a535-ea340859dfe2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -791,9 +893,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:16:59 GMT
+      - Wed, 22 Apr 2020 09:02:57 GMT
       etag:
-      - 5d8f0863-f321-4eaa-9ecd-69c5e1da2a0e
+      - 83d861b1-0a55-45b0-a535-ea340859dfe2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -803,7 +905,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -835,7 +937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/200?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4234b006-2ce0-41c8-b023-63ddc1926f59","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"146d97bc-71d1-4231-8d28-8c3c31932f1d","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -844,9 +946,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:00 GMT
+      - Wed, 22 Apr 2020 09:02:59 GMT
       etag:
-      - 4234b006-2ce0-41c8-b023-63ddc1926f59
+      - 146d97bc-71d1-4231-8d28-8c3c31932f1d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -856,7 +958,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -900,7 +1002,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cb224149-2427-49ee-9b85-52f07d27f732","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"23ea6c51-4481-4b75-97c4-6ede006b467c","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
         is a super long txt record...wow, it is really really long!  And I even used
         copy and paste to make it longer....this is a super long txt record...wow,
         it is really really long!  And I even used copy and paste to make it longer....this
@@ -921,9 +1023,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:01 GMT
+      - Wed, 22 Apr 2020 09:03:00 GMT
       etag:
-      - cb224149-2427-49ee-9b85-52f07d27f732
+      - 23ea6c51-4481-4b75-97c4-6ede006b467c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -933,7 +1035,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -966,7 +1068,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"949a0bd6-868d-4106-b2c8-c3c8d27467b1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a56e3b35-229c-4ffa-bc5f-cfc71d85e8e1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -975,9 +1077,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:02 GMT
+      - Wed, 22 Apr 2020 09:03:01 GMT
       etag:
-      - 949a0bd6-868d-4106-b2c8-c3c8d27467b1
+      - a56e3b35-229c-4ffa-bc5f-cfc71d85e8e1
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1020,7 +1122,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/myspf?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a02843e-9bd7-4867-8b02-881ac4a96fd0","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d4e09f6f-fca8-45fb-a83d-cc6af4a2c9ef","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
         is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -1030,9 +1132,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:03 GMT
+      - Wed, 22 Apr 2020 09:03:02 GMT
       etag:
-      - 9a02843e-9bd7-4867-8b02-881ac4a96fd0
+      - d4e09f6f-fca8-45fb-a83d-cc6af4a2c9ef
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1042,7 +1144,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -1074,7 +1176,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"cb37f17e-011b-44a8-847e-a8c42a8ff9f5","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c97b6c02-e644-42e5-bf33-52d15bd2efc7","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1083,9 +1185,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:04 GMT
+      - Wed, 22 Apr 2020 09:03:03 GMT
       etag:
-      - cb37f17e-011b-44a8-847e-a8c42a8ff9f5
+      - c97b6c02-e644-42e5-bf33-52d15bd2efc7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1128,7 +1230,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"82f10c36-65f6-41cb-be96-bf30649596fd","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"18268251-772e-4ee9-8788-2c7430eda3b9","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1137,9 +1239,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:05 GMT
+      - Wed, 22 Apr 2020 09:03:04 GMT
       etag:
-      - 82f10c36-65f6-41cb-be96-bf30649596fd
+      - 18268251-772e-4ee9-8788-2c7430eda3b9
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1149,7 +1251,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -1182,7 +1284,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.3?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"f6f804f8-d15d-441e-b6a0-955bd3c4083c","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"af4e55b1-6337-409b-8d0a-0c6570e48307","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1191,9 +1293,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:06 GMT
+      - Wed, 22 Apr 2020 09:03:05 GMT
       etag:
-      - f6f804f8-d15d-441e-b6a0-955bd3c4083c
+      - af4e55b1-6337-409b-8d0a-0c6570e48307
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1203,7 +1305,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -1235,7 +1337,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ae5ca740-464d-4ac9-8d1d-f7e8454e2d7e","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"777e5139-9536-496c-a51c-0694cab6332c","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1244,9 +1346,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:08 GMT
+      - Wed, 22 Apr 2020 09:03:07 GMT
       etag:
-      - ae5ca740-464d-4ac9-8d1d-f7e8454e2d7e
+      - 777e5139-9536-496c-a51c-0694cab6332c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1256,7 +1358,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -1288,7 +1390,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"09383659-6006-4d1d-9a91-2da66dba900e","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"309f5ec5-54ce-468a-a76a-d520924caf0d","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1297,9 +1399,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:09 GMT
+      - Wed, 22 Apr 2020 09:03:08 GMT
       etag:
-      - 09383659-6006-4d1d-9a91-2da66dba900e
+      - 309f5ec5-54ce-468a-a76a-d520924caf0d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1309,7 +1411,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -1341,7 +1443,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t3?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"85a8d91f-5dc5-4520-838c-82592fb50a51","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a1b2bf1-549f-4bf0-9605-beeff2eb1f6d","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1350,9 +1452,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:09 GMT
+      - Wed, 22 Apr 2020 09:03:09 GMT
       etag:
-      - 85a8d91f-5dc5-4520-838c-82592fb50a51
+      - 6a1b2bf1-549f-4bf0-9605-beeff2eb1f6d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1362,7 +1464,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -1394,7 +1496,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t4?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8aeebc1d-aa60-40ed-92c0-65c6a69474ed","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e0cf41a3-1678-4fd2-8cb6-e4008480c7f0","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1403,62 +1505,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:11 GMT
+      - Wed, 22 Apr 2020 09:03:11 GMT
       etag:
-      - 8aeebc1d-aa60-40ed-92c0-65c6a69474ed
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '71'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t5?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9b89b630-ebee-4a5d-8fd6-d60deb486dc6","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '442'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:17:11 GMT
-      etag:
-      - 9b89b630-ebee-4a5d-8fd6-d60deb486dc6
+      - e0cf41a3-1678-4fd2-8cb6-e4008480c7f0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1497,10 +1546,10 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t6?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t5?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c5cac27c-9d60-4590-9da7-e3c9feeb607a","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35fd720b-1ae8-48d2-8c33-5d636b294acd","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1509,9 +1558,62 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:12 GMT
+      - Wed, 22 Apr 2020 09:03:12 GMT
       etag:
-      - c5cac27c-9d60-4590-9da7-e3c9feeb607a
+      - 35fd720b-1ae8-48d2-8c33-5d636b294acd
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t6?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3aa17418-c8d0-4175-899d-17292e3706a2","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '442'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 09:03:13 GMT
+      etag:
+      - 3aa17418-c8d0-4175-899d-17292e3706a2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1553,7 +1655,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t7?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fd612258-fa53-4ca3-90d7-d31068b0506a","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"599cd463-8182-4ec6-a342-a7404d9c256e","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
         string\\\""]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -1563,9 +1665,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:13 GMT
+      - Wed, 22 Apr 2020 09:03:15 GMT
       etag:
-      - fd612258-fa53-4ca3-90d7-d31068b0506a
+      - 599cd463-8182-4ec6-a342-a7404d9c256e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1575,7 +1677,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -1607,7 +1709,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t8?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c80fe891-20e4-4639-9a33-25461713e747","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cac04611-68bd-4c6b-948e-91651f96db3c","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1616,9 +1718,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:15 GMT
+      - Wed, 22 Apr 2020 09:03:15 GMT
       etag:
-      - c80fe891-20e4-4639-9a33-25461713e747
+      - cac04611-68bd-4c6b-948e-91651f96db3c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1660,7 +1762,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t9?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7ddcd23f-b575-4265-a5c8-486d678b6254","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bd0637aa-377b-4263-8f09-3fd7b7cce108","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1669,9 +1771,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:16 GMT
+      - Wed, 22 Apr 2020 09:03:16 GMT
       etag:
-      - 7ddcd23f-b575-4265-a5c8-486d678b6254
+      - bd0637aa-377b-4263-8f09-3fd7b7cce108
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1713,7 +1815,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t10?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7bec5bc2-6bd4-4fa3-8ed5-92b304fc5b7c","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8784c942-4849-4891-b612-ab329d808a8a","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
         bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -1723,9 +1825,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:17 GMT
+      - Wed, 22 Apr 2020 09:03:18 GMT
       etag:
-      - 7bec5bc2-6bd4-4fa3-8ed5-92b304fc5b7c
+      - 8784c942-4849-4891-b612-ab329d808a8a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1735,7 +1837,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -1767,7 +1869,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t11?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4c27b429-5d95-41da-896c-0537f86bfe82","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"57ede89f-5f8f-4221-a429-f9d6ac0d502d","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1776,9 +1878,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:17 GMT
+      - Wed, 22 Apr 2020 09:03:19 GMT
       etag:
-      - 4c27b429-5d95-41da-896c-0537f86bfe82
+      - 57ede89f-5f8f-4221-a429-f9d6ac0d502d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1788,7 +1890,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
@@ -1820,7 +1922,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/base?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e782d6b6-6942-4480-8b88-1e10b0bb0c3a","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6e6da7ae-0621-4306-a2a2-8a5617f67128","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1829,9 +1931,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:19 GMT
+      - Wed, 22 Apr 2020 09:03:20 GMT
       etag:
-      - e782d6b6-6942-4480-8b88-1e10b0bb0c3a
+      - 6e6da7ae-0621-4306-a2a2-8a5617f67128
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1841,7 +1943,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -1874,7 +1976,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/base?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"d387272a-3259-4b33-af96-2090d8826e68","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"54784f74-b0bf-47cc-a2e3-7574d2fddd3e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1883,9 +1985,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:20 GMT
+      - Wed, 22 Apr 2020 09:03:21 GMT
       etag:
-      - d387272a-3259-4b33-af96-2090d8826e68
+      - 54784f74-b0bf-47cc-a2e3-7574d2fddd3e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1895,7 +1997,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -1929,7 +2031,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/base?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8db1c391-7da8-44d2-9e51-f0aca0b76ddc","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"68fb706b-f996-42da-9266-9feadf0c0056","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
         mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
         mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}}'
     headers:
@@ -1940,9 +2042,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:22 GMT
+      - Wed, 22 Apr 2020 09:03:23 GMT
       etag:
-      - 8db1c391-7da8-44d2-9e51-f0aca0b76ddc
+      - 68fb706b-f996-42da-9266-9feadf0c0056
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1952,7 +2054,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -1984,7 +2086,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/even?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bf9aa642-420d-4f0d-b5ea-42ab34c3f9d1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4d49f9f9-9c01-4dc9-a961-00ba66ca9e25","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1993,9 +2095,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:23 GMT
+      - Wed, 22 Apr 2020 09:03:24 GMT
       etag:
-      - bf9aa642-420d-4f0d-b5ea-42ab34c3f9d1
+      - 4d49f9f9-9c01-4dc9-a961-00ba66ca9e25
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2005,7 +2107,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -2038,7 +2140,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/even?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1295ce0-10c7-411e-bcdc-a54f7a0ae821","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a2f13a19-1f6a-45e0-b575-a526053431e7","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2047,9 +2149,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:24 GMT
+      - Wed, 22 Apr 2020 09:03:25 GMT
       etag:
-      - b1295ce0-10c7-411e-bcdc-a54f7a0ae821
+      - a2f13a19-1f6a-45e0-b575-a526053431e7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2059,7 +2161,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -2092,7 +2194,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/even?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"dbad0bfc-82be-4acd-8a80-8b9fa7ab9af1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"95089462-e006-4531-a903-7ff90a4d39be","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
         mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -2102,9 +2204,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:25 GMT
+      - Wed, 22 Apr 2020 09:03:27 GMT
       etag:
-      - dbad0bfc-82be-4acd-8a80-8b9fa7ab9af1
+      - 95089462-e006-4531-a903-7ff90a4d39be
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2114,7 +2216,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -2142,12 +2244,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"cb37f17e-011b-44a8-847e-a8c42a8ff9f5","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"82f10c36-65f6-41cb-be96-bf30649596fd","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4234b006-2ce0-41c8-b023-63ddc1926f59","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"f6f804f8-d15d-441e-b6a0-955bd3c4083c","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d8dc08bc-da53-4944-886f-363531cd85fa","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"379f3e65-bd47-4ef4-a8d8-d5aa92d3b3a6","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c97b6c02-e644-42e5-bf33-52d15bd2efc7","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"18268251-772e-4ee9-8788-2c7430eda3b9","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"146d97bc-71d1-4231-8d28-8c3c31932f1d","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"af4e55b1-6337-409b-8d0a-0c6570e48307","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5e89f385-9cb1-4f51-bff1-37dd4dc7f330","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"84c01b4f-eff1-49e0-9ed8-c39a7b9fbba7","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
         is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
-        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"de60001d-667e-434c-9388-187e19d65e42","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b1c1a584-2b9d-4244-9e97-09bbb856a2ab","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5d8f0863-f321-4eaa-9ecd-69c5e1da2a0e","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"cad2dc0b-46ce-4f89-b3e1-0d169c9518ee","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e782d6b6-6942-4480-8b88-1e10b0bb0c3a","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"d387272a-3259-4b33-af96-2090d8826e68","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8db1c391-7da8-44d2-9e51-f0aca0b76ddc","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1542e877-d4e5-4033-846e-458a5d2d3f2c","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8acb290f-4208-48d9-acc8-fb9fa7d9b35f","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"83d861b1-0a55-45b0-a535-ea340859dfe2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"7eb8c34e-4fa2-4786-bdf0-e40f312c04ec","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6e6da7ae-0621-4306-a2a2-8a5617f67128","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"54784f74-b0bf-47cc-a2e3-7574d2fddd3e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"68fb706b-f996-42da-9266-9feadf0c0056","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
         mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
-        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"018e3128-b5e9-403f-8ba4-9bd2c4996a3f","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bf9aa642-420d-4f0d-b5ea-42ab34c3f9d1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1295ce0-10c7-411e-bcdc-a54f7a0ae821","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"dbad0bfc-82be-4acd-8a80-8b9fa7ab9af1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"76f533ae-e680-45dc-961f-afda36cdfeb2","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cb224149-2427-49ee-9b85-52f07d27f732","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c451e862-8d1b-4427-9c82-9344d185236d","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4d49f9f9-9c01-4dc9-a961-00ba66ca9e25","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a2f13a19-1f6a-45e0-b575-a526053431e7","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"95089462-e006-4531-a903-7ff90a4d39be","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"ae703705-0cd2-43eb-ab84-3d0d1a2c80d8","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"23ea6c51-4481-4b75-97c4-6ede006b467c","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
         is a super long txt record...wow, it is really really long!  And I even used
         copy and paste to make it longer....this is a super long txt record...wow,
         it is really really long!  And I even used copy and paste to make it longer....this
@@ -2159,10 +2261,10 @@ interactions:
         it is really really long!  And I even used copy and paste to make it longer....this
         is a super long txt record...wow, it is really reall","y long!  And I even
         used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"949a0bd6-868d-4106-b2c8-c3c8d27467b1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"170f8c73-377c-47ab-98f0-a903a2548cf7","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a02843e-9bd7-4867-8b02-881ac4a96fd0","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
-        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a5b34796-183e-4b5a-909c-aacb27909188","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ae5ca740-464d-4ac9-8d1d-f7e8454e2d7e","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7bec5bc2-6bd4-4fa3-8ed5-92b304fc5b7c","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
-        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4c27b429-5d95-41da-896c-0537f86bfe82","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"09383659-6006-4d1d-9a91-2da66dba900e","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"85a8d91f-5dc5-4520-838c-82592fb50a51","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8aeebc1d-aa60-40ed-92c0-65c6a69474ed","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9b89b630-ebee-4a5d-8fd6-d60deb486dc6","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c5cac27c-9d60-4590-9da7-e3c9feeb607a","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fd612258-fa53-4ca3-90d7-d31068b0506a","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
-        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c80fe891-20e4-4639-9a33-25461713e747","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7ddcd23f-b575-4265-a5c8-486d678b6254","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"9935bd96-adb8-4a44-8c57-59f73099cb0b","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"247bfaf5-3fb8-48bb-b04d-738061465551","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a56e3b35-229c-4ffa-bc5f-cfc71d85e8e1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"3656fa8c-4eba-498e-9bcb-e2cf60fa1fa1","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d4e09f6f-fca8-45fb-a83d-cc6af4a2c9ef","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9c0fb31f-bf4e-41b0-9a1b-0370279137ac","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"777e5139-9536-496c-a51c-0694cab6332c","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8784c942-4849-4891-b612-ab329d808a8a","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"57ede89f-5f8f-4221-a429-f9d6ac0d502d","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"309f5ec5-54ce-468a-a76a-d520924caf0d","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a1b2bf1-549f-4bf0-9605-beeff2eb1f6d","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e0cf41a3-1678-4fd2-8cb6-e4008480c7f0","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35fd720b-1ae8-48d2-8c33-5d636b294acd","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3aa17418-c8d0-4175-899d-17292e3706a2","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"599cd463-8182-4ec6-a342-a7404d9c256e","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cac04611-68bd-4c6b-948e-91651f96db3c","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bd0637aa-377b-4263-8f09-3fd7b7cce108","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"24cbfe41-46df-4eda-a1a7-9589b230da1c","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"200f0f71-bc80-4a29-b0a7-d65a8d1f38f0","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
@@ -2172,7 +2274,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:26 GMT
+      - Wed, 22 Apr 2020 09:03:27 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2216,7 +2318,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d8dc08bc-da53-4944-886f-363531cd85fa","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5e89f385-9cb1-4f51-bff1-37dd4dc7f330","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -2225,7 +2327,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:27 GMT
+      - Wed, 22 Apr 2020 09:03:29 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2241,7 +2343,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59999'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -2269,12 +2371,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"cb37f17e-011b-44a8-847e-a8c42a8ff9f5","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"82f10c36-65f6-41cb-be96-bf30649596fd","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4234b006-2ce0-41c8-b023-63ddc1926f59","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"f6f804f8-d15d-441e-b6a0-955bd3c4083c","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d8dc08bc-da53-4944-886f-363531cd85fa","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"379f3e65-bd47-4ef4-a8d8-d5aa92d3b3a6","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c97b6c02-e644-42e5-bf33-52d15bd2efc7","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"18268251-772e-4ee9-8788-2c7430eda3b9","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"146d97bc-71d1-4231-8d28-8c3c31932f1d","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"af4e55b1-6337-409b-8d0a-0c6570e48307","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5e89f385-9cb1-4f51-bff1-37dd4dc7f330","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"84c01b4f-eff1-49e0-9ed8-c39a7b9fbba7","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
         is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
-        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"de60001d-667e-434c-9388-187e19d65e42","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b1c1a584-2b9d-4244-9e97-09bbb856a2ab","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5d8f0863-f321-4eaa-9ecd-69c5e1da2a0e","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"cad2dc0b-46ce-4f89-b3e1-0d169c9518ee","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e782d6b6-6942-4480-8b88-1e10b0bb0c3a","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"d387272a-3259-4b33-af96-2090d8826e68","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8db1c391-7da8-44d2-9e51-f0aca0b76ddc","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1542e877-d4e5-4033-846e-458a5d2d3f2c","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8acb290f-4208-48d9-acc8-fb9fa7d9b35f","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"83d861b1-0a55-45b0-a535-ea340859dfe2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"7eb8c34e-4fa2-4786-bdf0-e40f312c04ec","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6e6da7ae-0621-4306-a2a2-8a5617f67128","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"54784f74-b0bf-47cc-a2e3-7574d2fddd3e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"68fb706b-f996-42da-9266-9feadf0c0056","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
         mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
-        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"018e3128-b5e9-403f-8ba4-9bd2c4996a3f","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bf9aa642-420d-4f0d-b5ea-42ab34c3f9d1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1295ce0-10c7-411e-bcdc-a54f7a0ae821","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"dbad0bfc-82be-4acd-8a80-8b9fa7ab9af1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"76f533ae-e680-45dc-961f-afda36cdfeb2","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cb224149-2427-49ee-9b85-52f07d27f732","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c451e862-8d1b-4427-9c82-9344d185236d","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4d49f9f9-9c01-4dc9-a961-00ba66ca9e25","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a2f13a19-1f6a-45e0-b575-a526053431e7","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"95089462-e006-4531-a903-7ff90a4d39be","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"ae703705-0cd2-43eb-ab84-3d0d1a2c80d8","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"23ea6c51-4481-4b75-97c4-6ede006b467c","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
         is a super long txt record...wow, it is really really long!  And I even used
         copy and paste to make it longer....this is a super long txt record...wow,
         it is really really long!  And I even used copy and paste to make it longer....this
@@ -2286,10 +2388,10 @@ interactions:
         it is really really long!  And I even used copy and paste to make it longer....this
         is a super long txt record...wow, it is really reall","y long!  And I even
         used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"949a0bd6-868d-4106-b2c8-c3c8d27467b1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"170f8c73-377c-47ab-98f0-a903a2548cf7","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a02843e-9bd7-4867-8b02-881ac4a96fd0","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
-        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a5b34796-183e-4b5a-909c-aacb27909188","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ae5ca740-464d-4ac9-8d1d-f7e8454e2d7e","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7bec5bc2-6bd4-4fa3-8ed5-92b304fc5b7c","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
-        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4c27b429-5d95-41da-896c-0537f86bfe82","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"09383659-6006-4d1d-9a91-2da66dba900e","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"85a8d91f-5dc5-4520-838c-82592fb50a51","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8aeebc1d-aa60-40ed-92c0-65c6a69474ed","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9b89b630-ebee-4a5d-8fd6-d60deb486dc6","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c5cac27c-9d60-4590-9da7-e3c9feeb607a","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fd612258-fa53-4ca3-90d7-d31068b0506a","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
-        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c80fe891-20e4-4639-9a33-25461713e747","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7ddcd23f-b575-4265-a5c8-486d678b6254","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"9935bd96-adb8-4a44-8c57-59f73099cb0b","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"247bfaf5-3fb8-48bb-b04d-738061465551","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a56e3b35-229c-4ffa-bc5f-cfc71d85e8e1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"3656fa8c-4eba-498e-9bcb-e2cf60fa1fa1","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d4e09f6f-fca8-45fb-a83d-cc6af4a2c9ef","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9c0fb31f-bf4e-41b0-9a1b-0370279137ac","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"777e5139-9536-496c-a51c-0694cab6332c","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8784c942-4849-4891-b612-ab329d808a8a","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"57ede89f-5f8f-4221-a429-f9d6ac0d502d","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"309f5ec5-54ce-468a-a76a-d520924caf0d","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a1b2bf1-549f-4bf0-9605-beeff2eb1f6d","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e0cf41a3-1678-4fd2-8cb6-e4008480c7f0","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35fd720b-1ae8-48d2-8c33-5d636b294acd","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3aa17418-c8d0-4175-899d-17292e3706a2","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"599cd463-8182-4ec6-a342-a7404d9c256e","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cac04611-68bd-4c6b-948e-91651f96db3c","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bd0637aa-377b-4263-8f09-3fd7b7cce108","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"24cbfe41-46df-4eda-a1a7-9589b230da1c","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"200f0f71-bc80-4a29-b0a7-d65a8d1f38f0","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
@@ -2299,7 +2401,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:17:27 GMT
+      - Wed, 22 Apr 2020 09:03:29 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2322,45 +2424,41 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": "global"}'
+    body: null
     headers:
       Accept:
       - application/json
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - network private-dns zone import
+      - network private-dns zone delete
       Connection:
       - keep-alive
       Content-Length:
-      - '22'
-      Content-Type:
-      - application/json; charset=utf-8
+      - '0'
       ParameterSetName:
-      - -n -g --file-name
+      - -g -n -y
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
-    method: PUT
+    method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
   response:
     body:
-      string: '{}'
+      string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTswZGE4NmZiYS1hNmUyLTQ4MTktYmViNS1lYzdjMGUzOTg4OTU=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3NGQ2N2MxZC03OTA2LTQ5MWItOTg3Yy1hYjlhY2JjOWI1MTY=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
+      - '0'
       date:
-      - Tue, 21 Apr 2020 05:17:29 GMT
+      - Wed, 22 Apr 2020 09:03:32 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTswZGE4NmZiYS1hNmUyLTQ4MTktYmViNS1lYzdjMGUzOTg4OTU=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3NGQ2N2MxZC03OTA2LTQ5MWItOTg3Yy1hYjlhY2JjOWI1MTY=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2370,7 +2468,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -2384,83 +2482,28 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - network private-dns zone import
+      - network private-dns zone delete
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d8dc08bc-da53-4944-886f-363531cd85fa","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '569'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:00 GMT
-      etag:
-      - d8dc08bc-da53-4944-886f-363531cd85fa
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --file-name
+      - -g -n -y
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3NGQ2N2MxZC03OTA2LTQ5MWItOTg3Yy1hYjlhY2JjOWI1MTY=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"8a849252-2201-47af-8823-adc7450a501e","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":36,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '614'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:18:00 GMT
-      etag:
-      - 8a849252-2201-47af-8823-adc7450a501e
+      - Wed, 22 Apr 2020 09:04:02 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2473,2186 +2516,6 @@ interactions:
       - 4.0.30319
       x-content-type-options:
       - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
-      "email": "hostmaster.", "serialNumber": 1, "refreshTime": 900, "retryTime":
-      600, "expireTime": 86400, "minimumTtl": 3600}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '197'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"8c2afe5b-671a-450a-807d-0bb962db33e1","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '569'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:00 GMT
-      etag:
-      - 8c2afe5b-671a-450a-807d-0bb962db33e1
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 200, "txtRecords": [{"value": ["this is another
-      SPF, this time as TXT"]}, {"value": ["v=spf1 mx ip4:14.14.22.0/23 a:mail.trum.ch
-      mx:mese.ch include:spf.mapp.com ?all"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '194'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/@?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fe96893d-0d58-49ca-92ec-79bb6d2e4140","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
-        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
-        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '559'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:02 GMT
-      etag:
-      - fe96893d-0d58-49ca-92ec-79bb6d2e4140
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '71'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.1?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c694d08f-1d1d-48f4-93ed-aeb537f4fbcf","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '451'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:03 GMT
-      etag:
-      - c694d08f-1d1d-48f4-93ed-aeb537f4fbcf
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foobar.com."},
-      {"ptrdname": "bar.com."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '100'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"462e2553-f4ec-426b-af09-0fee63c1b683","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '478'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:05 GMT
-      etag:
-      - 462e2553-f4ec-426b-af09-0fee63c1b683
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "7.8.9.0"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '71'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/200?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c505862d-3f50-4739-a875-79c66b383006","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '441'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:05 GMT
-      etag:
-      - c505862d-3f50-4739-a875-79c66b383006
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}, {"ptrdname":
-      "bar.com."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '97'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.3?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"7e3e63b9-68b4-43f6-ae7b-913930d2f339","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '475'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:07 GMT
-      etag:
-      - 7e3e63b9-68b4-43f6-ae7b-913930d2f339
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}, {"ipv4Address":
-      "2.3.4.5"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '99'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/a2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ceb1c123-fec4-49e0-a7c7-4b7acb1ea1f3","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '464'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:08 GMT
-      etag:
-      - ceb1c123-fec4-49e0-a7c7-4b7acb1ea1f3
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "4.5.6.7"}, {"ipv4Address":
-      "6.7.8.9"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '98'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/aa?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b67d85e4-4c1f-4103-a53e-2cd01283d294","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '463'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:10 GMT
-      etag:
-      - b67d85e4-4c1f-4103-a53e-2cd01283d294
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 300, "mxRecords": [{"preference": 1, "exchange":
-      "foo.com.zone2.com."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '96'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/aa?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"899b1f54-1a66-41f3-b90c-624b834cc6ec","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '463'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:10 GMT
-      etag:
-      - 899b1f54-1a66-41f3-b90c-624b834cc6ec
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:cafe:130::100"},
-      {"ipv6Address": "2001:cafe:130::101"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '124'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/AAAA/aaaa2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"aa077503-9de7-412f-bf9e-7d35d866d71f","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '504'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:13 GMT
-      etag:
-      - aa077503-9de7-412f-bf9e-7d35d866d71f
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/base?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9d73112d-3e47-401c-9c16-01af764ac65e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '452'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:14 GMT
-      etag:
-      - 9d73112d-3e47-401c-9c16-01af764ac65e
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
-      "be.xpiler.de."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '93'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/base?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"4f58be5f-be4a-4932-a092-6f5550352be9","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '466'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:15 GMT
-      etag:
-      - 4f58be5f-be4a-4932-a092-6f5550352be9
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xcaign.de
-      include:_spf6.xcaign.de -all"]}, {"value": ["spf2.0/mfrom,pra mx ip4:15.19.14.0/24
-      ip4:8.8.11.4/27 ip4:9.16.20.19/26 -all"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '217'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/base?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c54c49ef-3190-46d6-8798-1478f68b7972","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
-        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '596'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:17 GMT
-      etag:
-      - c54c49ef-3190-46d6-8798-1478f68b7972
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '170'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/doozie?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d26104f6-5cb2-4a78-96c0-4c86617a52e2","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '553'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:17 GMT
-      etag:
-      - d26104f6-5cb2-4a78-96c0-4c86617a52e2
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11991'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/even?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c0c1a7f6-b2ea-439e-9ac5-12e5b1e8afa6","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '452'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:18 GMT
-      etag:
-      - c0c1a7f6-b2ea-439e-9ac5-12e5b1e8afa6
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11990'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
-      "be.xpiler.de."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '93'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/even?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b5590c1f-642c-4b92-9452-2849cdcb416e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '466'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:19 GMT
-      etag:
-      - b5590c1f-642c-4b92-9452-2849cdcb416e
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xgn.de
-      include:_spf6.xgn.de -all"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '118'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/even?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"2bd7dba1-313d-4821-bff8-e47f9e11363e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '495'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:20 GMT
-      etag:
-      - 2bd7dba1-313d-4821-bff8-e47f9e11363e
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "bar.com."}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '67'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/CNAME/fee2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"75b9b022-c142-4e46-a2bc-ef8ba39898b7","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '448'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:22 GMT
-      etag:
-      - 75b9b022-c142-4e46-a2bc-ef8ba39898b7
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 999, "txtRecords": [{"value": ["this is a super
-      long txt record...wow, it is really really long!  And I even used copy and paste
-      to make it longer....this is a super long txt record...wow, it is really really
-      long!  And I even used copy and paste to make it longer....this is a super lon",
-      "g txt record...wow, it is really really long!  And I even used copy and paste
-      to make it longer....this is a super long txt record...wow, it is really really
-      long!  And I even used copy and paste to make it longer....this is a super long
-      txt record...wow,", " it is really really long!  And I even used copy and paste
-      to make it longer....this is a super long txt record...wow, it is really really
-      long!  And I even used copy and paste to make it longer....this is a super long
-      txt record...wow, it is really reall", "y long!  And I even used copy and paste
-      to make it longer....this is a super long txt record...wow, it is really really
-      long!  And I even used copy and paste to make it longer...."]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1017'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d81a4b8b-8de8-4618-89e6-7aec060f0dbf","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
-        is a super long txt record...wow, it is really really long!  And I even used
-        copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super lon","g txt record...wow, it is really really long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super long txt record...wow,"," it is really really long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super long txt record...wow, it is really reall","y long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '1400'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:24 GMT
-      etag:
-      - d81a4b8b-8de8-4618-89e6-7aec060f0dbf
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 100, "txtRecords": [{"value": ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
-      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '565'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5d890917-c374-497d-96ea-686fd999232e","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '953'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:25 GMT
-      etag:
-      - 5d890917-c374-497d-96ea-686fd999232e
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
-      "mail1.mymail.com."}, {"preference": 11, "exchange": "flooble."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '141'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/mail?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a4a0ac3a-3397-4fff-ade0-f2e865ffc93b","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '510'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:25 GMT
-      etag:
-      - a4a0ac3a-3397-4fff-ade0-f2e865ffc93b
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 100, "txtRecords": [{"value": ["this is an SPF record!
-      Convert to TXT on import"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '108'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/myspf?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"eaa3ff68-21d2-4a93-9e7a-5e9c69a72972","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
-        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '488'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:27 GMT
-      etag:
-      - eaa3ff68-21d2-4a93-9e7a-5e9c69a72972
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["  a  "]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '67'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/spaces?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"736a0489-6284-46d0-8d55-8a2df56ec61d","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '450'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:29 GMT
-      etag:
-      - 736a0489-6284-46d0-8d55-8a2df56ec61d
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '68'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t1?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ce7bd650-6721-4399-87c3-653e0fc179ba","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '439'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:29 GMT
-      etag:
-      - ce7bd650-6721-4399-87c3-653e0fc179ba
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo bar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '69'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t10?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"82c521e3-ee3c-4dd9-924a-2c773811ef5b","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
-        bar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '443'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:31 GMT
-      etag:
-      - 82c521e3-ee3c-4dd9-924a-2c773811ef5b
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '68'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t11?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8ef0c534-058f-41ed-91e1-921277636de0","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '442'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:32 GMT
-      etag:
-      - 8ef0c534-058f-41ed-91e1-921277636de0
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '68'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a78e5960-893f-40f7-9caf-8b6d04996037","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '439'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:33 GMT
-      etag:
-      - a78e5960-893f-40f7-9caf-8b6d04996037
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11991'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '68'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t3?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"51504c1a-66bd-4626-b4b9-a0023f5a0f47","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '439'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:34 GMT
-      etag:
-      - 51504c1a-66bd-4626-b4b9-a0023f5a0f47
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11990'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo;bar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '69'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t4?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cfde5207-19ee-4ac0-b0aa-75622e37c127","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '440'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:35 GMT
-      etag:
-      - cfde5207-19ee-4ac0-b0aa-75622e37c127
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11989'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '71'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t5?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9023ac31-d14e-4ab3-8f71-808b9885c705","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '442'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:37 GMT
-      etag:
-      - 9023ac31-d14e-4ab3-8f71-808b9885c705
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '71'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t6?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"988e653c-d802-47f9-94c2-24516749bd6e","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '442'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:38 GMT
-      etag:
-      - 988e653c-d802-47f9-94c2-24516749bd6e
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["\\\"quoted string\\\""]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t7?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"beec5a55-7df2-4686-9317-d118048410a0","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
-        string\\\""]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '454'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:39 GMT
-      etag:
-      - beec5a55-7df2-4686-9317-d118048410a0
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '68'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t8?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"174a544f-24ea-480b-8eb0-66f120a4cea9","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '439'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:40 GMT
-      etag:
-      - 174a544f-24ea-480b-8eb0-66f120a4cea9
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11990'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobarr"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '69'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t9?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"907cd8a2-9a6a-48e8-bd7d-72b33cff2102","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '440'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:41 GMT
-      etag:
-      - 907cd8a2-9a6a-48e8-bd7d-72b33cff2102
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 10, "weight":
-      20, "port": 30, "target": "foobar."}, {"priority": 55, "weight": 66, "port":
-      77, "target": "zoo."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SRV/sip.tcp?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b7ed8761-833e-4e6c-b37d-4b2936c9ef24","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '544'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:43 GMT
-      etag:
-      - b7ed8761-833e-4e6c-b37d-4b2936c9ef24
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1"]}, {"value":
-      ["string 2"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '95'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/test-txt2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"2052bcfb-5e42-406a-9995-3aaf7e5fddd2","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
-        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '485'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:44 GMT
-      etag:
-      - 2052bcfb-5e42-406a-9995-3aaf7e5fddd2
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns record-set list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -z
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
-  response:
-    body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c694d08f-1d1d-48f4-93ed-aeb537f4fbcf","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"462e2553-f4ec-426b-af09-0fee63c1b683","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c505862d-3f50-4739-a875-79c66b383006","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"7e3e63b9-68b4-43f6-ae7b-913930d2f339","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"8c2afe5b-671a-450a-807d-0bb962db33e1","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fe96893d-0d58-49ca-92ec-79bb6d2e4140","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
-        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
-        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ceb1c123-fec4-49e0-a7c7-4b7acb1ea1f3","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b67d85e4-4c1f-4103-a53e-2cd01283d294","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"899b1f54-1a66-41f3-b90c-624b834cc6ec","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"aa077503-9de7-412f-bf9e-7d35d866d71f","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9d73112d-3e47-401c-9c16-01af764ac65e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"4f58be5f-be4a-4932-a092-6f5550352be9","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c54c49ef-3190-46d6-8798-1478f68b7972","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
-        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d26104f6-5cb2-4a78-96c0-4c86617a52e2","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c0c1a7f6-b2ea-439e-9ac5-12e5b1e8afa6","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b5590c1f-642c-4b92-9452-2849cdcb416e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"2bd7dba1-313d-4821-bff8-e47f9e11363e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"75b9b022-c142-4e46-a2bc-ef8ba39898b7","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d81a4b8b-8de8-4618-89e6-7aec060f0dbf","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
-        is a super long txt record...wow, it is really really long!  And I even used
-        copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super lon","g txt record...wow, it is really really long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super long txt record...wow,"," it is really really long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super long txt record...wow, it is really reall","y long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5d890917-c374-497d-96ea-686fd999232e","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a4a0ac3a-3397-4fff-ade0-f2e865ffc93b","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"eaa3ff68-21d2-4a93-9e7a-5e9c69a72972","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
-        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"736a0489-6284-46d0-8d55-8a2df56ec61d","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ce7bd650-6721-4399-87c3-653e0fc179ba","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"82c521e3-ee3c-4dd9-924a-2c773811ef5b","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
-        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8ef0c534-058f-41ed-91e1-921277636de0","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a78e5960-893f-40f7-9caf-8b6d04996037","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"51504c1a-66bd-4626-b4b9-a0023f5a0f47","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cfde5207-19ee-4ac0-b0aa-75622e37c127","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9023ac31-d14e-4ab3-8f71-808b9885c705","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"988e653c-d802-47f9-94c2-24516749bd6e","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"beec5a55-7df2-4686-9317-d118048410a0","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
-        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"174a544f-24ea-480b-8eb0-66f120a4cea9","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"907cd8a2-9a6a-48e8-bd7d-72b33cff2102","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b7ed8761-833e-4e6c-b37d-4b2936c9ef24","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"2052bcfb-5e42-406a-9995-3aaf7e5fddd2","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
-        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '18531'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:18:45 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59964'
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone2_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone2_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiMjYyYTQ2MC03YzNmLTQxOGQtODYxOS1lYzZlYTlhZTQ2YmQ=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzM5OWRhNC05NWRiLTQxMGUtYTg0Mi1lOGNkM2IyZDgzMGE=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:29:30 GMT
+      - Tue, 21 Apr 2020 05:16:16 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiMjYyYTQ2MC03YzNmLTQxOGQtODYxOS1lYzZlYTlhZTQ2YmQ=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzM5OWRhNC05NWRiLTQxMGUtYTg0Mi1lOGNkM2IyZDgzMGE=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -48,7 +48,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -70,24 +70,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzM5OWRhNC05NWRiLTQxMGUtYTg0Mi1lOGNkM2IyZDgzMGE=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"060de239-695d-48f9-a983-c0e58cfd7788","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:01 GMT
-      etag:
-      - 060de239-695d-48f9-a983-c0e58cfd7788
+      - Tue, 21 Apr 2020 05:16:46 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -101,7 +97,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -127,7 +123,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"2683ad9c-e3f3-4f9e-aabd-9095a3efcc26","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"c52cb37f-6cf0-4872-9ced-6437215aa44e","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -136,9 +132,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:02 GMT
+      - Tue, 21 Apr 2020 05:16:46 GMT
       etag:
-      - 2683ad9c-e3f3-4f9e-aabd-9095a3efcc26
+      - c52cb37f-6cf0-4872-9ced-6437215aa44e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -152,7 +148,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -186,7 +182,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4fd70fe4-9a79-45d3-9692-2be8fd07262c","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d8dc08bc-da53-4944-886f-363531cd85fa","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -195,9 +191,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:02 GMT
+      - Tue, 21 Apr 2020 05:16:47 GMT
       etag:
-      - 4fd70fe4-9a79-45d3-9692-2be8fd07262c
+      - d8dc08bc-da53-4944-886f-363531cd85fa
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -245,7 +241,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"aef4eb2f-fa16-452d-a3c5-25cbe37b0e4a","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"379f3e65-bd47-4ef4-a8d8-d5aa92d3b3a6","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
         is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
         a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}}'
     headers:
@@ -256,9 +252,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:03 GMT
+      - Tue, 21 Apr 2020 05:16:48 GMT
       etag:
-      - aef4eb2f-fa16-452d-a3c5-25cbe37b0e4a
+      - 379f3e65-bd47-4ef4-a8d8-d5aa92d3b3a6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -268,7 +264,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -300,7 +296,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/spaces?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"92bdcf87-b753-4306-a516-2c3a33c36ace","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a5b34796-183e-4b5a-909c-aacb27909188","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -309,9 +305,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:04 GMT
+      - Tue, 21 Apr 2020 05:16:48 GMT
       etag:
-      - 92bdcf87-b753-4306-a516-2c3a33c36ace
+      - a5b34796-183e-4b5a-909c-aacb27909188
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -321,7 +317,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -354,7 +350,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/a2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4e772834-2fee-407a-b9a5-b0d179e5eac7","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"de60001d-667e-434c-9388-187e19d65e42","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -363,9 +359,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:06 GMT
+      - Tue, 21 Apr 2020 05:16:50 GMT
       etag:
-      - 4e772834-2fee-407a-b9a5-b0d179e5eac7
+      - de60001d-667e-434c-9388-187e19d65e42
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -375,7 +371,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
@@ -408,7 +404,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/AAAA/aaaa2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"93e29ab0-db00-4a11-9bf4-0b1814be309e","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"cad2dc0b-46ce-4f89-b3e1-0d169c9518ee","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -417,9 +413,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:07 GMT
+      - Tue, 21 Apr 2020 05:16:51 GMT
       etag:
-      - 93e29ab0-db00-4a11-9bf4-0b1814be309e
+      - cad2dc0b-46ce-4f89-b3e1-0d169c9518ee
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -461,7 +457,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/doozie?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3d859368-14ab-4cb5-8ce2-4fc56da9d8b6","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"018e3128-b5e9-403f-8ba4-9bd2c4996a3f","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -470,9 +466,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:07 GMT
+      - Tue, 21 Apr 2020 05:16:52 GMT
       etag:
-      - 3d859368-14ab-4cb5-8ce2-4fc56da9d8b6
+      - 018e3128-b5e9-403f-8ba4-9bd2c4996a3f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -482,7 +478,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -514,7 +510,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/CNAME/fee2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"6cfdbff6-706f-4464-bccd-a13786880682","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"76f533ae-e680-45dc-961f-afda36cdfeb2","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -523,9 +519,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:09 GMT
+      - Tue, 21 Apr 2020 05:16:53 GMT
       etag:
-      - 6cfdbff6-706f-4464-bccd-a13786880682
+      - 76f533ae-e680-45dc-961f-afda36cdfeb2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -535,7 +531,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -568,7 +564,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/mail?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"29712271-125f-4ff1-bbdd-028a2d89da6c","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"170f8c73-377c-47ab-98f0-a903a2548cf7","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -577,9 +573,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:10 GMT
+      - Tue, 21 Apr 2020 05:16:54 GMT
       etag:
-      - 29712271-125f-4ff1-bbdd-028a2d89da6c
+      - 170f8c73-377c-47ab-98f0-a903a2548cf7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -589,7 +585,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -623,7 +619,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SRV/sip.tcp?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"42fcfe8a-ab97-41d6-b7e1-be13a5cfbe2f","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"9935bd96-adb8-4a44-8c57-59f73099cb0b","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -632,9 +628,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:11 GMT
+      - Tue, 21 Apr 2020 05:16:55 GMT
       etag:
-      - 42fcfe8a-ab97-41d6-b7e1-be13a5cfbe2f
+      - 9935bd96-adb8-4a44-8c57-59f73099cb0b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -644,7 +640,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -677,7 +673,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/test-txt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8bca831c-3c34-43f6-8330-138e8119bf38","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"247bfaf5-3fb8-48bb-b04d-738061465551","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]},{"value":["string 2"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -687,9 +683,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:12 GMT
+      - Tue, 21 Apr 2020 05:16:56 GMT
       etag:
-      - 8bca831c-3c34-43f6-8330-138e8119bf38
+      - 247bfaf5-3fb8-48bb-b04d-738061465551
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -699,7 +695,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -732,7 +728,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/aa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"810e7944-67a1-42f7-9f8a-5e1364aa1719","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b1c1a584-2b9d-4244-9e97-09bbb856a2ab","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -741,9 +737,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:14 GMT
+      - Tue, 21 Apr 2020 05:16:57 GMT
       etag:
-      - 810e7944-67a1-42f7-9f8a-5e1364aa1719
+      - b1c1a584-2b9d-4244-9e97-09bbb856a2ab
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -753,7 +749,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -786,7 +782,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/aa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7dab57ff-ca55-442e-91a0-5b59cb396ad2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5d8f0863-f321-4eaa-9ecd-69c5e1da2a0e","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -795,9 +791,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:15 GMT
+      - Tue, 21 Apr 2020 05:16:59 GMT
       etag:
-      - 7dab57ff-ca55-442e-91a0-5b59cb396ad2
+      - 5d8f0863-f321-4eaa-9ecd-69c5e1da2a0e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -807,7 +803,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -839,7 +835,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/200?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f62518fe-c966-4649-b401-63db9be908dc","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4234b006-2ce0-41c8-b023-63ddc1926f59","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -848,9 +844,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:16 GMT
+      - Tue, 21 Apr 2020 05:17:00 GMT
       etag:
-      - f62518fe-c966-4649-b401-63db9be908dc
+      - 4234b006-2ce0-41c8-b023-63ddc1926f59
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -860,7 +856,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -904,7 +900,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1da925ca-2159-43ef-9304-28ab3027561e","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cb224149-2427-49ee-9b85-52f07d27f732","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
         is a super long txt record...wow, it is really really long!  And I even used
         copy and paste to make it longer....this is a super long txt record...wow,
         it is really really long!  And I even used copy and paste to make it longer....this
@@ -925,9 +921,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:17 GMT
+      - Tue, 21 Apr 2020 05:17:01 GMT
       etag:
-      - 1da925ca-2159-43ef-9304-28ab3027561e
+      - cb224149-2427-49ee-9b85-52f07d27f732
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -937,7 +933,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -970,7 +966,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f46dc6e-f3ad-4465-b8c3-83010f526653","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"949a0bd6-868d-4106-b2c8-c3c8d27467b1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -979,9 +975,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:18 GMT
+      - Tue, 21 Apr 2020 05:17:02 GMT
       etag:
-      - 7f46dc6e-f3ad-4465-b8c3-83010f526653
+      - 949a0bd6-868d-4106-b2c8-c3c8d27467b1
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -991,7 +987,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -1024,7 +1020,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/myspf?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7720c774-25d5-432c-ba1e-dfeb3e876baf","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a02843e-9bd7-4867-8b02-881ac4a96fd0","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
         is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -1034,9 +1030,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:18 GMT
+      - Tue, 21 Apr 2020 05:17:03 GMT
       etag:
-      - 7720c774-25d5-432c-ba1e-dfeb3e876baf
+      - 9a02843e-9bd7-4867-8b02-881ac4a96fd0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1046,7 +1042,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -1078,7 +1074,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"1cb66c76-af79-4dca-9bc4-06bcfb64b7df","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"cb37f17e-011b-44a8-847e-a8c42a8ff9f5","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1087,9 +1083,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:20 GMT
+      - Tue, 21 Apr 2020 05:17:04 GMT
       etag:
-      - 1cb66c76-af79-4dca-9bc4-06bcfb64b7df
+      - cb37f17e-011b-44a8-847e-a8c42a8ff9f5
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1099,7 +1095,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -1132,7 +1128,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8cfadc2b-e8b0-4595-944f-1a78d77be1cc","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"82f10c36-65f6-41cb-be96-bf30649596fd","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1141,9 +1137,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:20 GMT
+      - Tue, 21 Apr 2020 05:17:05 GMT
       etag:
-      - 8cfadc2b-e8b0-4595-944f-1a78d77be1cc
+      - 82f10c36-65f6-41cb-be96-bf30649596fd
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1153,7 +1149,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -1186,7 +1182,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.3?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a793fb80-82bd-4a69-9771-4e0cb3c6f5bd","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"f6f804f8-d15d-441e-b6a0-955bd3c4083c","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1195,9 +1191,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:22 GMT
+      - Tue, 21 Apr 2020 05:17:06 GMT
       etag:
-      - a793fb80-82bd-4a69-9771-4e0cb3c6f5bd
+      - f6f804f8-d15d-441e-b6a0-955bd3c4083c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1239,7 +1235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9de19b41-c45f-41e8-a806-e7972e553f75","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ae5ca740-464d-4ac9-8d1d-f7e8454e2d7e","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1248,9 +1244,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:23 GMT
+      - Tue, 21 Apr 2020 05:17:08 GMT
       etag:
-      - 9de19b41-c45f-41e8-a806-e7972e553f75
+      - ae5ca740-464d-4ac9-8d1d-f7e8454e2d7e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1260,7 +1256,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -1292,7 +1288,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ec953705-1885-419e-8e3d-d0854b387cde","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"09383659-6006-4d1d-9a91-2da66dba900e","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1301,9 +1297,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:24 GMT
+      - Tue, 21 Apr 2020 05:17:09 GMT
       etag:
-      - ec953705-1885-419e-8e3d-d0854b387cde
+      - 09383659-6006-4d1d-9a91-2da66dba900e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1313,7 +1309,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -1345,7 +1341,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t3?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6ed6d751-2196-47ba-8913-fa436fe8e7aa","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"85a8d91f-5dc5-4520-838c-82592fb50a51","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1354,9 +1350,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:25 GMT
+      - Tue, 21 Apr 2020 05:17:09 GMT
       etag:
-      - 6ed6d751-2196-47ba-8913-fa436fe8e7aa
+      - 85a8d91f-5dc5-4520-838c-82592fb50a51
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1366,7 +1362,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -1398,7 +1394,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t4?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8be42881-e2ef-4ad9-884c-aebb0f8b47f2","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8aeebc1d-aa60-40ed-92c0-65c6a69474ed","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1407,9 +1403,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:26 GMT
+      - Tue, 21 Apr 2020 05:17:11 GMT
       etag:
-      - 8be42881-e2ef-4ad9-884c-aebb0f8b47f2
+      - 8aeebc1d-aa60-40ed-92c0-65c6a69474ed
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1419,7 +1415,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -1451,7 +1447,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t5?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f0e689c-8222-41a2-88b7-2c805d9210d7","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9b89b630-ebee-4a5d-8fd6-d60deb486dc6","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1460,9 +1456,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:27 GMT
+      - Tue, 21 Apr 2020 05:17:11 GMT
       etag:
-      - 7f0e689c-8222-41a2-88b7-2c805d9210d7
+      - 9b89b630-ebee-4a5d-8fd6-d60deb486dc6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1472,7 +1468,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -1504,7 +1500,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t6?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01eb0016-f3bc-4bb6-a1de-63a2bde3d42b","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c5cac27c-9d60-4590-9da7-e3c9feeb607a","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1513,9 +1509,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:28 GMT
+      - Tue, 21 Apr 2020 05:17:12 GMT
       etag:
-      - 01eb0016-f3bc-4bb6-a1de-63a2bde3d42b
+      - c5cac27c-9d60-4590-9da7-e3c9feeb607a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1525,7 +1521,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -1557,7 +1553,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t7?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ffc18716-409d-4a95-91d9-70035113bc3c","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fd612258-fa53-4ca3-90d7-d31068b0506a","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
         string\\\""]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -1567,9 +1563,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:29 GMT
+      - Tue, 21 Apr 2020 05:17:13 GMT
       etag:
-      - ffc18716-409d-4a95-91d9-70035113bc3c
+      - fd612258-fa53-4ca3-90d7-d31068b0506a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1579,7 +1575,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -1611,7 +1607,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t8?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c00bd9fb-8037-4be7-9858-4705bc722f20","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c80fe891-20e4-4639-9a33-25461713e747","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1620,9 +1616,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:30 GMT
+      - Tue, 21 Apr 2020 05:17:15 GMT
       etag:
-      - c00bd9fb-8037-4be7-9858-4705bc722f20
+      - c80fe891-20e4-4639-9a33-25461713e747
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1632,7 +1628,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -1664,7 +1660,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t9?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bcebbaf5-0707-4b84-bf44-39627869af7d","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7ddcd23f-b575-4265-a5c8-486d678b6254","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1673,9 +1669,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:31 GMT
+      - Tue, 21 Apr 2020 05:17:16 GMT
       etag:
-      - bcebbaf5-0707-4b84-bf44-39627869af7d
+      - 7ddcd23f-b575-4265-a5c8-486d678b6254
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1685,7 +1681,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
@@ -1717,7 +1713,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t10?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"51a9f359-fe01-41f0-b3a4-561c68deb280","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7bec5bc2-6bd4-4fa3-8ed5-92b304fc5b7c","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
         bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -1727,9 +1723,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:32 GMT
+      - Tue, 21 Apr 2020 05:17:17 GMT
       etag:
-      - 51a9f359-fe01-41f0-b3a4-561c68deb280
+      - 7bec5bc2-6bd4-4fa3-8ed5-92b304fc5b7c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1739,7 +1735,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -1771,7 +1767,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t11?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1912e602-ad13-42f3-9aed-5d2ca458d1f7","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4c27b429-5d95-41da-896c-0537f86bfe82","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1780,9 +1776,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:33 GMT
+      - Tue, 21 Apr 2020 05:17:17 GMT
       etag:
-      - 1912e602-ad13-42f3-9aed-5d2ca458d1f7
+      - 4c27b429-5d95-41da-896c-0537f86bfe82
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1792,7 +1788,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -1824,7 +1820,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/base?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9ee155dc-3c39-42b4-8eae-f1f5c1959504","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e782d6b6-6942-4480-8b88-1e10b0bb0c3a","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1833,9 +1829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:34 GMT
+      - Tue, 21 Apr 2020 05:17:19 GMT
       etag:
-      - 9ee155dc-3c39-42b4-8eae-f1f5c1959504
+      - e782d6b6-6942-4480-8b88-1e10b0bb0c3a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1845,7 +1841,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -1878,7 +1874,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/base?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"38314aa9-644c-4a57-92d2-3bf5a423779f","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"d387272a-3259-4b33-af96-2090d8826e68","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1887,9 +1883,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:35 GMT
+      - Tue, 21 Apr 2020 05:17:20 GMT
       etag:
-      - 38314aa9-644c-4a57-92d2-3bf5a423779f
+      - d387272a-3259-4b33-af96-2090d8826e68
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1899,7 +1895,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -1933,7 +1929,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/base?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"21ee6543-46ca-4e0a-a2bf-cc79d5ca6b5c","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8db1c391-7da8-44d2-9e51-f0aca0b76ddc","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
         mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
         mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}}'
     headers:
@@ -1944,9 +1940,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:37 GMT
+      - Tue, 21 Apr 2020 05:17:22 GMT
       etag:
-      - 21ee6543-46ca-4e0a-a2bf-cc79d5ca6b5c
+      - 8db1c391-7da8-44d2-9e51-f0aca0b76ddc
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1956,7 +1952,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
@@ -1988,7 +1984,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/even?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cb7dcd07-3c59-440f-866a-96f1c6f6e70e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bf9aa642-420d-4f0d-b5ea-42ab34c3f9d1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1997,9 +1993,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:38 GMT
+      - Tue, 21 Apr 2020 05:17:23 GMT
       etag:
-      - cb7dcd07-3c59-440f-866a-96f1c6f6e70e
+      - bf9aa642-420d-4f0d-b5ea-42ab34c3f9d1
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2009,7 +2005,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -2042,7 +2038,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/even?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"6c8af5d2-130c-4059-bfd3-497ddb3ad0ac","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1295ce0-10c7-411e-bcdc-a54f7a0ae821","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2051,9 +2047,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:39 GMT
+      - Tue, 21 Apr 2020 05:17:24 GMT
       etag:
-      - 6c8af5d2-130c-4059-bfd3-497ddb3ad0ac
+      - b1295ce0-10c7-411e-bcdc-a54f7a0ae821
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2063,7 +2059,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -2096,7 +2092,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/even?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"458c397b-172f-458e-8762-bba3d1a78152","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"dbad0bfc-82be-4acd-8a80-8b9fa7ab9af1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
         mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -2106,9 +2102,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:41 GMT
+      - Tue, 21 Apr 2020 05:17:25 GMT
       etag:
-      - 458c397b-172f-458e-8762-bba3d1a78152
+      - dbad0bfc-82be-4acd-8a80-8b9fa7ab9af1
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2118,7 +2114,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -2146,12 +2142,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"1cb66c76-af79-4dca-9bc4-06bcfb64b7df","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8cfadc2b-e8b0-4595-944f-1a78d77be1cc","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f62518fe-c966-4649-b401-63db9be908dc","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a793fb80-82bd-4a69-9771-4e0cb3c6f5bd","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4fd70fe4-9a79-45d3-9692-2be8fd07262c","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"aef4eb2f-fa16-452d-a3c5-25cbe37b0e4a","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"cb37f17e-011b-44a8-847e-a8c42a8ff9f5","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"82f10c36-65f6-41cb-be96-bf30649596fd","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4234b006-2ce0-41c8-b023-63ddc1926f59","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"f6f804f8-d15d-441e-b6a0-955bd3c4083c","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d8dc08bc-da53-4944-886f-363531cd85fa","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"379f3e65-bd47-4ef4-a8d8-d5aa92d3b3a6","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
         is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
-        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4e772834-2fee-407a-b9a5-b0d179e5eac7","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"810e7944-67a1-42f7-9f8a-5e1364aa1719","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7dab57ff-ca55-442e-91a0-5b59cb396ad2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"93e29ab0-db00-4a11-9bf4-0b1814be309e","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9ee155dc-3c39-42b4-8eae-f1f5c1959504","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"38314aa9-644c-4a57-92d2-3bf5a423779f","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"21ee6543-46ca-4e0a-a2bf-cc79d5ca6b5c","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"de60001d-667e-434c-9388-187e19d65e42","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b1c1a584-2b9d-4244-9e97-09bbb856a2ab","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5d8f0863-f321-4eaa-9ecd-69c5e1da2a0e","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"cad2dc0b-46ce-4f89-b3e1-0d169c9518ee","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e782d6b6-6942-4480-8b88-1e10b0bb0c3a","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"d387272a-3259-4b33-af96-2090d8826e68","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8db1c391-7da8-44d2-9e51-f0aca0b76ddc","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
         mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
-        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3d859368-14ab-4cb5-8ce2-4fc56da9d8b6","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cb7dcd07-3c59-440f-866a-96f1c6f6e70e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"6c8af5d2-130c-4059-bfd3-497ddb3ad0ac","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"458c397b-172f-458e-8762-bba3d1a78152","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"6cfdbff6-706f-4464-bccd-a13786880682","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1da925ca-2159-43ef-9304-28ab3027561e","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"018e3128-b5e9-403f-8ba4-9bd2c4996a3f","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bf9aa642-420d-4f0d-b5ea-42ab34c3f9d1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1295ce0-10c7-411e-bcdc-a54f7a0ae821","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"dbad0bfc-82be-4acd-8a80-8b9fa7ab9af1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"76f533ae-e680-45dc-961f-afda36cdfeb2","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cb224149-2427-49ee-9b85-52f07d27f732","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
         is a super long txt record...wow, it is really really long!  And I even used
         copy and paste to make it longer....this is a super long txt record...wow,
         it is really really long!  And I even used copy and paste to make it longer....this
@@ -2163,10 +2159,10 @@ interactions:
         it is really really long!  And I even used copy and paste to make it longer....this
         is a super long txt record...wow, it is really reall","y long!  And I even
         used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f46dc6e-f3ad-4465-b8c3-83010f526653","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"29712271-125f-4ff1-bbdd-028a2d89da6c","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7720c774-25d5-432c-ba1e-dfeb3e876baf","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
-        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"92bdcf87-b753-4306-a516-2c3a33c36ace","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9de19b41-c45f-41e8-a806-e7972e553f75","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"51a9f359-fe01-41f0-b3a4-561c68deb280","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
-        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1912e602-ad13-42f3-9aed-5d2ca458d1f7","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ec953705-1885-419e-8e3d-d0854b387cde","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6ed6d751-2196-47ba-8913-fa436fe8e7aa","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8be42881-e2ef-4ad9-884c-aebb0f8b47f2","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f0e689c-8222-41a2-88b7-2c805d9210d7","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01eb0016-f3bc-4bb6-a1de-63a2bde3d42b","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ffc18716-409d-4a95-91d9-70035113bc3c","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
-        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c00bd9fb-8037-4be7-9858-4705bc722f20","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bcebbaf5-0707-4b84-bf44-39627869af7d","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"42fcfe8a-ab97-41d6-b7e1-be13a5cfbe2f","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8bca831c-3c34-43f6-8330-138e8119bf38","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"949a0bd6-868d-4106-b2c8-c3c8d27467b1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"170f8c73-377c-47ab-98f0-a903a2548cf7","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a02843e-9bd7-4867-8b02-881ac4a96fd0","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a5b34796-183e-4b5a-909c-aacb27909188","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ae5ca740-464d-4ac9-8d1d-f7e8454e2d7e","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7bec5bc2-6bd4-4fa3-8ed5-92b304fc5b7c","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4c27b429-5d95-41da-896c-0537f86bfe82","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"09383659-6006-4d1d-9a91-2da66dba900e","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"85a8d91f-5dc5-4520-838c-82592fb50a51","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8aeebc1d-aa60-40ed-92c0-65c6a69474ed","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9b89b630-ebee-4a5d-8fd6-d60deb486dc6","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c5cac27c-9d60-4590-9da7-e3c9feeb607a","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fd612258-fa53-4ca3-90d7-d31068b0506a","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c80fe891-20e4-4639-9a33-25461713e747","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7ddcd23f-b575-4265-a5c8-486d678b6254","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"9935bd96-adb8-4a44-8c57-59f73099cb0b","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"247bfaf5-3fb8-48bb-b04d-738061465551","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
@@ -2176,134 +2172,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:30:41 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59951'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone export
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA?api-version=2018-09-01
-  response:
-    body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4fd70fe4-9a79-45d3-9692-2be8fd07262c","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}]}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '581'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:30:42 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59999'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone export
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
-  response:
-    body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"1cb66c76-af79-4dca-9bc4-06bcfb64b7df","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8cfadc2b-e8b0-4595-944f-1a78d77be1cc","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f62518fe-c966-4649-b401-63db9be908dc","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a793fb80-82bd-4a69-9771-4e0cb3c6f5bd","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4fd70fe4-9a79-45d3-9692-2be8fd07262c","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"aef4eb2f-fa16-452d-a3c5-25cbe37b0e4a","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
-        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
-        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4e772834-2fee-407a-b9a5-b0d179e5eac7","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"810e7944-67a1-42f7-9f8a-5e1364aa1719","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7dab57ff-ca55-442e-91a0-5b59cb396ad2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"93e29ab0-db00-4a11-9bf4-0b1814be309e","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9ee155dc-3c39-42b4-8eae-f1f5c1959504","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"38314aa9-644c-4a57-92d2-3bf5a423779f","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"21ee6543-46ca-4e0a-a2bf-cc79d5ca6b5c","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
-        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3d859368-14ab-4cb5-8ce2-4fc56da9d8b6","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cb7dcd07-3c59-440f-866a-96f1c6f6e70e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"6c8af5d2-130c-4059-bfd3-497ddb3ad0ac","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"458c397b-172f-458e-8762-bba3d1a78152","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"6cfdbff6-706f-4464-bccd-a13786880682","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1da925ca-2159-43ef-9304-28ab3027561e","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
-        is a super long txt record...wow, it is really really long!  And I even used
-        copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super lon","g txt record...wow, it is really really long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super long txt record...wow,"," it is really really long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super long txt record...wow, it is really reall","y long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f46dc6e-f3ad-4465-b8c3-83010f526653","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"29712271-125f-4ff1-bbdd-028a2d89da6c","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7720c774-25d5-432c-ba1e-dfeb3e876baf","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
-        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"92bdcf87-b753-4306-a516-2c3a33c36ace","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9de19b41-c45f-41e8-a806-e7972e553f75","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"51a9f359-fe01-41f0-b3a4-561c68deb280","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
-        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1912e602-ad13-42f3-9aed-5d2ca458d1f7","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ec953705-1885-419e-8e3d-d0854b387cde","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6ed6d751-2196-47ba-8913-fa436fe8e7aa","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8be42881-e2ef-4ad9-884c-aebb0f8b47f2","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7f0e689c-8222-41a2-88b7-2c805d9210d7","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01eb0016-f3bc-4bb6-a1de-63a2bde3d42b","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ffc18716-409d-4a95-91d9-70035113bc3c","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
-        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c00bd9fb-8037-4be7-9858-4705bc722f20","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bcebbaf5-0707-4b84-bf44-39627869af7d","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"42fcfe8a-ab97-41d6-b7e1-be13a5cfbe2f","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8bca831c-3c34-43f6-8330-138e8119bf38","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
-        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '18531'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:30:43 GMT
+      - Tue, 21 Apr 2020 05:17:26 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2333,79 +2202,30 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - network private-dns zone delete
+      - network private-dns zone export
       Connection:
       - keep-alive
-      Content-Length:
-      - '0'
       ParameterSetName:
-      - -g -n -y
+      - -g -n --file-name
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZjRlY2E4OC1iOGUyLTQ1YjYtOGU0Zi1iY2I1ZGVlNjUyZDc=?api-version=2018-09-01
-      cache-control:
-      - private
-      content-length:
-      - '0'
-      date:
-      - Thu, 16 Apr 2020 14:30:45 GMT
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZjRlY2E4OC1iOGUyLTQ1YjYtOGU0Zi1iY2I1ZGVlNjUyZDc=?api-version=2018-09-01
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZjRlY2E4OC1iOGUyLTQ1YjYtOGU0Zi1iY2I1ZGVlNjUyZDc=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"status":"Succeeded"}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d8dc08bc-da53-4944-886f-363531cd85fa","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
       content-length:
-      - '22'
+      - '581'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:31:15 GMT
+      - Tue, 21 Apr 2020 05:17:27 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2418,6 +2238,82 @@ interactions:
       - 4.0.30319
       x-content-type-options:
       - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"cb37f17e-011b-44a8-847e-a8c42a8ff9f5","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"82f10c36-65f6-41cb-be96-bf30649596fd","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4234b006-2ce0-41c8-b023-63ddc1926f59","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"f6f804f8-d15d-441e-b6a0-955bd3c4083c","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d8dc08bc-da53-4944-886f-363531cd85fa","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"379f3e65-bd47-4ef4-a8d8-d5aa92d3b3a6","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"de60001d-667e-434c-9388-187e19d65e42","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b1c1a584-2b9d-4244-9e97-09bbb856a2ab","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5d8f0863-f321-4eaa-9ecd-69c5e1da2a0e","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"cad2dc0b-46ce-4f89-b3e1-0d169c9518ee","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e782d6b6-6942-4480-8b88-1e10b0bb0c3a","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"d387272a-3259-4b33-af96-2090d8826e68","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8db1c391-7da8-44d2-9e51-f0aca0b76ddc","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"018e3128-b5e9-403f-8ba4-9bd2c4996a3f","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bf9aa642-420d-4f0d-b5ea-42ab34c3f9d1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1295ce0-10c7-411e-bcdc-a54f7a0ae821","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"dbad0bfc-82be-4acd-8a80-8b9fa7ab9af1","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"76f533ae-e680-45dc-961f-afda36cdfeb2","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cb224149-2427-49ee-9b85-52f07d27f732","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        is a super long txt record...wow, it is really really long!  And I even used
+        copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super lon","g txt record...wow, it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow,"," it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow, it is really reall","y long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"949a0bd6-868d-4106-b2c8-c3c8d27467b1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"170f8c73-377c-47ab-98f0-a903a2548cf7","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a02843e-9bd7-4867-8b02-881ac4a96fd0","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a5b34796-183e-4b5a-909c-aacb27909188","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ae5ca740-464d-4ac9-8d1d-f7e8454e2d7e","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7bec5bc2-6bd4-4fa3-8ed5-92b304fc5b7c","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4c27b429-5d95-41da-896c-0537f86bfe82","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"09383659-6006-4d1d-9a91-2da66dba900e","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"85a8d91f-5dc5-4520-838c-82592fb50a51","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8aeebc1d-aa60-40ed-92c0-65c6a69474ed","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9b89b630-ebee-4a5d-8fd6-d60deb486dc6","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c5cac27c-9d60-4590-9da7-e3c9feeb607a","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fd612258-fa53-4ca3-90d7-d31068b0506a","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c80fe891-20e4-4639-9a33-25461713e747","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7ddcd23f-b575-4265-a5c8-486d678b6254","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"9935bd96-adb8-4a44-8c57-59f73099cb0b","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"247bfaf5-3fb8-48bb-b04d-738061465551","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '18531'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:17:27 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59964'
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:
@@ -2454,7 +2350,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmM2VmYzhiZS1hNTgzLTQ2ODctOTljMy0xNWQyN2VkNDJkOTQ=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTswZGE4NmZiYS1hNmUyLTQ4MTktYmViNS1lYzdjMGUzOTg4OTU=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -2462,9 +2358,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:31:43 GMT
+      - Tue, 21 Apr 2020 05:17:29 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmM2VmYzhiZS1hNTgzLTQ2ODctOTljMy0xNWQyN2VkNDJkOTQ=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTswZGE4NmZiYS1hNmUyLTQ4MTktYmViNS1lYzdjMGUzOTg4OTU=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2502,18 +2398,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1ec3988a-61df-4de6-bf0a-99145facc308","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d8dc08bc-da53-4944-886f-363531cd85fa","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '569'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:14 GMT
+      - Tue, 21 Apr 2020 05:18:00 GMT
       etag:
-      - 1ec3988a-61df-4de6-bf0a-99145facc308
+      - d8dc08bc-da53-4944-886f-363531cd85fa
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2527,7 +2423,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -2553,18 +2449,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"f22064df-82cf-4174-85c4-484d0e634395","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"8a849252-2201-47af-8823-adc7450a501e","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":36,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '613'
+      - '614'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:14 GMT
+      - Tue, 21 Apr 2020 05:18:00 GMT
       etag:
-      - f22064df-82cf-4174-85c4-484d0e634395
+      - 8a849252-2201-47af-8823-adc7450a501e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2578,7 +2474,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -2612,7 +2508,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4c12002b-8acf-48a4-ac74-2b184d1dc1a9","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"8c2afe5b-671a-450a-807d-0bb962db33e1","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2621,9 +2517,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:14 GMT
+      - Tue, 21 Apr 2020 05:18:00 GMT
       etag:
-      - 4c12002b-8acf-48a4-ac74-2b184d1dc1a9
+      - 8c2afe5b-671a-450a-807d-0bb962db33e1
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2637,7 +2533,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -2671,7 +2567,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f57c447c-4a79-474e-8746-7e67f5068674","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fe96893d-0d58-49ca-92ec-79bb6d2e4140","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
         is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
         a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}}'
     headers:
@@ -2682,24 +2578,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:15 GMT
+      - Tue, 21 Apr 2020 05:18:02 GMT
       etag:
-      - f57c447c-4a79-474e-8746-7e67f5068674
+      - fe96893d-0d58-49ca-92ec-79bb6d2e4140
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}]}}'
     headers:
@@ -2726,7 +2626,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e4bdb93d-2b33-4071-8116-7121e517ad25","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c694d08f-1d1d-48f4-93ed-aeb537f4fbcf","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2735,13 +2635,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:16 GMT
+      - Tue, 21 Apr 2020 05:18:03 GMT
       etag:
-      - e4bdb93d-2b33-4071-8116-7121e517ad25
+      - c694d08f-1d1d-48f4-93ed-aeb537f4fbcf
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -2751,8 +2655,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foobar.com."},
       {"ptrdname": "bar.com."}]}}'
@@ -2780,7 +2684,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a27544f5-0a82-4813-81e4-9fee9d15ec68","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"462e2553-f4ec-426b-af09-0fee63c1b683","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2789,24 +2693,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:17 GMT
+      - Tue, 21 Apr 2020 05:18:05 GMT
       etag:
-      - a27544f5-0a82-4813-81e4-9fee9d15ec68
+      - 462e2553-f4ec-426b-af09-0fee63c1b683
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "7.8.9.0"}]}}'
     headers:
@@ -2833,7 +2741,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/200?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"81dd8c2d-7f39-40f7-a3b3-bd55e9b1018c","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c505862d-3f50-4739-a875-79c66b383006","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2842,24 +2750,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:19 GMT
+      - Tue, 21 Apr 2020 05:18:05 GMT
       etag:
-      - 81dd8c2d-7f39-40f7-a3b3-bd55e9b1018c
+      - c505862d-3f50-4739-a875-79c66b383006
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}, {"ptrdname":
       "bar.com."}]}}'
@@ -2887,7 +2799,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.3?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"b0a3448a-56a6-48ce-9a36-9d2041fc191c","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"7e3e63b9-68b4-43f6-ae7b-913930d2f339","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2896,24 +2808,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:20 GMT
+      - Tue, 21 Apr 2020 05:18:07 GMT
       etag:
-      - b0a3448a-56a6-48ce-9a36-9d2041fc191c
+      - 7e3e63b9-68b4-43f6-ae7b-913930d2f339
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}, {"ipv4Address":
       "2.3.4.5"}]}}'
@@ -2941,7 +2857,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/a2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"22dece0b-3a43-4b39-9c1a-667f1adfa442","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ceb1c123-fec4-49e0-a7c7-4b7acb1ea1f3","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2950,24 +2866,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:21 GMT
+      - Tue, 21 Apr 2020 05:18:08 GMT
       etag:
-      - 22dece0b-3a43-4b39-9c1a-667f1adfa442
+      - ceb1c123-fec4-49e0-a7c7-4b7acb1ea1f3
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "4.5.6.7"}, {"ipv4Address":
       "6.7.8.9"}]}}'
@@ -2995,7 +2915,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/aa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"72e4248a-7749-4168-b20d-639fcadc9a2f","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b67d85e4-4c1f-4103-a53e-2cd01283d294","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3004,24 +2924,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:22 GMT
+      - Tue, 21 Apr 2020 05:18:10 GMT
       etag:
-      - 72e4248a-7749-4168-b20d-639fcadc9a2f
+      - b67d85e4-4c1f-4103-a53e-2cd01283d294
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 300, "mxRecords": [{"preference": 1, "exchange":
       "foo.com.zone2.com."}]}}'
@@ -3049,7 +2973,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/aa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"71f33003-b9b7-429c-9907-6641c928ed62","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"899b1f54-1a66-41f3-b90c-624b834cc6ec","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3058,24 +2982,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:24 GMT
+      - Tue, 21 Apr 2020 05:18:10 GMT
       etag:
-      - 71f33003-b9b7-429c-9907-6641c928ed62
+      - 899b1f54-1a66-41f3-b90c-624b834cc6ec
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:cafe:130::100"},
       {"ipv6Address": "2001:cafe:130::101"}]}}'
@@ -3103,7 +3031,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/AAAA/aaaa2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"b1deb492-3046-49d9-8e91-81f6c67d0108","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"aa077503-9de7-412f-bf9e-7d35d866d71f","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3112,24 +3040,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:25 GMT
+      - Tue, 21 Apr 2020 05:18:13 GMT
       etag:
-      - b1deb492-3046-49d9-8e91-81f6c67d0108
+      - aa077503-9de7-412f-bf9e-7d35d866d71f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
     headers:
@@ -3156,7 +3088,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/base?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"42f5ad03-8382-4b1d-8e70-00ad446b80de","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9d73112d-3e47-401c-9c16-01af764ac65e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3165,24 +3097,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:26 GMT
+      - Tue, 21 Apr 2020 05:18:14 GMT
       etag:
-      - 42f5ad03-8382-4b1d-8e70-00ad446b80de
+      - 9d73112d-3e47-401c-9c16-01af764ac65e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
       "be.xpiler.de."}]}}'
@@ -3210,7 +3146,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/base?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b8774030-e1b3-4a06-9e22-96375dc1041e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"4f58be5f-be4a-4932-a092-6f5550352be9","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3219,24 +3155,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:27 GMT
+      - Tue, 21 Apr 2020 05:18:15 GMT
       etag:
-      - b8774030-e1b3-4a06-9e22-96375dc1041e
+      - 4f58be5f-be4a-4932-a092-6f5550352be9
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xcaign.de
       include:_spf6.xcaign.de -all"]}, {"value": ["spf2.0/mfrom,pra mx ip4:15.19.14.0/24
@@ -3265,7 +3205,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/base?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a9f7f18b-38ee-4dc6-bf46-2e9d92fce724","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c54c49ef-3190-46d6-8798-1478f68b7972","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
         mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
         mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}}'
     headers:
@@ -3276,24 +3216,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:28 GMT
+      - Tue, 21 Apr 2020 05:18:17 GMT
       etag:
-      - a9f7f18b-38ee-4dc6-bf46-2e9d92fce724
+      - c54c49ef-3190-46d6-8798-1478f68b7972
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}]}}'
     headers:
@@ -3320,7 +3264,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/doozie?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d1449f9f-0bc7-4785-a4bb-779ffd572e8e","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d26104f6-5cb2-4a78-96c0-4c86617a52e2","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3329,24 +3273,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:30 GMT
+      - Tue, 21 Apr 2020 05:18:17 GMT
       etag:
-      - d1449f9f-0bc7-4785-a4bb-779ffd572e8e
+      - d26104f6-5cb2-4a78-96c0-4c86617a52e2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
     headers:
@@ -3373,7 +3321,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/even?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"03a38819-4eeb-4883-9a45-49fb3a1382f9","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c0c1a7f6-b2ea-439e-9ac5-12e5b1e8afa6","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3382,24 +3330,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:31 GMT
+      - Tue, 21 Apr 2020 05:18:18 GMT
       etag:
-      - 03a38819-4eeb-4883-9a45-49fb3a1382f9
+      - c0c1a7f6-b2ea-439e-9ac5-12e5b1e8afa6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
       "be.xpiler.de."}]}}'
@@ -3427,7 +3379,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/even?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"fa770551-25cc-40b8-8fb0-019e263603c0","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b5590c1f-642c-4b92-9452-2849cdcb416e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3436,24 +3388,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:32 GMT
+      - Tue, 21 Apr 2020 05:18:19 GMT
       etag:
-      - fa770551-25cc-40b8-8fb0-019e263603c0
+      - b5590c1f-642c-4b92-9452-2849cdcb416e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xgn.de
       include:_spf6.xgn.de -all"]}]}}'
@@ -3481,7 +3437,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/even?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7d8cf5fc-7976-4dba-b938-4c34c02d7401","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"2bd7dba1-313d-4821-bff8-e47f9e11363e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
         mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -3491,24 +3447,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:33 GMT
+      - Tue, 21 Apr 2020 05:18:20 GMT
       etag:
-      - 7d8cf5fc-7976-4dba-b938-4c34c02d7401
+      - 2bd7dba1-313d-4821-bff8-e47f9e11363e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "bar.com."}}}'
     headers:
@@ -3535,7 +3495,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/CNAME/fee2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"da83925f-b2f4-4f19-b241-5828a2052bae","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"75b9b022-c142-4e46-a2bc-ef8ba39898b7","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3544,24 +3504,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:34 GMT
+      - Tue, 21 Apr 2020 05:18:22 GMT
       etag:
-      - da83925f-b2f4-4f19-b241-5828a2052bae
+      - 75b9b022-c142-4e46-a2bc-ef8ba39898b7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 999, "txtRecords": [{"value": ["this is a super
       long txt record...wow, it is really really long!  And I even used copy and paste
@@ -3600,7 +3564,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9cbfe400-043c-4c0f-ac39-4d19e989ecd2","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d81a4b8b-8de8-4618-89e6-7aec060f0dbf","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
         is a super long txt record...wow, it is really really long!  And I even used
         copy and paste to make it longer....this is a super long txt record...wow,
         it is really really long!  And I even used copy and paste to make it longer....this
@@ -3621,24 +3585,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:35 GMT
+      - Tue, 21 Apr 2020 05:18:24 GMT
       etag:
-      - 9cbfe400-043c-4c0f-ac39-4d19e989ecd2
+      - d81a4b8b-8de8-4618-89e6-7aec060f0dbf
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 100, "txtRecords": [{"value": ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
       "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'
@@ -3666,7 +3634,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"31438c09-4dcd-4360-9c7f-891e59a42397","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5d890917-c374-497d-96ea-686fd999232e","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3675,24 +3643,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:37 GMT
+      - Tue, 21 Apr 2020 05:18:25 GMT
       etag:
-      - 31438c09-4dcd-4360-9c7f-891e59a42397
+      - 5d890917-c374-497d-96ea-686fd999232e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
       "mail1.mymail.com."}, {"preference": 11, "exchange": "flooble."}]}}'
@@ -3720,7 +3692,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/mail?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"e0420400-061b-4bf9-8a4a-732bc21a5fda","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a4a0ac3a-3397-4fff-ade0-f2e865ffc93b","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3729,24 +3701,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:37 GMT
+      - Tue, 21 Apr 2020 05:18:25 GMT
       etag:
-      - e0420400-061b-4bf9-8a4a-732bc21a5fda
+      - a4a0ac3a-3397-4fff-ade0-f2e865ffc93b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 100, "txtRecords": [{"value": ["this is an SPF record!
       Convert to TXT on import"]}]}}'
@@ -3774,7 +3750,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/myspf?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9bd75f9c-ece0-43ae-8ff1-df038a48d4d3","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"eaa3ff68-21d2-4a93-9e7a-5e9c69a72972","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
         is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -3784,24 +3760,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:38 GMT
+      - Tue, 21 Apr 2020 05:18:27 GMT
       etag:
-      - 9bd75f9c-ece0-43ae-8ff1-df038a48d4d3
+      - eaa3ff68-21d2-4a93-9e7a-5e9c69a72972
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["  a  "]}]}}'
     headers:
@@ -3828,7 +3808,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/spaces?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"eb6fa9aa-61ab-49cd-879e-9a3d82ca2e64","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"736a0489-6284-46d0-8d55-8a2df56ec61d","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3837,24 +3817,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:39 GMT
+      - Tue, 21 Apr 2020 05:18:29 GMT
       etag:
-      - eb6fa9aa-61ab-49cd-879e-9a3d82ca2e64
+      - 736a0489-6284-46d0-8d55-8a2df56ec61d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
     headers:
@@ -3881,7 +3865,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"31123e41-25c1-4838-b06a-64be257cf1db","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ce7bd650-6721-4399-87c3-653e0fc179ba","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3890,24 +3874,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:40 GMT
+      - Tue, 21 Apr 2020 05:18:29 GMT
       etag:
-      - 31123e41-25c1-4838-b06a-64be257cf1db
+      - ce7bd650-6721-4399-87c3-653e0fc179ba
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo bar"]}]}}'
     headers:
@@ -3934,7 +3922,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t10?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0c4f2cee-d737-4ee5-bcea-b031a1ebddf2","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"82c521e3-ee3c-4dd9-924a-2c773811ef5b","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
         bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -3944,24 +3932,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:41 GMT
+      - Tue, 21 Apr 2020 05:18:31 GMT
       etag:
-      - 0c4f2cee-d737-4ee5-bcea-b031a1ebddf2
+      - 82c521e3-ee3c-4dd9-924a-2c773811ef5b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
     headers:
@@ -3988,7 +3980,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t11?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d7b05e3c-8e3c-4a22-9880-f0c2f124ca52","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8ef0c534-058f-41ed-91e1-921277636de0","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -3997,13 +3989,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:42 GMT
+      - Tue, 21 Apr 2020 05:18:32 GMT
       etag:
-      - d7b05e3c-8e3c-4a22-9880-f0c2f124ca52
+      - 8ef0c534-058f-41ed-91e1-921277636de0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -4013,8 +4009,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
     headers:
@@ -4041,7 +4037,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"566dd78d-1bff-4fc1-96df-dbacdcd3d0ae","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a78e5960-893f-40f7-9caf-8b6d04996037","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -4050,24 +4046,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:43 GMT
+      - Tue, 21 Apr 2020 05:18:33 GMT
       etag:
-      - 566dd78d-1bff-4fc1-96df-dbacdcd3d0ae
+      - a78e5960-893f-40f7-9caf-8b6d04996037
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
     headers:
@@ -4094,7 +4094,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t3?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7afcd5ce-8ca2-49bd-99aa-4e2d3c406747","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"51504c1a-66bd-4626-b4b9-a0023f5a0f47","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -4103,24 +4103,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:45 GMT
+      - Tue, 21 Apr 2020 05:18:34 GMT
       etag:
-      - 7afcd5ce-8ca2-49bd-99aa-4e2d3c406747
+      - 51504c1a-66bd-4626-b4b9-a0023f5a0f47
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo;bar"]}]}}'
     headers:
@@ -4147,7 +4151,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t4?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"27f4fec0-df82-435b-8145-48e31c5df431","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cfde5207-19ee-4ac0-b0aa-75622e37c127","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -4156,24 +4160,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:46 GMT
+      - Tue, 21 Apr 2020 05:18:35 GMT
       etag:
-      - 27f4fec0-df82-435b-8145-48e31c5df431
+      - cfde5207-19ee-4ac0-b0aa-75622e37c127
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11989'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
     headers:
@@ -4200,7 +4208,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t5?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"266d8635-e855-408c-bcc4-aae8ed441866","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9023ac31-d14e-4ab3-8f71-808b9885c705","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -4209,24 +4217,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:47 GMT
+      - Tue, 21 Apr 2020 05:18:37 GMT
       etag:
-      - 266d8635-e855-408c-bcc4-aae8ed441866
+      - 9023ac31-d14e-4ab3-8f71-808b9885c705
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
     headers:
@@ -4253,7 +4265,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t6?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4c3ad0ed-14e2-4cb8-b635-8a6ea7f7399a","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"988e653c-d802-47f9-94c2-24516749bd6e","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -4262,24 +4274,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:48 GMT
+      - Tue, 21 Apr 2020 05:18:38 GMT
       etag:
-      - 4c3ad0ed-14e2-4cb8-b635-8a6ea7f7399a
+      - 988e653c-d802-47f9-94c2-24516749bd6e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["\\\"quoted string\\\""]}]}}'
     headers:
@@ -4306,7 +4322,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t7?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c1b84b1e-9acd-47bf-a475-b56ddfcea363","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"beec5a55-7df2-4686-9317-d118048410a0","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
         string\\\""]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -4316,24 +4332,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:49 GMT
+      - Tue, 21 Apr 2020 05:18:39 GMT
       etag:
-      - c1b84b1e-9acd-47bf-a475-b56ddfcea363
+      - beec5a55-7df2-4686-9317-d118048410a0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
     headers:
@@ -4360,7 +4380,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t8?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8de813eb-ec91-4dbd-850f-4ab9ec33ef99","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"174a544f-24ea-480b-8eb0-66f120a4cea9","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -4369,24 +4389,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:50 GMT
+      - Tue, 21 Apr 2020 05:18:40 GMT
       etag:
-      - 8de813eb-ec91-4dbd-850f-4ab9ec33ef99
+      - 174a544f-24ea-480b-8eb0-66f120a4cea9
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobarr"]}]}}'
     headers:
@@ -4413,7 +4437,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t9?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"522d3d2f-9129-40cb-bb39-a691c380a814","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"907cd8a2-9a6a-48e8-bd7d-72b33cff2102","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -4422,24 +4446,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:51 GMT
+      - Tue, 21 Apr 2020 05:18:41 GMT
       etag:
-      - 522d3d2f-9129-40cb-bb39-a691c380a814
+      - 907cd8a2-9a6a-48e8-bd7d-72b33cff2102
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 10, "weight":
       20, "port": 30, "target": "foobar."}, {"priority": 55, "weight": 66, "port":
@@ -4468,7 +4496,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SRV/sip.tcp?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"43fdc37f-c45e-4606-9960-8e94f00dd72b","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b7ed8761-833e-4e6c-b37d-4b2936c9ef24","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -4477,24 +4505,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:53 GMT
+      - Tue, 21 Apr 2020 05:18:43 GMT
       etag:
-      - 43fdc37f-c45e-4606-9960-8e94f00dd72b
+      - b7ed8761-833e-4e6c-b37d-4b2936c9ef24
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1"]}, {"value":
       ["string 2"]}]}}'
@@ -4522,7 +4554,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/test-txt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"84f9a199-ae8a-44a6-87dc-5f04f14bbf56","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"2052bcfb-5e42-406a-9995-3aaf7e5fddd2","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]},{"value":["string 2"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -4532,24 +4564,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:54 GMT
+      - Tue, 21 Apr 2020 05:18:44 GMT
       etag:
-      - 84f9a199-ae8a-44a6-87dc-5f04f14bbf56
+      - 2052bcfb-5e42-406a-9995-3aaf7e5fddd2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -4572,12 +4608,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"e4bdb93d-2b33-4071-8116-7121e517ad25","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"a27544f5-0a82-4813-81e4-9fee9d15ec68","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"81dd8c2d-7f39-40f7-a3b3-bd55e9b1018c","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"b0a3448a-56a6-48ce-9a36-9d2041fc191c","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4c12002b-8acf-48a4-ac74-2b184d1dc1a9","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f57c447c-4a79-474e-8746-7e67f5068674","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c694d08f-1d1d-48f4-93ed-aeb537f4fbcf","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"462e2553-f4ec-426b-af09-0fee63c1b683","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c505862d-3f50-4739-a875-79c66b383006","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"7e3e63b9-68b4-43f6-ae7b-913930d2f339","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"8c2afe5b-671a-450a-807d-0bb962db33e1","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fe96893d-0d58-49ca-92ec-79bb6d2e4140","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
         is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
-        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"22dece0b-3a43-4b39-9c1a-667f1adfa442","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"72e4248a-7749-4168-b20d-639fcadc9a2f","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"71f33003-b9b7-429c-9907-6641c928ed62","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"b1deb492-3046-49d9-8e91-81f6c67d0108","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"42f5ad03-8382-4b1d-8e70-00ad446b80de","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b8774030-e1b3-4a06-9e22-96375dc1041e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a9f7f18b-38ee-4dc6-bf46-2e9d92fce724","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ceb1c123-fec4-49e0-a7c7-4b7acb1ea1f3","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b67d85e4-4c1f-4103-a53e-2cd01283d294","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"899b1f54-1a66-41f3-b90c-624b834cc6ec","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"aa077503-9de7-412f-bf9e-7d35d866d71f","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9d73112d-3e47-401c-9c16-01af764ac65e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"4f58be5f-be4a-4932-a092-6f5550352be9","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c54c49ef-3190-46d6-8798-1478f68b7972","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
         mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
-        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d1449f9f-0bc7-4785-a4bb-779ffd572e8e","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"03a38819-4eeb-4883-9a45-49fb3a1382f9","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"fa770551-25cc-40b8-8fb0-019e263603c0","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7d8cf5fc-7976-4dba-b938-4c34c02d7401","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"da83925f-b2f4-4f19-b241-5828a2052bae","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9cbfe400-043c-4c0f-ac39-4d19e989ecd2","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d26104f6-5cb2-4a78-96c0-4c86617a52e2","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c0c1a7f6-b2ea-439e-9ac5-12e5b1e8afa6","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b5590c1f-642c-4b92-9452-2849cdcb416e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"2bd7dba1-313d-4821-bff8-e47f9e11363e","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"75b9b022-c142-4e46-a2bc-ef8ba39898b7","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d81a4b8b-8de8-4618-89e6-7aec060f0dbf","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
         is a super long txt record...wow, it is really really long!  And I even used
         copy and paste to make it longer....this is a super long txt record...wow,
         it is really really long!  And I even used copy and paste to make it longer....this
@@ -4589,10 +4625,10 @@ interactions:
         it is really really long!  And I even used copy and paste to make it longer....this
         is a super long txt record...wow, it is really reall","y long!  And I even
         used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"31438c09-4dcd-4360-9c7f-891e59a42397","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"e0420400-061b-4bf9-8a4a-732bc21a5fda","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9bd75f9c-ece0-43ae-8ff1-df038a48d4d3","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
-        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"eb6fa9aa-61ab-49cd-879e-9a3d82ca2e64","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"31123e41-25c1-4838-b06a-64be257cf1db","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0c4f2cee-d737-4ee5-bcea-b031a1ebddf2","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
-        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d7b05e3c-8e3c-4a22-9880-f0c2f124ca52","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"566dd78d-1bff-4fc1-96df-dbacdcd3d0ae","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7afcd5ce-8ca2-49bd-99aa-4e2d3c406747","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"27f4fec0-df82-435b-8145-48e31c5df431","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"266d8635-e855-408c-bcc4-aae8ed441866","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4c3ad0ed-14e2-4cb8-b635-8a6ea7f7399a","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c1b84b1e-9acd-47bf-a475-b56ddfcea363","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
-        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8de813eb-ec91-4dbd-850f-4ab9ec33ef99","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"522d3d2f-9129-40cb-bb39-a691c380a814","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"43fdc37f-c45e-4606-9960-8e94f00dd72b","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"84f9a199-ae8a-44a6-87dc-5f04f14bbf56","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5d890917-c374-497d-96ea-686fd999232e","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a4a0ac3a-3397-4fff-ade0-f2e865ffc93b","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"eaa3ff68-21d2-4a93-9e7a-5e9c69a72972","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"736a0489-6284-46d0-8d55-8a2df56ec61d","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ce7bd650-6721-4399-87c3-653e0fc179ba","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"82c521e3-ee3c-4dd9-924a-2c773811ef5b","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8ef0c534-058f-41ed-91e1-921277636de0","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a78e5960-893f-40f7-9caf-8b6d04996037","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"51504c1a-66bd-4626-b4b9-a0023f5a0f47","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cfde5207-19ee-4ac0-b0aa-75622e37c127","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9023ac31-d14e-4ab3-8f71-808b9885c705","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"988e653c-d802-47f9-94c2-24516749bd6e","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"beec5a55-7df2-4686-9317-d118048410a0","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"174a544f-24ea-480b-8eb0-66f120a4cea9","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"907cd8a2-9a6a-48e8-bd7d-72b33cff2102","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b7ed8761-833e-4e6c-b37d-4b2936c9ef24","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"2052bcfb-5e42-406a-9995-3aaf7e5fddd2","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
@@ -4602,7 +4638,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:32:54 GMT
+      - Tue, 21 Apr 2020 05:18:45 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone2_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone2_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlMTVmNDVkNC0yZWQxLTQ0Y2QtODg0NS1lZDVhZTk4NjI2ZDc=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:01:40 GMT
+      - Wed, 22 Apr 2020 12:06:13 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlMTVmNDVkNC0yZWQxLTQ0Y2QtODg0NS1lZDVhZTk4NjI2ZDc=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -71,56 +71,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"InProgress"}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
-      cache-control:
-      - private
-      content-length:
-      - '23'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:02:10 GMT
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlZjI0MGNhMy0xNGNiLTQzMjMtOGM3ZC1lYWE3NjM1ZWVmNTI=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtlMTVmNDVkNC0yZWQxLTQ0Y2QtODg0NS1lZDVhZTk4NjI2ZDc=?api-version=2018-09-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -132,7 +83,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:02:41 GMT
+      - Wed, 22 Apr 2020 12:06:43 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -146,7 +97,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '497'
       x-powered-by:
       - ASP.NET
     status:
@@ -172,7 +123,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"42beae59-a297-4250-aa97-e98310f3fb3f","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"399d54de-9815-4b72-894d-a550cd683559","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -181,9 +132,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:02:42 GMT
+      - Wed, 22 Apr 2020 12:06:43 GMT
       etag:
-      - 42beae59-a297-4250-aa97-e98310f3fb3f
+      - 399d54de-9815-4b72-894d-a550cd683559
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -225,7 +176,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"544f9071-d492-4dbb-8d79-05617395857b","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6cdbcad1-77eb-4b69-801b-3069389ce698","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -234,9 +185,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:02:42 GMT
+      - Wed, 22 Apr 2020 12:06:45 GMT
       etag:
-      - 544f9071-d492-4dbb-8d79-05617395857b
+      - 6cdbcad1-77eb-4b69-801b-3069389ce698
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -284,7 +235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5e89f385-9cb1-4f51-bff1-37dd4dc7f330","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"8b334c78-70c8-4808-9a39-47ffd9888311","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -293,9 +244,2484 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:02:43 GMT
+      - Wed, 22 Apr 2020 12:06:46 GMT
       etag:
-      - 5e89f385-9cb1-4f51-bff1-37dd4dc7f330
+      - 8b334c78-70c8-4808-9a39-47ffd9888311
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 200, "txtRecords": [{"value": ["this is another
+      SPF, this time as TXT"]}, {"value": ["v=spf1 mx ip4:14.14.22.0/23 a:mail.trum.ch
+      mx:mese.ch include:spf.mapp.com ?all"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '194'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ae062b5b-db9a-4cfe-92b6-bae9b43085d8","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '559'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:06:47 GMT
+      etag:
+      - ae062b5b-db9a-4cfe-92b6-bae9b43085d8
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["  a  "]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/spaces?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ce6eed16-bcc1-41b7-a8b6-2dc8810e6ce3","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:06:48 GMT
+      etag:
+      - ce6eed16-bcc1-41b7-a8b6-2dc8810e6ce3
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11993'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}, {"ipv4Address":
+      "2.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/a2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c3016c09-2d0a-4fdf-9ef2-55c9e73e0250","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:06:50 GMT
+      etag:
+      - c3016c09-2d0a-4fdf-9ef2-55c9e73e0250
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:cafe:130::100"},
+      {"ipv6Address": "2001:cafe:130::101"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '124'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/AAAA/aaaa2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"418dd08f-3378-4ede-8c0d-5e3d2f670dfd","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '504'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:06:52 GMT
+      etag:
+      - 418dd08f-3378-4ede-8c0d-5e3d2f670dfd
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '170'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/doozie?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"265dc3bb-c333-45a9-90fc-e92f12837960","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:06:52 GMT
+      etag:
+      - 265dc3bb-c333-45a9-90fc-e92f12837960
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "bar.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/CNAME/fee2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"de604d63-0a0a-4f30-bbb4-6b5b57450ed4","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '448'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:06:53 GMT
+      etag:
+      - de604d63-0a0a-4f30-bbb4-6b5b57450ed4
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "mail1.mymail.com."}, {"preference": 11, "exchange": "flooble."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '141'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/mail?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"0057d7e1-9247-4485-9ddd-0bacd527d9e9","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '510'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:06:54 GMT
+      etag:
+      - 0057d7e1-9247-4485-9ddd-0bacd527d9e9
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 10, "weight":
+      20, "port": 30, "target": "foobar."}, {"priority": 55, "weight": 66, "port":
+      77, "target": "zoo."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SRV/sip.tcp?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ed1d1e1d-f164-4209-9b36-c823dc2ab8c9","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '544'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:06:56 GMT
+      etag:
+      - ed1d1e1d-f164-4209-9b36-c823dc2ab8c9
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1"]}, {"value":
+      ["string 2"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '95'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/test-txt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d73777ad-28ea-43a8-8644-0727632696de","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '485'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:06:57 GMT
+      etag:
+      - d73777ad-28ea-43a8-8644-0727632696de
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "4.5.6.7"}, {"ipv4Address":
+      "6.7.8.9"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/aa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3c99b7ef-3972-4f8b-b9b0-26ff7a0c6542","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:06:58 GMT
+      etag:
+      - 3c99b7ef-3972-4f8b-b9b0-26ff7a0c6542
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 300, "mxRecords": [{"preference": 1, "exchange":
+      "foo.com.zone2.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/aa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a78c73c4-efec-4278-94a3-b6bc9e205285","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:00 GMT
+      etag:
+      - a78c73c4-efec-4278-94a3-b6bc9e205285
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "7.8.9.0"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/200?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"92fedbf5-70cc-4723-901d-d86d03814c1d","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '441'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:01 GMT
+      etag:
+      - 92fedbf5-70cc-4723-901d-d86d03814c1d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 999, "txtRecords": [{"value": ["this is a super
+      long txt record...wow, it is really really long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer....this is a super lon",
+      "g txt record...wow, it is really really long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer....this is a super long
+      txt record...wow,", " it is really really long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer....this is a super long
+      txt record...wow, it is really reall", "y long!  And I even used copy and paste
+      to make it longer....this is a super long txt record...wow, it is really really
+      long!  And I even used copy and paste to make it longer...."]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1017'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bc6581f9-7cae-4553-b1ea-2856550f5e69","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        is a super long txt record...wow, it is really really long!  And I even used
+        copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super lon","g txt record...wow, it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow,"," it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow, it is really reall","y long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1400'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:02 GMT
+      etag:
+      - bc6581f9-7cae-4553-b1ea-2856550f5e69
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "txtRecords": [{"value": ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
+      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '565'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3ddabe24-48fc-47e5-80b3-6221959460a6","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '953'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:03 GMT
+      etag:
+      - 3ddabe24-48fc-47e5-80b3-6221959460a6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "txtRecords": [{"value": ["this is an SPF record!
+      Convert to TXT on import"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '108'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/myspf?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c67da928-297e-4b0d-952b-694b23fac6e4","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '488'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:04 GMT
+      etag:
+      - c67da928-297e-4b0d-952b-694b23fac6e4
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"baa756e1-aa65-4a4b-852e-123fb0467aea","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '451'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:06 GMT
+      etag:
+      - baa756e1-aa65-4a4b-852e-123fb0467aea
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foobar.com."},
+      {"ptrdname": "bar.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"7a631447-ee9c-4edb-8ea5-867b261241cb","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '478'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:07 GMT
+      etag:
+      - 7a631447-ee9c-4edb-8ea5-867b261241cb
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}, {"ptrdname":
+      "bar.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '97'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.3?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"0177d457-1c21-4d98-851c-dd6db8041ea2","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:08 GMT
+      etag:
+      - 0177d457-1c21-4d98-851c-dd6db8041ea2
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1aa60946-1378-417f-901c-689d72a69dc1","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:09 GMT
+      etag:
+      - 1aa60946-1378-417f-901c-689d72a69dc1
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0cccd0a2-9f23-4056-afc9-eba115d3c890","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:10 GMT
+      etag:
+      - 0cccd0a2-9f23-4056-afc9-eba115d3c890
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t3?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"60a9db25-02c9-4577-8d3a-245865565e2c","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:11 GMT
+      etag:
+      - 60a9db25-02c9-4577-8d3a-245865565e2c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo;bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t4?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b37bc24d-7abd-418e-b23c-6599080e9358","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '440'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:13 GMT
+      etag:
+      - b37bc24d-7abd-418e-b23c-6599080e9358
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t5?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"be0c648e-d5ce-4904-9c2a-3f791235f141","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '442'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:14 GMT
+      etag:
+      - be0c648e-d5ce-4904-9c2a-3f791235f141
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11993'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo\\;bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t6?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f3e26b6a-5f05-4ec1-8be8-3f1923539989","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '442'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:15 GMT
+      etag:
+      - f3e26b6a-5f05-4ec1-8be8-3f1923539989
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["\\\"quoted string\\\""]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t7?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"52975ff1-5c43-4f81-b35c-f55e4edd7623","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:16 GMT
+      etag:
+      - 52975ff1-5c43-4f81-b35c-f55e4edd7623
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t8?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c1e270da-6a6f-47d3-8658-27621ebf66cf","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '439'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:17 GMT
+      etag:
+      - c1e270da-6a6f-47d3-8658-27621ebf66cf
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11992'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobarr"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t9?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ca4c1f27-a85d-4b21-ad5e-db8afc2c7867","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '440'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:19 GMT
+      etag:
+      - ca4c1f27-a85d-4b21-ad5e-db8afc2c7867
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11992'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t10?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"59bb9b1e-73ac-44ca-87b4-a1031cdfdad6","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '443'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:19 GMT
+      etag:
+      - 59bb9b1e-73ac-44ca-87b4-a1031cdfdad6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t11?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cec3d20a-f61f-4487-beb7-0ca63f6f6a9a","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '442'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:21 GMT
+      etag:
+      - cec3d20a-f61f-4487-beb7-0ca63f6f6a9a
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11993'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"50e1f8f7-7f40-48b5-89ad-14d220ae6b25","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:22 GMT
+      etag:
+      - 50e1f8f7-7f40-48b5-89ad-14d220ae6b25
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "be.xpiler.de."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"914f8cd1-22ac-47eb-bc34-83d3a17edcb7","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:23 GMT
+      etag:
+      - 914f8cd1-22ac-47eb-bc34-83d3a17edcb7
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xcaign.de
+      include:_spf6.xcaign.de -all"]}, {"value": ["spf2.0/mfrom,pra mx ip4:15.19.14.0/24
+      ip4:8.8.11.4/27 ip4:9.16.20.19/26 -all"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '217'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"15b971ef-9987-40ef-9c18-748f4cf21c2e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '596'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:25 GMT
+      etag:
+      - 15b971ef-9987-40ef-9c18-748f4cf21c2e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"79ddf828-96f7-4058-9e79-0c883f477889","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:26 GMT
+      etag:
+      - 79ddf828-96f7-4058-9e79-0c883f477889
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "be.xpiler.de."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b5f576d7-a60f-4782-9784-e2f00c2894fe","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:27 GMT
+      etag:
+      - b5f576d7-a60f-4782-9784-e2f00c2894fe
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xgn.de
+      include:_spf6.xgn.de -all"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8e7b4097-76e2-4704-a8f0-56496e7ae49f","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '495'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:29 GMT
+      etag:
+      - 8e7b4097-76e2-4704-a8f0-56496e7ae49f
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11991'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"baa756e1-aa65-4a4b-852e-123fb0467aea","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"7a631447-ee9c-4edb-8ea5-867b261241cb","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"92fedbf5-70cc-4723-901d-d86d03814c1d","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"0177d457-1c21-4d98-851c-dd6db8041ea2","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"8b334c78-70c8-4808-9a39-47ffd9888311","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ae062b5b-db9a-4cfe-92b6-bae9b43085d8","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c3016c09-2d0a-4fdf-9ef2-55c9e73e0250","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3c99b7ef-3972-4f8b-b9b0-26ff7a0c6542","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a78c73c4-efec-4278-94a3-b6bc9e205285","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"418dd08f-3378-4ede-8c0d-5e3d2f670dfd","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"50e1f8f7-7f40-48b5-89ad-14d220ae6b25","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"914f8cd1-22ac-47eb-bc34-83d3a17edcb7","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"15b971ef-9987-40ef-9c18-748f4cf21c2e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"265dc3bb-c333-45a9-90fc-e92f12837960","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"79ddf828-96f7-4058-9e79-0c883f477889","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b5f576d7-a60f-4782-9784-e2f00c2894fe","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8e7b4097-76e2-4704-a8f0-56496e7ae49f","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"de604d63-0a0a-4f30-bbb4-6b5b57450ed4","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bc6581f9-7cae-4553-b1ea-2856550f5e69","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        is a super long txt record...wow, it is really really long!  And I even used
+        copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super lon","g txt record...wow, it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow,"," it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow, it is really reall","y long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3ddabe24-48fc-47e5-80b3-6221959460a6","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"0057d7e1-9247-4485-9ddd-0bacd527d9e9","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c67da928-297e-4b0d-952b-694b23fac6e4","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ce6eed16-bcc1-41b7-a8b6-2dc8810e6ce3","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1aa60946-1378-417f-901c-689d72a69dc1","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"59bb9b1e-73ac-44ca-87b4-a1031cdfdad6","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cec3d20a-f61f-4487-beb7-0ca63f6f6a9a","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0cccd0a2-9f23-4056-afc9-eba115d3c890","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"60a9db25-02c9-4577-8d3a-245865565e2c","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b37bc24d-7abd-418e-b23c-6599080e9358","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"be0c648e-d5ce-4904-9c2a-3f791235f141","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f3e26b6a-5f05-4ec1-8be8-3f1923539989","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"52975ff1-5c43-4f81-b35c-f55e4edd7623","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c1e270da-6a6f-47d3-8658-27621ebf66cf","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ca4c1f27-a85d-4b21-ad5e-db8afc2c7867","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ed1d1e1d-f164-4209-9b36-c823dc2ab8c9","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d73777ad-28ea-43a8-8644-0727632696de","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '18531'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:30 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59938'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '497'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"8b334c78-70c8-4808-9a39-47ffd9888311","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '581'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:30 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"baa756e1-aa65-4a4b-852e-123fb0467aea","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"7a631447-ee9c-4edb-8ea5-867b261241cb","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"92fedbf5-70cc-4723-901d-d86d03814c1d","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"0177d457-1c21-4d98-851c-dd6db8041ea2","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"8b334c78-70c8-4808-9a39-47ffd9888311","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ae062b5b-db9a-4cfe-92b6-bae9b43085d8","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c3016c09-2d0a-4fdf-9ef2-55c9e73e0250","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3c99b7ef-3972-4f8b-b9b0-26ff7a0c6542","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a78c73c4-efec-4278-94a3-b6bc9e205285","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"418dd08f-3378-4ede-8c0d-5e3d2f670dfd","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"50e1f8f7-7f40-48b5-89ad-14d220ae6b25","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"914f8cd1-22ac-47eb-bc34-83d3a17edcb7","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"15b971ef-9987-40ef-9c18-748f4cf21c2e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"265dc3bb-c333-45a9-90fc-e92f12837960","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"79ddf828-96f7-4058-9e79-0c883f477889","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b5f576d7-a60f-4782-9784-e2f00c2894fe","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8e7b4097-76e2-4704-a8f0-56496e7ae49f","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"de604d63-0a0a-4f30-bbb4-6b5b57450ed4","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bc6581f9-7cae-4553-b1ea-2856550f5e69","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        is a super long txt record...wow, it is really really long!  And I even used
+        copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super lon","g txt record...wow, it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow,"," it is really really long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer....this
+        is a super long txt record...wow, it is really reall","y long!  And I even
+        used copy and paste to make it longer....this is a super long txt record...wow,
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3ddabe24-48fc-47e5-80b3-6221959460a6","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"0057d7e1-9247-4485-9ddd-0bacd527d9e9","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c67da928-297e-4b0d-952b-694b23fac6e4","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ce6eed16-bcc1-41b7-a8b6-2dc8810e6ce3","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1aa60946-1378-417f-901c-689d72a69dc1","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"59bb9b1e-73ac-44ca-87b4-a1031cdfdad6","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cec3d20a-f61f-4487-beb7-0ca63f6f6a9a","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0cccd0a2-9f23-4056-afc9-eba115d3c890","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"60a9db25-02c9-4577-8d3a-245865565e2c","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b37bc24d-7abd-418e-b23c-6599080e9358","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"be0c648e-d5ce-4904-9c2a-3f791235f141","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f3e26b6a-5f05-4ec1-8be8-3f1923539989","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"52975ff1-5c43-4f81-b35c-f55e4edd7623","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c1e270da-6a6f-47d3-8658-27621ebf66cf","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ca4c1f27-a85d-4b21-ad5e-db8afc2c7867","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ed1d1e1d-f164-4209-9b36-c823dc2ab8c9","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d73777ad-28ea-43a8-8644-0727632696de","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '18531'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:07:30 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59964'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTtmOGJiNGU2ZS0zOWFkLTRiMTYtYWYyYy05ZjNiYzA4M2ZjYzI=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Wed, 22 Apr 2020 12:07:33 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTtmOGJiNGU2ZS0zOWFkLTRiMTYtYWYyYy05ZjNiYzA4M2ZjYzI=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTtmOGJiNGU2ZS0zOWFkLTRiMTYtYWYyYy05ZjNiYzA4M2ZjYzI=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:08:05 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTswNjU2YmRiNi1hNmUwLTQxZmYtOTUzMy1kMGVkYmEyYmMyYzM=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:08:23 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTswNjU2YmRiNi1hNmUwLTQxZmYtOTUzMy1kMGVkYmEyYmMyYzM=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTswNjU2YmRiNi1hNmUwLTQxZmYtOTUzMy1kMGVkYmEyYmMyYzM=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:08:53 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com","name":"zone2.com","type":"Microsoft.Network\/privateDnsZones","etag":"cc747057-12f7-4c80-add7-718f5ef521ee","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:08:53 GMT
+      etag:
+      - cc747057-12f7-4c80-add7-718f5ef521ee
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '496'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"ccf52578-aae2-4d9a-9843-2dfdf044094e","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:08:54 GMT
+      etag:
+      - ccf52578-aae2-4d9a-9843-2dfdf044094e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "hostmaster.", "serialNumber": 1, "refreshTime": 900, "retryTime":
+      600, "expireTime": 86400, "minimumTtl": 3600}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '197'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b15e785e-54c7-4814-bc14-fabaf559bd91","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '569'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:08:55 GMT
+      etag:
+      - b15e785e-54c7-4814-bc14-fabaf559bd91
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -343,7 +2769,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"84c01b4f-eff1-49e0-9ed8-c39a7b9fbba7","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"43f5b1bf-2d17-43fd-a0f6-ca5dd7a704ff","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
         is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
         a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}}'
     headers:
@@ -354,9 +2780,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:02:45 GMT
+      - Wed, 22 Apr 2020 12:08:56 GMT
       etag:
-      - 84c01b4f-eff1-49e0-9ed8-c39a7b9fbba7
+      - 43f5b1bf-2d17-43fd-a0f6-ca5dd7a704ff
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -366,14 +2792,14 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
       code: 201
       message: Created
 - request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["  a  "]}]}}'
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}]}}'
     headers:
       Accept:
       - application/json
@@ -384,7 +2810,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '67'
+      - '71'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -395,129 +2821,21 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/spaces?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9c0fb31f-bf4e-41b0-9a1b-0370279137ac","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"568c3570-53e9-4531-9522-bae1dea19329","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '450'
+      - '451'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:02:46 GMT
+      - Wed, 22 Apr 2020 12:08:57 GMT
       etag:
-      - 9c0fb31f-bf4e-41b0-9a1b-0370279137ac
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}, {"ipv4Address":
-      "2.3.4.5"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '99'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/a2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1542e877-d4e5-4033-846e-458a5d2d3f2c","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '464'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:02:47 GMT
-      etag:
-      - 1542e877-d4e5-4033-846e-458a5d2d3f2c
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:cafe:130::100"},
-      {"ipv6Address": "2001:cafe:130::101"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '124'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/AAAA/aaaa2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"7eb8c34e-4fa2-4786-bdf0-e40f312c04ec","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '504'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:02:48 GMT
-      etag:
-      - 7eb8c34e-4fa2-4786-bdf0-e40f312c04ec
+      - 568c3570-53e9-4531-9522-bae1dea19329
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -534,7 +2852,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}]}}'
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foobar.com."},
+      {"ptrdname": "bar.com."}]}}'
     headers:
       Accept:
       - application/json
@@ -545,7 +2864,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '170'
+      - '100'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -556,346 +2875,21 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/doozie?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c451e862-8d1b-4427-9c82-9344d185236d","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"b76306b0-8075-42b0-a02f-1d5d496ec3fc","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '553'
+      - '478'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:02:50 GMT
+      - Wed, 22 Apr 2020 12:08:59 GMT
       etag:
-      - c451e862-8d1b-4427-9c82-9344d185236d
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "bar.com."}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '67'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/CNAME/fee2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"ae703705-0cd2-43eb-ab84-3d0d1a2c80d8","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '448'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:02:51 GMT
-      etag:
-      - ae703705-0cd2-43eb-ab84-3d0d1a2c80d8
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
-      "mail1.mymail.com."}, {"preference": 11, "exchange": "flooble."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '141'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/mail?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"3656fa8c-4eba-498e-9bcb-e2cf60fa1fa1","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '510'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:02:52 GMT
-      etag:
-      - 3656fa8c-4eba-498e-9bcb-e2cf60fa1fa1
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 10, "weight":
-      20, "port": 30, "target": "foobar."}, {"priority": 55, "weight": 66, "port":
-      77, "target": "zoo."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SRV/sip.tcp?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"24cbfe41-46df-4eda-a1a7-9589b230da1c","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '544'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:02:53 GMT
-      etag:
-      - 24cbfe41-46df-4eda-a1a7-9589b230da1c
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1"]}, {"value":
-      ["string 2"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '95'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/test-txt2?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"200f0f71-bc80-4a29-b0a7-d65a8d1f38f0","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
-        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '485'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:02:54 GMT
-      etag:
-      - 200f0f71-bc80-4a29-b0a7-d65a8d1f38f0
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "4.5.6.7"}, {"ipv4Address":
-      "6.7.8.9"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '98'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/aa?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8acb290f-4208-48d9-acc8-fb9fa7d9b35f","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '463'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:02:56 GMT
-      etag:
-      - 8acb290f-4208-48d9-acc8-fb9fa7d9b35f
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 300, "mxRecords": [{"preference": 1, "exchange":
-      "foo.com.zone2.com."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '96'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/aa?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"83d861b1-0a55-45b0-a535-ea340859dfe2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '463'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:02:57 GMT
-      etag:
-      - 83d861b1-0a55-45b0-a535-ea340859dfe2
+      - b76306b0-8075-42b0-a02f-1d5d496ec3fc
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -937,7 +2931,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/200?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"146d97bc-71d1-4231-8d28-8c3c31932f1d","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d002a7f6-5b32-4b1e-83ab-692f7d62e9bb","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -946,9 +2940,711 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:02:59 GMT
+      - Wed, 22 Apr 2020 12:09:00 GMT
       etag:
-      - 146d97bc-71d1-4231-8d28-8c3c31932f1d
+      - d002a7f6-5b32-4b1e-83ab-692f7d62e9bb
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}, {"ptrdname":
+      "bar.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '97'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.3?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"951e5ffa-b3a7-4d52-b28e-c3f1116269ba","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:01 GMT
+      etag:
+      - 951e5ffa-b3a7-4d52-b28e-c3f1116269ba
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}, {"ipv4Address":
+      "2.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/a2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e091ac25-1941-4650-b427-2d778212e53a","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:02 GMT
+      etag:
+      - e091ac25-1941-4650-b427-2d778212e53a
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "4.5.6.7"}, {"ipv4Address":
+      "6.7.8.9"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/aa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ecf2d718-063c-459d-ba92-fd17ca7850a2","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:03 GMT
+      etag:
+      - ecf2d718-063c-459d-ba92-fd17ca7850a2
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 300, "mxRecords": [{"preference": 1, "exchange":
+      "foo.com.zone2.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/aa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a9cf811c-e189-42b9-8013-4e72bebbfdd2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:05 GMT
+      etag:
+      - a9cf811c-e189-42b9-8013-4e72bebbfdd2
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:cafe:130::100"},
+      {"ipv6Address": "2001:cafe:130::101"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '124'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/AAAA/aaaa2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"f82f7ae5-8e70-46c5-a73e-c40353f9a12b","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '504'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:06 GMT
+      etag:
+      - f82f7ae5-8e70-46c5-a73e-c40353f9a12b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a4322133-4d8b-41fe-9f69-dd82c4ad2ab6","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:07 GMT
+      etag:
+      - a4322133-4d8b-41fe-9f69-dd82c4ad2ab6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "be.xpiler.de."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"027dc470-d6f0-4647-926d-d98d93ae164a","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:09 GMT
+      etag:
+      - 027dc470-d6f0-4647-926d-d98d93ae164a
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xcaign.de
+      include:_spf6.xcaign.de -all"]}, {"value": ["spf2.0/mfrom,pra mx ip4:15.19.14.0/24
+      ip4:8.8.11.4/27 ip4:9.16.20.19/26 -all"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '217'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/base?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e59b2398-d021-4380-9d07-e98215d69c05","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '596'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:10 GMT
+      etag:
+      - e59b2398-d021-4380-9d07-e98215d69c05
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '170'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/doozie?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7dc58160-25fc-461e-b5fc-beedd75d73fa","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '553'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:11 GMT
+      etag:
+      - 7dc58160-25fc-461e-b5fc-beedd75d73fa
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11992'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"62718b52-4ba1-4a0d-b3aa-26fc2338b629","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:13 GMT
+      etag:
+      - 62718b52-4ba1-4a0d-b3aa-26fc2338b629
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "be.xpiler.de."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"2a2a73f6-f202-49e4-8ca1-670f32a936ca","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:14 GMT
+      etag:
+      - 2a2a73f6-f202-49e4-8ca1-670f32a936ca
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xgn.de
+      include:_spf6.xgn.de -all"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/even?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b89a3e57-c45e-4493-af61-013a4f711124","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '495'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:15 GMT
+      etag:
+      - b89a3e57-c45e-4493-af61-013a4f711124
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "bar.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/CNAME/fee2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"9a5a6127-e6d8-4888-a933-fa8b2c06c174","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '448'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:17 GMT
+      etag:
+      - 9a5a6127-e6d8-4888-a933-fa8b2c06c174
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1002,7 +3698,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"23ea6c51-4481-4b75-97c4-6ede006b467c","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"461f7a97-c347-4963-934f-d90c43cd0e2f","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
         is a super long txt record...wow, it is really really long!  And I even used
         copy and paste to make it longer....this is a super long txt record...wow,
         it is really really long!  And I even used copy and paste to make it longer....this
@@ -1023,9 +3719,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:00 GMT
+      - Wed, 22 Apr 2020 12:09:18 GMT
       etag:
-      - 23ea6c51-4481-4b75-97c4-6ede006b467c
+      - 461f7a97-c347-4963-934f-d90c43cd0e2f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1035,7 +3731,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
@@ -1068,7 +3764,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/longtxt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a56e3b35-229c-4ffa-bc5f-cfc71d85e8e1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b952a0e0-ab87-467d-bc66-62e98bfc61a8","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1077,9 +3773,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:01 GMT
+      - Wed, 22 Apr 2020 12:09:20 GMT
       etag:
-      - a56e3b35-229c-4ffa-bc5f-cfc71d85e8e1
+      - b952a0e0-ab87-467d-bc66-62e98bfc61a8
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1089,7 +3785,61 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11991'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "mail1.mymail.com."}, {"preference": 11, "exchange": "flooble."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '141'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/mail?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"95f393da-84f6-4af6-ab35-f0bc5dac9db6","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '510'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:09:21 GMT
+      etag:
+      - 95f393da-84f6-4af6-ab35-f0bc5dac9db6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -1122,7 +3872,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/myspf?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d4e09f6f-fca8-45fb-a83d-cc6af4a2c9ef","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"870aa492-4232-461b-bd8f-9ce8608d06d7","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
         is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -1132,9 +3882,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:02 GMT
+      - Wed, 22 Apr 2020 12:09:22 GMT
       etag:
-      - d4e09f6f-fca8-45fb-a83d-cc6af4a2c9ef
+      - 870aa492-4232-461b-bd8f-9ce8608d06d7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1144,14 +3894,14 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11989'
       x-powered-by:
       - ASP.NET
     status:
       code: 201
       message: Created
 - request:
-    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}]}}'
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["  a  "]}]}}'
     headers:
       Accept:
       - application/json
@@ -1162,7 +3912,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '71'
+      - '67'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -1173,21 +3923,21 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.1?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/spaces?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c97b6c02-e644-42e5-bf33-52d15bd2efc7","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"33d7b8f5-91da-46e2-832b-bf6f38bdf554","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '451'
+      - '450'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:03 GMT
+      - Wed, 22 Apr 2020 12:09:22 GMT
       etag:
-      - c97b6c02-e644-42e5-bf33-52d15bd2efc7
+      - 33d7b8f5-91da-46e2-832b-bf6f38bdf554
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1197,15 +3947,14 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
       code: 201
       message: Created
 - request:
-    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foobar.com."},
-      {"ptrdname": "bar.com."}]}}'
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
     headers:
       Accept:
       - application/json
@@ -1216,7 +3965,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '100'
+      - '68'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -1227,21 +3976,21 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.2?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"18268251-772e-4ee9-8788-2c7430eda3b9","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6f400350-191b-4f13-96fa-de6d1bf76ec6","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '478'
+      - '439'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:04 GMT
+      - Wed, 22 Apr 2020 12:09:23 GMT
       etag:
-      - 18268251-772e-4ee9-8788-2c7430eda3b9
+      - 6f400350-191b-4f13-96fa-de6d1bf76ec6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1251,15 +4000,14 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
       code: 201
       message: Created
 - request:
-    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "foo.com."}, {"ptrdname":
-      "bar.com."}]}}'
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo bar"]}]}}'
     headers:
       Accept:
       - application/json
@@ -1270,7 +4018,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '97'
+      - '69'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -1281,21 +4029,22 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/PTR/160.3?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t10?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"af4e55b1-6337-409b-8d0a-0c6570e48307","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1976cd9c-802c-42f6-b433-4bf7e7e8c486","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '475'
+      - '443'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:05 GMT
+      - Wed, 22 Apr 2020 12:09:25 GMT
       etag:
-      - af4e55b1-6337-409b-8d0a-0c6570e48307
+      - 1976cd9c-802c-42f6-b433-4bf7e7e8c486
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1334,21 +4083,21 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t1?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t11?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"777e5139-9536-496c-a51c-0694cab6332c","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"dba76788-c6db-43b7-b221-f89679c86a07","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '439'
+      - '442'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:07 GMT
+      - Wed, 22 Apr 2020 12:09:26 GMT
       etag:
-      - 777e5139-9536-496c-a51c-0694cab6332c
+      - dba76788-c6db-43b7-b221-f89679c86a07
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1358,7 +4107,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -1390,7 +4139,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"309f5ec5-54ce-468a-a76a-d520924caf0d","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"57c25c3a-6af2-46cf-9c88-b2a643128bb8","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1399,9 +4148,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:08 GMT
+      - Wed, 22 Apr 2020 12:09:27 GMT
       etag:
-      - 309f5ec5-54ce-468a-a76a-d520924caf0d
+      - 57c25c3a-6af2-46cf-9c88-b2a643128bb8
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1411,7 +4160,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -1443,7 +4192,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t3?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a1b2bf1-549f-4bf0-9605-beeff2eb1f6d","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"abb6fe29-927b-4243-ab5d-70d7dad0192e","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1452,9 +4201,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:09 GMT
+      - Wed, 22 Apr 2020 12:09:28 GMT
       etag:
-      - 6a1b2bf1-549f-4bf0-9605-beeff2eb1f6d
+      - abb6fe29-927b-4243-ab5d-70d7dad0192e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1464,7 +4213,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -1496,7 +4245,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t4?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e0cf41a3-1678-4fd2-8cb6-e4008480c7f0","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4bef976c-99bb-4b12-a25d-bc153569ac39","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1505,9 +4254,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:11 GMT
+      - Wed, 22 Apr 2020 12:09:30 GMT
       etag:
-      - e0cf41a3-1678-4fd2-8cb6-e4008480c7f0
+      - 4bef976c-99bb-4b12-a25d-bc153569ac39
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1517,7 +4266,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -1549,7 +4298,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t5?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35fd720b-1ae8-48d2-8c33-5d636b294acd","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ca6a6d47-272b-4a33-9b67-be464b0e459f","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1558,9 +4307,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:12 GMT
+      - Wed, 22 Apr 2020 12:09:31 GMT
       etag:
-      - 35fd720b-1ae8-48d2-8c33-5d636b294acd
+      - ca6a6d47-272b-4a33-9b67-be464b0e459f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1570,7 +4319,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -1602,7 +4351,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t6?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3aa17418-c8d0-4175-899d-17292e3706a2","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d1e6d3fc-84b2-4afa-b9ca-4929ab73a9a7","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1611,9 +4360,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:13 GMT
+      - Wed, 22 Apr 2020 12:09:32 GMT
       etag:
-      - 3aa17418-c8d0-4175-899d-17292e3706a2
+      - d1e6d3fc-84b2-4afa-b9ca-4929ab73a9a7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1623,7 +4372,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -1655,7 +4404,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t7?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"599cd463-8182-4ec6-a342-a7404d9c256e","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f271bc95-acc0-403d-b6f0-99cbb71b72b0","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
         string\\\""]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -1665,9 +4414,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:15 GMT
+      - Wed, 22 Apr 2020 12:09:33 GMT
       etag:
-      - 599cd463-8182-4ec6-a342-a7404d9c256e
+      - f271bc95-acc0-403d-b6f0-99cbb71b72b0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1709,7 +4458,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t8?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cac04611-68bd-4c6b-948e-91651f96db3c","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fa6cf116-616d-40ea-b4d2-1206b2872cfb","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1718,9 +4467,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:15 GMT
+      - Wed, 22 Apr 2020 12:09:34 GMT
       etag:
-      - cac04611-68bd-4c6b-948e-91651f96db3c
+      - fa6cf116-616d-40ea-b4d2-1206b2872cfb
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1762,7 +4511,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t9?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bd0637aa-377b-4263-8f09-3fd7b7cce108","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f9ccfffc-4d9d-48fe-8fde-25f8c529de98","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1771,9 +4520,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:16 GMT
+      - Wed, 22 Apr 2020 12:09:36 GMT
       etag:
-      - bd0637aa-377b-4263-8f09-3fd7b7cce108
+      - f9ccfffc-4d9d-48fe-8fde-25f8c529de98
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1783,14 +4532,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11988'
       x-powered-by:
       - ASP.NET
     status:
       code: 201
       message: Created
 - request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foo bar"]}]}}'
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 10, "weight":
+      20, "port": 30, "target": "foobar."}, {"priority": 55, "weight": 66, "port":
+      77, "target": "zoo."}]}}'
     headers:
       Accept:
       - application/json
@@ -1801,7 +4552,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '69'
+      - '172'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -1812,182 +4563,21 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t10?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SRV/sip.tcp?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8784c942-4849-4891-b612-ab329d808a8a","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
-        bar"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"02ca9529-bfbb-4b37-a03e-43b8fc7c06db","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '443'
+      - '544'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:18 GMT
+      - Wed, 22 Apr 2020 12:09:37 GMT
       etag:
-      - 8784c942-4849-4891-b612-ab329d808a8a
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["foobar"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '68'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/t11?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"57ede89f-5f8f-4221-a429-f9d6ac0d502d","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '442'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:03:19 GMT
-      etag:
-      - 57ede89f-5f8f-4221-a429-f9d6ac0d502d
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11991'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/base?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6e6da7ae-0621-4306-a2a2-8a5617f67128","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '452'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:03:20 GMT
-      etag:
-      - 6e6da7ae-0621-4306-a2a2-8a5617f67128
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
-      "be.xpiler.de."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '93'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/base?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"54784f74-b0bf-47cc-a2e3-7574d2fddd3e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '466'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:03:21 GMT
-      etag:
-      - 54784f74-b0bf-47cc-a2e3-7574d2fddd3e
+      - 02ca9529-bfbb-4b37-a03e-43b8fc7c06db
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2004,9 +4594,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xcaign.de
-      include:_spf6.xcaign.de -all"]}, {"value": ["spf2.0/mfrom,pra mx ip4:15.19.14.0/24
-      ip4:8.8.11.4/27 ip4:9.16.20.19/26 -all"]}]}}'
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1"]}, {"value":
+      ["string 2"]}]}}'
     headers:
       Accept:
       - application/json
@@ -2017,7 +4606,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '217'
+      - '95'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -2028,23 +4617,22 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/base?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/test-txt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"68fb706b-f996-42da-9266-9feadf0c0056","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
-        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"aa989be5-c29d-4fd1-ab30-f6e74f16e782","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '596'
+      - '485'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:23 GMT
+      - Wed, 22 Apr 2020 12:09:38 GMT
       etag:
-      - 68fb706b-f996-42da-9266-9feadf0c0056
+      - aa989be5-c29d-4fd1-ab30-f6e74f16e782
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2054,169 +4642,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "194.124.202.114"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/A/even?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4d49f9f9-9c01-4dc9-a961-00ba66ca9e25","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '452'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:03:24 GMT
-      etag:
-      - 4d49f9f9-9c01-4dc9-a961-00ba66ca9e25
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
-      "be.xpiler.de."}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '93'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/MX/even?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a2f13a19-1f6a-45e0-b575-a526053431e7","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '466'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:03:25 GMT
-      etag:
-      - a2f13a19-1f6a-45e0-b575-a526053431e7
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["v=spf1 mx include:_spf4.xgn.de
-      include:_spf6.xgn.de -all"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '118'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/TXT/even?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"95089462-e006-4531-a903-7ff90a4d39be","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '495'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:03:27 GMT
-      etag:
-      - 95089462-e006-4531-a903-7ff90a4d39be
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11987'
       x-powered-by:
       - ASP.NET
     status:
@@ -2244,12 +4670,12 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c97b6c02-e644-42e5-bf33-52d15bd2efc7","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"18268251-772e-4ee9-8788-2c7430eda3b9","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"146d97bc-71d1-4231-8d28-8c3c31932f1d","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"af4e55b1-6337-409b-8d0a-0c6570e48307","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5e89f385-9cb1-4f51-bff1-37dd4dc7f330","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"84c01b4f-eff1-49e0-9ed8-c39a7b9fbba7","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"568c3570-53e9-4531-9522-bae1dea19329","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"b76306b0-8075-42b0-a02f-1d5d496ec3fc","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d002a7f6-5b32-4b1e-83ab-692f7d62e9bb","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"951e5ffa-b3a7-4d52-b28e-c3f1116269ba","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b15e785e-54c7-4814-bc14-fabaf559bd91","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"43f5b1bf-2d17-43fd-a0f6-ca5dd7a704ff","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
         is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
-        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1542e877-d4e5-4033-846e-458a5d2d3f2c","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8acb290f-4208-48d9-acc8-fb9fa7d9b35f","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"83d861b1-0a55-45b0-a535-ea340859dfe2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"7eb8c34e-4fa2-4786-bdf0-e40f312c04ec","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6e6da7ae-0621-4306-a2a2-8a5617f67128","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"54784f74-b0bf-47cc-a2e3-7574d2fddd3e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"68fb706b-f996-42da-9266-9feadf0c0056","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e091ac25-1941-4650-b427-2d778212e53a","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ecf2d718-063c-459d-ba92-fd17ca7850a2","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a9cf811c-e189-42b9-8013-4e72bebbfdd2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"f82f7ae5-8e70-46c5-a73e-c40353f9a12b","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a4322133-4d8b-41fe-9f69-dd82c4ad2ab6","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"027dc470-d6f0-4647-926d-d98d93ae164a","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e59b2398-d021-4380-9d07-e98215d69c05","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
         mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
-        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c451e862-8d1b-4427-9c82-9344d185236d","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4d49f9f9-9c01-4dc9-a961-00ba66ca9e25","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a2f13a19-1f6a-45e0-b575-a526053431e7","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"95089462-e006-4531-a903-7ff90a4d39be","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"ae703705-0cd2-43eb-ab84-3d0d1a2c80d8","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"23ea6c51-4481-4b75-97c4-6ede006b467c","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
+        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7dc58160-25fc-461e-b5fc-beedd75d73fa","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"62718b52-4ba1-4a0d-b3aa-26fc2338b629","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"2a2a73f6-f202-49e4-8ca1-670f32a936ca","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b89a3e57-c45e-4493-af61-013a4f711124","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
+        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"9a5a6127-e6d8-4888-a933-fa8b2c06c174","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"461f7a97-c347-4963-934f-d90c43cd0e2f","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
         is a super long txt record...wow, it is really really long!  And I even used
         copy and paste to make it longer....this is a super long txt record...wow,
         it is really really long!  And I even used copy and paste to make it longer....this
@@ -2261,10 +4687,10 @@ interactions:
         it is really really long!  And I even used copy and paste to make it longer....this
         is a super long txt record...wow, it is really reall","y long!  And I even
         used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a56e3b35-229c-4ffa-bc5f-cfc71d85e8e1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"3656fa8c-4eba-498e-9bcb-e2cf60fa1fa1","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d4e09f6f-fca8-45fb-a83d-cc6af4a2c9ef","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
-        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9c0fb31f-bf4e-41b0-9a1b-0370279137ac","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"777e5139-9536-496c-a51c-0694cab6332c","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8784c942-4849-4891-b612-ab329d808a8a","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
-        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"57ede89f-5f8f-4221-a429-f9d6ac0d502d","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"309f5ec5-54ce-468a-a76a-d520924caf0d","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a1b2bf1-549f-4bf0-9605-beeff2eb1f6d","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e0cf41a3-1678-4fd2-8cb6-e4008480c7f0","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35fd720b-1ae8-48d2-8c33-5d636b294acd","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3aa17418-c8d0-4175-899d-17292e3706a2","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"599cd463-8182-4ec6-a342-a7404d9c256e","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
-        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cac04611-68bd-4c6b-948e-91651f96db3c","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bd0637aa-377b-4263-8f09-3fd7b7cce108","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"24cbfe41-46df-4eda-a1a7-9589b230da1c","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"200f0f71-bc80-4a29-b0a7-d65a8d1f38f0","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
+        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"b952a0e0-ab87-467d-bc66-62e98bfc61a8","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"95f393da-84f6-4af6-ab35-f0bc5dac9db6","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"870aa492-4232-461b-bd8f-9ce8608d06d7","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
+        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"33d7b8f5-91da-46e2-832b-bf6f38bdf554","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6f400350-191b-4f13-96fa-de6d1bf76ec6","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1976cd9c-802c-42f6-b433-4bf7e7e8c486","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
+        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"dba76788-c6db-43b7-b221-f89679c86a07","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"57c25c3a-6af2-46cf-9c88-b2a643128bb8","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"abb6fe29-927b-4243-ab5d-70d7dad0192e","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4bef976c-99bb-4b12-a25d-bc153569ac39","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ca6a6d47-272b-4a33-9b67-be464b0e459f","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d1e6d3fc-84b2-4afa-b9ca-4929ab73a9a7","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f271bc95-acc0-403d-b6f0-99cbb71b72b0","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
+        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"fa6cf116-616d-40ea-b4d2-1206b2872cfb","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f9ccfffc-4d9d-48fe-8fde-25f8c529de98","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"02ca9529-bfbb-4b37-a03e-43b8fc7c06db","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"aa989be5-c29d-4fd1-ab30-f6e74f16e782","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
@@ -2274,7 +4700,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 22 Apr 2020 09:03:27 GMT
+      - Wed, 22 Apr 2020 12:09:39 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2289,233 +4715,6 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59964'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone export
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/SOA?api-version=2018-09-01
-  response:
-    body:
-      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5e89f385-9cb1-4f51-bff1-37dd4dc7f330","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}}]}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '581'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:03:29 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59999'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone export
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com/ALL?api-version=2018-09-01
-  response:
-    body:
-      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.1","name":"160.1","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"c97b6c02-e644-42e5-bf33-52d15bd2efc7","properties":{"fqdn":"160.1.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.2","name":"160.2","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"18268251-772e-4ee9-8788-2c7430eda3b9","properties":{"fqdn":"160.2.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foobar.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/200","name":"200","type":"Microsoft.Network\/privateDnsZones\/A","etag":"146d97bc-71d1-4231-8d28-8c3c31932f1d","properties":{"fqdn":"200.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/PTR\/160.3","name":"160.3","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"af4e55b1-6337-409b-8d0a-0c6570e48307","properties":{"fqdn":"160.3.zone2.com.","ttl":3600,"ptrRecords":[{"ptrdname":"foo.com."},{"ptrdname":"bar.com."}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5e89f385-9cb1-4f51-bff1-37dd4dc7f330","properties":{"fqdn":"zone2.com.","ttl":3600,"soaRecord":{"email":"hostmaster.","expireTime":86400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":900,"retryTime":600,"serialNumber":1,"minimumTtl":3600},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"84c01b4f-eff1-49e0-9ed8-c39a7b9fbba7","properties":{"fqdn":"zone2.com.","ttl":200,"txtRecords":[{"value":["this
-        is another SPF, this time as TXT"]},{"value":["v=spf1 mx ip4:14.14.22.0\/23
-        a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/a2","name":"a2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1542e877-d4e5-4033-846e-458a5d2d3f2c","properties":{"fqdn":"a2.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8acb290f-4208-48d9-acc8-fb9fa7d9b35f","properties":{"fqdn":"aa.zone2.com.","ttl":100,"aRecords":[{"ipv4Address":"4.5.6.7"},{"ipv4Address":"6.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/aa","name":"aa","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"83d861b1-0a55-45b0-a535-ea340859dfe2","properties":{"fqdn":"aa.zone2.com.","ttl":300,"mxRecords":[{"exchange":"foo.com.zone2.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/AAAA\/aaaa2","name":"aaaa2","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"7eb8c34e-4fa2-4786-bdf0-e40f312c04ec","properties":{"fqdn":"aaaa2.zone2.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"},{"ipv6Address":"2001:cafe:130::101"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6e6da7ae-0621-4306-a2a2-8a5617f67128","properties":{"fqdn":"base.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"54784f74-b0bf-47cc-a2e3-7574d2fddd3e","properties":{"fqdn":"base.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/base","name":"base","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"68fb706b-f996-42da-9266-9feadf0c0056","properties":{"fqdn":"base.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all"]},{"value":["spf2.0\/mfrom,pra
-        mx ip4:15.19.14.0\/24 ip4:8.8.11.4\/27 ip4:9.16.20.19\/26 -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/doozie","name":"doozie","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c451e862-8d1b-4427-9c82-9344d185236d","properties":{"fqdn":"doozie.zone2.com.","ttl":3600,"txtRecords":[{"value":["abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz1234567890"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/A\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4d49f9f9-9c01-4dc9-a961-00ba66ca9e25","properties":{"fqdn":"even.zone2.com.","ttl":3600,"aRecords":[{"ipv4Address":"194.124.202.114"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a2f13a19-1f6a-45e0-b575-a526053431e7","properties":{"fqdn":"even.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"be.xpiler.de.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/even","name":"even","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"95089462-e006-4531-a903-7ff90a4d39be","properties":{"fqdn":"even.zone2.com.","ttl":3600,"txtRecords":[{"value":["v=spf1
-        mx include:_spf4.xgn.de include:_spf6.xgn.de -all"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/CNAME\/fee2","name":"fee2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"ae703705-0cd2-43eb-ab84-3d0d1a2c80d8","properties":{"fqdn":"fee2.zone2.com.","ttl":3600,"cnameRecord":{"cname":"bar.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"23ea6c51-4481-4b75-97c4-6ede006b467c","properties":{"fqdn":"longtxt.zone2.com.","ttl":999,"txtRecords":[{"value":["this
-        is a super long txt record...wow, it is really really long!  And I even used
-        copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super lon","g txt record...wow, it is really really long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super long txt record...wow,"," it is really really long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer....this
-        is a super long txt record...wow, it is really reall","y long!  And I even
-        used copy and paste to make it longer....this is a super long txt record...wow,
-        it is really really long!  And I even used copy and paste to make it longer...."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/longtxt2","name":"longtxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"a56e3b35-229c-4ffa-bc5f-cfc71d85e8e1","properties":{"fqdn":"longtxt2.zone2.com.","ttl":100,"txtRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"3656fa8c-4eba-498e-9bcb-e2cf60fa1fa1","properties":{"fqdn":"mail.zone2.com.","ttl":3600,"mxRecords":[{"exchange":"mail1.mymail.com.","preference":10},{"exchange":"flooble.","preference":11}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/myspf","name":"myspf","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"d4e09f6f-fca8-45fb-a83d-cc6af4a2c9ef","properties":{"fqdn":"myspf.zone2.com.","ttl":100,"txtRecords":[{"value":["this
-        is an SPF record! Convert to TXT on import"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/spaces","name":"spaces","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9c0fb31f-bf4e-41b0-9a1b-0370279137ac","properties":{"fqdn":"spaces.zone2.com.","ttl":3600,"txtRecords":[{"value":["  a  "]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t1","name":"t1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"777e5139-9536-496c-a51c-0694cab6332c","properties":{"fqdn":"t1.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t10","name":"t10","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8784c942-4849-4891-b612-ab329d808a8a","properties":{"fqdn":"t10.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo
-        bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t11","name":"t11","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"57ede89f-5f8f-4221-a429-f9d6ac0d502d","properties":{"fqdn":"t11.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t2","name":"t2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"309f5ec5-54ce-468a-a76a-d520924caf0d","properties":{"fqdn":"t2.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t3","name":"t3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a1b2bf1-549f-4bf0-9605-beeff2eb1f6d","properties":{"fqdn":"t3.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t4","name":"t4","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e0cf41a3-1678-4fd2-8cb6-e4008480c7f0","properties":{"fqdn":"t4.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t5","name":"t5","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35fd720b-1ae8-48d2-8c33-5d636b294acd","properties":{"fqdn":"t5.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t6","name":"t6","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3aa17418-c8d0-4175-899d-17292e3706a2","properties":{"fqdn":"t6.zone2.com.","ttl":3600,"txtRecords":[{"value":["foo\\;bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t7","name":"t7","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"599cd463-8182-4ec6-a342-a7404d9c256e","properties":{"fqdn":"t7.zone2.com.","ttl":3600,"txtRecords":[{"value":["\\\"quoted
-        string\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t8","name":"t8","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cac04611-68bd-4c6b-948e-91651f96db3c","properties":{"fqdn":"t8.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/t9","name":"t9","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"bd0637aa-377b-4263-8f09-3fd7b7cce108","properties":{"fqdn":"t9.zone2.com.","ttl":3600,"txtRecords":[{"value":["foobarr"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/SRV\/sip.tcp","name":"sip.tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"24cbfe41-46df-4eda-a1a7-9589b230da1c","properties":{"fqdn":"sip.tcp.zone2.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foobar.","weight":20},{"port":77,"priority":55,"target":"zoo.","weight":66}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone2_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone2.com\/TXT\/test-txt2","name":"test-txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"200f0f71-bc80-4a29-b0a7-d65a8d1f38f0","properties":{"fqdn":"test-txt2.zone2.com.","ttl":3600,"txtRecords":[{"value":["string
-        1"]},{"value":["string 2"]}],"isAutoRegistered":false}}]}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '18531'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:03:29 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59964'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsZones/zone2.com?api-version=2018-09-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3NGQ2N2MxZC03OTA2LTQ5MWItOTg3Yy1hYjlhY2JjOWI1MTY=?api-version=2018-09-01
-      cache-control:
-      - private
-      content-length:
-      - '0'
-      date:
-      - Wed, 22 Apr 2020 09:03:32 GMT
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3NGQ2N2MxZC03OTA2LTQ5MWItOTg3Yy1hYjlhY2JjOWI1MTY=?api-version=2018-09-01
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone2_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3NGQ2N2MxZC03OTA2LTQ5MWItOTg3Yy1hYjlhY2JjOWI1MTY=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"Succeeded"}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '22'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 22 Apr 2020 09:04:02 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone3_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone3_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs4MTdlOGQ4Ny00Y2Y1LTQ2MjAtYWM4YS1kZjg2MzY2ZTI1ZDY=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTthYzUyYmU3Yi0xNGI3LTQxZWEtYmJlNi0yZDE2M2UzOTZmODM=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:42:36 GMT
+      - Tue, 21 Apr 2020 05:19:13 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs4MTdlOGQ4Ny00Y2Y1LTQ2MjAtYWM4YS1kZjg2MzY2ZTI1ZDY=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTthYzUyYmU3Yi0xNGI3LTQxZWEtYmJlNi0yZDE2M2UzOTZmODM=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -48,7 +48,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -70,75 +70,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTthYzUyYmU3Yi0xNGI3LTQxZWEtYmJlNi0yZDE2M2UzOTZmODM=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"9cf323ef-cd7c-418d-9413-7c21b3eaf4f1","properties":{"fqdn":"zone3.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:06 GMT
-      etag:
-      - 9cf323ef-cd7c-418d-9413-7c21b3eaf4f1
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com","name":"zone3.com","type":"Microsoft.Network\/privateDnsZones","etag":"25322e6d-bf83-4a86-8301-331eaca060b9","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '613'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:43:07 GMT
-      etag:
-      - 25322e6d-bf83-4a86-8301-331eaca060b9
+      - Tue, 21 Apr 2020 05:19:44 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -186,7 +131,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1e4063f6-5d89-43dd-86b2-9dddfd44c3a7","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f06895a4-2f71-48b8-acd2-87c43af1e0de","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -195,9 +140,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:08 GMT
+      - Tue, 21 Apr 2020 05:19:45 GMT
       etag:
-      - 1e4063f6-5d89-43dd-86b2-9dddfd44c3a7
+      - f06895a4-2f71-48b8-acd2-87c43af1e0de
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -211,7 +156,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -243,7 +188,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/test-a?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bfc75aaf-62fa-4ac0-969a-213394f806f6","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"216df201-2724-4d41-a171-e738c37a3fea","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -252,9 +197,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:09 GMT
+      - Tue, 21 Apr 2020 05:19:46 GMT
       etag:
-      - bfc75aaf-62fa-4ac0-969a-213394f806f6
+      - 216df201-2724-4d41-a171-e738c37a3fea
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -264,7 +209,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
@@ -296,7 +241,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/AAAA/test-aaaa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"a9c800a2-8de7-4afb-af49-9791acbb106c","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"0dc07e20-baa3-4486-b298-40bab833bd19","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -305,9 +250,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:09 GMT
+      - Tue, 21 Apr 2020 05:19:47 GMT
       etag:
-      - a9c800a2-8de7-4afb-af49-9791acbb106c
+      - 0dc07e20-baa3-4486-b298-40bab833bd19
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -317,7 +262,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -349,7 +294,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"7d8965f8-6c49-4d48-b01d-44a8d742f7ec","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"010ddac1-821a-4e26-80ce-c36368fb217b","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -358,9 +303,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:11 GMT
+      - Tue, 21 Apr 2020 05:19:49 GMT
       etag:
-      - 7d8965f8-6c49-4d48-b01d-44a8d742f7ec
+      - 010ddac1-821a-4e26-80ce-c36368fb217b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -370,7 +315,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -402,7 +347,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"42ecbdea-0ed9-43f0-ad79-021e94582ce6","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d708aaa4-f950-4e5d-a840-96714268a554","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -411,9 +356,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:12 GMT
+      - Tue, 21 Apr 2020 05:19:50 GMT
       etag:
-      - 42ecbdea-0ed9-43f0-ad79-021e94582ce6
+      - d708aaa4-f950-4e5d-a840-96714268a554
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -423,7 +368,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -456,7 +401,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/test-mx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5e27478e-a797-4d5f-8ab9-dd62bd52298e","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a0067fc8-4ead-4996-a45d-a633422035e6","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -465,9 +410,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:13 GMT
+      - Tue, 21 Apr 2020 05:19:51 GMT
       etag:
-      - 5e27478e-a797-4d5f-8ab9-dd62bd52298e
+      - a0067fc8-4ead-4996-a45d-a633422035e6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -477,7 +422,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -510,7 +455,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp.test-srv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b941a6b8-f446-42ca-ab5d-5115fb0ed667","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"a9bd188d-e7c0-49ab-a17d-e2b26292e82e","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -519,9 +464,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:14 GMT
+      - Tue, 21 Apr 2020 05:19:52 GMT
       etag:
-      - b941a6b8-f446-42ca-ab5d-5115fb0ed667
+      - a9bd188d-e7c0-49ab-a17d-e2b26292e82e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -563,7 +508,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/test-txt?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"316c8e6e-8b58-4bb5-9622-68ad025fb3cd","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ea1b1c97-53ab-44e1-815e-c6c5a67e01df","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -573,9 +518,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:15 GMT
+      - Tue, 21 Apr 2020 05:19:54 GMT
       etag:
-      - 316c8e6e-8b58-4bb5-9622-68ad025fb3cd
+      - ea1b1c97-53ab-44e1-815e-c6c5a67e01df
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -585,7 +530,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -618,7 +563,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/d1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"937d3326-e7d6-4d2b-80d6-101360d31b06","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"29e2b6f1-9a64-4c8f-bf9a-71483d121d4c","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -627,9 +572,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:16 GMT
+      - Tue, 21 Apr 2020 05:19:55 GMT
       etag:
-      - 937d3326-e7d6-4d2b-80d6-101360d31b06
+      - 29e2b6f1-9a64-4c8f-bf9a-71483d121d4c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -639,7 +584,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
@@ -671,7 +616,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/d1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5f2224e7-d975-4d4f-84b4-9d2daa318c7d","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1b4fb960-0664-4518-ae2d-69d5ffc78ce2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -680,9 +625,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:18 GMT
+      - Tue, 21 Apr 2020 05:19:56 GMT
       etag:
-      - 5f2224e7-d975-4d4f-84b4-9d2daa318c7d
+      - 1b4fb960-0664-4518-ae2d-69d5ffc78ce2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -692,7 +637,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -725,7 +670,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0d931ac3-65c5-4c51-8596-5d3266693e77","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"67641fee-216b-42bf-ae1b-18e208323206","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -734,9 +679,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:19 GMT
+      - Tue, 21 Apr 2020 05:19:57 GMT
       etag:
-      - 0d931ac3-65c5-4c51-8596-5d3266693e77
+      - 67641fee-216b-42bf-ae1b-18e208323206
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -746,7 +691,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
@@ -779,7 +724,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"db47dd95-21b3-404a-ab13-e0505b817d4e","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe10633-879d-4ecb-92fd-865ff4a4f199","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -788,9 +733,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:20 GMT
+      - Tue, 21 Apr 2020 05:19:58 GMT
       etag:
-      - db47dd95-21b3-404a-ab13-e0505b817d4e
+      - 5fe10633-879d-4ecb-92fd-865ff4a4f199
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -800,7 +745,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
@@ -833,7 +778,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"e152cf6b-6db7-470d-a68a-7a7e4f3c93f8","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ed101b61-8fc7-4619-b6d9-85a0d5af239e","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -842,9 +787,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:21 GMT
+      - Tue, 21 Apr 2020 05:19:59 GMT
       etag:
-      - e152cf6b-6db7-470d-a68a-7a7e4f3c93f8
+      - ed101b61-8fc7-4619-b6d9-85a0d5af239e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -854,7 +799,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -887,7 +832,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/mail?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"90dc9221-6727-4106-8c72-9de8369cfe67","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7e0f5b70-2185-45de-a224-291bf8b1a3ee","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -896,9 +841,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:22 GMT
+      - Tue, 21 Apr 2020 05:20:00 GMT
       etag:
-      - 90dc9221-6727-4106-8c72-9de8369cfe67
+      - 7e0f5b70-2185-45de-a224-291bf8b1a3ee
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -908,7 +853,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -941,7 +886,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/noclass?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6efeb2dd-e996-4afc-bc3d-74956349d526","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"899377b9-75cf-40b1-8e8a-28696f13b42f","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -950,9 +895,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:23 GMT
+      - Tue, 21 Apr 2020 05:20:01 GMT
       etag:
-      - 6efeb2dd-e996-4afc-bc3d-74956349d526
+      - 899377b9-75cf-40b1-8e8a-28696f13b42f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -962,7 +907,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -994,7 +939,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0d85d807-c0d4-4d68-847c-0c8acdbe213f","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01b40f5b-9340-4be5-a6f3-191fd674a598","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
         1 only"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -1004,9 +949,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:24 GMT
+      - Tue, 21 Apr 2020 05:20:02 GMT
       etag:
-      - 0d85d807-c0d4-4d68-847c-0c8acdbe213f
+      - 01b40f5b-9340-4be5-a6f3-191fd674a598
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1016,7 +961,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
@@ -1048,7 +993,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35172986-ef84-46fe-af6a-cf828a5b5982","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"75826f37-d524-4783-bc9e-cb7bd1e2fd9f","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1057,9 +1002,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:25 GMT
+      - Tue, 21 Apr 2020 05:20:03 GMT
       etag:
-      - 35172986-ef84-46fe-af6a-cf828a5b5982
+      - 75826f37-d524-4783-bc9e-cb7bd1e2fd9f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1069,7 +1014,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
@@ -1105,7 +1050,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt3?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"443a747c-b114-4206-a7e5-d0c536a1b327","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"71cc050e-5299-48f5-a39f-ef66c4ff756e","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
@@ -1118,9 +1063,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:27 GMT
+      - Tue, 21 Apr 2020 05:20:04 GMT
       etag:
-      - 443a747c-b114-4206-a7e5-d0c536a1b327
+      - 71cc050e-5299-48f5-a39f-ef66c4ff756e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1130,7 +1075,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -1158,9 +1103,9 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1e4063f6-5d89-43dd-86b2-9dddfd44c3a7","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"e152cf6b-6db7-470d-a68a-7a7e4f3c93f8","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"937d3326-e7d6-4d2b-80d6-101360d31b06","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5f2224e7-d975-4d4f-84b4-9d2daa318c7d","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0d931ac3-65c5-4c51-8596-5d3266693e77","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"db47dd95-21b3-404a-ab13-e0505b817d4e","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"90dc9221-6727-4106-8c72-9de8369cfe67","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6efeb2dd-e996-4afc-bc3d-74956349d526","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bfc75aaf-62fa-4ac0-969a-213394f806f6","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"a9c800a2-8de7-4afb-af49-9791acbb106c","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"7d8965f8-6c49-4d48-b01d-44a8d742f7ec","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"42ecbdea-0ed9-43f0-ad79-021e94582ce6","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5e27478e-a797-4d5f-8ab9-dd62bd52298e","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b941a6b8-f446-42ca-ab5d-5115fb0ed667","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"316c8e6e-8b58-4bb5-9622-68ad025fb3cd","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0d85d807-c0d4-4d68-847c-0c8acdbe213f","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35172986-ef84-46fe-af6a-cf828a5b5982","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"443a747c-b114-4206-a7e5-d0c536a1b327","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f06895a4-2f71-48b8-acd2-87c43af1e0de","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ed101b61-8fc7-4619-b6d9-85a0d5af239e","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"29e2b6f1-9a64-4c8f-bf9a-71483d121d4c","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1b4fb960-0664-4518-ae2d-69d5ffc78ce2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"67641fee-216b-42bf-ae1b-18e208323206","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe10633-879d-4ecb-92fd-865ff4a4f199","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7e0f5b70-2185-45de-a224-291bf8b1a3ee","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"899377b9-75cf-40b1-8e8a-28696f13b42f","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"216df201-2724-4d41-a171-e738c37a3fea","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"0dc07e20-baa3-4486-b298-40bab833bd19","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"010ddac1-821a-4e26-80ce-c36368fb217b","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d708aaa4-f950-4e5d-a840-96714268a554","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a0067fc8-4ead-4996-a45d-a633422035e6","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"a9bd188d-e7c0-49ab-a17d-e2b26292e82e","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ea1b1c97-53ab-44e1-815e-c6c5a67e01df","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01b40f5b-9340-4be5-a6f3-191fd674a598","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"75826f37-d524-4783-bc9e-cb7bd1e2fd9f","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"71cc050e-5299-48f5-a39f-ef66c4ff756e","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
@@ -1173,7 +1118,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:26 GMT
+      - Tue, 21 Apr 2020 05:20:05 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1217,7 +1162,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1e4063f6-5d89-43dd-86b2-9dddfd44c3a7","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f06895a4-2f71-48b8-acd2-87c43af1e0de","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1226,7 +1171,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:27 GMT
+      - Tue, 21 Apr 2020 05:20:06 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1270,9 +1215,9 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1e4063f6-5d89-43dd-86b2-9dddfd44c3a7","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"e152cf6b-6db7-470d-a68a-7a7e4f3c93f8","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"937d3326-e7d6-4d2b-80d6-101360d31b06","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5f2224e7-d975-4d4f-84b4-9d2daa318c7d","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0d931ac3-65c5-4c51-8596-5d3266693e77","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"db47dd95-21b3-404a-ab13-e0505b817d4e","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"90dc9221-6727-4106-8c72-9de8369cfe67","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6efeb2dd-e996-4afc-bc3d-74956349d526","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bfc75aaf-62fa-4ac0-969a-213394f806f6","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"a9c800a2-8de7-4afb-af49-9791acbb106c","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"7d8965f8-6c49-4d48-b01d-44a8d742f7ec","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"42ecbdea-0ed9-43f0-ad79-021e94582ce6","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5e27478e-a797-4d5f-8ab9-dd62bd52298e","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b941a6b8-f446-42ca-ab5d-5115fb0ed667","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"316c8e6e-8b58-4bb5-9622-68ad025fb3cd","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0d85d807-c0d4-4d68-847c-0c8acdbe213f","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35172986-ef84-46fe-af6a-cf828a5b5982","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"443a747c-b114-4206-a7e5-d0c536a1b327","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f06895a4-2f71-48b8-acd2-87c43af1e0de","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ed101b61-8fc7-4619-b6d9-85a0d5af239e","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"29e2b6f1-9a64-4c8f-bf9a-71483d121d4c","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1b4fb960-0664-4518-ae2d-69d5ffc78ce2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"67641fee-216b-42bf-ae1b-18e208323206","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe10633-879d-4ecb-92fd-865ff4a4f199","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7e0f5b70-2185-45de-a224-291bf8b1a3ee","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"899377b9-75cf-40b1-8e8a-28696f13b42f","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"216df201-2724-4d41-a171-e738c37a3fea","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"0dc07e20-baa3-4486-b298-40bab833bd19","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"010ddac1-821a-4e26-80ce-c36368fb217b","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d708aaa4-f950-4e5d-a840-96714268a554","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a0067fc8-4ead-4996-a45d-a633422035e6","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"a9bd188d-e7c0-49ab-a17d-e2b26292e82e","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ea1b1c97-53ab-44e1-815e-c6c5a67e01df","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01b40f5b-9340-4be5-a6f3-191fd674a598","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"75826f37-d524-4783-bc9e-cb7bd1e2fd9f","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"71cc050e-5299-48f5-a39f-ef66c4ff756e","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
@@ -1285,7 +1230,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:43:27 GMT
+      - Tue, 21 Apr 2020 05:20:07 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1300,106 +1245,6 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59982'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com?api-version=2018-09-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTsxYTkzODFlZC03MWRkLTRkOWQtODNjYy01YTc4ZWVkNWVmNTc=?api-version=2018-09-01
-      cache-control:
-      - private
-      content-length:
-      - '0'
-      date:
-      - Thu, 16 Apr 2020 14:43:31 GMT
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTsxYTkzODFlZC03MWRkLTRkOWQtODNjYy01YTc4ZWVkNWVmNTc=?api-version=2018-09-01
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTsxYTkzODFlZC03MWRkLTRkOWQtODNjYy01YTc4ZWVkNWVmNTc=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"Succeeded"}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '22'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:44:01 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:
@@ -1436,7 +1281,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0OTYyYjE4Mi1mZWEyLTQwMmItODkyYi0xNTllOWE1NTYxZWM=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyNmE2OTRhYy0xOTk1LTQwZDktYjFiZS0yZmUyZWE1ZTljOWY=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -1444,9 +1289,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:44:28 GMT
+      - Tue, 21 Apr 2020 05:20:08 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0OTYyYjE4Mi1mZWEyLTQwMmItODkyYi0xNTllOWE1NTYxZWM=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyNmE2OTRhYy0xOTk1LTQwZDktYjFiZS0yZmUyZWE1ZTljOWY=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1456,7 +1301,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -1484,18 +1329,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"91a66d8f-88c8-4a11-a4ec-39a8c506c869","properties":{"fqdn":"zone3.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f06895a4-2f71-48b8-acd2-87c43af1e0de","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '585'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:44:59 GMT
+      - Tue, 21 Apr 2020 05:20:39 GMT
       etag:
-      - 91a66d8f-88c8-4a11-a4ec-39a8c506c869
+      - f06895a4-2f71-48b8-acd2-87c43af1e0de
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1509,7 +1354,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -1535,18 +1380,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com","name":"zone3.com","type":"Microsoft.Network\/privateDnsZones","etag":"757491b7-d80d-4820-ae74-af6343cf8ce6","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com","name":"zone3.com","type":"Microsoft.Network\/privateDnsZones","etag":"87865eef-f6f8-46c2-988f-74ad588dd241","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":18,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '613'
+      - '614'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:44:59 GMT
+      - Tue, 21 Apr 2020 05:20:39 GMT
       etag:
-      - 757491b7-d80d-4820-ae74-af6343cf8ce6
+      - 87865eef-f6f8-46c2-988f-74ad588dd241
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1594,7 +1439,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"61843d40-0ed2-4019-9cdf-3bf36c77f52d","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a55c6a12-2845-4cf0-a36a-23fb92336fd8","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1603,9 +1448,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:00 GMT
+      - Tue, 21 Apr 2020 05:20:39 GMT
       etag:
-      - 61843d40-0ed2-4019-9cdf-3bf36c77f52d
+      - a55c6a12-2845-4cf0-a36a-23fb92336fd8
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1652,7 +1497,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"8e8d1427-4b00-4d6e-9a49-5b28ea91e232","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"7a2dc68a-8f4c-4580-afc9-fa05fd35c0cf","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1661,24 +1506,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:00 GMT
+      - Tue, 21 Apr 2020 05:20:41 GMT
       etag:
-      - 8e8d1427-4b00-4d6e-9a49-5b28ea91e232
+      - 7a2dc68a-8f4c-4580-afc9-fa05fd35c0cf
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "12.1.2.3"},
       {"ipv4Address": "12.2.3.4"}, {"ipv4Address": "12.3.4.5"}, {"ipv4Address": "12.4.5.6"}]}}'
@@ -1706,7 +1555,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/d1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e5220f8c-82dd-479d-b0b3-32503a020a26","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6cd61512-cc56-4fe6-ac9a-0a400104f7b2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1715,24 +1564,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:02 GMT
+      - Tue, 21 Apr 2020 05:20:42 GMT
       etag:
-      - e5220f8c-82dd-479d-b0b3-32503a020a26
+      - 6cd61512-cc56-4fe6-ac9a-0a400104f7b2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11989'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["fishfishfish"]}]}}'
     headers:
@@ -1759,7 +1612,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/d1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c5f05bc1-6b97-4ba3-8b41-d1682f8ace0d","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f10ad4d3-5c96-457d-b378-4ee5898e9d40","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1768,13 +1621,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:03 GMT
+      - Tue, 21 Apr 2020 05:20:43 GMT
       etag:
-      - c5f05bc1-6b97-4ba3-8b41-d1682f8ace0d
+      - f10ad4d3-5c96-457d-b378-4ee5898e9d40
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -1784,8 +1641,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "11.1.2.3"},
       {"ipv4Address": "11.2.3.3"}]}}'
@@ -1813,7 +1670,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c1c76571-0202-4fb4-938c-b5ed69256dc6","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"21827f7b-cee0-4afa-8853-8f2b3ec467fe","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1822,24 +1679,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:03 GMT
+      - Tue, 21 Apr 2020 05:20:45 GMT
       etag:
-      - c1c76571-0202-4fb4-938c-b5ed69256dc6
+      - 21827f7b-cee0-4afa-8853-8f2b3ec467fe
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "11.2.3.4"},
       {"ipv4Address": "11.5.6.7"}]}}'
@@ -1867,7 +1728,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d237ca4d-bfe1-4835-a89d-956643121545","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ded63564-b6d6-4a63-8d7a-7c2157f3b97b","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1876,24 +1737,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:05 GMT
+      - Tue, 21 Apr 2020 05:20:46 GMT
       etag:
-      - d237ca4d-bfe1-4835-a89d-956643121545
+      - ded63564-b6d6-4a63-8d7a-7c2157f3b97b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 100, "exchange":
       "mail.test.com."}]}}'
@@ -1921,7 +1786,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/mail?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b4cde896-df83-4781-b090-bd95291ee436","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"ff0f6201-3dcd-41da-b351-a59429485798","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1930,24 +1795,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:05 GMT
+      - Tue, 21 Apr 2020 05:20:47 GMT
       etag:
-      - b4cde896-df83-4781-b090-bd95291ee436
+      - ff0f6201-3dcd-41da-b351-a59429485798
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}, {"ipv4Address":
       "2.3.4.5"}]}}'
@@ -1975,7 +1844,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/noclass?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e0c43f64-0ecb-48a9-b99c-839a4e1f1b04","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2d21410b-8c2a-486a-8773-0497f1b4cd1e","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1984,24 +1853,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:07 GMT
+      - Tue, 21 Apr 2020 05:20:49 GMT
       etag:
-      - e0c43f64-0ecb-48a9-b99c-839a4e1f1b04
+      - 2d21410b-8c2a-486a-8773-0497f1b4cd1e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11989'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}]}}'
     headers:
@@ -2028,7 +1901,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/test-a?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"633941ec-5f08-4af6-a4ef-7dc698271d94","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2b9e9dd6-b280-4502-85a7-a7de5964d6c6","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2037,13 +1910,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:08 GMT
+      - Tue, 21 Apr 2020 05:20:50 GMT
       etag:
-      - 633941ec-5f08-4af6-a4ef-7dc698271d94
+      - 2b9e9dd6-b280-4502-85a7-a7de5964d6c6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -2053,8 +1930,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:cafe:130::100"}]}}'
     headers:
@@ -2081,7 +1958,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/AAAA/test-aaaa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"2b09fc87-7e9f-4f7d-908f-1357d1ed6d4f","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"23e4c036-bbd2-43cf-af81-823bf74f89ed","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2090,13 +1967,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:09 GMT
+      - Tue, 21 Apr 2020 05:20:51 GMT
       etag:
-      - 2b09fc87-7e9f-4f7d-908f-1357d1ed6d4f
+      - 23e4c036-bbd2-43cf-af81-823bf74f89ed
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -2106,8 +1987,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "target.com."}}}'
     headers:
@@ -2134,7 +2015,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"55f01a7e-df15-4f83-8fd5-5af93d127bbd","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"33bde5da-8bc7-4aaf-b53a-a062bd66c365","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2143,24 +2024,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:10 GMT
+      - Tue, 21 Apr 2020 05:20:53 GMT
       etag:
-      - 55f01a7e-df15-4f83-8fd5-5af93d127bbd
+      - 33bde5da-8bc7-4aaf-b53a-a062bd66c365
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "target.org.zone3.com."}}}'
     headers:
@@ -2187,7 +2072,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"65a61adf-8242-48bc-8fd1-8210866fd85d","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"e32686ab-7673-4963-b031-3170cc800451","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2196,24 +2081,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:11 GMT
+      - Tue, 21 Apr 2020 05:20:54 GMT
       etag:
-      - 65a61adf-8242-48bc-8fd1-8210866fd85d
+      - e32686ab-7673-4963-b031-3170cc800451
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
       "mail.com."}]}}'
@@ -2241,7 +2130,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/test-mx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"617d47c2-60e0-4790-909e-61d3f4fd59e9","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"fb4b197e-90cd-4d01-acaa-0952e9d0ed36","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2250,24 +2139,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:13 GMT
+      - Tue, 21 Apr 2020 05:20:55 GMT
       etag:
-      - 617d47c2-60e0-4790-909e-61d3f4fd59e9
+      - fb4b197e-90cd-4d01-acaa-0952e9d0ed36
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
       "port": 3, "target": "target.com."}]}}'
@@ -2295,7 +2188,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp.test-srv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"c5f521a9-c895-4b5a-88ab-3037129e545c","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"727020dc-ef3c-44dd-a7a8-943223bff466","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2304,24 +2197,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:14 GMT
+      - Tue, 21 Apr 2020 05:20:56 GMT
       etag:
-      - c5f521a9-c895-4b5a-88ab-3037129e545c
+      - 727020dc-ef3c-44dd-a7a8-943223bff466
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1"]}]}}'
     headers:
@@ -2348,7 +2245,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/test-txt?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"136157bf-d1e1-4da7-84e8-380f1c4cb060","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e931238a-6aff-4272-814d-9b38df3f13ca","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -2358,24 +2255,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:15 GMT
+      - Tue, 21 Apr 2020 05:20:58 GMT
       etag:
-      - 136157bf-d1e1-4da7-84e8-380f1c4cb060
+      - e931238a-6aff-4272-814d-9b38df3f13ca
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1 only"]}]}}'
     headers:
@@ -2402,7 +2303,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"85850f2a-1303-4e4b-8d34-4d3fd18f2757","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cebca78d-8d05-4f6d-9a88-5bf1b0b181d7","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
         1 only"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -2412,24 +2313,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:16 GMT
+      - Tue, 21 Apr 2020 05:20:58 GMT
       etag:
-      - 85850f2a-1303-4e4b-8d34-4d3fd18f2757
+      - cebca78d-8d05-4f6d-9a88-5bf1b0b181d7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11988'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string1string2"]}]}}'
     headers:
@@ -2456,7 +2361,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e964e477-9c35-4e93-ac3c-9c99158a29c8","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"64e972db-600c-4ace-bcd7-e8bb0c83b176","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2465,24 +2370,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:17 GMT
+      - Tue, 21 Apr 2020 05:21:00 GMT
       etag:
-      - e964e477-9c35-4e93-ac3c-9c99158a29c8
+      - 64e972db-600c-4ace-bcd7-e8bb0c83b176
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11989'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["this is a very
       long string with lots of text, in fact is has 74 charactersthis is a very long
@@ -2513,7 +2422,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt3?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"15d1b05b-be4e-4f81-bb3e-0d0a765da0f3","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ce04615a-10b9-48f8-b65e-00dca88e7e33","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
@@ -2526,13 +2435,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:18 GMT
+      - Tue, 21 Apr 2020 05:21:02 GMT
       etag:
-      - 15d1b05b-be4e-4f81-bb3e-0d0a765da0f3
+      - ce04615a-10b9-48f8-b65e-00dca88e7e33
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -2542,8 +2455,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -2566,9 +2479,9 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"61843d40-0ed2-4019-9cdf-3bf36c77f52d","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"8e8d1427-4b00-4d6e-9a49-5b28ea91e232","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e5220f8c-82dd-479d-b0b3-32503a020a26","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c5f05bc1-6b97-4ba3-8b41-d1682f8ace0d","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c1c76571-0202-4fb4-938c-b5ed69256dc6","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d237ca4d-bfe1-4835-a89d-956643121545","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b4cde896-df83-4781-b090-bd95291ee436","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e0c43f64-0ecb-48a9-b99c-839a4e1f1b04","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"633941ec-5f08-4af6-a4ef-7dc698271d94","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"2b09fc87-7e9f-4f7d-908f-1357d1ed6d4f","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"55f01a7e-df15-4f83-8fd5-5af93d127bbd","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"65a61adf-8242-48bc-8fd1-8210866fd85d","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"617d47c2-60e0-4790-909e-61d3f4fd59e9","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"c5f521a9-c895-4b5a-88ab-3037129e545c","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"136157bf-d1e1-4da7-84e8-380f1c4cb060","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"85850f2a-1303-4e4b-8d34-4d3fd18f2757","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e964e477-9c35-4e93-ac3c-9c99158a29c8","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"15d1b05b-be4e-4f81-bb3e-0d0a765da0f3","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a55c6a12-2845-4cf0-a36a-23fb92336fd8","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"7a2dc68a-8f4c-4580-afc9-fa05fd35c0cf","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6cd61512-cc56-4fe6-ac9a-0a400104f7b2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f10ad4d3-5c96-457d-b378-4ee5898e9d40","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"21827f7b-cee0-4afa-8853-8f2b3ec467fe","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ded63564-b6d6-4a63-8d7a-7c2157f3b97b","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"ff0f6201-3dcd-41da-b351-a59429485798","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2d21410b-8c2a-486a-8773-0497f1b4cd1e","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2b9e9dd6-b280-4502-85a7-a7de5964d6c6","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"23e4c036-bbd2-43cf-af81-823bf74f89ed","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"33bde5da-8bc7-4aaf-b53a-a062bd66c365","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"e32686ab-7673-4963-b031-3170cc800451","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"fb4b197e-90cd-4d01-acaa-0952e9d0ed36","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"727020dc-ef3c-44dd-a7a8-943223bff466","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e931238a-6aff-4272-814d-9b38df3f13ca","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cebca78d-8d05-4f6d-9a88-5bf1b0b181d7","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"64e972db-600c-4ace-bcd7-e8bb0c83b176","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ce04615a-10b9-48f8-b65e-00dca88e7e33","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
@@ -2581,7 +2494,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:19 GMT
+      - Tue, 21 Apr 2020 05:21:02 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2595,9 +2508,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59982'
+      - '59964'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone3_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone3_Import.yaml
@@ -1,0 +1,2606 @@
+interactions:
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs4MTdlOGQ4Ny00Y2Y1LTQ2MjAtYWM4YS1kZjg2MzY2ZTI1ZDY=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:42:36 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs4MTdlOGQ4Ny00Y2Y1LTQ2MjAtYWM4YS1kZjg2MzY2ZTI1ZDY=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"9cf323ef-cd7c-418d-9413-7c21b3eaf4f1","properties":{"fqdn":"zone3.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:06 GMT
+      etag:
+      - 9cf323ef-cd7c-418d-9413-7c21b3eaf4f1
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com","name":"zone3.com","type":"Microsoft.Network\/privateDnsZones","etag":"25322e6d-bf83-4a86-8301-331eaca060b9","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:07 GMT
+      etag:
+      - 25322e6d-bf83-4a86-8301-331eaca060b9
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 86400, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "hostmaster.zone3.com.", "serialNumber": 2003080800, "refreshTime":
+      43200, "retryTime": 900, "expireTime": 1814400, "minimumTtl": 10800}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1e4063f6-5d89-43dd-86b2-9dddfd44c3a7","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '585'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:08 GMT
+      etag:
+      - 1e4063f6-5d89-43dd-86b2-9dddfd44c3a7
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/test-a?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bfc75aaf-62fa-4ac0-969a-213394f806f6","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:09 GMT
+      etag:
+      - bfc75aaf-62fa-4ac0-969a-213394f806f6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:cafe:130::100"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/AAAA/test-aaaa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"a9c800a2-8de7-4afb-af49-9791acbb106c","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '479'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:09 GMT
+      etag:
+      - a9c800a2-8de7-4afb-af49-9791acbb106c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "target.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"7d8965f8-6c49-4d48-b01d-44a8d742f7ec","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '469'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:11 GMT
+      etag:
+      - 7d8965f8-6c49-4d48-b01d-44a8d742f7ec
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "target.org.zone3.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '80'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"42ecbdea-0ed9-43f0-ad79-021e94582ce6","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '482'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:12 GMT
+      etag:
+      - 42ecbdea-0ed9-43f0-ad79-021e94582ce6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "mail.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/test-mx?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5e27478e-a797-4d5f-8ab9-dd62bd52298e","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '471'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:13 GMT
+      etag:
+      - 5e27478e-a797-4d5f-8ab9-dd62bd52298e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
+      "port": 3, "target": "target.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '111'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp.test-srv?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b941a6b8-f446-42ca-ab5d-5115fb0ed667","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '524'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:14 GMT
+      etag:
+      - b941a6b8-f446-42ca-ab5d-5115fb0ed667
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/test-txt?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"316c8e6e-8b58-4bb5-9622-68ad025fb3cd","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '459'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:15 GMT
+      etag:
+      - 316c8e6e-8b58-4bb5-9622-68ad025fb3cd
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "12.1.2.3"},
+      {"ipv4Address": "12.2.3.4"}, {"ipv4Address": "12.3.4.5"}, {"ipv4Address": "12.4.5.6"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/d1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"937d3326-e7d6-4d2b-80d6-101360d31b06","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '520'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:16 GMT
+      etag:
+      - 937d3326-e7d6-4d2b-80d6-101360d31b06
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["fishfishfish"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/d1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5f2224e7-d975-4d4f-84b4-9d2daa318c7d","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '445'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:18 GMT
+      etag:
+      - 5f2224e7-d975-4d4f-84b4-9d2daa318c7d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11992'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "11.1.2.3"},
+      {"ipv4Address": "11.2.3.3"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '101'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0d931ac3-65c5-4c51-8596-5d3266693e77","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:19 GMT
+      etag:
+      - 0d931ac3-65c5-4c51-8596-5d3266693e77
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "11.2.3.4"},
+      {"ipv4Address": "11.5.6.7"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '101'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"db47dd95-21b3-404a-ab13-e0505b817d4e","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:20 GMT
+      etag:
+      - db47dd95-21b3-404a-ab13-e0505b817d4e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 10, "weight":
+      20, "port": 30, "target": "foo.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '111'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"e152cf6b-6db7-470d-a68a-7a7e4f3c93f8","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '497'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:21 GMT
+      etag:
+      - e152cf6b-6db7-470d-a68a-7a7e4f3c93f8
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 100, "exchange":
+      "mail.test.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '95'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/mail?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"90dc9221-6727-4106-8c72-9de8369cfe67","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '468'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:22 GMT
+      etag:
+      - 90dc9221-6727-4106-8c72-9de8369cfe67
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}, {"ipv4Address":
+      "2.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/noclass?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6efeb2dd-e996-4afc-bc3d-74956349d526","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '479'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:23 GMT
+      etag:
+      - 6efeb2dd-e996-4afc-bc3d-74956349d526
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1 only"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0d85d807-c0d4-4d68-847c-0c8acdbe213f","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1 only"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:24 GMT
+      etag:
+      - 0d85d807-c0d4-4d68-847c-0c8acdbe213f
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string1string2"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35172986-ef84-46fe-af6a-cf828a5b5982","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:25 GMT
+      etag:
+      - 35172986-ef84-46fe-af6a-cf828a5b5982
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["this is a very
+      long string with lots of text, in fact is has 74 charactersthis is a very long
+      string with lots of text, in fact is has 74 charactersthis is a very long string
+      with lots of text, in fact is has 74 charactersthis is a very long string with
+      l", "ots of text, in fact is has 74 characters"]}, {"value": ["string;string;string"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '399'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt3?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"443a747c-b114-4206-a7e5-d0c536a1b327","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with l","ots of text, in fact is has 74 characters"]},{"value":["string;string;string"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '773'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:27 GMT
+      etag:
+      - 443a747c-b114-4206-a7e5-d0c536a1b327
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1e4063f6-5d89-43dd-86b2-9dddfd44c3a7","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"e152cf6b-6db7-470d-a68a-7a7e4f3c93f8","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"937d3326-e7d6-4d2b-80d6-101360d31b06","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5f2224e7-d975-4d4f-84b4-9d2daa318c7d","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0d931ac3-65c5-4c51-8596-5d3266693e77","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"db47dd95-21b3-404a-ab13-e0505b817d4e","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"90dc9221-6727-4106-8c72-9de8369cfe67","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6efeb2dd-e996-4afc-bc3d-74956349d526","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bfc75aaf-62fa-4ac0-969a-213394f806f6","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"a9c800a2-8de7-4afb-af49-9791acbb106c","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"7d8965f8-6c49-4d48-b01d-44a8d742f7ec","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"42ecbdea-0ed9-43f0-ad79-021e94582ce6","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5e27478e-a797-4d5f-8ab9-dd62bd52298e","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b941a6b8-f446-42ca-ab5d-5115fb0ed667","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"316c8e6e-8b58-4bb5-9622-68ad025fb3cd","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0d85d807-c0d4-4d68-847c-0c8acdbe213f","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35172986-ef84-46fe-af6a-cf828a5b5982","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"443a747c-b114-4206-a7e5-d0c536a1b327","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with l","ots of text, in fact is has 74 characters"]},{"value":["string;string;string"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '8967'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:26 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59982'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1e4063f6-5d89-43dd-86b2-9dddfd44c3a7","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '597'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:27 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1e4063f6-5d89-43dd-86b2-9dddfd44c3a7","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"e152cf6b-6db7-470d-a68a-7a7e4f3c93f8","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"937d3326-e7d6-4d2b-80d6-101360d31b06","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5f2224e7-d975-4d4f-84b4-9d2daa318c7d","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0d931ac3-65c5-4c51-8596-5d3266693e77","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"db47dd95-21b3-404a-ab13-e0505b817d4e","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"90dc9221-6727-4106-8c72-9de8369cfe67","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6efeb2dd-e996-4afc-bc3d-74956349d526","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bfc75aaf-62fa-4ac0-969a-213394f806f6","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"a9c800a2-8de7-4afb-af49-9791acbb106c","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"7d8965f8-6c49-4d48-b01d-44a8d742f7ec","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"42ecbdea-0ed9-43f0-ad79-021e94582ce6","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"5e27478e-a797-4d5f-8ab9-dd62bd52298e","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b941a6b8-f446-42ca-ab5d-5115fb0ed667","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"316c8e6e-8b58-4bb5-9622-68ad025fb3cd","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0d85d807-c0d4-4d68-847c-0c8acdbe213f","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"35172986-ef84-46fe-af6a-cf828a5b5982","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"443a747c-b114-4206-a7e5-d0c536a1b327","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with l","ots of text, in fact is has 74 characters"]},{"value":["string;string;string"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '8967'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:43:27 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59982'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTsxYTkzODFlZC03MWRkLTRkOWQtODNjYy01YTc4ZWVkNWVmNTc=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Thu, 16 Apr 2020 14:43:31 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTsxYTkzODFlZC03MWRkLTRkOWQtODNjYy01YTc4ZWVkNWVmNTc=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTsxYTkzODFlZC03MWRkLTRkOWQtODNjYy01YTc4ZWVkNWVmNTc=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:44:01 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0OTYyYjE4Mi1mZWEyLTQwMmItODkyYi0xNTllOWE1NTYxZWM=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:44:28 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0OTYyYjE4Mi1mZWEyLTQwMmItODkyYi0xNTllOWE1NTYxZWM=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"91a66d8f-88c8-4a11-a4ec-39a8c506c869","properties":{"fqdn":"zone3.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:44:59 GMT
+      etag:
+      - 91a66d8f-88c8-4a11-a4ec-39a8c506c869
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com","name":"zone3.com","type":"Microsoft.Network\/privateDnsZones","etag":"757491b7-d80d-4820-ae74-af6343cf8ce6","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:44:59 GMT
+      etag:
+      - 757491b7-d80d-4820-ae74-af6343cf8ce6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 86400, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "hostmaster.zone3.com.", "serialNumber": 1, "refreshTime": 43200, "retryTime":
+      900, "expireTime": 1814400, "minimumTtl": 10800}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '213'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"61843d40-0ed2-4019-9cdf-3bf36c77f52d","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '585'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:00 GMT
+      etag:
+      - 61843d40-0ed2-4019-9cdf-3bf36c77f52d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 10, "weight":
+      20, "port": 30, "target": "foo.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '111'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"8e8d1427-4b00-4d6e-9a49-5b28ea91e232","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '497'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:00 GMT
+      etag:
+      - 8e8d1427-4b00-4d6e-9a49-5b28ea91e232
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "12.1.2.3"},
+      {"ipv4Address": "12.2.3.4"}, {"ipv4Address": "12.3.4.5"}, {"ipv4Address": "12.4.5.6"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/d1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e5220f8c-82dd-479d-b0b3-32503a020a26","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '520'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:02 GMT
+      etag:
+      - e5220f8c-82dd-479d-b0b3-32503a020a26
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["fishfishfish"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/d1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c5f05bc1-6b97-4ba3-8b41-d1682f8ace0d","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '445'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:03 GMT
+      etag:
+      - c5f05bc1-6b97-4ba3-8b41-d1682f8ace0d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11993'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "11.1.2.3"},
+      {"ipv4Address": "11.2.3.3"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '101'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c1c76571-0202-4fb4-938c-b5ed69256dc6","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:03 GMT
+      etag:
+      - c1c76571-0202-4fb4-938c-b5ed69256dc6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "11.2.3.4"},
+      {"ipv4Address": "11.5.6.7"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '101'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d237ca4d-bfe1-4835-a89d-956643121545","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '466'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:05 GMT
+      etag:
+      - d237ca4d-bfe1-4835-a89d-956643121545
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 100, "exchange":
+      "mail.test.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '95'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/mail?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b4cde896-df83-4781-b090-bd95291ee436","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '468'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:05 GMT
+      etag:
+      - b4cde896-df83-4781-b090-bd95291ee436
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}, {"ipv4Address":
+      "2.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/noclass?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e0c43f64-0ecb-48a9-b99c-839a4e1f1b04","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '479'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:07 GMT
+      etag:
+      - e0c43f64-0ecb-48a9-b99c-839a4e1f1b04
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/test-a?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"633941ec-5f08-4af6-a4ef-7dc698271d94","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:08 GMT
+      etag:
+      - 633941ec-5f08-4af6-a4ef-7dc698271d94
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:cafe:130::100"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/AAAA/test-aaaa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"2b09fc87-7e9f-4f7d-908f-1357d1ed6d4f","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '479'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:09 GMT
+      etag:
+      - 2b09fc87-7e9f-4f7d-908f-1357d1ed6d4f
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "target.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"55f01a7e-df15-4f83-8fd5-5af93d127bbd","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '469'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:10 GMT
+      etag:
+      - 55f01a7e-df15-4f83-8fd5-5af93d127bbd
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "target.org.zone3.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '80'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"65a61adf-8242-48bc-8fd1-8210866fd85d","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '482'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:11 GMT
+      etag:
+      - 65a61adf-8242-48bc-8fd1-8210866fd85d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "mail.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/test-mx?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"617d47c2-60e0-4790-909e-61d3f4fd59e9","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '471'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:13 GMT
+      etag:
+      - 617d47c2-60e0-4790-909e-61d3f4fd59e9
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
+      "port": 3, "target": "target.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '111'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp.test-srv?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"c5f521a9-c895-4b5a-88ab-3037129e545c","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '524'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:14 GMT
+      etag:
+      - c5f521a9-c895-4b5a-88ab-3037129e545c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/test-txt?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"136157bf-d1e1-4da7-84e8-380f1c4cb060","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '459'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:15 GMT
+      etag:
+      - 136157bf-d1e1-4da7-84e8-380f1c4cb060
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1 only"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"85850f2a-1303-4e4b-8d34-4d3fd18f2757","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1 only"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:16 GMT
+      etag:
+      - 85850f2a-1303-4e4b-8d34-4d3fd18f2757
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string1string2"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e964e477-9c35-4e93-ac3c-9c99158a29c8","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:17 GMT
+      etag:
+      - e964e477-9c35-4e93-ac3c-9c99158a29c8
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["this is a very
+      long string with lots of text, in fact is has 74 charactersthis is a very long
+      string with lots of text, in fact is has 74 charactersthis is a very long string
+      with lots of text, in fact is has 74 charactersthis is a very long string with
+      l", "ots of text, in fact is has 74 characters"]}, {"value": ["string;string;string"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '399'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt3?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"15d1b05b-be4e-4f81-bb3e-0d0a765da0f3","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with l","ots of text, in fact is has 74 characters"]},{"value":["string;string;string"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '773'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:18 GMT
+      etag:
+      - 15d1b05b-be4e-4f81-bb3e-0d0a765da0f3
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11992'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"61843d40-0ed2-4019-9cdf-3bf36c77f52d","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"8e8d1427-4b00-4d6e-9a49-5b28ea91e232","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e5220f8c-82dd-479d-b0b3-32503a020a26","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c5f05bc1-6b97-4ba3-8b41-d1682f8ace0d","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c1c76571-0202-4fb4-938c-b5ed69256dc6","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d237ca4d-bfe1-4835-a89d-956643121545","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b4cde896-df83-4781-b090-bd95291ee436","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e0c43f64-0ecb-48a9-b99c-839a4e1f1b04","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"633941ec-5f08-4af6-a4ef-7dc698271d94","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"2b09fc87-7e9f-4f7d-908f-1357d1ed6d4f","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"55f01a7e-df15-4f83-8fd5-5af93d127bbd","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"65a61adf-8242-48bc-8fd1-8210866fd85d","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"617d47c2-60e0-4790-909e-61d3f4fd59e9","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"c5f521a9-c895-4b5a-88ab-3037129e545c","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"136157bf-d1e1-4da7-84e8-380f1c4cb060","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"85850f2a-1303-4e4b-8d34-4d3fd18f2757","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e964e477-9c35-4e93-ac3c-9c99158a29c8","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"15d1b05b-be4e-4f81-bb3e-0d0a765da0f3","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with lots of text, in fact is has 74 charactersthis
+        is a very long string with l","ots of text, in fact is has 74 characters"]},{"value":["string;string;string"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '8967'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:19 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59982'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone3_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone3_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTthYzUyYmU3Yi0xNGI3LTQxZWEtYmJlNi0yZDE2M2UzOTZmODM=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyNmZjM2ViZC1iNDNlLTQ0MGQtODI1Yi0xMDdiNGU5YzkyZmM=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:13 GMT
+      - Wed, 22 Apr 2020 12:10:05 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTthYzUyYmU3Yi0xNGI3LTQxZWEtYmJlNi0yZDE2M2UzOTZmODM=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyNmZjM2ViZC1iNDNlLTQ0MGQtODI1Yi0xMDdiNGU5YzkyZmM=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -71,7 +71,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTthYzUyYmU3Yi0xNGI3LTQxZWEtYmJlNi0yZDE2M2UzOTZmODM=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyNmZjM2ViZC1iNDNlLTQ0MGQtODI1Yi0xMDdiNGU5YzkyZmM=?api-version=2018-09-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -83,7 +83,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:44 GMT
+      - Wed, 22 Apr 2020 12:10:35 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -97,7 +97,111 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com","name":"zone3.com","type":"Microsoft.Network\/privateDnsZones","etag":"a3943d2e-d96a-4acc-a728-67da46a01f5e","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:10:35 GMT
+      etag:
+      - a3943d2e-d96a-4acc-a728-67da46a01f5e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '494'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b93106d1-642f-44aa-8210-3fb5b5d007cf","properties":{"fqdn":"zone3.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:10:36 GMT
+      etag:
+      - b93106d1-642f-44aa-8210-3fb5b5d007cf
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -131,7 +235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f06895a4-2f71-48b8-acd2-87c43af1e0de","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"7615540f-7fb5-4ee2-96c0-77f123a1d9e5","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -140,9 +244,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:45 GMT
+      - Wed, 22 Apr 2020 12:10:37 GMT
       etag:
-      - f06895a4-2f71-48b8-acd2-87c43af1e0de
+      - 7615540f-7fb5-4ee2-96c0-77f123a1d9e5
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -188,7 +292,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/test-a?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"216df201-2724-4d41-a171-e738c37a3fea","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"352b7b36-25bd-44c9-a87e-1a6e00c02a51","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -197,9 +301,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:46 GMT
+      - Wed, 22 Apr 2020 12:10:38 GMT
       etag:
-      - 216df201-2724-4d41-a171-e738c37a3fea
+      - 352b7b36-25bd-44c9-a87e-1a6e00c02a51
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -209,7 +313,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -241,7 +345,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/AAAA/test-aaaa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"0dc07e20-baa3-4486-b298-40bab833bd19","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"68b18eb5-29b0-4c62-9961-e1be35256cc2","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -250,9 +354,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:47 GMT
+      - Wed, 22 Apr 2020 12:10:39 GMT
       etag:
-      - 0dc07e20-baa3-4486-b298-40bab833bd19
+      - 68b18eb5-29b0-4c62-9961-e1be35256cc2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -262,7 +366,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -294,7 +398,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"010ddac1-821a-4e26-80ce-c36368fb217b","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"aee493a4-230e-4089-a7c0-ca2bc883fe26","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -303,9 +407,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:49 GMT
+      - Wed, 22 Apr 2020 12:10:41 GMT
       etag:
-      - 010ddac1-821a-4e26-80ce-c36368fb217b
+      - aee493a4-230e-4089-a7c0-ca2bc883fe26
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -315,7 +419,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -347,7 +451,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d708aaa4-f950-4e5d-a840-96714268a554","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"11f85004-4175-4fc3-b6a8-47b2868e8af9","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -356,9 +460,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:50 GMT
+      - Wed, 22 Apr 2020 12:10:42 GMT
       etag:
-      - d708aaa4-f950-4e5d-a840-96714268a554
+      - 11f85004-4175-4fc3-b6a8-47b2868e8af9
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -368,7 +472,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -401,7 +505,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/test-mx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a0067fc8-4ead-4996-a45d-a633422035e6","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"46bdc738-5bca-45a3-9d9e-943818379b1d","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -410,9 +514,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:51 GMT
+      - Wed, 22 Apr 2020 12:10:42 GMT
       etag:
-      - a0067fc8-4ead-4996-a45d-a633422035e6
+      - 46bdc738-5bca-45a3-9d9e-943818379b1d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -455,7 +559,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp.test-srv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"a9bd188d-e7c0-49ab-a17d-e2b26292e82e","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"7b3de8c9-9e62-442d-b1c1-e1dcbb90ac43","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -464,9 +568,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:52 GMT
+      - Wed, 22 Apr 2020 12:10:44 GMT
       etag:
-      - a9bd188d-e7c0-49ab-a17d-e2b26292e82e
+      - 7b3de8c9-9e62-442d-b1c1-e1dcbb90ac43
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -508,7 +612,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/test-txt?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ea1b1c97-53ab-44e1-815e-c6c5a67e01df","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"61eaf7ea-44f0-42f2-bd4a-22208d4034ee","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -518,9 +622,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:54 GMT
+      - Wed, 22 Apr 2020 12:10:45 GMT
       etag:
-      - ea1b1c97-53ab-44e1-815e-c6c5a67e01df
+      - 61eaf7ea-44f0-42f2-bd4a-22208d4034ee
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -530,7 +634,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -563,7 +667,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/d1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"29e2b6f1-9a64-4c8f-bf9a-71483d121d4c","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"baa7fbaa-1fc1-43b1-b58a-717a4be60701","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -572,9 +676,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:55 GMT
+      - Wed, 22 Apr 2020 12:10:46 GMT
       etag:
-      - 29e2b6f1-9a64-4c8f-bf9a-71483d121d4c
+      - baa7fbaa-1fc1-43b1-b58a-717a4be60701
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -584,7 +688,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11990'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -616,7 +720,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/d1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1b4fb960-0664-4518-ae2d-69d5ffc78ce2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c019699e-f2e9-4cce-9129-fa793710bf84","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -625,9 +729,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:56 GMT
+      - Wed, 22 Apr 2020 12:10:47 GMT
       etag:
-      - 1b4fb960-0664-4518-ae2d-69d5ffc78ce2
+      - c019699e-f2e9-4cce-9129-fa793710bf84
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -637,7 +741,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -670,7 +774,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"67641fee-216b-42bf-ae1b-18e208323206","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a045c1db-2d13-4a45-ab52-95e082bdf70c","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -679,9 +783,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:57 GMT
+      - Wed, 22 Apr 2020 12:10:49 GMT
       etag:
-      - 67641fee-216b-42bf-ae1b-18e208323206
+      - a045c1db-2d13-4a45-ab52-95e082bdf70c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -691,7 +795,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11991'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -724,7 +828,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe10633-879d-4ecb-92fd-865ff4a4f199","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b19a0ed7-c34c-46be-866d-346c945eaa01","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -733,9 +837,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:58 GMT
+      - Wed, 22 Apr 2020 12:10:49 GMT
       etag:
-      - 5fe10633-879d-4ecb-92fd-865ff4a4f199
+      - b19a0ed7-c34c-46be-866d-346c945eaa01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -745,7 +849,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11990'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -778,7 +882,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ed101b61-8fc7-4619-b6d9-85a0d5af239e","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"37252974-eadd-4c65-a0a5-d560a3239bd3","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -787,9 +891,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:19:59 GMT
+      - Wed, 22 Apr 2020 12:10:50 GMT
       etag:
-      - ed101b61-8fc7-4619-b6d9-85a0d5af239e
+      - 37252974-eadd-4c65-a0a5-d560a3239bd3
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -799,7 +903,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -832,7 +936,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/mail?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7e0f5b70-2185-45de-a224-291bf8b1a3ee","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"28710a75-97e6-4da6-8f9f-5da86c3c2454","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -841,9 +945,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:00 GMT
+      - Wed, 22 Apr 2020 12:10:52 GMT
       etag:
-      - 7e0f5b70-2185-45de-a224-291bf8b1a3ee
+      - 28710a75-97e6-4da6-8f9f-5da86c3c2454
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -853,7 +957,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -886,7 +990,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/noclass?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"899377b9-75cf-40b1-8e8a-28696f13b42f","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cb28876b-336e-41a4-bdfb-cfbd7a7d219f","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -895,9 +999,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:01 GMT
+      - Wed, 22 Apr 2020 12:10:53 GMT
       etag:
-      - 899377b9-75cf-40b1-8e8a-28696f13b42f
+      - cb28876b-336e-41a4-bdfb-cfbd7a7d219f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -907,7 +1011,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -939,7 +1043,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01b40f5b-9340-4be5-a6f3-191fd674a598","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"23daa905-afb1-46bd-b12b-2fff5d666c1d","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
         1 only"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -949,9 +1053,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:02 GMT
+      - Wed, 22 Apr 2020 12:10:54 GMT
       etag:
-      - 01b40f5b-9340-4be5-a6f3-191fd674a598
+      - 23daa905-afb1-46bd-b12b-2fff5d666c1d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -993,7 +1097,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"75826f37-d524-4783-bc9e-cb7bd1e2fd9f","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1d267d23-2515-4fd4-b958-c47316b478a3","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1002,9 +1106,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:03 GMT
+      - Wed, 22 Apr 2020 12:10:56 GMT
       etag:
-      - 75826f37-d524-4783-bc9e-cb7bd1e2fd9f
+      - 1d267d23-2515-4fd4-b958-c47316b478a3
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1014,7 +1118,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11991'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -1050,7 +1154,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt3?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"71cc050e-5299-48f5-a39f-ef66c4ff756e","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"299f5ef4-cd46-43b0-b796-6fcabe41a2a6","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
@@ -1063,9 +1167,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:04 GMT
+      - Wed, 22 Apr 2020 12:10:57 GMT
       etag:
-      - 71cc050e-5299-48f5-a39f-ef66c4ff756e
+      - 299f5ef4-cd46-43b0-b796-6fcabe41a2a6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1075,7 +1179,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
@@ -1103,9 +1207,9 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f06895a4-2f71-48b8-acd2-87c43af1e0de","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ed101b61-8fc7-4619-b6d9-85a0d5af239e","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"29e2b6f1-9a64-4c8f-bf9a-71483d121d4c","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1b4fb960-0664-4518-ae2d-69d5ffc78ce2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"67641fee-216b-42bf-ae1b-18e208323206","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe10633-879d-4ecb-92fd-865ff4a4f199","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7e0f5b70-2185-45de-a224-291bf8b1a3ee","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"899377b9-75cf-40b1-8e8a-28696f13b42f","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"216df201-2724-4d41-a171-e738c37a3fea","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"0dc07e20-baa3-4486-b298-40bab833bd19","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"010ddac1-821a-4e26-80ce-c36368fb217b","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d708aaa4-f950-4e5d-a840-96714268a554","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a0067fc8-4ead-4996-a45d-a633422035e6","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"a9bd188d-e7c0-49ab-a17d-e2b26292e82e","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ea1b1c97-53ab-44e1-815e-c6c5a67e01df","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01b40f5b-9340-4be5-a6f3-191fd674a598","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"75826f37-d524-4783-bc9e-cb7bd1e2fd9f","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"71cc050e-5299-48f5-a39f-ef66c4ff756e","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"7615540f-7fb5-4ee2-96c0-77f123a1d9e5","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"37252974-eadd-4c65-a0a5-d560a3239bd3","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"baa7fbaa-1fc1-43b1-b58a-717a4be60701","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c019699e-f2e9-4cce-9129-fa793710bf84","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a045c1db-2d13-4a45-ab52-95e082bdf70c","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b19a0ed7-c34c-46be-866d-346c945eaa01","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"28710a75-97e6-4da6-8f9f-5da86c3c2454","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cb28876b-336e-41a4-bdfb-cfbd7a7d219f","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"352b7b36-25bd-44c9-a87e-1a6e00c02a51","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"68b18eb5-29b0-4c62-9961-e1be35256cc2","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"aee493a4-230e-4089-a7c0-ca2bc883fe26","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"11f85004-4175-4fc3-b6a8-47b2868e8af9","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"46bdc738-5bca-45a3-9d9e-943818379b1d","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"7b3de8c9-9e62-442d-b1c1-e1dcbb90ac43","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"61eaf7ea-44f0-42f2-bd4a-22208d4034ee","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"23daa905-afb1-46bd-b12b-2fff5d666c1d","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1d267d23-2515-4fd4-b958-c47316b478a3","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"299f5ef4-cd46-43b0-b796-6fcabe41a2a6","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
@@ -1118,7 +1222,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:05 GMT
+      - Wed, 22 Apr 2020 12:10:57 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1162,7 +1266,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f06895a4-2f71-48b8-acd2-87c43af1e0de","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"7615540f-7fb5-4ee2-96c0-77f123a1d9e5","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1171,7 +1275,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:06 GMT
+      - Wed, 22 Apr 2020 12:10:58 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1185,9 +1289,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59999'
+      - '59998'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -1215,9 +1319,9 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f06895a4-2f71-48b8-acd2-87c43af1e0de","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ed101b61-8fc7-4619-b6d9-85a0d5af239e","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"29e2b6f1-9a64-4c8f-bf9a-71483d121d4c","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1b4fb960-0664-4518-ae2d-69d5ffc78ce2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"67641fee-216b-42bf-ae1b-18e208323206","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe10633-879d-4ecb-92fd-865ff4a4f199","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"7e0f5b70-2185-45de-a224-291bf8b1a3ee","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"899377b9-75cf-40b1-8e8a-28696f13b42f","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"216df201-2724-4d41-a171-e738c37a3fea","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"0dc07e20-baa3-4486-b298-40bab833bd19","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"010ddac1-821a-4e26-80ce-c36368fb217b","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d708aaa4-f950-4e5d-a840-96714268a554","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a0067fc8-4ead-4996-a45d-a633422035e6","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"a9bd188d-e7c0-49ab-a17d-e2b26292e82e","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ea1b1c97-53ab-44e1-815e-c6c5a67e01df","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01b40f5b-9340-4be5-a6f3-191fd674a598","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"75826f37-d524-4783-bc9e-cb7bd1e2fd9f","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"71cc050e-5299-48f5-a39f-ef66c4ff756e","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"7615540f-7fb5-4ee2-96c0-77f123a1d9e5","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"37252974-eadd-4c65-a0a5-d560a3239bd3","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"baa7fbaa-1fc1-43b1-b58a-717a4be60701","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"c019699e-f2e9-4cce-9129-fa793710bf84","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a045c1db-2d13-4a45-ab52-95e082bdf70c","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b19a0ed7-c34c-46be-866d-346c945eaa01","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"28710a75-97e6-4da6-8f9f-5da86c3c2454","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cb28876b-336e-41a4-bdfb-cfbd7a7d219f","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"352b7b36-25bd-44c9-a87e-1a6e00c02a51","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"68b18eb5-29b0-4c62-9961-e1be35256cc2","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"aee493a4-230e-4089-a7c0-ca2bc883fe26","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"11f85004-4175-4fc3-b6a8-47b2868e8af9","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"46bdc738-5bca-45a3-9d9e-943818379b1d","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"7b3de8c9-9e62-442d-b1c1-e1dcbb90ac43","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"61eaf7ea-44f0-42f2-bd4a-22208d4034ee","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"23daa905-afb1-46bd-b12b-2fff5d666c1d","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"1d267d23-2515-4fd4-b958-c47316b478a3","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"299f5ef4-cd46-43b0-b796-6fcabe41a2a6","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
@@ -1230,7 +1334,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:07 GMT
+      - Wed, 22 Apr 2020 12:10:58 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1245,6 +1349,106 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59982'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTswYWI0ZWNmMi01MDFlLTQ3NjYtODA1Ni0xMjkwZWY2OTRlNzc=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Wed, 22 Apr 2020 12:11:02 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTswYWI0ZWNmMi01MDFlLTQ3NjYtODA1Ni0xMjkwZWY2OTRlNzc=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTswYWI0ZWNmMi01MDFlLTQ3NjYtODA1Ni0xMjkwZWY2OTRlNzc=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:11:32 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:
@@ -1281,7 +1485,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyNmE2OTRhYy0xOTk1LTQwZDktYjFiZS0yZmUyZWE1ZTljOWY=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs4ZmVhZTBiNi0yZjU2LTQ3NGQtYTJjYS0xZmUyMzhjMThlZGY=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -1289,9 +1493,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:08 GMT
+      - Wed, 22 Apr 2020 12:11:49 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyNmE2OTRhYy0xOTk1LTQwZDktYjFiZS0yZmUyZWE1ZTljOWY=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs4ZmVhZTBiNi0yZjU2LTQ3NGQtYTJjYS0xZmUyMzhjMThlZGY=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1301,7 +1505,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -1323,24 +1527,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs4ZmVhZTBiNi0yZjU2LTQ3NGQtYTJjYS0xZmUyMzhjMThlZGY=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f06895a4-2f71-48b8-acd2-87c43af1e0de","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '585'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:39 GMT
-      etag:
-      - f06895a4-2f71-48b8-acd2-87c43af1e0de
+      - Wed, 22 Apr 2020 12:12:20 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1380,18 +1580,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com","name":"zone3.com","type":"Microsoft.Network\/privateDnsZones","etag":"87865eef-f6f8-46c2-988f-74ad588dd241","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":18,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com","name":"zone3.com","type":"Microsoft.Network\/privateDnsZones","etag":"fc30853a-fe2c-4430-9097-63d37aa586e0","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '614'
+      - '613'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:39 GMT
+      - Wed, 22 Apr 2020 12:12:20 GMT
       etag:
-      - 87865eef-f6f8-46c2-988f-74ad588dd241
+      - fc30853a-fe2c-4430-9097-63d37aa586e0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1405,7 +1605,60 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '495'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6ecb2ac4-74a6-4270-b39e-345558534525","properties":{"fqdn":"zone3.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:12:20 GMT
+      etag:
+      - 6ecb2ac4-74a6-4270-b39e-345558534525
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -1439,7 +1692,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a55c6a12-2845-4cf0-a36a-23fb92336fd8","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"c2f64109-430b-4a2d-81d5-cc1413b31b8c","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1448,9 +1701,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:39 GMT
+      - Wed, 22 Apr 2020 12:12:21 GMT
       etag:
-      - a55c6a12-2845-4cf0-a36a-23fb92336fd8
+      - c2f64109-430b-4a2d-81d5-cc1413b31b8c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1497,7 +1750,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"7a2dc68a-8f4c-4580-afc9-fa05fd35c0cf","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"87125bb9-e8c5-4dba-946b-f30f1bc58687","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1506,17 +1759,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:41 GMT
+      - Wed, 22 Apr 2020 12:12:22 GMT
       etag:
-      - 7a2dc68a-8f4c-4580-afc9-fa05fd35c0cf
+      - 87125bb9-e8c5-4dba-946b-f30f1bc58687
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -1526,8 +1775,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "12.1.2.3"},
       {"ipv4Address": "12.2.3.4"}, {"ipv4Address": "12.3.4.5"}, {"ipv4Address": "12.4.5.6"}]}}'
@@ -1555,7 +1804,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/d1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6cd61512-cc56-4fe6-ac9a-0a400104f7b2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"16b550df-995c-4663-928b-89fd70ea5bc2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1564,28 +1813,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:42 GMT
+      - Wed, 22 Apr 2020 12:12:24 GMT
       etag:
-      - 6cd61512-cc56-4fe6-ac9a-0a400104f7b2
+      - 16b550df-995c-4663-928b-89fd70ea5bc2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11989'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["fishfishfish"]}]}}'
     headers:
@@ -1612,7 +1857,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/d1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f10ad4d3-5c96-457d-b378-4ee5898e9d40","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8dcce2e4-1ee4-4b3e-a655-f613adc460ed","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1621,17 +1866,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:43 GMT
+      - Wed, 22 Apr 2020 12:12:25 GMT
       etag:
-      - f10ad4d3-5c96-457d-b378-4ee5898e9d40
+      - 8dcce2e4-1ee4-4b3e-a655-f613adc460ed
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -1641,8 +1882,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "11.1.2.3"},
       {"ipv4Address": "11.2.3.3"}]}}'
@@ -1670,7 +1911,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"21827f7b-cee0-4afa-8853-8f2b3ec467fe","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"936dac47-cd7b-4e9d-8c81-5c5f34da646b","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1679,28 +1920,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:45 GMT
+      - Wed, 22 Apr 2020 12:12:27 GMT
       etag:
-      - 21827f7b-cee0-4afa-8853-8f2b3ec467fe
+      - 936dac47-cd7b-4e9d-8c81-5c5f34da646b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11990'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "11.2.3.4"},
       {"ipv4Address": "11.5.6.7"}]}}'
@@ -1728,7 +1965,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/f2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ded63564-b6d6-4a63-8d7a-7c2157f3b97b","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a40db6c5-262b-440d-b8d0-647d1db85db9","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1737,28 +1974,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:46 GMT
+      - Wed, 22 Apr 2020 12:12:28 GMT
       etag:
-      - ded63564-b6d6-4a63-8d7a-7c2157f3b97b
+      - a40db6c5-262b-440d-b8d0-647d1db85db9
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 100, "exchange":
       "mail.test.com."}]}}'
@@ -1786,7 +2019,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/mail?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"ff0f6201-3dcd-41da-b351-a59429485798","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a2cf0603-1de1-4a9a-9992-4f946823b593","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1795,28 +2028,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:47 GMT
+      - Wed, 22 Apr 2020 12:12:29 GMT
       etag:
-      - ff0f6201-3dcd-41da-b351-a59429485798
+      - a2cf0603-1de1-4a9a-9992-4f946823b593
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}, {"ipv4Address":
       "2.3.4.5"}]}}'
@@ -1844,7 +2073,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/noclass?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2d21410b-8c2a-486a-8773-0497f1b4cd1e","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"56e87ccf-cfc8-43e8-8012-d14e312199ab","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1853,28 +2082,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:49 GMT
+      - Wed, 22 Apr 2020 12:12:30 GMT
       etag:
-      - 2d21410b-8c2a-486a-8773-0497f1b4cd1e
+      - 56e87ccf-cfc8-43e8-8012-d14e312199ab
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11989'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}]}}'
     headers:
@@ -1901,7 +2126,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/A/test-a?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2b9e9dd6-b280-4502-85a7-a7de5964d6c6","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8a52e8c7-fb91-46ec-9eb7-ec07c1824bfd","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1910,28 +2135,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:50 GMT
+      - Wed, 22 Apr 2020 12:12:31 GMT
       etag:
-      - 2b9e9dd6-b280-4502-85a7-a7de5964d6c6
+      - 8a52e8c7-fb91-46ec-9eb7-ec07c1824bfd
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:cafe:130::100"}]}}'
     headers:
@@ -1958,7 +2179,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/AAAA/test-aaaa?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"23e4c036-bbd2-43cf-af81-823bf74f89ed","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"5d032a93-5def-42f9-96df-f29f2de9d8fc","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1967,28 +2188,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:51 GMT
+      - Wed, 22 Apr 2020 12:12:33 GMT
       etag:
-      - 23e4c036-bbd2-43cf-af81-823bf74f89ed
+      - 5d032a93-5def-42f9-96df-f29f2de9d8fc
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "target.com."}}}'
     headers:
@@ -2015,7 +2232,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"33bde5da-8bc7-4aaf-b53a-a062bd66c365","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"634f23a2-1a3a-407e-a4b9-6aad1ea7e127","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2024,28 +2241,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:53 GMT
+      - Wed, 22 Apr 2020 12:12:34 GMT
       etag:
-      - 33bde5da-8bc7-4aaf-b53a-a062bd66c365
+      - 634f23a2-1a3a-407e-a4b9-6aad1ea7e127
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "target.org.zone3.com."}}}'
     headers:
@@ -2072,7 +2285,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/CNAME/test-cname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"e32686ab-7673-4963-b031-3170cc800451","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"36992ba9-6d68-4c4c-a17b-bc35ccc3f34f","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2081,28 +2294,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:54 GMT
+      - Wed, 22 Apr 2020 12:12:36 GMT
       etag:
-      - e32686ab-7673-4963-b031-3170cc800451
+      - 36992ba9-6d68-4c4c-a17b-bc35ccc3f34f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
       "mail.com."}]}}'
@@ -2130,7 +2339,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/MX/test-mx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"fb4b197e-90cd-4d01-acaa-0952e9d0ed36","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"1ebdd494-5d9e-4bf4-9181-6e939e65d557","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2139,17 +2348,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:55 GMT
+      - Wed, 22 Apr 2020 12:12:36 GMT
       etag:
-      - fb4b197e-90cd-4d01-acaa-0952e9d0ed36
+      - 1ebdd494-5d9e-4bf4-9181-6e939e65d557
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -2159,8 +2364,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
       "port": 3, "target": "target.com."}]}}'
@@ -2188,7 +2393,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/SRV/_sip._tcp.test-srv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"727020dc-ef3c-44dd-a7a8-943223bff466","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"61dcae4d-3860-40b3-b5da-5c7cc2359dd6","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2197,28 +2402,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:56 GMT
+      - Wed, 22 Apr 2020 12:12:37 GMT
       etag:
-      - 727020dc-ef3c-44dd-a7a8-943223bff466
+      - 61dcae4d-3860-40b3-b5da-5c7cc2359dd6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1"]}]}}'
     headers:
@@ -2245,7 +2446,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/test-txt?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e931238a-6aff-4272-814d-9b38df3f13ca","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"19baae30-a1ea-43fa-a224-26c21ee1ed41","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
         1"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -2255,28 +2456,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:58 GMT
+      - Wed, 22 Apr 2020 12:12:39 GMT
       etag:
-      - e931238a-6aff-4272-814d-9b38df3f13ca
+      - 19baae30-a1ea-43fa-a224-26c21ee1ed41
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11990'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string 1 only"]}]}}'
     headers:
@@ -2303,7 +2500,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cebca78d-8d05-4f6d-9a88-5bf1b0b181d7","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"887c4334-0c91-428c-aa37-fe1518d646b6","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
         1 only"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -2313,28 +2510,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:20:58 GMT
+      - Wed, 22 Apr 2020 12:12:40 GMT
       etag:
-      - cebca78d-8d05-4f6d-9a88-5bf1b0b181d7
+      - 887c4334-0c91-428c-aa37-fe1518d646b6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11988'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["string1string2"]}]}}'
     headers:
@@ -2361,7 +2554,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"64e972db-600c-4ace-bcd7-e8bb0c83b176","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"90cffbef-5a22-40d3-8462-7070b3d8f575","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2370,28 +2563,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:21:00 GMT
+      - Wed, 22 Apr 2020 12:12:41 GMT
       etag:
-      - 64e972db-600c-4ace-bcd7-e8bb0c83b176
+      - 90cffbef-5a22-40d3-8462-7070b3d8f575
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11989'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["this is a very
       long string with lots of text, in fact is has 74 charactersthis is a very long
@@ -2422,7 +2611,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/TXT/txt3?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ce04615a-10b9-48f8-b65e-00dca88e7e33","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8503584c-6222-4710-af3f-677f6214ce2e","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
@@ -2435,28 +2624,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:21:02 GMT
+      - Wed, 22 Apr 2020 12:12:42 GMT
       etag:
-      - ce04615a-10b9-48f8-b65e-00dca88e7e33
+      - 8503584c-6222-4710-af3f-677f6214ce2e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11986'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: null
     headers:
@@ -2479,9 +2664,9 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone3_import000001/providers/Microsoft.Network/privateDnsZones/zone3.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a55c6a12-2845-4cf0-a36a-23fb92336fd8","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"7a2dc68a-8f4c-4580-afc9-fa05fd35c0cf","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6cd61512-cc56-4fe6-ac9a-0a400104f7b2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f10ad4d3-5c96-457d-b378-4ee5898e9d40","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"21827f7b-cee0-4afa-8853-8f2b3ec467fe","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ded63564-b6d6-4a63-8d7a-7c2157f3b97b","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"ff0f6201-3dcd-41da-b351-a59429485798","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2d21410b-8c2a-486a-8773-0497f1b4cd1e","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2b9e9dd6-b280-4502-85a7-a7de5964d6c6","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"23e4c036-bbd2-43cf-af81-823bf74f89ed","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"33bde5da-8bc7-4aaf-b53a-a062bd66c365","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"e32686ab-7673-4963-b031-3170cc800451","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"fb4b197e-90cd-4d01-acaa-0952e9d0ed36","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"727020dc-ef3c-44dd-a7a8-943223bff466","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"e931238a-6aff-4272-814d-9b38df3f13ca","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"cebca78d-8d05-4f6d-9a88-5bf1b0b181d7","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
-        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"64e972db-600c-4ace-bcd7-e8bb0c83b176","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ce04615a-10b9-48f8-b65e-00dca88e7e33","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"c2f64109-430b-4a2d-81d5-cc1413b31b8c","properties":{"fqdn":"zone3.com.","ttl":86400,"soaRecord":{"email":"hostmaster.zone3.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp","name":"_sip._tcp","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"87125bb9-e8c5-4dba-946b-f30f1bc58687","properties":{"fqdn":"_sip._tcp.zone3.com.","ttl":3600,"srvRecords":[{"port":30,"priority":10,"target":"foo.com.","weight":20}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"16b550df-995c-4663-928b-89fd70ea5bc2","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"12.1.2.3"},{"ipv4Address":"12.2.3.4"},{"ipv4Address":"12.3.4.5"},{"ipv4Address":"12.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/d1","name":"d1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8dcce2e4-1ee4-4b3e-a655-f613adc460ed","properties":{"fqdn":"d1.zone3.com.","ttl":3600,"txtRecords":[{"value":["fishfishfish"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f1","name":"f1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"936dac47-cd7b-4e9d-8c81-5c5f34da646b","properties":{"fqdn":"f1.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/f2","name":"f2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a40db6c5-262b-440d-b8d0-647d1db85db9","properties":{"fqdn":"f2.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/mail","name":"mail","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"a2cf0603-1de1-4a9a-9992-4f946823b593","properties":{"fqdn":"mail.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.test.com.","preference":100}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/noclass","name":"noclass","type":"Microsoft.Network\/privateDnsZones\/A","etag":"56e87ccf-cfc8-43e8-8012-d14e312199ab","properties":{"fqdn":"noclass.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"},{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/A\/test-a","name":"test-a","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8a52e8c7-fb91-46ec-9eb7-ec07c1824bfd","properties":{"fqdn":"test-a.zone3.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/AAAA\/test-aaaa","name":"test-aaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"5d032a93-5def-42f9-96df-f29f2de9d8fc","properties":{"fqdn":"test-aaaa.zone3.com.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:cafe:130::100"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"634f23a2-1a3a-407e-a4b9-6aad1ea7e127","properties":{"fqdn":"test-cname.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"36992ba9-6d68-4c4c-a17b-bc35ccc3f34f","properties":{"fqdn":"test-cname2.zone3.com.","ttl":3600,"cnameRecord":{"cname":"target.org.zone3.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"1ebdd494-5d9e-4bf4-9181-6e939e65d557","properties":{"fqdn":"test-mx.zone3.com.","ttl":3600,"mxRecords":[{"exchange":"mail.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/SRV\/_sip._tcp.test-srv","name":"_sip._tcp.test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"61dcae4d-3860-40b3-b5da-5c7cc2359dd6","properties":{"fqdn":"_sip._tcp.test-srv.zone3.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"target.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/test-txt","name":"test-txt","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"19baae30-a1ea-43fa-a224-26c21ee1ed41","properties":{"fqdn":"test-txt.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"887c4334-0c91-428c-aa37-fe1518d646b6","properties":{"fqdn":"txt1.zone3.com.","ttl":3600,"txtRecords":[{"value":["string
+        1 only"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt2","name":"txt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"90cffbef-5a22-40d3-8462-7070b3d8f575","properties":{"fqdn":"txt2.zone3.com.","ttl":3600,"txtRecords":[{"value":["string1string2"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone3_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone3.com\/TXT\/txt3","name":"txt3","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"8503584c-6222-4710-af3f-677f6214ce2e","properties":{"fqdn":"txt3.zone3.com.","ttl":3600,"txtRecords":[{"value":["this
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
         is a very long string with lots of text, in fact is has 74 charactersthis
@@ -2494,7 +2679,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:21:02 GMT
+      - Wed, 22 Apr 2020 12:12:43 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2508,9 +2693,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59964'
+      - '59982'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone4_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone4_Import.yaml
@@ -1,0 +1,2717 @@
+interactions:
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1Y2UwZDhlOC00OWViLTQxYTgtOTVmZC0wNDNjMDhmMTlkMTE=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:45:55 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1Y2UwZDhlOC00OWViLTQxYTgtOTVmZC0wNDNjMDhmMTlkMTE=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1c2bf2bd-4c9f-448b-ac0d-7123c0148be1","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:25 GMT
+      etag:
+      - 1c2bf2bd-4c9f-448b-ac0d-7123c0148be1
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com","name":"zone4.com","type":"Microsoft.Network\/privateDnsZones","etag":"09c99c92-5be8-4461-95f9-9b9dd2f859f3","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:26 GMT
+      etag:
+      - 09c99c92-5be8-4461-95f9-9b9dd2f859f3
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "hostmaster.zone4.com.", "serialNumber": 2003080800, "refreshTime":
+      43200, "retryTime": 900, "expireTime": 1814400, "minimumTtl": 10800}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '221'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"55dcc797-ddb2-4d7e-8a43-fdf154535be0","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '584'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:26 GMT
+      etag:
+      - 55dcc797-ddb2-4d7e-8a43-fdf154535be0
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 300, "aRecords": [{"ipv4Address": "10.1.2.3"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-300?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c6f1f5f7-b87d-4ea9-8cd0-ea5a45cce913","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:27 GMT
+      etag:
+      - c6f1f5f7-b87d-4ea9-8cd0-ea5a45cce913
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 0, "aRecords": [{"ipv4Address": "10.2.3.4"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-0?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"20e94d89-f47a-4a77-a60e-0ae7787f36c1","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '445'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:29 GMT
+      etag:
+      - 20e94d89-f47a-4a77-a60e-0ae7787f36c1
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 60, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-60?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a0e82845-b696-4b56-8a1c-a6ecb65ed0b0","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '449'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:29 GMT
+      etag:
+      - a0e82845-b696-4b56-8a1c-a6ecb65ed0b0
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 604800, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1w?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"53109686-0a99-4845-9f99-7fe9975b2bdf","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:30 GMT
+      etag:
+      - 53109686-0a99-4845-9f99-7fe9975b2bdf
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 86400, "aRecords": [{"ipv4Address": "10.7.8.9"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1d?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ad175138-629e-4da0-9a84-65b6ec09beb6","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:32 GMT
+      etag:
+      - ad175138-629e-4da0-9a84-65b6ec09beb6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.4.5.6"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1h?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0f466cc9-2381-4817-a5f4-b9c091e515e9","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '451'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:32 GMT
+      etag:
+      - 0f466cc9-2381-4817-a5f4-b9c091e515e9
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 99, "aRecords": [{"ipv4Address": "10.5.6.7"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-99s?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"70efa1bd-a33c-4e21-8e72-3fff2b019baf","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:34 GMT
+      etag:
+      - 70efa1bd-a33c-4e21-8e72-3fff2b019baf
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "10.6.7.8"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-100?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"38df460c-2b47-4e52-9c51-de7c4c0484c6","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:35 GMT
+      etag:
+      - 38df460c-2b47-4e52-9c51-de7c4c0484c6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 360, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-6m?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e4b186a2-c274-4d8e-b82d-5b04bf44074d","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:36 GMT
+      etag:
+      - e4b186a2-c274-4d8e-b82d-5b04bf44074d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 788645, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-mix?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4c51c83-e4b4-4818-9d33-4176517900a8","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '456'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:37 GMT
+      etag:
+      - f4c51c83-e4b4-4818-9d33-4176517900a8
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 604800, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1w?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffdee772-7038-43d1-a2cd-601da77a9cf6","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '456'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:39 GMT
+      etag:
+      - ffdee772-7038-43d1-a2cd-601da77a9cf6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 86400, "aRecords": [{"ipv4Address": "10.7.8.9"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1d?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3d8be300-dfc3-4266-be8c-10069caa9cb0","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '455'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:39 GMT
+      etag:
+      - 3d8be300-dfc3-4266-be8c-10069caa9cb0
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.4.5.6"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1h?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"025f55ff-c26a-4b2b-9e26-697f5eb6d958","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:40 GMT
+      etag:
+      - 025f55ff-c26a-4b2b-9e26-697f5eb6d958
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 99, "aRecords": [{"ipv4Address": "10.5.6.7"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-99s?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3dba9c49-1d4e-4803-b1da-1a70296b2076","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '455'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:41 GMT
+      etag:
+      - 3dba9c49-1d4e-4803-b1da-1a70296b2076
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "10.6.7.8"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-100?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f47fce49-6f98-44dc-b571-b10864717d83","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '456'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:43 GMT
+      etag:
+      - f47fce49-6f98-44dc-b571-b10864717d83
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 360, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-6m?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1b77842d-17c4-4100-b2ac-42d04774f311","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:44 GMT
+      etag:
+      - 1b77842d-17c4-4100-b2ac-42d04774f311
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 788645, "aRecords": [{"ipv4Address": "10.9.9.9"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-mix?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4d3b34b-c2ba-4c2e-b792-4fa0ee61ef4d","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '459'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:45 GMT
+      etag:
+      - f4d3b34b-c2ba-4c2e-b792-4fa0ee61ef4d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 10, "aRecords": [{"ipv4Address": "11.1.2.3"}, {"ipv4Address":
+      "11.2.3.3"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"336b4e00-1aab-40ff-bc98-f9e203bf7814","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:46 GMT
+      etag:
+      - 336b4e00-1aab-40ff-bc98-f9e203bf7814
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 5, "aRecords": [{"ipv4Address": "11.2.3.4"}, {"ipv4Address":
+      "11.5.6.7"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5561bf76-56fd-4202-9d33-1285785d67d2","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:46 GMT
+      etag:
+      - 5561bf76-56fd-4202-9d33-1285785d67d2
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"55dcc797-ddb2-4d7e-8a43-fdf154535be0","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"336b4e00-1aab-40ff-bc98-f9e203bf7814","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5561bf76-56fd-4202-9d33-1285785d67d2","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"20e94d89-f47a-4a77-a60e-0ae7787f36c1","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"38df460c-2b47-4e52-9c51-de7c4c0484c6","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ad175138-629e-4da0-9a84-65b6ec09beb6","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0f466cc9-2381-4817-a5f4-b9c091e515e9","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"53109686-0a99-4845-9f99-7fe9975b2bdf","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c6f1f5f7-b87d-4ea9-8cd0-ea5a45cce913","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a0e82845-b696-4b56-8a1c-a6ecb65ed0b0","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e4b186a2-c274-4d8e-b82d-5b04bf44074d","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"70efa1bd-a33c-4e21-8e72-3fff2b019baf","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4c51c83-e4b4-4818-9d33-4176517900a8","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f47fce49-6f98-44dc-b571-b10864717d83","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3d8be300-dfc3-4266-be8c-10069caa9cb0","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"025f55ff-c26a-4b2b-9e26-697f5eb6d958","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffdee772-7038-43d1-a2cd-601da77a9cf6","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1b77842d-17c4-4100-b2ac-42d04774f311","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3dba9c49-1d4e-4803-b1da-1a70296b2076","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4d3b34b-c2ba-4c2e-b792-4fa0ee61ef4d","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '9244'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:47 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59980'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"55dcc797-ddb2-4d7e-8a43-fdf154535be0","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '596'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:48 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"55dcc797-ddb2-4d7e-8a43-fdf154535be0","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"336b4e00-1aab-40ff-bc98-f9e203bf7814","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5561bf76-56fd-4202-9d33-1285785d67d2","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"20e94d89-f47a-4a77-a60e-0ae7787f36c1","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"38df460c-2b47-4e52-9c51-de7c4c0484c6","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ad175138-629e-4da0-9a84-65b6ec09beb6","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0f466cc9-2381-4817-a5f4-b9c091e515e9","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"53109686-0a99-4845-9f99-7fe9975b2bdf","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c6f1f5f7-b87d-4ea9-8cd0-ea5a45cce913","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a0e82845-b696-4b56-8a1c-a6ecb65ed0b0","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e4b186a2-c274-4d8e-b82d-5b04bf44074d","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"70efa1bd-a33c-4e21-8e72-3fff2b019baf","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4c51c83-e4b4-4818-9d33-4176517900a8","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f47fce49-6f98-44dc-b571-b10864717d83","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3d8be300-dfc3-4266-be8c-10069caa9cb0","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"025f55ff-c26a-4b2b-9e26-697f5eb6d958","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffdee772-7038-43d1-a2cd-601da77a9cf6","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1b77842d-17c4-4100-b2ac-42d04774f311","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3dba9c49-1d4e-4803-b1da-1a70296b2076","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4d3b34b-c2ba-4c2e-b792-4fa0ee61ef4d","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '9244'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:46:49 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59962'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs5OTQ2MjVhMS0yMmY4LTQ3M2EtODY5Zi1lOGM1MDFjNDY4ZTM=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Thu, 16 Apr 2020 14:46:52 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs5OTQ2MjVhMS0yMmY4LTQ3M2EtODY5Zi1lOGM1MDFjNDY4ZTM=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs5OTQ2MjVhMS0yMmY4LTQ3M2EtODY5Zi1lOGM1MDFjNDY4ZTM=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:47:22 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmZWRiZWZmZS02MjdiLTQxNGItOGVkMi02NTUwYWVmNGFjNzE=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:47:50 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmZWRiZWZmZS02MjdiLTQxNGItOGVkMi02NTUwYWVmNGFjNzE=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"3f6831de-1935-4533-bdb8-63603b9e7390","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:21 GMT
+      etag:
+      - 3f6831de-1935-4533-bdb8-63603b9e7390
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "hostmaster.zone4.com.", "serialNumber": 1, "refreshTime": 43200, "retryTime":
+      900, "expireTime": 1814400, "minimumTtl": 10800}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '212'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6d49edfc-384a-4015-a73e-fbf455ac81cd","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '584'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:22 GMT
+      etag:
+      - 6d49edfc-384a-4015-a73e-fbf455ac81cd
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 10, "aRecords": [{"ipv4Address": "11.1.2.3"}, {"ipv4Address":
+      "11.2.3.3"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d1379b1b-b8a3-40f8-ba24-d6191f28df14","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:23 GMT
+      etag:
+      - d1379b1b-b8a3-40f8-ba24-d6191f28df14
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 5, "aRecords": [{"ipv4Address": "11.2.3.4"}, {"ipv4Address":
+      "11.5.6.7"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dbd82830-4471-4b3c-9174-2b003a9b9194","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:24 GMT
+      etag:
+      - dbd82830-4471-4b3c-9174-2b003a9b9194
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 0, "aRecords": [{"ipv4Address": "10.2.3.4"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-0?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"14bcbfff-9bdf-4044-8a61-87297e30f872","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '445'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:26 GMT
+      etag:
+      - 14bcbfff-9bdf-4044-8a61-87297e30f872
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "10.6.7.8"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-100?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d534c217-b1ad-48bc-8620-c7073d3e51e6","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:27 GMT
+      etag:
+      - d534c217-b1ad-48bc-8620-c7073d3e51e6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 86400, "aRecords": [{"ipv4Address": "10.7.8.9"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1d?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f7ee592f-bbe9-4329-b9b9-19d3ac31319c","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:28 GMT
+      etag:
+      - f7ee592f-bbe9-4329-b9b9-19d3ac31319c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.4.5.6"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1h?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"df9cf357-18ad-4bfe-aca3-ed09c5d4999c","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '451'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:29 GMT
+      etag:
+      - df9cf357-18ad-4bfe-aca3-ed09c5d4999c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 604800, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1w?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c3609773-eb16-4cb1-a424-18db668d87a1","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:30 GMT
+      etag:
+      - c3609773-eb16-4cb1-a424-18db668d87a1
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 300, "aRecords": [{"ipv4Address": "10.1.2.3"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-300?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b3d12906-2c90-4fc4-a4b5-52b4f7c63b85","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:31 GMT
+      etag:
+      - b3d12906-2c90-4fc4-a4b5-52b4f7c63b85
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 60, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-60?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"071e2e08-f27a-4cc3-9a77-001ef8e457ea","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '449'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:32 GMT
+      etag:
+      - 071e2e08-f27a-4cc3-9a77-001ef8e457ea
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 360, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-6m?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b9b095a0-1992-44bd-aefd-4f03ed832c07","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:33 GMT
+      etag:
+      - b9b095a0-1992-44bd-aefd-4f03ed832c07
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 99, "aRecords": [{"ipv4Address": "10.5.6.7"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-99s?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cbc26ed5-016d-412b-8de2-9a3ef468aed4","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:34 GMT
+      etag:
+      - cbc26ed5-016d-412b-8de2-9a3ef468aed4
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 788645, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-mix?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3c2bfc95-7890-44f8-b9e5-1d543b39f5f8","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '456'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:35 GMT
+      etag:
+      - 3c2bfc95-7890-44f8-b9e5-1d543b39f5f8
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "10.6.7.8"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-100?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"22fbebb0-1ca2-458b-a8ac-0ef51871bf96","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '456'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:36 GMT
+      etag:
+      - 22fbebb0-1ca2-458b-a8ac-0ef51871bf96
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 86400, "aRecords": [{"ipv4Address": "10.7.8.9"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1d?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bd15bd14-6283-4623-853c-3cfb0fc8b750","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '455'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:37 GMT
+      etag:
+      - bd15bd14-6283-4623-853c-3cfb0fc8b750
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.4.5.6"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1h?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f808f42e-0253-4ecc-96b7-1667ca6d8c77","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '454'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:38 GMT
+      etag:
+      - f808f42e-0253-4ecc-96b7-1667ca6d8c77
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 604800, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1w?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"219fbd06-1837-4360-a24d-882fb0f346a5","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '456'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:39 GMT
+      etag:
+      - 219fbd06-1837-4360-a24d-882fb0f346a5
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11993'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 360, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-6m?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a74642bb-c2b1-450d-acf6-3e8aba67e4d6","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:41 GMT
+      etag:
+      - a74642bb-c2b1-450d-acf6-3e8aba67e4d6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 99, "aRecords": [{"ipv4Address": "10.5.6.7"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-99s?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5013145c-ccff-436b-8a6e-313e45400a49","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '455'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:41 GMT
+      etag:
+      - 5013145c-ccff-436b-8a6e-313e45400a49
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11993'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 788645, "aRecords": [{"ipv4Address": "10.9.9.9"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-mix?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4b3f71c5-16fc-4d20-ae77-26102fc02ecd","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '459'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:43 GMT
+      etag:
+      - 4b3f71c5-16fc-4d20-ae77-26102fc02ecd
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11993'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6d49edfc-384a-4015-a73e-fbf455ac81cd","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d1379b1b-b8a3-40f8-ba24-d6191f28df14","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dbd82830-4471-4b3c-9174-2b003a9b9194","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"14bcbfff-9bdf-4044-8a61-87297e30f872","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d534c217-b1ad-48bc-8620-c7073d3e51e6","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f7ee592f-bbe9-4329-b9b9-19d3ac31319c","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"df9cf357-18ad-4bfe-aca3-ed09c5d4999c","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c3609773-eb16-4cb1-a424-18db668d87a1","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b3d12906-2c90-4fc4-a4b5-52b4f7c63b85","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"071e2e08-f27a-4cc3-9a77-001ef8e457ea","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b9b095a0-1992-44bd-aefd-4f03ed832c07","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cbc26ed5-016d-412b-8de2-9a3ef468aed4","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3c2bfc95-7890-44f8-b9e5-1d543b39f5f8","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"22fbebb0-1ca2-458b-a8ac-0ef51871bf96","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bd15bd14-6283-4623-853c-3cfb0fc8b750","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f808f42e-0253-4ecc-96b7-1667ca6d8c77","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"219fbd06-1837-4360-a24d-882fb0f346a5","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a74642bb-c2b1-450d-acf6-3e8aba67e4d6","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5013145c-ccff-436b-8a6e-313e45400a49","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4b3f71c5-16fc-4d20-ae77-26102fc02ecd","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '9244'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:48:43 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59980'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone4_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone4_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1Y2UwZDhlOC00OWViLTQxYTgtOTVmZC0wNDNjMDhmMTlkMTE=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsxZmMxNWE3ZC00Y2QyLTRkOWItOTlhYy03ZTYyNDM3ODcyOWI=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:45:55 GMT
+      - Tue, 21 Apr 2020 05:21:30 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1Y2UwZDhlOC00OWViLTQxYTgtOTVmZC0wNDNjMDhmMTlkMTE=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsxZmMxNWE3ZC00Y2QyLTRkOWItOTlhYy03ZTYyNDM3ODcyOWI=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -76,7 +76,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1c2bf2bd-4c9f-448b-ac0d-7123c0148be1","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"ae659c41-0e1c-48d3-a969-acb1afc005bb","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -85,9 +85,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:25 GMT
+      - Tue, 21 Apr 2020 05:22:01 GMT
       etag:
-      - 1c2bf2bd-4c9f-448b-ac0d-7123c0148be1
+      - ae659c41-0e1c-48d3-a969-acb1afc005bb
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -127,7 +127,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com","name":"zone4.com","type":"Microsoft.Network\/privateDnsZones","etag":"09c99c92-5be8-4461-95f9-9b9dd2f859f3","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com","name":"zone4.com","type":"Microsoft.Network\/privateDnsZones","etag":"8ab528ea-61d1-4995-ba90-519996add758","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -136,9 +136,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:26 GMT
+      - Tue, 21 Apr 2020 05:22:01 GMT
       etag:
-      - 09c99c92-5be8-4461-95f9-9b9dd2f859f3
+      - 8ab528ea-61d1-4995-ba90-519996add758
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -186,7 +186,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"55dcc797-ddb2-4d7e-8a43-fdf154535be0","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -195,9 +195,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:26 GMT
+      - Tue, 21 Apr 2020 05:22:01 GMT
       etag:
-      - 55dcc797-ddb2-4d7e-8a43-fdf154535be0
+      - abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -243,7 +243,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-300?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c6f1f5f7-b87d-4ea9-8cd0-ea5a45cce913","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e7620c4a-59e3-474e-bd86-769b87dee091","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -252,9 +252,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:27 GMT
+      - Tue, 21 Apr 2020 05:22:02 GMT
       etag:
-      - c6f1f5f7-b87d-4ea9-8cd0-ea5a45cce913
+      - e7620c4a-59e3-474e-bd86-769b87dee091
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -264,7 +264,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
@@ -296,7 +296,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-0?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"20e94d89-f47a-4a77-a60e-0ae7787f36c1","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"333240c0-340a-457b-976b-42f16fdfd656","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -305,9 +305,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:29 GMT
+      - Tue, 21 Apr 2020 05:22:03 GMT
       etag:
-      - 20e94d89-f47a-4a77-a60e-0ae7787f36c1
+      - 333240c0-340a-457b-976b-42f16fdfd656
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -317,7 +317,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -349,7 +349,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-60?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a0e82845-b696-4b56-8a1c-a6ecb65ed0b0","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2a40e5a4-3bf3-4b05-8b71-179f33cf6af6","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -358,9 +358,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:29 GMT
+      - Tue, 21 Apr 2020 05:22:04 GMT
       etag:
-      - a0e82845-b696-4b56-8a1c-a6ecb65ed0b0
+      - 2a40e5a4-3bf3-4b05-8b71-179f33cf6af6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -370,7 +370,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11988'
       x-powered-by:
       - ASP.NET
     status:
@@ -402,7 +402,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1w?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"53109686-0a99-4845-9f99-7fe9975b2bdf","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c42ca8f-7540-4209-99ae-98ea6cbe7c05","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -411,9 +411,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:30 GMT
+      - Tue, 21 Apr 2020 05:22:05 GMT
       etag:
-      - 53109686-0a99-4845-9f99-7fe9975b2bdf
+      - 8c42ca8f-7540-4209-99ae-98ea6cbe7c05
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -423,7 +423,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
@@ -455,7 +455,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1d?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ad175138-629e-4da0-9a84-65b6ec09beb6","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dcc953ac-87af-49d4-aace-a7202bb3922f","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -464,9 +464,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:32 GMT
+      - Tue, 21 Apr 2020 05:22:06 GMT
       etag:
-      - ad175138-629e-4da0-9a84-65b6ec09beb6
+      - dcc953ac-87af-49d4-aace-a7202bb3922f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -476,7 +476,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11989'
       x-powered-by:
       - ASP.NET
     status:
@@ -508,7 +508,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1h?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0f466cc9-2381-4817-a5f4-b9c091e515e9","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2f741eb7-e5d6-473a-9eb3-33ada56ceb0a","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -517,9 +517,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:32 GMT
+      - Tue, 21 Apr 2020 05:22:07 GMT
       etag:
-      - 0f466cc9-2381-4817-a5f4-b9c091e515e9
+      - 2f741eb7-e5d6-473a-9eb3-33ada56ceb0a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -529,7 +529,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -561,7 +561,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-99s?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"70efa1bd-a33c-4e21-8e72-3fff2b019baf","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"be504b7f-7661-4f31-aa86-f83996260012","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -570,9 +570,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:34 GMT
+      - Tue, 21 Apr 2020 05:22:08 GMT
       etag:
-      - 70efa1bd-a33c-4e21-8e72-3fff2b019baf
+      - be504b7f-7661-4f31-aa86-f83996260012
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -582,7 +582,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -614,7 +614,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-100?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"38df460c-2b47-4e52-9c51-de7c4c0484c6","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5d55a2a9-c507-45d8-a23b-f619ae161732","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -623,9 +623,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:35 GMT
+      - Tue, 21 Apr 2020 05:22:09 GMT
       etag:
-      - 38df460c-2b47-4e52-9c51-de7c4c0484c6
+      - 5d55a2a9-c507-45d8-a23b-f619ae161732
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -635,7 +635,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -667,7 +667,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-6m?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e4b186a2-c274-4d8e-b82d-5b04bf44074d","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"286c8f5a-e096-4507-86a4-5632c1cf9d77","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -676,9 +676,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:36 GMT
+      - Tue, 21 Apr 2020 05:22:11 GMT
       etag:
-      - e4b186a2-c274-4d8e-b82d-5b04bf44074d
+      - 286c8f5a-e096-4507-86a4-5632c1cf9d77
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -688,7 +688,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11988'
       x-powered-by:
       - ASP.NET
     status:
@@ -720,7 +720,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-mix?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4c51c83-e4b4-4818-9d33-4176517900a8","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"858a9230-7088-4b5f-a7b9-314000f4addb","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -729,9 +729,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:37 GMT
+      - Tue, 21 Apr 2020 05:22:12 GMT
       etag:
-      - f4c51c83-e4b4-4818-9d33-4176517900a8
+      - 858a9230-7088-4b5f-a7b9-314000f4addb
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -741,7 +741,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -773,7 +773,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1w?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffdee772-7038-43d1-a2cd-601da77a9cf6","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cc550ba8-30e0-4cb8-a99c-13d5081293bc","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -782,9 +782,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:39 GMT
+      - Tue, 21 Apr 2020 05:22:13 GMT
       etag:
-      - ffdee772-7038-43d1-a2cd-601da77a9cf6
+      - cc550ba8-30e0-4cb8-a99c-13d5081293bc
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -794,7 +794,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -826,7 +826,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1d?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3d8be300-dfc3-4266-be8c-10069caa9cb0","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d2b6c661-3f8b-4442-8b21-6aac2595f58d","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -835,9 +835,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:39 GMT
+      - Tue, 21 Apr 2020 05:22:14 GMT
       etag:
-      - 3d8be300-dfc3-4266-be8c-10069caa9cb0
+      - d2b6c661-3f8b-4442-8b21-6aac2595f58d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -847,7 +847,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11987'
       x-powered-by:
       - ASP.NET
     status:
@@ -879,7 +879,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1h?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"025f55ff-c26a-4b2b-9e26-697f5eb6d958","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe5c157-69db-4720-84d1-144205cc4363","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -888,9 +888,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:40 GMT
+      - Tue, 21 Apr 2020 05:22:15 GMT
       etag:
-      - 025f55ff-c26a-4b2b-9e26-697f5eb6d958
+      - 5fe5c157-69db-4720-84d1-144205cc4363
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -900,7 +900,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11986'
       x-powered-by:
       - ASP.NET
     status:
@@ -932,7 +932,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-99s?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3dba9c49-1d4e-4803-b1da-1a70296b2076","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8b9401bc-4b1c-4191-a463-f54436c49809","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -941,9 +941,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:41 GMT
+      - Tue, 21 Apr 2020 05:22:16 GMT
       etag:
-      - 3dba9c49-1d4e-4803-b1da-1a70296b2076
+      - 8b9401bc-4b1c-4191-a463-f54436c49809
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -953,7 +953,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11985'
       x-powered-by:
       - ASP.NET
     status:
@@ -985,7 +985,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-100?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f47fce49-6f98-44dc-b571-b10864717d83","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b09f4d49-6133-4841-a11d-1479afee55db","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -994,9 +994,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:43 GMT
+      - Tue, 21 Apr 2020 05:22:16 GMT
       etag:
-      - f47fce49-6f98-44dc-b571-b10864717d83
+      - b09f4d49-6133-4841-a11d-1479afee55db
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1006,7 +1006,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11984'
       x-powered-by:
       - ASP.NET
     status:
@@ -1038,7 +1038,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-6m?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1b77842d-17c4-4100-b2ac-42d04774f311","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f16b193f-4c93-4790-ad52-7520f8df680a","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1047,9 +1047,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:44 GMT
+      - Tue, 21 Apr 2020 05:22:18 GMT
       etag:
-      - 1b77842d-17c4-4100-b2ac-42d04774f311
+      - f16b193f-4c93-4790-ad52-7520f8df680a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1059,7 +1059,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
@@ -1091,7 +1091,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-mix?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4d3b34b-c2ba-4c2e-b792-4fa0ee61ef4d","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9f51f27f-e6f1-4a6b-a9c3-57cc41bff37e","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1100,9 +1100,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:45 GMT
+      - Tue, 21 Apr 2020 05:22:19 GMT
       etag:
-      - f4d3b34b-c2ba-4c2e-b792-4fa0ee61ef4d
+      - 9f51f27f-e6f1-4a6b-a9c3-57cc41bff37e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1112,7 +1112,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11989'
       x-powered-by:
       - ASP.NET
     status:
@@ -1145,7 +1145,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"336b4e00-1aab-40ff-bc98-f9e203bf7814","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"300bc027-70df-4260-9a98-5dfff6d57ddb","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1154,9 +1154,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:46 GMT
+      - Tue, 21 Apr 2020 05:22:20 GMT
       etag:
-      - 336b4e00-1aab-40ff-bc98-f9e203bf7814
+      - 300bc027-70df-4260-9a98-5dfff6d57ddb
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1166,7 +1166,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -1199,7 +1199,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5561bf76-56fd-4202-9d33-1285785d67d2","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f596e01-8c0d-4bc2-92f4-ac91bbddbe57","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1208,9 +1208,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:46 GMT
+      - Tue, 21 Apr 2020 05:22:21 GMT
       etag:
-      - 5561bf76-56fd-4202-9d33-1285785d67d2
+      - 1f596e01-8c0d-4bc2-92f4-ac91bbddbe57
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1220,7 +1220,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11983'
       x-powered-by:
       - ASP.NET
     status:
@@ -1248,7 +1248,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"55dcc797-ddb2-4d7e-8a43-fdf154535be0","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"336b4e00-1aab-40ff-bc98-f9e203bf7814","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5561bf76-56fd-4202-9d33-1285785d67d2","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"20e94d89-f47a-4a77-a60e-0ae7787f36c1","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"38df460c-2b47-4e52-9c51-de7c4c0484c6","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ad175138-629e-4da0-9a84-65b6ec09beb6","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0f466cc9-2381-4817-a5f4-b9c091e515e9","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"53109686-0a99-4845-9f99-7fe9975b2bdf","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c6f1f5f7-b87d-4ea9-8cd0-ea5a45cce913","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a0e82845-b696-4b56-8a1c-a6ecb65ed0b0","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e4b186a2-c274-4d8e-b82d-5b04bf44074d","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"70efa1bd-a33c-4e21-8e72-3fff2b019baf","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4c51c83-e4b4-4818-9d33-4176517900a8","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f47fce49-6f98-44dc-b571-b10864717d83","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3d8be300-dfc3-4266-be8c-10069caa9cb0","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"025f55ff-c26a-4b2b-9e26-697f5eb6d958","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffdee772-7038-43d1-a2cd-601da77a9cf6","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1b77842d-17c4-4100-b2ac-42d04774f311","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3dba9c49-1d4e-4803-b1da-1a70296b2076","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4d3b34b-c2ba-4c2e-b792-4fa0ee61ef4d","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"300bc027-70df-4260-9a98-5dfff6d57ddb","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f596e01-8c0d-4bc2-92f4-ac91bbddbe57","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"333240c0-340a-457b-976b-42f16fdfd656","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5d55a2a9-c507-45d8-a23b-f619ae161732","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dcc953ac-87af-49d4-aace-a7202bb3922f","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2f741eb7-e5d6-473a-9eb3-33ada56ceb0a","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c42ca8f-7540-4209-99ae-98ea6cbe7c05","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e7620c4a-59e3-474e-bd86-769b87dee091","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2a40e5a4-3bf3-4b05-8b71-179f33cf6af6","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"286c8f5a-e096-4507-86a4-5632c1cf9d77","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"be504b7f-7661-4f31-aa86-f83996260012","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"858a9230-7088-4b5f-a7b9-314000f4addb","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b09f4d49-6133-4841-a11d-1479afee55db","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d2b6c661-3f8b-4442-8b21-6aac2595f58d","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe5c157-69db-4720-84d1-144205cc4363","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cc550ba8-30e0-4cb8-a99c-13d5081293bc","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f16b193f-4c93-4790-ad52-7520f8df680a","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8b9401bc-4b1c-4191-a463-f54436c49809","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9f51f27f-e6f1-4a6b-a9c3-57cc41bff37e","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1257,7 +1257,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:47 GMT
+      - Tue, 21 Apr 2020 05:22:21 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1271,9 +1271,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59980'
+      - '59967'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -1301,7 +1301,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"55dcc797-ddb2-4d7e-8a43-fdf154535be0","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1310,7 +1310,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:48 GMT
+      - Tue, 21 Apr 2020 05:22:22 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1326,7 +1326,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59999'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -1354,7 +1354,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"55dcc797-ddb2-4d7e-8a43-fdf154535be0","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"336b4e00-1aab-40ff-bc98-f9e203bf7814","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5561bf76-56fd-4202-9d33-1285785d67d2","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"20e94d89-f47a-4a77-a60e-0ae7787f36c1","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"38df460c-2b47-4e52-9c51-de7c4c0484c6","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ad175138-629e-4da0-9a84-65b6ec09beb6","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0f466cc9-2381-4817-a5f4-b9c091e515e9","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"53109686-0a99-4845-9f99-7fe9975b2bdf","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c6f1f5f7-b87d-4ea9-8cd0-ea5a45cce913","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a0e82845-b696-4b56-8a1c-a6ecb65ed0b0","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e4b186a2-c274-4d8e-b82d-5b04bf44074d","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"70efa1bd-a33c-4e21-8e72-3fff2b019baf","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4c51c83-e4b4-4818-9d33-4176517900a8","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f47fce49-6f98-44dc-b571-b10864717d83","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3d8be300-dfc3-4266-be8c-10069caa9cb0","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"025f55ff-c26a-4b2b-9e26-697f5eb6d958","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffdee772-7038-43d1-a2cd-601da77a9cf6","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1b77842d-17c4-4100-b2ac-42d04774f311","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3dba9c49-1d4e-4803-b1da-1a70296b2076","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f4d3b34b-c2ba-4c2e-b792-4fa0ee61ef4d","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"300bc027-70df-4260-9a98-5dfff6d57ddb","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f596e01-8c0d-4bc2-92f4-ac91bbddbe57","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"333240c0-340a-457b-976b-42f16fdfd656","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5d55a2a9-c507-45d8-a23b-f619ae161732","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dcc953ac-87af-49d4-aace-a7202bb3922f","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2f741eb7-e5d6-473a-9eb3-33ada56ceb0a","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c42ca8f-7540-4209-99ae-98ea6cbe7c05","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e7620c4a-59e3-474e-bd86-769b87dee091","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2a40e5a4-3bf3-4b05-8b71-179f33cf6af6","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"286c8f5a-e096-4507-86a4-5632c1cf9d77","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"be504b7f-7661-4f31-aa86-f83996260012","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"858a9230-7088-4b5f-a7b9-314000f4addb","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b09f4d49-6133-4841-a11d-1479afee55db","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d2b6c661-3f8b-4442-8b21-6aac2595f58d","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe5c157-69db-4720-84d1-144205cc4363","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cc550ba8-30e0-4cb8-a99c-13d5081293bc","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f16b193f-4c93-4790-ad52-7520f8df680a","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8b9401bc-4b1c-4191-a463-f54436c49809","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9f51f27f-e6f1-4a6b-a9c3-57cc41bff37e","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1363,7 +1363,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:46:49 GMT
+      - Tue, 21 Apr 2020 05:22:23 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1377,109 +1377,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59962'
+      - '59944'
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '498'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com?api-version=2018-09-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs5OTQ2MjVhMS0yMmY4LTQ3M2EtODY5Zi1lOGM1MDFjNDY4ZTM=?api-version=2018-09-01
-      cache-control:
-      - private
-      content-length:
-      - '0'
-      date:
-      - Thu, 16 Apr 2020 14:46:52 GMT
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs5OTQ2MjVhMS0yMmY4LTQ3M2EtODY5Zi1lOGM1MDFjNDY4ZTM=?api-version=2018-09-01
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs5OTQ2MjVhMS0yMmY4LTQ3M2EtODY5Zi1lOGM1MDFjNDY4ZTM=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"Succeeded"}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '22'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:47:22 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -1514,7 +1414,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmZWRiZWZmZS02MjdiLTQxNGItOGVkMi02NTUwYWVmNGFjNzE=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkZTEzY2ZkZC04ZmE0LTRlOWUtODhiOC05NGUwNTc4MzFiODY=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -1522,9 +1422,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:47:50 GMT
+      - Tue, 21 Apr 2020 05:22:25 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmZWRiZWZmZS02MjdiLTQxNGItOGVkMi02NTUwYWVmNGFjNzE=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkZTEzY2ZkZC04ZmE0LTRlOWUtODhiOC05NGUwNTc4MzFiODY=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1534,7 +1434,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -1562,18 +1462,69 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"3f6831de-1935-4533-bdb8-63603b9e7390","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:21 GMT
+      - Tue, 21 Apr 2020 05:22:56 GMT
       etag:
-      - 3f6831de-1935-4533-bdb8-63603b9e7390
+      - abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com","name":"zone4.com","type":"Microsoft.Network\/privateDnsZones","etag":"25c74d30-c52b-4704-9d79-be31ef1d5fed","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":20,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '614'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:22:56 GMT
+      etag:
+      - 25c74d30-c52b-4704-9d79-be31ef1d5fed
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1621,7 +1572,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6d49edfc-384a-4015-a73e-fbf455ac81cd","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"aca14954-1362-4342-88ca-2e5cfda3daa9","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1630,9 +1581,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:22 GMT
+      - Tue, 21 Apr 2020 05:22:57 GMT
       etag:
-      - 6d49edfc-384a-4015-a73e-fbf455ac81cd
+      - aca14954-1362-4342-88ca-2e5cfda3daa9
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1646,7 +1597,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -1679,7 +1630,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d1379b1b-b8a3-40f8-ba24-d6191f28df14","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dddb7244-cd73-4982-9fee-a8cf44ba37f4","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1688,24 +1639,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:23 GMT
+      - Tue, 21 Apr 2020 05:22:58 GMT
       etag:
-      - d1379b1b-b8a3-40f8-ba24-d6191f28df14
+      - dddb7244-cd73-4982-9fee-a8cf44ba37f4
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11987'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 5, "aRecords": [{"ipv4Address": "11.2.3.4"}, {"ipv4Address":
       "11.5.6.7"}]}}'
@@ -1733,7 +1688,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dbd82830-4471-4b3c-9174-2b003a9b9194","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ce069be2-15ef-420b-bf0f-3fc685565ad7","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1742,24 +1697,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:24 GMT
+      - Tue, 21 Apr 2020 05:22:59 GMT
       etag:
-      - dbd82830-4471-4b3c-9174-2b003a9b9194
+      - ce069be2-15ef-420b-bf0f-3fc685565ad7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11986'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 0, "aRecords": [{"ipv4Address": "10.2.3.4"}]}}'
     headers:
@@ -1786,7 +1745,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-0?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"14bcbfff-9bdf-4044-8a61-87297e30f872","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6f041c7e-28d9-4dd9-a4d8-c7d72007a1ec","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1795,24 +1754,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:26 GMT
+      - Tue, 21 Apr 2020 05:23:00 GMT
       etag:
-      - 14bcbfff-9bdf-4044-8a61-87297e30f872
+      - 6f041c7e-28d9-4dd9-a4d8-c7d72007a1ec
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "10.6.7.8"}]}}'
     headers:
@@ -1839,7 +1802,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-100?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d534c217-b1ad-48bc-8620-c7073d3e51e6","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"87186729-0cd4-4544-86bb-38e85f1ea59c","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1848,24 +1811,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:27 GMT
+      - Tue, 21 Apr 2020 05:23:02 GMT
       etag:
-      - d534c217-b1ad-48bc-8620-c7073d3e51e6
+      - 87186729-0cd4-4544-86bb-38e85f1ea59c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11988'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 86400, "aRecords": [{"ipv4Address": "10.7.8.9"}]}}'
     headers:
@@ -1892,7 +1859,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1d?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f7ee592f-bbe9-4329-b9b9-19d3ac31319c","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e8ee1527-5831-4e5e-bab6-b0176fe9e2dd","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1901,24 +1868,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:28 GMT
+      - Tue, 21 Apr 2020 05:23:04 GMT
       etag:
-      - f7ee592f-bbe9-4329-b9b9-19d3ac31319c
+      - e8ee1527-5831-4e5e-bab6-b0176fe9e2dd
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11987'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.4.5.6"}]}}'
     headers:
@@ -1945,7 +1916,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1h?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"df9cf357-18ad-4bfe-aca3-ed09c5d4999c","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"13ecf48a-d366-4bb7-bf5b-f700323c948c","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1954,24 +1925,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:29 GMT
+      - Tue, 21 Apr 2020 05:23:05 GMT
       etag:
-      - df9cf357-18ad-4bfe-aca3-ed09c5d4999c
+      - 13ecf48a-d366-4bb7-bf5b-f700323c948c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 604800, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
     headers:
@@ -1998,7 +1973,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1w?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c3609773-eb16-4cb1-a424-18db668d87a1","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c621fbef-355c-4938-86ac-a7bef47ea6f3","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2007,24 +1982,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:30 GMT
+      - Tue, 21 Apr 2020 05:23:06 GMT
       etag:
-      - c3609773-eb16-4cb1-a424-18db668d87a1
+      - c621fbef-355c-4938-86ac-a7bef47ea6f3
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 300, "aRecords": [{"ipv4Address": "10.1.2.3"}]}}'
     headers:
@@ -2051,7 +2030,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-300?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b3d12906-2c90-4fc4-a4b5-52b4f7c63b85","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8d5baa15-9e97-4cbd-910b-c02c32490d27","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2060,24 +2039,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:31 GMT
+      - Tue, 21 Apr 2020 05:23:07 GMT
       etag:
-      - b3d12906-2c90-4fc4-a4b5-52b4f7c63b85
+      - 8d5baa15-9e97-4cbd-910b-c02c32490d27
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 60, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
     headers:
@@ -2104,7 +2087,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-60?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"071e2e08-f27a-4cc3-9a77-001ef8e457ea","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cdfce0f9-3d74-4c62-b25a-87cd67b7f59f","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2113,24 +2096,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:32 GMT
+      - Tue, 21 Apr 2020 05:23:08 GMT
       etag:
-      - 071e2e08-f27a-4cc3-9a77-001ef8e457ea
+      - cdfce0f9-3d74-4c62-b25a-87cd67b7f59f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11986'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 360, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
     headers:
@@ -2157,7 +2144,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-6m?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b9b095a0-1992-44bd-aefd-4f03ed832c07","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"37bf7fc6-452b-4d9d-a9bc-6459518b933d","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2166,24 +2153,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:33 GMT
+      - Tue, 21 Apr 2020 05:23:10 GMT
       etag:
-      - b9b095a0-1992-44bd-aefd-4f03ed832c07
+      - 37bf7fc6-452b-4d9d-a9bc-6459518b933d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 99, "aRecords": [{"ipv4Address": "10.5.6.7"}]}}'
     headers:
@@ -2210,7 +2201,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-99s?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cbc26ed5-016d-412b-8de2-9a3ef468aed4","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a9114a16-3146-498b-a553-8073dabc1745","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2219,24 +2210,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:34 GMT
+      - Tue, 21 Apr 2020 05:23:11 GMT
       etag:
-      - cbc26ed5-016d-412b-8de2-9a3ef468aed4
+      - a9114a16-3146-498b-a553-8073dabc1745
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 788645, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
     headers:
@@ -2263,7 +2258,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-mix?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3c2bfc95-7890-44f8-b9e5-1d543b39f5f8","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"85bb9133-2537-48b5-88e0-a8e428e36a8d","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2272,24 +2267,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:35 GMT
+      - Tue, 21 Apr 2020 05:23:12 GMT
       etag:
-      - 3c2bfc95-7890-44f8-b9e5-1d543b39f5f8
+      - 85bb9133-2537-48b5-88e0-a8e428e36a8d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "10.6.7.8"}]}}'
     headers:
@@ -2316,7 +2315,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-100?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"22fbebb0-1ca2-458b-a8ac-0ef51871bf96","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a77e4c9a-b264-421d-a060-4d5f72429beb","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2325,24 +2324,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:36 GMT
+      - Tue, 21 Apr 2020 05:23:14 GMT
       etag:
-      - 22fbebb0-1ca2-458b-a8ac-0ef51871bf96
+      - a77e4c9a-b264-421d-a060-4d5f72429beb
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 86400, "aRecords": [{"ipv4Address": "10.7.8.9"}]}}'
     headers:
@@ -2369,7 +2372,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1d?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bd15bd14-6283-4623-853c-3cfb0fc8b750","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"69520144-ae83-4697-a4ca-e32147808be8","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2378,24 +2381,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:37 GMT
+      - Tue, 21 Apr 2020 05:23:15 GMT
       etag:
-      - bd15bd14-6283-4623-853c-3cfb0fc8b750
+      - 69520144-ae83-4697-a4ca-e32147808be8
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11988'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.4.5.6"}]}}'
     headers:
@@ -2422,7 +2429,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1h?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f808f42e-0253-4ecc-96b7-1667ca6d8c77","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dad2d777-ce0c-4fc3-bbb4-e0cbca3f5c7e","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2431,24 +2438,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:38 GMT
+      - Tue, 21 Apr 2020 05:23:17 GMT
       etag:
-      - f808f42e-0253-4ecc-96b7-1667ca6d8c77
+      - dad2d777-ce0c-4fc3-bbb4-e0cbca3f5c7e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 604800, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
     headers:
@@ -2475,7 +2486,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1w?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"219fbd06-1837-4360-a24d-882fb0f346a5","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0bd61037-443c-4c62-bf00-cb9ebccf893d","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2484,13 +2495,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:39 GMT
+      - Tue, 21 Apr 2020 05:23:18 GMT
       etag:
-      - 219fbd06-1837-4360-a24d-882fb0f346a5
+      - 0bd61037-443c-4c62-bf00-cb9ebccf893d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -2500,8 +2515,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 360, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
     headers:
@@ -2528,7 +2543,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-6m?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a74642bb-c2b1-450d-acf6-3e8aba67e4d6","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b535304b-f9af-4ca2-9455-422bf9651cfe","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2537,24 +2552,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:41 GMT
+      - Tue, 21 Apr 2020 05:23:19 GMT
       etag:
-      - a74642bb-c2b1-450d-acf6-3e8aba67e4d6
+      - b535304b-f9af-4ca2-9455-422bf9651cfe
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 99, "aRecords": [{"ipv4Address": "10.5.6.7"}]}}'
     headers:
@@ -2581,7 +2600,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-99s?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5013145c-ccff-436b-8a6e-313e45400a49","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ee0ede19-10ef-4462-a3d2-d3b655732f7d","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2590,13 +2609,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:41 GMT
+      - Tue, 21 Apr 2020 05:23:21 GMT
       etag:
-      - 5013145c-ccff-436b-8a6e-313e45400a49
+      - ee0ede19-10ef-4462-a3d2-d3b655732f7d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -2606,8 +2629,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 788645, "aRecords": [{"ipv4Address": "10.9.9.9"}]}}'
     headers:
@@ -2634,7 +2657,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-mix?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4b3f71c5-16fc-4d20-ae77-26102fc02ecd","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a4fa7c12-1e97-4dfa-bf07-a2e4ab0a6db3","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2643,24 +2666,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:43 GMT
+      - Tue, 21 Apr 2020 05:23:22 GMT
       etag:
-      - 4b3f71c5-16fc-4d20-ae77-26102fc02ecd
+      - a4fa7c12-1e97-4dfa-bf07-a2e4ab0a6db3
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -2683,7 +2710,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6d49edfc-384a-4015-a73e-fbf455ac81cd","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d1379b1b-b8a3-40f8-ba24-d6191f28df14","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dbd82830-4471-4b3c-9174-2b003a9b9194","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"14bcbfff-9bdf-4044-8a61-87297e30f872","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d534c217-b1ad-48bc-8620-c7073d3e51e6","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f7ee592f-bbe9-4329-b9b9-19d3ac31319c","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"df9cf357-18ad-4bfe-aca3-ed09c5d4999c","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c3609773-eb16-4cb1-a424-18db668d87a1","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b3d12906-2c90-4fc4-a4b5-52b4f7c63b85","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"071e2e08-f27a-4cc3-9a77-001ef8e457ea","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b9b095a0-1992-44bd-aefd-4f03ed832c07","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cbc26ed5-016d-412b-8de2-9a3ef468aed4","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3c2bfc95-7890-44f8-b9e5-1d543b39f5f8","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"22fbebb0-1ca2-458b-a8ac-0ef51871bf96","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bd15bd14-6283-4623-853c-3cfb0fc8b750","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f808f42e-0253-4ecc-96b7-1667ca6d8c77","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"219fbd06-1837-4360-a24d-882fb0f346a5","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a74642bb-c2b1-450d-acf6-3e8aba67e4d6","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5013145c-ccff-436b-8a6e-313e45400a49","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4b3f71c5-16fc-4d20-ae77-26102fc02ecd","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"aca14954-1362-4342-88ca-2e5cfda3daa9","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dddb7244-cd73-4982-9fee-a8cf44ba37f4","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ce069be2-15ef-420b-bf0f-3fc685565ad7","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6f041c7e-28d9-4dd9-a4d8-c7d72007a1ec","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"87186729-0cd4-4544-86bb-38e85f1ea59c","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e8ee1527-5831-4e5e-bab6-b0176fe9e2dd","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"13ecf48a-d366-4bb7-bf5b-f700323c948c","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c621fbef-355c-4938-86ac-a7bef47ea6f3","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8d5baa15-9e97-4cbd-910b-c02c32490d27","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cdfce0f9-3d74-4c62-b25a-87cd67b7f59f","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"37bf7fc6-452b-4d9d-a9bc-6459518b933d","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a9114a16-3146-498b-a553-8073dabc1745","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"85bb9133-2537-48b5-88e0-a8e428e36a8d","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a77e4c9a-b264-421d-a060-4d5f72429beb","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"69520144-ae83-4697-a4ca-e32147808be8","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dad2d777-ce0c-4fc3-bbb4-e0cbca3f5c7e","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0bd61037-443c-4c62-bf00-cb9ebccf893d","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b535304b-f9af-4ca2-9455-422bf9651cfe","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ee0ede19-10ef-4462-a3d2-d3b655732f7d","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a4fa7c12-1e97-4dfa-bf07-a2e4ab0a6db3","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -2692,7 +2719,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:48:43 GMT
+      - Tue, 21 Apr 2020 05:23:23 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2706,9 +2733,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59980'
+      - '59944'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '497'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone4_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone4_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsxZmMxNWE3ZC00Y2QyLTRkOWItOTlhYy03ZTYyNDM3ODcyOWI=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiZjc4YWUxNS04NmZlLTRkMDgtODY2MS00NTZmODU2MWI4OWU=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:21:30 GMT
+      - Wed, 22 Apr 2020 12:13:11 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsxZmMxNWE3ZC00Y2QyLTRkOWItOTlhYy03ZTYyNDM3ODcyOWI=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiZjc4YWUxNS04NmZlLTRkMDgtODY2MS00NTZmODU2MWI4OWU=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -70,24 +70,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiZjc4YWUxNS04NmZlLTRkMDgtODY2MS00NTZmODU2MWI4OWU=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"ae659c41-0e1c-48d3-a969-acb1afc005bb","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:01 GMT
-      etag:
-      - ae659c41-0e1c-48d3-a969-acb1afc005bb
+      - Wed, 22 Apr 2020 12:13:41 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -127,7 +123,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com","name":"zone4.com","type":"Microsoft.Network\/privateDnsZones","etag":"8ab528ea-61d1-4995-ba90-519996add758","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com","name":"zone4.com","type":"Microsoft.Network\/privateDnsZones","etag":"427e115c-6c9d-43bc-b5b3-093c17fd26e4","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -136,9 +132,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:01 GMT
+      - Wed, 22 Apr 2020 12:13:42 GMT
       etag:
-      - 8ab528ea-61d1-4995-ba90-519996add758
+      - 427e115c-6c9d-43bc-b5b3-093c17fd26e4
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -152,7 +148,60 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '486'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b1bc3713-4d6e-4e1d-a668-19a29aa46f03","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:13:43 GMT
+      etag:
+      - b1bc3713-4d6e-4e1d-a668-19a29aa46f03
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -186,7 +235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"e7b412bc-8986-4b3e-ae8f-c12881c8b1ed","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -195,9 +244,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:01 GMT
+      - Wed, 22 Apr 2020 12:13:44 GMT
       etag:
-      - abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5
+      - e7b412bc-8986-4b3e-ae8f-c12881c8b1ed
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -211,7 +260,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -243,7 +292,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-300?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e7620c4a-59e3-474e-bd86-769b87dee091","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e6570487-0346-472a-af98-a2bf4c0d781d","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -252,9 +301,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:02 GMT
+      - Wed, 22 Apr 2020 12:13:46 GMT
       etag:
-      - e7620c4a-59e3-474e-bd86-769b87dee091
+      - e6570487-0346-472a-af98-a2bf4c0d781d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -264,7 +313,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -296,7 +345,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-0?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"333240c0-340a-457b-976b-42f16fdfd656","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"117916da-9aa5-4305-8847-3d37f66f9d58","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -305,9 +354,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:03 GMT
+      - Wed, 22 Apr 2020 12:13:47 GMT
       etag:
-      - 333240c0-340a-457b-976b-42f16fdfd656
+      - 117916da-9aa5-4305-8847-3d37f66f9d58
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -317,7 +366,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -349,7 +398,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-60?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2a40e5a4-3bf3-4b05-8b71-179f33cf6af6","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b183b89b-60b9-4305-b8c5-a3ffb6e97d58","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -358,9 +407,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:04 GMT
+      - Wed, 22 Apr 2020 12:13:48 GMT
       etag:
-      - 2a40e5a4-3bf3-4b05-8b71-179f33cf6af6
+      - b183b89b-60b9-4305-b8c5-a3ffb6e97d58
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -370,7 +419,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11988'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -402,7 +451,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1w?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c42ca8f-7540-4209-99ae-98ea6cbe7c05","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"60db9859-acb5-41d2-a887-31d779fd0701","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -411,9 +460,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:05 GMT
+      - Wed, 22 Apr 2020 12:13:49 GMT
       etag:
-      - 8c42ca8f-7540-4209-99ae-98ea6cbe7c05
+      - 60db9859-acb5-41d2-a887-31d779fd0701
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -423,7 +472,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11991'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -455,7 +504,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1d?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dcc953ac-87af-49d4-aace-a7202bb3922f","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"947e13b3-12f9-419c-b5b5-f77ce18b2b4d","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -464,9 +513,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:06 GMT
+      - Wed, 22 Apr 2020 12:13:51 GMT
       etag:
-      - dcc953ac-87af-49d4-aace-a7202bb3922f
+      - 947e13b3-12f9-419c-b5b5-f77ce18b2b4d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -476,7 +525,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11989'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -508,7 +557,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1h?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2f741eb7-e5d6-473a-9eb3-33ada56ceb0a","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1681fa00-75e7-4a50-8da8-fddd98f07b2e","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -517,9 +566,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:07 GMT
+      - Wed, 22 Apr 2020 12:13:52 GMT
       etag:
-      - 2f741eb7-e5d6-473a-9eb3-33ada56ceb0a
+      - 1681fa00-75e7-4a50-8da8-fddd98f07b2e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -529,7 +578,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -561,7 +610,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-99s?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"be504b7f-7661-4f31-aa86-f83996260012","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d8e15629-32bb-4c78-9757-0da05ad5b2b1","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -570,9 +619,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:08 GMT
+      - Wed, 22 Apr 2020 12:13:53 GMT
       etag:
-      - be504b7f-7661-4f31-aa86-f83996260012
+      - d8e15629-32bb-4c78-9757-0da05ad5b2b1
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -582,7 +631,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -614,7 +663,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-100?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5d55a2a9-c507-45d8-a23b-f619ae161732","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3f11c21a-d82e-4233-8311-9db489650193","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -623,9 +672,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:09 GMT
+      - Wed, 22 Apr 2020 12:13:55 GMT
       etag:
-      - 5d55a2a9-c507-45d8-a23b-f619ae161732
+      - 3f11c21a-d82e-4233-8311-9db489650193
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -635,7 +684,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -667,7 +716,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-6m?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"286c8f5a-e096-4507-86a4-5632c1cf9d77","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4c2a5d7f-5f5a-4478-bbd3-fffec08c1ff3","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -676,9 +725,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:11 GMT
+      - Wed, 22 Apr 2020 12:13:55 GMT
       etag:
-      - 286c8f5a-e096-4507-86a4-5632c1cf9d77
+      - 4c2a5d7f-5f5a-4478-bbd3-fffec08c1ff3
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -688,7 +737,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11988'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -720,7 +769,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-mix?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"858a9230-7088-4b5f-a7b9-314000f4addb","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0a9b9205-16d5-405b-862e-85dedc9cf0a5","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -729,9 +778,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:12 GMT
+      - Wed, 22 Apr 2020 12:13:57 GMT
       etag:
-      - 858a9230-7088-4b5f-a7b9-314000f4addb
+      - 0a9b9205-16d5-405b-862e-85dedc9cf0a5
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -741,7 +790,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -773,7 +822,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1w?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cc550ba8-30e0-4cb8-a99c-13d5081293bc","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1134f38a-15c7-48aa-809b-d1e460e108b7","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -782,9 +831,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:13 GMT
+      - Wed, 22 Apr 2020 12:13:58 GMT
       etag:
-      - cc550ba8-30e0-4cb8-a99c-13d5081293bc
+      - 1134f38a-15c7-48aa-809b-d1e460e108b7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -794,7 +843,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -826,7 +875,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1d?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d2b6c661-3f8b-4442-8b21-6aac2595f58d","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"90633820-aec4-4ccc-aecd-962c968e3c34","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -835,9 +884,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:14 GMT
+      - Wed, 22 Apr 2020 12:13:59 GMT
       etag:
-      - d2b6c661-3f8b-4442-8b21-6aac2595f58d
+      - 90633820-aec4-4ccc-aecd-962c968e3c34
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -847,7 +896,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11987'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -879,7 +928,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1h?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe5c157-69db-4720-84d1-144205cc4363","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6f470dec-b16c-48f4-83a2-9e33c0c98ebb","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -888,9 +937,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:15 GMT
+      - Wed, 22 Apr 2020 12:14:00 GMT
       etag:
-      - 5fe5c157-69db-4720-84d1-144205cc4363
+      - 6f470dec-b16c-48f4-83a2-9e33c0c98ebb
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -900,7 +949,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11986'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -932,7 +981,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-99s?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8b9401bc-4b1c-4191-a463-f54436c49809","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"50bd6b92-6b73-42d1-86ae-52bd50f40b59","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -941,9 +990,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:16 GMT
+      - Wed, 22 Apr 2020 12:14:02 GMT
       etag:
-      - 8b9401bc-4b1c-4191-a463-f54436c49809
+      - 50bd6b92-6b73-42d1-86ae-52bd50f40b59
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -953,7 +1002,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11985'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -985,7 +1034,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-100?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b09f4d49-6133-4841-a11d-1479afee55db","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c38e71b1-e0e2-43cf-86bb-691ba8a2c90e","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -994,9 +1043,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:16 GMT
+      - Wed, 22 Apr 2020 12:14:03 GMT
       etag:
-      - b09f4d49-6133-4841-a11d-1479afee55db
+      - c38e71b1-e0e2-43cf-86bb-691ba8a2c90e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1006,7 +1055,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11984'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -1038,7 +1087,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-6m?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f16b193f-4c93-4790-ad52-7520f8df680a","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"112bcece-16b5-4d5a-b579-d8d02d25b079","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1047,9 +1096,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:18 GMT
+      - Wed, 22 Apr 2020 12:14:04 GMT
       etag:
-      - f16b193f-4c93-4790-ad52-7520f8df680a
+      - 112bcece-16b5-4d5a-b579-d8d02d25b079
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1059,7 +1108,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11990'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -1091,7 +1140,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-mix?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9f51f27f-e6f1-4a6b-a9c3-57cc41bff37e","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4541e90a-eac9-438e-bd2d-e51883449d22","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1100,9 +1149,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:19 GMT
+      - Wed, 22 Apr 2020 12:14:06 GMT
       etag:
-      - 9f51f27f-e6f1-4a6b-a9c3-57cc41bff37e
+      - 4541e90a-eac9-438e-bd2d-e51883449d22
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1112,7 +1161,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11989'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -1145,7 +1194,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"300bc027-70df-4260-9a98-5dfff6d57ddb","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a383c7a5-769c-4537-83ea-03fb7d23216e","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1154,9 +1203,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:20 GMT
+      - Wed, 22 Apr 2020 12:14:07 GMT
       etag:
-      - 300bc027-70df-4260-9a98-5dfff6d57ddb
+      - a383c7a5-769c-4537-83ea-03fb7d23216e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1166,7 +1215,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -1199,7 +1248,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f596e01-8c0d-4bc2-92f4-ac91bbddbe57","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"08b781e5-7080-4218-9c9e-77f98ddefe49","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1208,9 +1257,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:21 GMT
+      - Wed, 22 Apr 2020 12:14:08 GMT
       etag:
-      - 1f596e01-8c0d-4bc2-92f4-ac91bbddbe57
+      - 08b781e5-7080-4218-9c9e-77f98ddefe49
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1220,7 +1269,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11983'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -1248,7 +1297,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"300bc027-70df-4260-9a98-5dfff6d57ddb","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f596e01-8c0d-4bc2-92f4-ac91bbddbe57","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"333240c0-340a-457b-976b-42f16fdfd656","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5d55a2a9-c507-45d8-a23b-f619ae161732","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dcc953ac-87af-49d4-aace-a7202bb3922f","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2f741eb7-e5d6-473a-9eb3-33ada56ceb0a","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c42ca8f-7540-4209-99ae-98ea6cbe7c05","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e7620c4a-59e3-474e-bd86-769b87dee091","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2a40e5a4-3bf3-4b05-8b71-179f33cf6af6","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"286c8f5a-e096-4507-86a4-5632c1cf9d77","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"be504b7f-7661-4f31-aa86-f83996260012","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"858a9230-7088-4b5f-a7b9-314000f4addb","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b09f4d49-6133-4841-a11d-1479afee55db","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d2b6c661-3f8b-4442-8b21-6aac2595f58d","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe5c157-69db-4720-84d1-144205cc4363","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cc550ba8-30e0-4cb8-a99c-13d5081293bc","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f16b193f-4c93-4790-ad52-7520f8df680a","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8b9401bc-4b1c-4191-a463-f54436c49809","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9f51f27f-e6f1-4a6b-a9c3-57cc41bff37e","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"e7b412bc-8986-4b3e-ae8f-c12881c8b1ed","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a383c7a5-769c-4537-83ea-03fb7d23216e","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"08b781e5-7080-4218-9c9e-77f98ddefe49","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"117916da-9aa5-4305-8847-3d37f66f9d58","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3f11c21a-d82e-4233-8311-9db489650193","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"947e13b3-12f9-419c-b5b5-f77ce18b2b4d","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1681fa00-75e7-4a50-8da8-fddd98f07b2e","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"60db9859-acb5-41d2-a887-31d779fd0701","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e6570487-0346-472a-af98-a2bf4c0d781d","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b183b89b-60b9-4305-b8c5-a3ffb6e97d58","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4c2a5d7f-5f5a-4478-bbd3-fffec08c1ff3","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d8e15629-32bb-4c78-9757-0da05ad5b2b1","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0a9b9205-16d5-405b-862e-85dedc9cf0a5","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c38e71b1-e0e2-43cf-86bb-691ba8a2c90e","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"90633820-aec4-4ccc-aecd-962c968e3c34","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6f470dec-b16c-48f4-83a2-9e33c0c98ebb","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1134f38a-15c7-48aa-809b-d1e460e108b7","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"112bcece-16b5-4d5a-b579-d8d02d25b079","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"50bd6b92-6b73-42d1-86ae-52bd50f40b59","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4541e90a-eac9-438e-bd2d-e51883449d22","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1257,7 +1306,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:21 GMT
+      - Wed, 22 Apr 2020 12:14:09 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1271,7 +1320,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59967'
+      - '59944'
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '498'
       x-powered-by:
@@ -1301,7 +1350,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"e7b412bc-8986-4b3e-ae8f-c12881c8b1ed","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1310,7 +1359,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:22 GMT
+      - Wed, 22 Apr 2020 12:14:10 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1326,7 +1375,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59999'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -1354,7 +1403,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"300bc027-70df-4260-9a98-5dfff6d57ddb","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f596e01-8c0d-4bc2-92f4-ac91bbddbe57","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"333240c0-340a-457b-976b-42f16fdfd656","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5d55a2a9-c507-45d8-a23b-f619ae161732","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dcc953ac-87af-49d4-aace-a7202bb3922f","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2f741eb7-e5d6-473a-9eb3-33ada56ceb0a","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c42ca8f-7540-4209-99ae-98ea6cbe7c05","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e7620c4a-59e3-474e-bd86-769b87dee091","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2a40e5a4-3bf3-4b05-8b71-179f33cf6af6","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"286c8f5a-e096-4507-86a4-5632c1cf9d77","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"be504b7f-7661-4f31-aa86-f83996260012","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"858a9230-7088-4b5f-a7b9-314000f4addb","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b09f4d49-6133-4841-a11d-1479afee55db","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d2b6c661-3f8b-4442-8b21-6aac2595f58d","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5fe5c157-69db-4720-84d1-144205cc4363","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cc550ba8-30e0-4cb8-a99c-13d5081293bc","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"f16b193f-4c93-4790-ad52-7520f8df680a","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8b9401bc-4b1c-4191-a463-f54436c49809","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9f51f27f-e6f1-4a6b-a9c3-57cc41bff37e","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"e7b412bc-8986-4b3e-ae8f-c12881c8b1ed","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a383c7a5-769c-4537-83ea-03fb7d23216e","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"08b781e5-7080-4218-9c9e-77f98ddefe49","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"117916da-9aa5-4305-8847-3d37f66f9d58","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3f11c21a-d82e-4233-8311-9db489650193","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"947e13b3-12f9-419c-b5b5-f77ce18b2b4d","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1681fa00-75e7-4a50-8da8-fddd98f07b2e","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"60db9859-acb5-41d2-a887-31d779fd0701","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e6570487-0346-472a-af98-a2bf4c0d781d","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b183b89b-60b9-4305-b8c5-a3ffb6e97d58","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4c2a5d7f-5f5a-4478-bbd3-fffec08c1ff3","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d8e15629-32bb-4c78-9757-0da05ad5b2b1","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0a9b9205-16d5-405b-862e-85dedc9cf0a5","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c38e71b1-e0e2-43cf-86bb-691ba8a2c90e","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"90633820-aec4-4ccc-aecd-962c968e3c34","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6f470dec-b16c-48f4-83a2-9e33c0c98ebb","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1134f38a-15c7-48aa-809b-d1e460e108b7","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"112bcece-16b5-4d5a-b579-d8d02d25b079","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"50bd6b92-6b73-42d1-86ae-52bd50f40b59","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"4541e90a-eac9-438e-bd2d-e51883449d22","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1363,7 +1412,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:23 GMT
+      - Wed, 22 Apr 2020 12:14:10 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1377,9 +1426,109 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59944'
+      - '59980'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTtjN2ZjZDBiYS0xZDFiLTRlNTktOTdlNC1lN2ZkODIyMjhlYjk=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Wed, 22 Apr 2020 12:14:13 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTtjN2ZjZDBiYS0xZDFiLTRlNTktOTdlNC1lN2ZkODIyMjhlYjk=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTtjN2ZjZDBiYS0xZDFiLTRlNTktOTdlNC1lN2ZkODIyMjhlYjk=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:14:44 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -1414,7 +1563,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkZTEzY2ZkZC04ZmE0LTRlOWUtODhiOC05NGUwNTc4MzFiODY=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmMTdmNjA1Mi1jZjdkLTQ2YTYtYmMyNi0wNWUyMzc3OGQ4NDk=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -1422,9 +1571,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:25 GMT
+      - Wed, 22 Apr 2020 12:15:02 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkZTEzY2ZkZC04ZmE0LTRlOWUtODhiOC05NGUwNTc4MzFiODY=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmMTdmNjA1Mi1jZjdkLTQ2YTYtYmMyNi0wNWUyMzc3OGQ4NDk=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1456,24 +1605,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmMTdmNjA1Mi1jZjdkLTQ2YTYtYmMyNi0wNWUyMzc3OGQ4NDk=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '584'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:56 GMT
-      etag:
-      - abf4b2be-ac1e-4aa4-844d-ba0c0580b3b5
+      - Wed, 22 Apr 2020 12:15:31 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1487,7 +1632,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -1513,18 +1658,71 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com","name":"zone4.com","type":"Microsoft.Network\/privateDnsZones","etag":"25c74d30-c52b-4704-9d79-be31ef1d5fed","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":20,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com","name":"zone4.com","type":"Microsoft.Network\/privateDnsZones","etag":"5cfd9851-d493-4cfb-8689-c9dd337cfcbb","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '614'
+      - '613'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:56 GMT
+      - Wed, 22 Apr 2020 12:15:32 GMT
       etag:
-      - 25c74d30-c52b-4704-9d79-be31ef1d5fed
+      - 5cfd9851-d493-4cfb-8689-c9dd337cfcbb
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '496'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"dd540770-c30b-4f35-af21-d44179d48143","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:15:33 GMT
+      etag:
+      - dd540770-c30b-4f35-af21-d44179d48143
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1572,7 +1770,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"aca14954-1362-4342-88ca-2e5cfda3daa9","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d1af0f18-03eb-4c01-8f1f-e0fe7aac9b66","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1581,9 +1779,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:57 GMT
+      - Wed, 22 Apr 2020 12:15:35 GMT
       etag:
-      - aca14954-1362-4342-88ca-2e5cfda3daa9
+      - d1af0f18-03eb-4c01-8f1f-e0fe7aac9b66
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1630,7 +1828,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dddb7244-cd73-4982-9fee-a8cf44ba37f4","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d9b1e563-7f2b-45fa-8444-c66f7d72e6dd","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1639,28 +1837,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:58 GMT
+      - Wed, 22 Apr 2020 12:15:36 GMT
       etag:
-      - dddb7244-cd73-4982-9fee-a8cf44ba37f4
+      - d9b1e563-7f2b-45fa-8444-c66f7d72e6dd
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11987'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 5, "aRecords": [{"ipv4Address": "11.2.3.4"}, {"ipv4Address":
       "11.5.6.7"}]}}'
@@ -1688,7 +1882,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/c2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ce069be2-15ef-420b-bf0f-3fc685565ad7","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"557d5cda-ca87-4c5e-86d5-77bff76866b7","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1697,28 +1891,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:22:59 GMT
+      - Wed, 22 Apr 2020 12:15:37 GMT
       etag:
-      - ce069be2-15ef-420b-bf0f-3fc685565ad7
+      - 557d5cda-ca87-4c5e-86d5-77bff76866b7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11986'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 0, "aRecords": [{"ipv4Address": "10.2.3.4"}]}}'
     headers:
@@ -1745,7 +1935,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-0?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6f041c7e-28d9-4dd9-a4d8-c7d72007a1ec","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"522bae0f-c477-4298-a799-8328835204f4","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1754,28 +1944,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:00 GMT
+      - Wed, 22 Apr 2020 12:15:38 GMT
       etag:
-      - 6f041c7e-28d9-4dd9-a4d8-c7d72007a1ec
+      - 522bae0f-c477-4298-a799-8328835204f4
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "10.6.7.8"}]}}'
     headers:
@@ -1802,7 +1988,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-100?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"87186729-0cd4-4544-86bb-38e85f1ea59c","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1c494161-fd65-434b-82f6-bbf85577e883","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1811,28 +1997,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:02 GMT
+      - Wed, 22 Apr 2020 12:15:40 GMT
       etag:
-      - 87186729-0cd4-4544-86bb-38e85f1ea59c
+      - 1c494161-fd65-434b-82f6-bbf85577e883
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11988'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 86400, "aRecords": [{"ipv4Address": "10.7.8.9"}]}}'
     headers:
@@ -1859,7 +2041,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1d?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e8ee1527-5831-4e5e-bab6-b0176fe9e2dd","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5d9a39e0-0477-43fa-9917-8c6bde05ad6d","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1868,28 +2050,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:04 GMT
+      - Wed, 22 Apr 2020 12:15:41 GMT
       etag:
-      - e8ee1527-5831-4e5e-bab6-b0176fe9e2dd
+      - 5d9a39e0-0477-43fa-9917-8c6bde05ad6d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11987'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.4.5.6"}]}}'
     headers:
@@ -1916,7 +2094,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1h?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"13ecf48a-d366-4bb7-bf5b-f700323c948c","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"35d3c822-bae1-483f-b5a9-ce65ff62405c","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1925,28 +2103,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:05 GMT
+      - Wed, 22 Apr 2020 12:15:42 GMT
       etag:
-      - 13ecf48a-d366-4bb7-bf5b-f700323c948c
+      - 35d3c822-bae1-483f-b5a9-ce65ff62405c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 604800, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
     headers:
@@ -1973,7 +2147,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-1w?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c621fbef-355c-4938-86ac-a7bef47ea6f3","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bf9a7fbd-9f12-49c9-b22f-7f057170292f","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1982,28 +2156,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:06 GMT
+      - Wed, 22 Apr 2020 12:15:43 GMT
       etag:
-      - c621fbef-355c-4938-86ac-a7bef47ea6f3
+      - bf9a7fbd-9f12-49c9-b22f-7f057170292f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 300, "aRecords": [{"ipv4Address": "10.1.2.3"}]}}'
     headers:
@@ -2030,7 +2200,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-300?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8d5baa15-9e97-4cbd-910b-c02c32490d27","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5f056718-b288-4ebc-b84e-82a23cc85422","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2039,28 +2209,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:07 GMT
+      - Wed, 22 Apr 2020 12:15:45 GMT
       etag:
-      - 8d5baa15-9e97-4cbd-910b-c02c32490d27
+      - 5f056718-b288-4ebc-b84e-82a23cc85422
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 60, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
     headers:
@@ -2087,7 +2253,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-60?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cdfce0f9-3d74-4c62-b25a-87cd67b7f59f","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c9b0c67c-9b5f-4149-a156-c83ed449c914","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2096,28 +2262,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:08 GMT
+      - Wed, 22 Apr 2020 12:15:46 GMT
       etag:
-      - cdfce0f9-3d74-4c62-b25a-87cd67b7f59f
+      - c9b0c67c-9b5f-4149-a156-c83ed449c914
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11986'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 360, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
     headers:
@@ -2144,7 +2306,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-6m?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"37bf7fc6-452b-4d9d-a9bc-6459518b933d","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b287f0d9-c54b-4ed7-87de-ad9f7a97379f","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2153,28 +2315,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:10 GMT
+      - Wed, 22 Apr 2020 12:15:46 GMT
       etag:
-      - 37bf7fc6-452b-4d9d-a9bc-6459518b933d
+      - b287f0d9-c54b-4ed7-87de-ad9f7a97379f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 99, "aRecords": [{"ipv4Address": "10.5.6.7"}]}}'
     headers:
@@ -2201,7 +2359,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-99s?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a9114a16-3146-498b-a553-8073dabc1745","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"26002f12-6953-40e2-848c-c04aec86b012","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2210,28 +2368,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:11 GMT
+      - Wed, 22 Apr 2020 12:15:48 GMT
       etag:
-      - a9114a16-3146-498b-a553-8073dabc1745
+      - 26002f12-6953-40e2-848c-c04aec86b012
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 788645, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
     headers:
@@ -2258,7 +2412,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/ttl-mix?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"85bb9133-2537-48b5-88e0-a8e428e36a8d","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e9e1a928-da17-4106-840c-1e700cdda8c2","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2267,28 +2421,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:12 GMT
+      - Wed, 22 Apr 2020 12:15:49 GMT
       etag:
-      - 85bb9133-2537-48b5-88e0-a8e428e36a8d
+      - e9e1a928-da17-4106-840c-1e700cdda8c2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 100, "aRecords": [{"ipv4Address": "10.6.7.8"}]}}'
     headers:
@@ -2315,7 +2465,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-100?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a77e4c9a-b264-421d-a060-4d5f72429beb","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"fd0a358f-206e-4f09-a123-fed8e4b875f4","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2324,28 +2474,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:14 GMT
+      - Wed, 22 Apr 2020 12:15:50 GMT
       etag:
-      - a77e4c9a-b264-421d-a060-4d5f72429beb
+      - fd0a358f-206e-4f09-a123-fed8e4b875f4
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 86400, "aRecords": [{"ipv4Address": "10.7.8.9"}]}}'
     headers:
@@ -2372,7 +2518,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1d?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"69520144-ae83-4697-a4ca-e32147808be8","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5f64e58b-5dcb-4ea2-beae-de673eddb943","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2381,28 +2527,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:15 GMT
+      - Wed, 22 Apr 2020 12:15:51 GMT
       etag:
-      - 69520144-ae83-4697-a4ca-e32147808be8
+      - 5f64e58b-5dcb-4ea2-beae-de673eddb943
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11988'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.4.5.6"}]}}'
     headers:
@@ -2429,7 +2571,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1h?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dad2d777-ce0c-4fc3-bbb4-e0cbca3f5c7e","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0788973c-1dfa-424f-8f45-98e8b2a59d1e","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2438,28 +2580,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:17 GMT
+      - Wed, 22 Apr 2020 12:15:52 GMT
       etag:
-      - dad2d777-ce0c-4fc3-bbb4-e0cbca3f5c7e
+      - 0788973c-1dfa-424f-8f45-98e8b2a59d1e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 604800, "aRecords": [{"ipv4Address": "10.3.4.5"}]}}'
     headers:
@@ -2486,7 +2624,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-1w?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0bd61037-443c-4c62-bf00-cb9ebccf893d","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"27f4eadf-1c52-4056-8b7c-a83d36ff9e90","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2495,28 +2633,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:18 GMT
+      - Wed, 22 Apr 2020 12:15:54 GMT
       etag:
-      - 0bd61037-443c-4c62-bf00-cb9ebccf893d
+      - 27f4eadf-1c52-4056-8b7c-a83d36ff9e90
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 360, "aRecords": [{"ipv4Address": "10.8.9.0"}]}}'
     headers:
@@ -2543,7 +2677,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-6m?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b535304b-f9af-4ca2-9455-422bf9651cfe","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"44fa0bab-eae6-406e-928b-550de3f2d5f0","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2552,28 +2686,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:19 GMT
+      - Wed, 22 Apr 2020 12:15:55 GMT
       etag:
-      - b535304b-f9af-4ca2-9455-422bf9651cfe
+      - 44fa0bab-eae6-406e-928b-550de3f2d5f0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 99, "aRecords": [{"ipv4Address": "10.5.6.7"}]}}'
     headers:
@@ -2600,7 +2730,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-99s?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ee0ede19-10ef-4462-a3d2-d3b655732f7d","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"24c9e90f-1d0a-4c90-b742-1233341a902c","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2609,28 +2739,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:21 GMT
+      - Wed, 22 Apr 2020 12:15:56 GMT
       etag:
-      - ee0ede19-10ef-4462-a3d2-d3b655732f7d
+      - 24c9e90f-1d0a-4c90-b742-1233341a902c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 788645, "aRecords": [{"ipv4Address": "10.9.9.9"}]}}'
     headers:
@@ -2657,7 +2783,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/A/xttl-mix?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a4fa7c12-1e97-4dfa-bf07-a2e4ab0a6db3","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"715ce728-7d64-4e88-bfc0-7d53aae3a6c3","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2666,28 +2792,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:22 GMT
+      - Wed, 22 Apr 2020 12:15:57 GMT
       etag:
-      - a4fa7c12-1e97-4dfa-bf07-a2e4ab0a6db3
+      - 715ce728-7d64-4e88-bfc0-7d53aae3a6c3
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11990'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: null
     headers:
@@ -2710,7 +2832,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone4_import000001/providers/Microsoft.Network/privateDnsZones/zone4.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"aca14954-1362-4342-88ca-2e5cfda3daa9","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dddb7244-cd73-4982-9fee-a8cf44ba37f4","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ce069be2-15ef-420b-bf0f-3fc685565ad7","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6f041c7e-28d9-4dd9-a4d8-c7d72007a1ec","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"87186729-0cd4-4544-86bb-38e85f1ea59c","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e8ee1527-5831-4e5e-bab6-b0176fe9e2dd","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"13ecf48a-d366-4bb7-bf5b-f700323c948c","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c621fbef-355c-4938-86ac-a7bef47ea6f3","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8d5baa15-9e97-4cbd-910b-c02c32490d27","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cdfce0f9-3d74-4c62-b25a-87cd67b7f59f","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"37bf7fc6-452b-4d9d-a9bc-6459518b933d","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a9114a16-3146-498b-a553-8073dabc1745","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"85bb9133-2537-48b5-88e0-a8e428e36a8d","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a77e4c9a-b264-421d-a060-4d5f72429beb","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"69520144-ae83-4697-a4ca-e32147808be8","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"dad2d777-ce0c-4fc3-bbb4-e0cbca3f5c7e","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0bd61037-443c-4c62-bf00-cb9ebccf893d","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b535304b-f9af-4ca2-9455-422bf9651cfe","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ee0ede19-10ef-4462-a3d2-d3b655732f7d","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a4fa7c12-1e97-4dfa-bf07-a2e4ab0a6db3","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"d1af0f18-03eb-4c01-8f1f-e0fe7aac9b66","properties":{"fqdn":"zone4.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone4.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c1","name":"c1","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d9b1e563-7f2b-45fa-8444-c66f7d72e6dd","properties":{"fqdn":"c1.zone4.com.","ttl":10,"aRecords":[{"ipv4Address":"11.1.2.3"},{"ipv4Address":"11.2.3.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/c2","name":"c2","type":"Microsoft.Network\/privateDnsZones\/A","etag":"557d5cda-ca87-4c5e-86d5-77bff76866b7","properties":{"fqdn":"c2.zone4.com.","ttl":5,"aRecords":[{"ipv4Address":"11.2.3.4"},{"ipv4Address":"11.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-0","name":"ttl-0","type":"Microsoft.Network\/privateDnsZones\/A","etag":"522bae0f-c477-4298-a799-8328835204f4","properties":{"fqdn":"ttl-0.zone4.com.","ttl":0,"aRecords":[{"ipv4Address":"10.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-100","name":"ttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1c494161-fd65-434b-82f6-bbf85577e883","properties":{"fqdn":"ttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1d","name":"ttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5d9a39e0-0477-43fa-9917-8c6bde05ad6d","properties":{"fqdn":"ttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1h","name":"ttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"35d3c822-bae1-483f-b5a9-ce65ff62405c","properties":{"fqdn":"ttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-1w","name":"ttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bf9a7fbd-9f12-49c9-b22f-7f057170292f","properties":{"fqdn":"ttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-300","name":"ttl-300","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5f056718-b288-4ebc-b84e-82a23cc85422","properties":{"fqdn":"ttl-300.zone4.com.","ttl":300,"aRecords":[{"ipv4Address":"10.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-60","name":"ttl-60","type":"Microsoft.Network\/privateDnsZones\/A","etag":"c9b0c67c-9b5f-4149-a156-c83ed449c914","properties":{"fqdn":"ttl-60.zone4.com.","ttl":60,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-6m","name":"ttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b287f0d9-c54b-4ed7-87de-ad9f7a97379f","properties":{"fqdn":"ttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-99s","name":"ttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"26002f12-6953-40e2-848c-c04aec86b012","properties":{"fqdn":"ttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/ttl-mix","name":"ttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e9e1a928-da17-4106-840c-1e700cdda8c2","properties":{"fqdn":"ttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-100","name":"xttl-100","type":"Microsoft.Network\/privateDnsZones\/A","etag":"fd0a358f-206e-4f09-a123-fed8e4b875f4","properties":{"fqdn":"xttl-100.zone4.com.","ttl":100,"aRecords":[{"ipv4Address":"10.6.7.8"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1d","name":"xttl-1d","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5f64e58b-5dcb-4ea2-beae-de673eddb943","properties":{"fqdn":"xttl-1d.zone4.com.","ttl":86400,"aRecords":[{"ipv4Address":"10.7.8.9"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1h","name":"xttl-1h","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0788973c-1dfa-424f-8f45-98e8b2a59d1e","properties":{"fqdn":"xttl-1h.zone4.com.","ttl":3600,"aRecords":[{"ipv4Address":"10.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-1w","name":"xttl-1w","type":"Microsoft.Network\/privateDnsZones\/A","etag":"27f4eadf-1c52-4056-8b7c-a83d36ff9e90","properties":{"fqdn":"xttl-1w.zone4.com.","ttl":604800,"aRecords":[{"ipv4Address":"10.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-6m","name":"xttl-6m","type":"Microsoft.Network\/privateDnsZones\/A","etag":"44fa0bab-eae6-406e-928b-550de3f2d5f0","properties":{"fqdn":"xttl-6m.zone4.com.","ttl":360,"aRecords":[{"ipv4Address":"10.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-99s","name":"xttl-99s","type":"Microsoft.Network\/privateDnsZones\/A","etag":"24c9e90f-1d0a-4c90-b742-1233341a902c","properties":{"fqdn":"xttl-99s.zone4.com.","ttl":99,"aRecords":[{"ipv4Address":"10.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone4_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone4.com\/A\/xttl-mix","name":"xttl-mix","type":"Microsoft.Network\/privateDnsZones\/A","etag":"715ce728-7d64-4e88-bfc0-7d53aae3a6c3","properties":{"fqdn":"xttl-mix.zone4.com.","ttl":788645,"aRecords":[{"ipv4Address":"10.9.9.9"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -2719,7 +2841,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:23 GMT
+      - Wed, 22 Apr 2020 12:15:57 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2733,9 +2855,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59944'
+      - '59980'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '497'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone5_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone5_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkNTZjOTM0Zi0yOGZjLTQ2OGYtOWRlYy0zODk3YzMzODY2OTQ=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1MjZjYjE4Ny0yMGNhLTRlNDItOWFmMS0zNDQ3MzY5ZGExYWY=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:16 GMT
+      - Tue, 21 Apr 2020 05:23:48 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkNTZjOTM0Zi0yOGZjLTQ2OGYtOWRlYy0zODk3YzMzODY2OTQ=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1MjZjYjE4Ny0yMGNhLTRlNDItOWFmMS0zNDQ3MzY5ZGExYWY=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -48,7 +48,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -70,24 +70,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1MjZjYjE4Ny0yMGNhLTRlNDItOWFmMS0zNDQ3MzY5ZGExYWY=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"647ad6d1-9ca0-4417-abd8-40172bde0823","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:46 GMT
-      etag:
-      - 647ad6d1-9ca0-4417-abd8-40172bde0823
+      - Tue, 21 Apr 2020 05:24:21 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -101,7 +97,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -135,7 +131,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"c5d58f47-9bf8-4a85-8e86-8de40805905f","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5a3d2618-4e96-447c-95c1-224ee8199bcd","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -144,9 +140,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:47 GMT
+      - Tue, 21 Apr 2020 05:24:23 GMT
       etag:
-      - c5d58f47-9bf8-4a85-8e86-8de40805905f
+      - 5a3d2618-4e96-447c-95c1-224ee8199bcd
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -160,7 +156,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -192,7 +188,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"608186d9-926c-45b6-8f22-2552331560a7","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9e0faeae-e6e7-4b2a-80cf-42ac0ba0fb3c","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -201,9 +197,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:48 GMT
+      - Tue, 21 Apr 2020 05:24:24 GMT
       etag:
-      - 608186d9-926c-45b6-8f22-2552331560a7
+      - 9e0faeae-e6e7-4b2a-80cf-42ac0ba0fb3c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -213,7 +209,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
@@ -245,7 +241,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/default?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a71dd007-e2a6-454c-9dd3-86ed8069f2b1","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c6ba7a6-af72-4994-b697-72d1246a8e78","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -254,9 +250,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:49 GMT
+      - Tue, 21 Apr 2020 05:24:25 GMT
       etag:
-      - a71dd007-e2a6-454c-9dd3-86ed8069f2b1
+      - 8c6ba7a6-af72-4994-b697-72d1246a8e78
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -266,7 +262,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11989'
       x-powered-by:
       - ASP.NET
     status:
@@ -298,7 +294,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/tc?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"75fb2092-1300-4eba-b69a-93cd873e0ead","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"306518d0-6614-4bdf-9e40-4bead1000425","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -307,9 +303,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:50 GMT
+      - Tue, 21 Apr 2020 05:24:26 GMT
       etag:
-      - 75fb2092-1300-4eba-b69a-93cd873e0ead
+      - 306518d0-6614-4bdf-9e40-4bead1000425
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -319,7 +315,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -351,7 +347,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0c356ae9-69ac-4f36-b6c8-8351556dced0","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"83aac2ad-9afc-457f-8011-0887a44c589b","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -360,9 +356,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:51 GMT
+      - Tue, 21 Apr 2020 05:24:27 GMT
       etag:
-      - 0c356ae9-69ac-4f36-b6c8-8351556dced0
+      - 83aac2ad-9afc-457f-8011-0887a44c589b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -372,7 +368,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11988'
       x-powered-by:
       - ASP.NET
     status:
@@ -404,7 +400,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f4a81d66-cecb-497b-aade-7b28b2dfe2ae","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a653e79e-bce9-4db0-8ec8-2545c217e602","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -413,9 +409,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:53 GMT
+      - Tue, 21 Apr 2020 05:24:28 GMT
       etag:
-      - f4a81d66-cecb-497b-aade-7b28b2dfe2ae
+      - a653e79e-bce9-4db0-8ec8-2545c217e602
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -425,7 +421,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -458,7 +454,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cfbd2481-2f39-40e1-98b9-e3a88e1446ec","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dfe52a8d-88f2-4f5d-9ca5-a0577ecbdc3a","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -467,9 +463,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:54 GMT
+      - Tue, 21 Apr 2020 05:24:30 GMT
       etag:
-      - cfbd2481-2f39-40e1-98b9-e3a88e1446ec
+      - dfe52a8d-88f2-4f5d-9ca5-a0577ecbdc3a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -479,7 +475,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -512,7 +508,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"84e369b7-5256-435a-8124-c91fdf81120c","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"897903ca-9337-411e-b626-17acb775deaf","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -521,9 +517,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:55 GMT
+      - Tue, 21 Apr 2020 05:24:31 GMT
       etag:
-      - 84e369b7-5256-435a-8124-c91fdf81120c
+      - 897903ca-9337-411e-b626-17acb775deaf
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -533,7 +529,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -565,7 +561,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"94bdd0e9-e6a9-43b5-bcdd-b27da2953dde","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8dea5252-7d82-4da6-a16a-2d3b8d86f9c1","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -574,9 +570,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:56 GMT
+      - Tue, 21 Apr 2020 05:24:31 GMT
       etag:
-      - 94bdd0e9-e6a9-43b5-bcdd-b27da2953dde
+      - 8dea5252-7d82-4da6-a16a-2d3b8d86f9c1
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -619,7 +615,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dc6ca673-3692-4371-a126-e26df29b5cf3","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1c0c753-b9a2-4936-a7fa-d7bbb0f0458d","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -628,9 +624,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:58 GMT
+      - Tue, 21 Apr 2020 05:24:33 GMT
       etag:
-      - dc6ca673-3692-4371-a126-e26df29b5cf3
+      - b1c0c753-b9a2-4936-a7fa-d7bbb0f0458d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -673,7 +669,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"71ea5fcd-3687-42cb-a949-0e95ea7bc8b6","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b3773f10-0102-49ab-8496-174342d99bfe","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -682,9 +678,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:58 GMT
+      - Tue, 21 Apr 2020 05:24:34 GMT
       etag:
-      - 71ea5fcd-3687-42cb-a949-0e95ea7bc8b6
+      - b3773f10-0102-49ab-8496-174342d99bfe
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -694,7 +690,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -726,7 +722,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3785e3c9-6b0e-4269-aeb6-1cd2688b3a9c","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a98fa04c-f6f5-44ad-994d-af70990bdedc","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -735,9 +731,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:49:59 GMT
+      - Tue, 21 Apr 2020 05:24:34 GMT
       etag:
-      - 3785e3c9-6b0e-4269-aeb6-1cd2688b3a9c
+      - a98fa04c-f6f5-44ad-994d-af70990bdedc
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -747,7 +743,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
@@ -779,7 +775,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www.subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"fafd5244-1a08-4582-b6ac-2d62ee68f34c","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7602745d-cb3d-42b6-b60c-ce8f625b0ca0","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -788,9 +784,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:50:00 GMT
+      - Tue, 21 Apr 2020 05:24:36 GMT
       etag:
-      - fafd5244-1a08-4582-b6ac-2d62ee68f34c
+      - 7602745d-cb3d-42b6-b60c-ce8f625b0ca0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -800,7 +796,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11989'
       x-powered-by:
       - ASP.NET
     status:
@@ -832,7 +828,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname.subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"81b99a93-a98d-4b24-8170-b1aa4a1fc7fb","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c499eb71-756d-4183-86b6-a4c179bf19d7","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -841,9 +837,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:50:01 GMT
+      - Tue, 21 Apr 2020 05:24:36 GMT
       etag:
-      - 81b99a93-a98d-4b24-8170-b1aa4a1fc7fb
+      - c499eb71-756d-4183-86b6-a4c179bf19d7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -853,7 +849,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -885,7 +881,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/record?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c0a1e716-0f32-4872-96e7-60d60ef3d8ed","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d522989a-00fe-4132-b501-1588637da09d","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -894,9 +890,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:50:03 GMT
+      - Tue, 21 Apr 2020 05:24:38 GMT
       etag:
-      - c0a1e716-0f32-4872-96e7-60d60ef3d8ed
+      - d522989a-00fe-4132-b501-1588637da09d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -906,7 +902,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -938,7 +934,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/test?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d3ece18d-aec1-400a-b284-c50b98774158","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e1475f02-ee48-40e2-a35d-3d4acfde5d96","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -947,9 +943,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:50:03 GMT
+      - Tue, 21 Apr 2020 05:24:39 GMT
       etag:
-      - d3ece18d-aec1-400a-b284-c50b98774158
+      - e1475f02-ee48-40e2-a35d-3d4acfde5d96
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -959,7 +955,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11987'
       x-powered-by:
       - ASP.NET
     status:
@@ -987,7 +983,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"608186d9-926c-45b6-8f22-2552331560a7","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"c5d58f47-9bf8-4a85-8e86-8de40805905f","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a71dd007-e2a6-454c-9dd3-86ed8069f2b1","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c0a1e716-0f32-4872-96e7-60d60ef3d8ed","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3785e3c9-6b0e-4269-aeb6-1cd2688b3a9c","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"81b99a93-a98d-4b24-8170-b1aa4a1fc7fb","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"fafd5244-1a08-4582-b6ac-2d62ee68f34c","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"75fb2092-1300-4eba-b69a-93cd873e0ead","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d3ece18d-aec1-400a-b284-c50b98774158","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f4a81d66-cecb-497b-aade-7b28b2dfe2ae","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"94bdd0e9-e6a9-43b5-bcdd-b27da2953dde","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cfbd2481-2f39-40e1-98b9-e3a88e1446ec","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dc6ca673-3692-4371-a126-e26df29b5cf3","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"84e369b7-5256-435a-8124-c91fdf81120c","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"71ea5fcd-3687-42cb-a949-0e95ea7bc8b6","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0c356ae9-69ac-4f36-b6c8-8351556dced0","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9e0faeae-e6e7-4b2a-80cf-42ac0ba0fb3c","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5a3d2618-4e96-447c-95c1-224ee8199bcd","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c6ba7a6-af72-4994-b697-72d1246a8e78","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d522989a-00fe-4132-b501-1588637da09d","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a98fa04c-f6f5-44ad-994d-af70990bdedc","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c499eb71-756d-4183-86b6-a4c179bf19d7","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7602745d-cb3d-42b6-b60c-ce8f625b0ca0","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"306518d0-6614-4bdf-9e40-4bead1000425","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e1475f02-ee48-40e2-a35d-3d4acfde5d96","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a653e79e-bce9-4db0-8ec8-2545c217e602","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8dea5252-7d82-4da6-a16a-2d3b8d86f9c1","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dfe52a8d-88f2-4f5d-9ca5-a0577ecbdc3a","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1c0c753-b9a2-4936-a7fa-d7bbb0f0458d","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"897903ca-9337-411e-b626-17acb775deaf","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b3773f10-0102-49ab-8496-174342d99bfe","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"83aac2ad-9afc-457f-8011-0887a44c589b","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -996,7 +992,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:50:05 GMT
+      - Tue, 21 Apr 2020 05:24:39 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1010,9 +1006,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59984'
+      - '59928'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '496'
       x-powered-by:
       - ASP.NET
     status:
@@ -1040,7 +1036,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"c5d58f47-9bf8-4a85-8e86-8de40805905f","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5a3d2618-4e96-447c-95c1-224ee8199bcd","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1049,7 +1045,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:50:05 GMT
+      - Tue, 21 Apr 2020 05:24:41 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1063,9 +1059,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59999'
+      - '59998'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '497'
       x-powered-by:
       - ASP.NET
     status:
@@ -1093,7 +1089,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"608186d9-926c-45b6-8f22-2552331560a7","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"c5d58f47-9bf8-4a85-8e86-8de40805905f","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a71dd007-e2a6-454c-9dd3-86ed8069f2b1","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c0a1e716-0f32-4872-96e7-60d60ef3d8ed","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3785e3c9-6b0e-4269-aeb6-1cd2688b3a9c","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"81b99a93-a98d-4b24-8170-b1aa4a1fc7fb","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"fafd5244-1a08-4582-b6ac-2d62ee68f34c","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"75fb2092-1300-4eba-b69a-93cd873e0ead","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d3ece18d-aec1-400a-b284-c50b98774158","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f4a81d66-cecb-497b-aade-7b28b2dfe2ae","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"94bdd0e9-e6a9-43b5-bcdd-b27da2953dde","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cfbd2481-2f39-40e1-98b9-e3a88e1446ec","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dc6ca673-3692-4371-a126-e26df29b5cf3","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"84e369b7-5256-435a-8124-c91fdf81120c","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"71ea5fcd-3687-42cb-a949-0e95ea7bc8b6","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0c356ae9-69ac-4f36-b6c8-8351556dced0","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9e0faeae-e6e7-4b2a-80cf-42ac0ba0fb3c","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5a3d2618-4e96-447c-95c1-224ee8199bcd","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c6ba7a6-af72-4994-b697-72d1246a8e78","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d522989a-00fe-4132-b501-1588637da09d","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a98fa04c-f6f5-44ad-994d-af70990bdedc","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c499eb71-756d-4183-86b6-a4c179bf19d7","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7602745d-cb3d-42b6-b60c-ce8f625b0ca0","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"306518d0-6614-4bdf-9e40-4bead1000425","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e1475f02-ee48-40e2-a35d-3d4acfde5d96","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a653e79e-bce9-4db0-8ec8-2545c217e602","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8dea5252-7d82-4da6-a16a-2d3b8d86f9c1","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dfe52a8d-88f2-4f5d-9ca5-a0577ecbdc3a","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1c0c753-b9a2-4936-a7fa-d7bbb0f0458d","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"897903ca-9337-411e-b626-17acb775deaf","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b3773f10-0102-49ab-8496-174342d99bfe","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"83aac2ad-9afc-457f-8011-0887a44c589b","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1102,7 +1098,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:50:05 GMT
+      - Tue, 21 Apr 2020 05:24:41 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1116,107 +1112,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59964'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com?api-version=2018-09-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2Yzc1NGZjZC04MDc2LTQwZGEtYWE5YS1lYmI0OTQxMjIxNzM=?api-version=2018-09-01
-      cache-control:
-      - private
-      content-length:
-      - '0'
-      date:
-      - Thu, 16 Apr 2020 14:50:08 GMT
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2Yzc1NGZjZC04MDc2LTQwZGEtYWE5YS1lYmI0OTQxMjIxNzM=?api-version=2018-09-01
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2Yzc1NGZjZC04MDc2LTQwZGEtYWE5YS1lYmI0OTQxMjIxNzM=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"Succeeded"}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '22'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:50:39 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
+      - '59984'
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:
@@ -1253,7 +1149,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkZjM1NjEyMi1mODk2LTQ3MjctYmIyNi01MjQ5NTQxN2E2ODI=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYjAwYzc2Yy1hZTYzLTQ2MzctYWU1YS1iOWZiMjFkYjM1OTk=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -1261,9 +1157,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:06 GMT
+      - Tue, 21 Apr 2020 05:24:43 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkZjM1NjEyMi1mODk2LTQ3MjctYmIyNi01MjQ5NTQxN2E2ODI=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYjAwYzc2Yy1hZTYzLTQ2MzctYWU1YS1iOWZiMjFkYjM1OTk=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1273,7 +1169,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -1295,24 +1191,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYjAwYzc2Yy1hZTYzLTQ2MzctYWU1YS1iOWZiMjFkYjM1OTk=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"dc2ff631-edc1-4577-8ac7-5b7b96835e3a","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:37 GMT
-      etag:
-      - dc2ff631-edc1-4577-8ac7-5b7b96835e3a
+      - Tue, 21 Apr 2020 05:25:14 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1326,7 +1218,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -1352,18 +1244,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com","name":"zone5.com","type":"Microsoft.Network\/privateDnsZones","etag":"de74b176-2e86-4b2d-96fa-8a0fd6c98142","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com","name":"zone5.com","type":"Microsoft.Network\/privateDnsZones","etag":"262c7340-c1d9-4255-9048-0937db2c87ad","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":16,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '613'
+      - '614'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:37 GMT
+      - Tue, 21 Apr 2020 05:25:14 GMT
       etag:
-      - de74b176-2e86-4b2d-96fa-8a0fd6c98142
+      - 262c7340-c1d9-4255-9048-0937db2c87ad
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1411,7 +1303,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6787713c-2584-45a5-885b-e2cfc3f807ab","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"11d3bbd9-1364-49d3-b26c-70e8897fa6c3","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1420,9 +1312,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:38 GMT
+      - Tue, 21 Apr 2020 05:25:15 GMT
       etag:
-      - 6787713c-2584-45a5-885b-e2cfc3f807ab
+      - 11d3bbd9-1364-49d3-b26c-70e8897fa6c3
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1436,7 +1328,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -1468,7 +1360,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0c84a0d5-af94-4ada-be9f-c58c90af8ac1","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"25f6eecf-615f-4cef-9f33-f8417b293fc1","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1477,24 +1369,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:39 GMT
+      - Tue, 21 Apr 2020 05:25:16 GMT
       etag:
-      - 0c84a0d5-af94-4ada-be9f-c58c90af8ac1
+      - 25f6eecf-615f-4cef-9f33-f8417b293fc1
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "0.1.2.3"}]}}'
     headers:
@@ -1521,7 +1417,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/default?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffbd5942-9c22-444f-9daf-e186fd615198","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8a1f3303-edc2-46df-aafa-87d74eb4ecc2","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1530,24 +1426,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:40 GMT
+      - Tue, 21 Apr 2020 05:25:17 GMT
       etag:
-      - ffbd5942-9c22-444f-9daf-e186fd615198
+      - 8a1f3303-edc2-46df-aafa-87d74eb4ecc2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "bar.foo.com."}}}'
     headers:
@@ -1574,7 +1474,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/record?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"6c28d20e-7b62-474a-8c40-15b2d7b3d5c4","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f2ed05bd-16c0-4a19-86f3-26f6e935e3ae","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1583,24 +1483,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:41 GMT
+      - Tue, 21 Apr 2020 05:25:18 GMT
       etag:
-      - 6c28d20e-7b62-474a-8c40-15b2d7b3d5c4
+      - f2ed05bd-16c0-4a19-86f3-26f6e935e3ae
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "3.4.5.6"}]}}'
     headers:
@@ -1627,7 +1531,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7f46c9f4-0697-4609-ab8a-159a2b2961b8","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f172c66-2195-49b8-b745-4fd11c577a5a","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1636,24 +1540,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:42 GMT
+      - Tue, 21 Apr 2020 05:25:19 GMT
       etag:
-      - 7f46c9f4-0697-4609-ab8a-159a2b2961b8
+      - 1f172c66-2195-49b8-b745-4fd11c577a5a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11982'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1.subzone.zone5.com."}}}'
     headers:
@@ -1680,7 +1588,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname.subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"bdfb6f84-a484-44aa-8883-59c7e41ba058","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a10d50ce-f05f-4d70-8fe6-716c6c12fca8","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1689,24 +1597,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:43 GMT
+      - Tue, 21 Apr 2020 05:25:21 GMT
       etag:
-      - bdfb6f84-a484-44aa-8883-59c7e41ba058
+      - a10d50ce-f05f-4d70-8fe6-716c6c12fca8
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "4.5.6.7"}]}}'
     headers:
@@ -1733,7 +1645,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www.subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8e07a4e5-7a5f-4f59-abe3-cf105e0a6881","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"860e5cd3-486e-4fae-beb9-80318a6aae97","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1742,24 +1654,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:44 GMT
+      - Tue, 21 Apr 2020 05:25:21 GMT
       etag:
-      - 8e07a4e5-7a5f-4f59-abe3-cf105e0a6881
+      - 860e5cd3-486e-4fae-beb9-80318a6aae97
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11981'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "test.zone5.com."}}}'
     headers:
@@ -1786,7 +1702,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/tc?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"86e125d8-6fef-407d-899e-016163ef9387","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"609ba9ec-69b7-4262-a958-f5226eafa72c","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1795,13 +1711,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:45 GMT
+      - Tue, 21 Apr 2020 05:25:23 GMT
       etag:
-      - 86e125d8-6fef-407d-899e-016163ef9387
+      - 609ba9ec-69b7-4262-a958-f5226eafa72c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -1811,8 +1731,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "7.8.9.0"}]}}'
     headers:
@@ -1839,7 +1759,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/test?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b5094d8a-93ec-4f6a-a135-7c3552fb76e6","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7201e88c-0f20-4efa-b6b2-b9301d6fe220","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1848,24 +1768,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:47 GMT
+      - Tue, 21 Apr 2020 05:25:25 GMT
       etag:
-      - b5094d8a-93ec-4f6a-a135-7c3552fb76e6
+      - 7201e88c-0f20-4efa-b6b2-b9301d6fe220
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1.zone5.com."}}}'
     headers:
@@ -1892,7 +1816,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a536cd02-0840-41fe-a994-ead4dbe8ec53","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"88ce2acb-33c5-481e-bcae-9053d1737256","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1901,24 +1825,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:48 GMT
+      - Tue, 21 Apr 2020 05:25:26 GMT
       etag:
-      - a536cd02-0840-41fe-a994-ead4dbe8ec53
+      - 88ce2acb-33c5-481e-bcae-9053d1737256
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1."}}}'
     headers:
@@ -1945,7 +1873,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"1fd7a236-2552-4d19-9b01-485e8e611e4b","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8e097355-c513-4111-ad25-acacd0df3d48","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1954,24 +1882,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:48 GMT
+      - Tue, 21 Apr 2020 05:25:27 GMT
       etag:
-      - 1fd7a236-2552-4d19-9b01-485e8e611e4b
+      - 8e097355-c513-4111-ad25-acacd0df3d48
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
       "m1.zone5.com."}]}}'
@@ -1999,7 +1931,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"8f6a0bc4-9a4f-48bd-8597-ab319d830886","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"f05ae970-e78f-42b3-ae13-b4122e3718bf","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2008,13 +1940,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:50 GMT
+      - Tue, 21 Apr 2020 05:25:28 GMT
       etag:
-      - 8f6a0bc4-9a4f-48bd-8597-ab319d830886
+      - f05ae970-e78f-42b3-ae13-b4122e3718bf
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -2024,8 +1960,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
       "m1."}]}}'
@@ -2053,7 +1989,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"8da57a9c-3ce1-4dd7-8811-8526454a27e5","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cd22a9c8-937e-4ac8-a2f6-ddc1ee0aed1f","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2062,13 +1998,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:50 GMT
+      - Tue, 21 Apr 2020 05:25:29 GMT
       etag:
-      - 8da57a9c-3ce1-4dd7-8811-8526454a27e5
+      - cd22a9c8-937e-4ac8-a2f6-ddc1ee0aed1f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -2078,8 +2018,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
       "port": 3, "target": "srv1.zone5.com."}]}}'
@@ -2107,7 +2047,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b42986a1-4caf-47a1-b2a2-e67ad583f1b2","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"6dd0ac2d-2735-4b6e-beb0-68c580e05e3e","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2116,24 +2056,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:52 GMT
+      - Tue, 21 Apr 2020 05:25:30 GMT
       etag:
-      - b42986a1-4caf-47a1-b2a2-e67ad583f1b2
+      - 6dd0ac2d-2735-4b6e-beb0-68c580e05e3e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
       "port": 3, "target": "srv1."}]}}'
@@ -2161,7 +2105,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"179f2742-4cc3-4449-85ca-7f0ee76042e4","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"fdac2bd2-242b-4a49-a299-40ebdc9af442","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2170,13 +2114,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:53 GMT
+      - Tue, 21 Apr 2020 05:25:32 GMT
       etag:
-      - 179f2742-4cc3-4449-85ca-7f0ee76042e4
+      - fdac2bd2-242b-4a49-a299-40ebdc9af442
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -2186,8 +2134,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "2.3.4.5"}]}}'
     headers:
@@ -2214,7 +2162,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"410f273f-8ae6-4f52-afc9-1fd99b3f9ae7","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"88a0df7e-7d28-4fbe-a8a3-fc53cf2c345f","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2223,24 +2171,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:53 GMT
+      - Tue, 21 Apr 2020 05:25:33 GMT
       etag:
-      - 410f273f-8ae6-4f52-afc9-1fd99b3f9ae7
+      - 88a0df7e-7d28-4fbe-a8a3-fc53cf2c345f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11987'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -2263,7 +2215,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0c84a0d5-af94-4ada-be9f-c58c90af8ac1","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6787713c-2584-45a5-885b-e2cfc3f807ab","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffbd5942-9c22-444f-9daf-e186fd615198","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"6c28d20e-7b62-474a-8c40-15b2d7b3d5c4","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7f46c9f4-0697-4609-ab8a-159a2b2961b8","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"bdfb6f84-a484-44aa-8883-59c7e41ba058","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8e07a4e5-7a5f-4f59-abe3-cf105e0a6881","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"86e125d8-6fef-407d-899e-016163ef9387","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b5094d8a-93ec-4f6a-a135-7c3552fb76e6","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a536cd02-0840-41fe-a994-ead4dbe8ec53","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"1fd7a236-2552-4d19-9b01-485e8e611e4b","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"8f6a0bc4-9a4f-48bd-8597-ab319d830886","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"8da57a9c-3ce1-4dd7-8811-8526454a27e5","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b42986a1-4caf-47a1-b2a2-e67ad583f1b2","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"179f2742-4cc3-4449-85ca-7f0ee76042e4","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"410f273f-8ae6-4f52-afc9-1fd99b3f9ae7","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"25f6eecf-615f-4cef-9f33-f8417b293fc1","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"11d3bbd9-1364-49d3-b26c-70e8897fa6c3","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8a1f3303-edc2-46df-aafa-87d74eb4ecc2","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f2ed05bd-16c0-4a19-86f3-26f6e935e3ae","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f172c66-2195-49b8-b745-4fd11c577a5a","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a10d50ce-f05f-4d70-8fe6-716c6c12fca8","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"860e5cd3-486e-4fae-beb9-80318a6aae97","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"609ba9ec-69b7-4262-a958-f5226eafa72c","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7201e88c-0f20-4efa-b6b2-b9301d6fe220","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"88ce2acb-33c5-481e-bcae-9053d1737256","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8e097355-c513-4111-ad25-acacd0df3d48","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"f05ae970-e78f-42b3-ae13-b4122e3718bf","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cd22a9c8-937e-4ac8-a2f6-ddc1ee0aed1f","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"6dd0ac2d-2735-4b6e-beb0-68c580e05e3e","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"fdac2bd2-242b-4a49-a299-40ebdc9af442","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"88a0df7e-7d28-4fbe-a8a3-fc53cf2c345f","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -2272,7 +2224,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:51:54 GMT
+      - Tue, 21 Apr 2020 05:25:34 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2286,9 +2238,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59966'
+      - '59912'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '495'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone5_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone5_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1MjZjYjE4Ny0yMGNhLTRlNDItOWFmMS0zNDQ3MzY5ZGExYWY=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NjUyNjUzOS1lOTc5LTRiN2QtYmNjMC1mYTAyNmM2NGRhNTc=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:23:48 GMT
+      - Wed, 22 Apr 2020 12:16:24 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1MjZjYjE4Ny0yMGNhLTRlNDItOWFmMS0zNDQ3MzY5ZGExYWY=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NjUyNjUzOS1lOTc5LTRiN2QtYmNjMC1mYTAyNmM2NGRhNTc=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -71,7 +71,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1MjZjYjE4Ny0yMGNhLTRlNDItOWFmMS0zNDQ3MzY5ZGExYWY=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NjUyNjUzOS1lOTc5LTRiN2QtYmNjMC1mYTAyNmM2NGRhNTc=?api-version=2018-09-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -83,7 +83,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:21 GMT
+      - Wed, 22 Apr 2020 12:16:55 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -97,7 +97,111 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com","name":"zone5.com","type":"Microsoft.Network\/privateDnsZones","etag":"6a6d591e-1c60-4067-bdfa-1b74df869621","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:16:56 GMT
+      etag:
+      - 6a6d591e-1c60-4067-bdfa-1b74df869621
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '494'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f2ec11e4-d898-4838-bc91-86cfd22ccba6","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:16:56 GMT
+      etag:
+      - f2ec11e4-d898-4838-bc91-86cfd22ccba6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -131,7 +235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5a3d2618-4e96-447c-95c1-224ee8199bcd","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"ee32775a-cb51-4a2f-bb3a-db5e849d84f5","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -140,9 +244,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:23 GMT
+      - Wed, 22 Apr 2020 12:16:57 GMT
       etag:
-      - 5a3d2618-4e96-447c-95c1-224ee8199bcd
+      - ee32775a-cb51-4a2f-bb3a-db5e849d84f5
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -156,7 +260,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -188,7 +292,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9e0faeae-e6e7-4b2a-80cf-42ac0ba0fb3c","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"57fa134b-188b-4c38-a298-8038c42423a2","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -197,9 +301,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:24 GMT
+      - Wed, 22 Apr 2020 12:16:58 GMT
       etag:
-      - 9e0faeae-e6e7-4b2a-80cf-42ac0ba0fb3c
+      - 57fa134b-188b-4c38-a298-8038c42423a2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -209,7 +313,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11991'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
@@ -241,7 +345,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/default?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c6ba7a6-af72-4994-b697-72d1246a8e78","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"802f87e3-4942-4d93-a374-2d9d9fe4abe2","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -250,9 +354,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:25 GMT
+      - Wed, 22 Apr 2020 12:16:59 GMT
       etag:
-      - 8c6ba7a6-af72-4994-b697-72d1246a8e78
+      - 802f87e3-4942-4d93-a374-2d9d9fe4abe2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -262,7 +366,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11989'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -294,7 +398,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/tc?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"306518d0-6614-4bdf-9e40-4bead1000425","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"9bd154ab-fd00-4863-a1fb-9a86f93cd714","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -303,9 +407,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:26 GMT
+      - Wed, 22 Apr 2020 12:17:00 GMT
       etag:
-      - 306518d0-6614-4bdf-9e40-4bead1000425
+      - 9bd154ab-fd00-4863-a1fb-9a86f93cd714
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -347,7 +451,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"83aac2ad-9afc-457f-8011-0887a44c589b","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"054beb6f-92df-451d-b77d-2d017341bf95","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -356,9 +460,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:27 GMT
+      - Wed, 22 Apr 2020 12:17:02 GMT
       etag:
-      - 83aac2ad-9afc-457f-8011-0887a44c589b
+      - 054beb6f-92df-451d-b77d-2d017341bf95
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -368,7 +472,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11988'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
@@ -400,7 +504,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a653e79e-bce9-4db0-8ec8-2545c217e602","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"ba1d5615-f440-4f0a-888f-219ba7c200ca","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -409,9 +513,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:28 GMT
+      - Wed, 22 Apr 2020 12:17:03 GMT
       etag:
-      - a653e79e-bce9-4db0-8ec8-2545c217e602
+      - ba1d5615-f440-4f0a-888f-219ba7c200ca
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -421,7 +525,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -454,7 +558,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dfe52a8d-88f2-4f5d-9ca5-a0577ecbdc3a","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"672fd8e9-ee7a-4831-ab17-9ac7f86fc092","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -463,9 +567,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:30 GMT
+      - Wed, 22 Apr 2020 12:17:04 GMT
       etag:
-      - dfe52a8d-88f2-4f5d-9ca5-a0577ecbdc3a
+      - 672fd8e9-ee7a-4831-ab17-9ac7f86fc092
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -475,7 +579,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -508,7 +612,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"897903ca-9337-411e-b626-17acb775deaf","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"17ca13f5-95c5-4718-b48b-5849e6bb1a88","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -517,9 +621,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:31 GMT
+      - Wed, 22 Apr 2020 12:17:06 GMT
       etag:
-      - 897903ca-9337-411e-b626-17acb775deaf
+      - 17ca13f5-95c5-4718-b48b-5849e6bb1a88
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -561,7 +665,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8dea5252-7d82-4da6-a16a-2d3b8d86f9c1","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"59f52edd-f1e7-4f1c-a16a-0a0505c9592d","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -570,9 +674,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:31 GMT
+      - Wed, 22 Apr 2020 12:17:06 GMT
       etag:
-      - 8dea5252-7d82-4da6-a16a-2d3b8d86f9c1
+      - 59f52edd-f1e7-4f1c-a16a-0a0505c9592d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -582,7 +686,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -615,7 +719,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1c0c753-b9a2-4936-a7fa-d7bbb0f0458d","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"419b7eca-ed6d-4356-a288-7c6a03249972","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -624,9 +728,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:33 GMT
+      - Wed, 22 Apr 2020 12:17:08 GMT
       etag:
-      - b1c0c753-b9a2-4936-a7fa-d7bbb0f0458d
+      - 419b7eca-ed6d-4356-a288-7c6a03249972
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -636,7 +740,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -669,7 +773,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b3773f10-0102-49ab-8496-174342d99bfe","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ae71d294-4e14-4714-b4b9-46d9661a0804","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -678,9 +782,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:34 GMT
+      - Wed, 22 Apr 2020 12:17:09 GMT
       etag:
-      - b3773f10-0102-49ab-8496-174342d99bfe
+      - ae71d294-4e14-4714-b4b9-46d9661a0804
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -690,7 +794,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -722,7 +826,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a98fa04c-f6f5-44ad-994d-af70990bdedc","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5b2dbe82-4cdf-4f8a-817a-ba2f0a63c748","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -731,9 +835,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:34 GMT
+      - Wed, 22 Apr 2020 12:17:10 GMT
       etag:
-      - a98fa04c-f6f5-44ad-994d-af70990bdedc
+      - 5b2dbe82-4cdf-4f8a-817a-ba2f0a63c748
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -743,7 +847,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
@@ -775,7 +879,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www.subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7602745d-cb3d-42b6-b60c-ce8f625b0ca0","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"170dbf20-2d11-456f-af57-5d369363c75a","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -784,9 +888,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:36 GMT
+      - Wed, 22 Apr 2020 12:17:11 GMT
       etag:
-      - 7602745d-cb3d-42b6-b60c-ce8f625b0ca0
+      - 170dbf20-2d11-456f-af57-5d369363c75a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -796,7 +900,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11989'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -828,7 +932,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname.subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c499eb71-756d-4183-86b6-a4c179bf19d7","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"5a25b7be-604c-455b-b803-db276f33c3e0","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -837,9 +941,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:36 GMT
+      - Wed, 22 Apr 2020 12:17:13 GMT
       etag:
-      - c499eb71-756d-4183-86b6-a4c179bf19d7
+      - 5a25b7be-604c-455b-b803-db276f33c3e0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -849,7 +953,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -881,7 +985,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/record?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d522989a-00fe-4132-b501-1588637da09d","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"babd0f33-339f-4aa0-892b-692868871025","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -890,9 +994,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:38 GMT
+      - Wed, 22 Apr 2020 12:17:13 GMT
       etag:
-      - d522989a-00fe-4132-b501-1588637da09d
+      - babd0f33-339f-4aa0-892b-692868871025
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -902,7 +1006,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -934,7 +1038,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/test?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e1475f02-ee48-40e2-a35d-3d4acfde5d96","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2db94241-6a37-4fed-8583-4e20b428f6cd","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -943,9 +1047,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:39 GMT
+      - Wed, 22 Apr 2020 12:17:15 GMT
       etag:
-      - e1475f02-ee48-40e2-a35d-3d4acfde5d96
+      - 2db94241-6a37-4fed-8583-4e20b428f6cd
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -955,7 +1059,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11987'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -983,7 +1087,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9e0faeae-e6e7-4b2a-80cf-42ac0ba0fb3c","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5a3d2618-4e96-447c-95c1-224ee8199bcd","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c6ba7a6-af72-4994-b697-72d1246a8e78","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d522989a-00fe-4132-b501-1588637da09d","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a98fa04c-f6f5-44ad-994d-af70990bdedc","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c499eb71-756d-4183-86b6-a4c179bf19d7","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7602745d-cb3d-42b6-b60c-ce8f625b0ca0","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"306518d0-6614-4bdf-9e40-4bead1000425","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e1475f02-ee48-40e2-a35d-3d4acfde5d96","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a653e79e-bce9-4db0-8ec8-2545c217e602","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8dea5252-7d82-4da6-a16a-2d3b8d86f9c1","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dfe52a8d-88f2-4f5d-9ca5-a0577ecbdc3a","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1c0c753-b9a2-4936-a7fa-d7bbb0f0458d","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"897903ca-9337-411e-b626-17acb775deaf","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b3773f10-0102-49ab-8496-174342d99bfe","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"83aac2ad-9afc-457f-8011-0887a44c589b","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"57fa134b-188b-4c38-a298-8038c42423a2","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"ee32775a-cb51-4a2f-bb3a-db5e849d84f5","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"802f87e3-4942-4d93-a374-2d9d9fe4abe2","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"babd0f33-339f-4aa0-892b-692868871025","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5b2dbe82-4cdf-4f8a-817a-ba2f0a63c748","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"5a25b7be-604c-455b-b803-db276f33c3e0","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"170dbf20-2d11-456f-af57-5d369363c75a","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"9bd154ab-fd00-4863-a1fb-9a86f93cd714","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2db94241-6a37-4fed-8583-4e20b428f6cd","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"ba1d5615-f440-4f0a-888f-219ba7c200ca","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"59f52edd-f1e7-4f1c-a16a-0a0505c9592d","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"672fd8e9-ee7a-4831-ab17-9ac7f86fc092","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"419b7eca-ed6d-4356-a288-7c6a03249972","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"17ca13f5-95c5-4718-b48b-5849e6bb1a88","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ae71d294-4e14-4714-b4b9-46d9661a0804","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"054beb6f-92df-451d-b77d-2d017341bf95","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -992,7 +1096,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:39 GMT
+      - Wed, 22 Apr 2020 12:17:16 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1006,9 +1110,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59928'
+      - '59984'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '496'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -1036,7 +1140,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5a3d2618-4e96-447c-95c1-224ee8199bcd","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"ee32775a-cb51-4a2f-bb3a-db5e849d84f5","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1045,7 +1149,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:41 GMT
+      - Wed, 22 Apr 2020 12:17:16 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1059,9 +1163,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59998'
+      - '59999'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '497'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -1089,7 +1193,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9e0faeae-e6e7-4b2a-80cf-42ac0ba0fb3c","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5a3d2618-4e96-447c-95c1-224ee8199bcd","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8c6ba7a6-af72-4994-b697-72d1246a8e78","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"d522989a-00fe-4132-b501-1588637da09d","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a98fa04c-f6f5-44ad-994d-af70990bdedc","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c499eb71-756d-4183-86b6-a4c179bf19d7","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7602745d-cb3d-42b6-b60c-ce8f625b0ca0","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"306518d0-6614-4bdf-9e40-4bead1000425","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e1475f02-ee48-40e2-a35d-3d4acfde5d96","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a653e79e-bce9-4db0-8ec8-2545c217e602","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8dea5252-7d82-4da6-a16a-2d3b8d86f9c1","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dfe52a8d-88f2-4f5d-9ca5-a0577ecbdc3a","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"b1c0c753-b9a2-4936-a7fa-d7bbb0f0458d","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"897903ca-9337-411e-b626-17acb775deaf","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b3773f10-0102-49ab-8496-174342d99bfe","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"83aac2ad-9afc-457f-8011-0887a44c589b","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"57fa134b-188b-4c38-a298-8038c42423a2","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"ee32775a-cb51-4a2f-bb3a-db5e849d84f5","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"802f87e3-4942-4d93-a374-2d9d9fe4abe2","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"babd0f33-339f-4aa0-892b-692868871025","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5b2dbe82-4cdf-4f8a-817a-ba2f0a63c748","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"5a25b7be-604c-455b-b803-db276f33c3e0","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"170dbf20-2d11-456f-af57-5d369363c75a","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"9bd154ab-fd00-4863-a1fb-9a86f93cd714","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2db94241-6a37-4fed-8583-4e20b428f6cd","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"ba1d5615-f440-4f0a-888f-219ba7c200ca","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"59f52edd-f1e7-4f1c-a16a-0a0505c9592d","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"672fd8e9-ee7a-4831-ab17-9ac7f86fc092","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"419b7eca-ed6d-4356-a288-7c6a03249972","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"17ca13f5-95c5-4718-b48b-5849e6bb1a88","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"ae71d294-4e14-4714-b4b9-46d9661a0804","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"054beb6f-92df-451d-b77d-2d017341bf95","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -1098,7 +1202,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:41 GMT
+      - Wed, 22 Apr 2020 12:17:16 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1113,6 +1217,106 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59984'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs1ZDhmOTUwMy02M2E1LTQwZTgtYjE4My1iNmNjNjYzZTIxM2E=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Wed, 22 Apr 2020 12:17:19 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs1ZDhmOTUwMy02M2E1LTQwZTgtYjE4My1iNmNjNjYzZTIxM2E=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs1ZDhmOTUwMy02M2E1LTQwZTgtYjE4My1iNmNjNjYzZTIxM2E=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:17:50 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:
@@ -1149,7 +1353,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYjAwYzc2Yy1hZTYzLTQ2MzctYWU1YS1iOWZiMjFkYjM1OTk=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0ZjY3YzJjMS02M2I0LTRhODUtYTM4NC03Y2RjZTAzMTcwZWU=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -1157,9 +1361,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:24:43 GMT
+      - Wed, 22 Apr 2020 12:18:08 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYjAwYzc2Yy1hZTYzLTQ2MzctYWU1YS1iOWZiMjFkYjM1OTk=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0ZjY3YzJjMS02M2I0LTRhODUtYTM4NC03Y2RjZTAzMTcwZWU=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1169,7 +1373,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -1192,7 +1396,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjYjAwYzc2Yy1hZTYzLTQ2MzctYWU1YS1iOWZiMjFkYjM1OTk=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0ZjY3YzJjMS02M2I0LTRhODUtYTM4NC03Y2RjZTAzMTcwZWU=?api-version=2018-09-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1204,7 +1408,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:14 GMT
+      - Wed, 22 Apr 2020 12:18:38 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1244,18 +1448,71 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com","name":"zone5.com","type":"Microsoft.Network\/privateDnsZones","etag":"262c7340-c1d9-4255-9048-0937db2c87ad","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":16,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com","name":"zone5.com","type":"Microsoft.Network\/privateDnsZones","etag":"55753d6b-025f-4ee2-811a-cc2c2060428b","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '614'
+      - '613'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:14 GMT
+      - Wed, 22 Apr 2020 12:18:38 GMT
       etag:
-      - 262c7340-c1d9-4255-9048-0937db2c87ad
+      - 55753d6b-025f-4ee2-811a-cc2c2060428b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '495'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"7a318eb1-6546-4efa-b12c-34cda81abf31","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:18:39 GMT
+      etag:
+      - 7a318eb1-6546-4efa-b12c-34cda81abf31
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1303,7 +1560,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"11d3bbd9-1364-49d3-b26c-70e8897fa6c3","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6917b362-8fda-4c36-8d43-8241506b7139","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1312,9 +1569,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:15 GMT
+      - Wed, 22 Apr 2020 12:18:40 GMT
       etag:
-      - 11d3bbd9-1364-49d3-b26c-70e8897fa6c3
+      - 6917b362-8fda-4c36-8d43-8241506b7139
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -1328,7 +1585,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -1360,7 +1617,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"25f6eecf-615f-4cef-9f33-f8417b293fc1","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"412a5655-4030-4e01-b59a-e873a9af3238","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1369,28 +1626,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:16 GMT
+      - Wed, 22 Apr 2020 12:18:41 GMT
       etag:
-      - 25f6eecf-615f-4cef-9f33-f8417b293fc1
+      - 412a5655-4030-4e01-b59a-e873a9af3238
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "0.1.2.3"}]}}'
     headers:
@@ -1417,7 +1670,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/default?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8a1f3303-edc2-46df-aafa-87d74eb4ecc2","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a46e23b6-b5f4-45b2-b7d3-0351fb8b133b","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1426,28 +1679,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:17 GMT
+      - Wed, 22 Apr 2020 12:18:43 GMT
       etag:
-      - 8a1f3303-edc2-46df-aafa-87d74eb4ecc2
+      - a46e23b6-b5f4-45b2-b7d3-0351fb8b133b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11991'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "bar.foo.com."}}}'
     headers:
@@ -1474,7 +1723,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/record?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f2ed05bd-16c0-4a19-86f3-26f6e935e3ae","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f078a020-ae6d-4d54-b355-8c802965326d","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1483,28 +1732,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:18 GMT
+      - Wed, 22 Apr 2020 12:18:44 GMT
       etag:
-      - f2ed05bd-16c0-4a19-86f3-26f6e935e3ae
+      - f078a020-ae6d-4d54-b355-8c802965326d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "3.4.5.6"}]}}'
     headers:
@@ -1531,7 +1776,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f172c66-2195-49b8-b745-4fd11c577a5a","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1b1d5e27-f0d1-4c35-b149-da7f3635473d","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1540,28 +1785,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:19 GMT
+      - Wed, 22 Apr 2020 12:18:46 GMT
       etag:
-      - 1f172c66-2195-49b8-b745-4fd11c577a5a
+      - 1b1d5e27-f0d1-4c35-b149-da7f3635473d
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11982'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1.subzone.zone5.com."}}}'
     headers:
@@ -1588,7 +1829,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname.subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a10d50ce-f05f-4d70-8fe6-716c6c12fca8","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"056b84a4-de49-4392-892f-29b0f174b75c","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1597,28 +1838,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:21 GMT
+      - Wed, 22 Apr 2020 12:18:47 GMT
       etag:
-      - a10d50ce-f05f-4d70-8fe6-716c6c12fca8
+      - 056b84a4-de49-4392-892f-29b0f174b75c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "4.5.6.7"}]}}'
     headers:
@@ -1645,7 +1882,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www.subzone?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"860e5cd3-486e-4fae-beb9-80318a6aae97","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e3a9ccc6-b76f-45f3-b82e-8e94951e84c2","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1654,28 +1891,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:21 GMT
+      - Wed, 22 Apr 2020 12:18:47 GMT
       etag:
-      - 860e5cd3-486e-4fae-beb9-80318a6aae97
+      - e3a9ccc6-b76f-45f3-b82e-8e94951e84c2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11981'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "test.zone5.com."}}}'
     headers:
@@ -1702,7 +1935,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/tc?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"609ba9ec-69b7-4262-a958-f5226eafa72c","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"cbedcc3d-d474-4c03-8d5a-4ce6fda6f66c","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1711,28 +1944,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:23 GMT
+      - Wed, 22 Apr 2020 12:18:49 GMT
       etag:
-      - 609ba9ec-69b7-4262-a958-f5226eafa72c
+      - cbedcc3d-d474-4c03-8d5a-4ce6fda6f66c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "7.8.9.0"}]}}'
     headers:
@@ -1759,7 +1988,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/test?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7201e88c-0f20-4efa-b6b2-b9301d6fe220","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f05df59-1342-4245-a2f3-d9f15916170a","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1768,28 +1997,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:25 GMT
+      - Wed, 22 Apr 2020 12:18:51 GMT
       etag:
-      - 7201e88c-0f20-4efa-b6b2-b9301d6fe220
+      - 1f05df59-1342-4245-a2f3-d9f15916170a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11991'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1.zone5.com."}}}'
     headers:
@@ -1816,7 +2041,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"88ce2acb-33c5-481e-bcae-9053d1737256","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"48cc9d81-01bf-4ae8-a290-10cef2e6c921","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1825,17 +2050,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:26 GMT
+      - Wed, 22 Apr 2020 12:18:52 GMT
       etag:
-      - 88ce2acb-33c5-481e-bcae-9053d1737256
+      - 48cc9d81-01bf-4ae8-a290-10cef2e6c921
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -1845,8 +2066,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1."}}}'
     headers:
@@ -1873,7 +2094,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8e097355-c513-4111-ad25-acacd0df3d48","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8ddfbece-8b31-40d5-af29-978ce80ce3d5","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1882,28 +2103,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:27 GMT
+      - Wed, 22 Apr 2020 12:18:53 GMT
       etag:
-      - 8e097355-c513-4111-ad25-acacd0df3d48
+      - 8ddfbece-8b31-40d5-af29-978ce80ce3d5
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
       "m1.zone5.com."}]}}'
@@ -1931,7 +2148,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"f05ae970-e78f-42b3-ae13-b4122e3718bf","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"bb856a14-247a-40be-a1d0-e5ddd5cb57d3","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1940,28 +2157,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:28 GMT
+      - Wed, 22 Apr 2020 12:18:54 GMT
       etag:
-      - f05ae970-e78f-42b3-ae13-b4122e3718bf
+      - bb856a14-247a-40be-a1d0-e5ddd5cb57d3
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
       "m1."}]}}'
@@ -1989,7 +2202,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cd22a9c8-937e-4ac8-a2f6-ddc1ee0aed1f","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cf4fc4c9-6a19-44ad-bcf5-cb77059e5121","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -1998,28 +2211,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:29 GMT
+      - Wed, 22 Apr 2020 12:18:56 GMT
       etag:
-      - cd22a9c8-937e-4ac8-a2f6-ddc1ee0aed1f
+      - cf4fc4c9-6a19-44ad-bcf5-cb77059e5121
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
       "port": 3, "target": "srv1.zone5.com."}]}}'
@@ -2047,7 +2256,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"6dd0ac2d-2735-4b6e-beb0-68c580e05e3e","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"97c5a2c1-3750-48c0-b23e-9a544d1477e4","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2056,28 +2265,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:30 GMT
+      - Wed, 22 Apr 2020 12:18:57 GMT
       etag:
-      - 6dd0ac2d-2735-4b6e-beb0-68c580e05e3e
+      - 97c5a2c1-3750-48c0-b23e-9a544d1477e4
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
       "port": 3, "target": "srv1."}]}}'
@@ -2105,7 +2310,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv2?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"fdac2bd2-242b-4a49-a299-40ebdc9af442","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"bb611c46-06c0-4a2c-9c6c-a4f76d03c444","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2114,17 +2319,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:32 GMT
+      - Wed, 22 Apr 2020 12:18:58 GMT
       etag:
-      - fdac2bd2-242b-4a49-a299-40ebdc9af442
+      - bb611c46-06c0-4a2c-9c6c-a4f76d03c444
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -2134,8 +2335,8 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "2.3.4.5"}]}}'
     headers:
@@ -2162,7 +2363,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"88a0df7e-7d28-4fbe-a8a3-fc53cf2c345f","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e119e46d-4bef-4d70-b47a-ee22f4696c87","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -2171,28 +2372,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:33 GMT
+      - Wed, 22 Apr 2020 12:19:00 GMT
       etag:
-      - 88a0df7e-7d28-4fbe-a8a3-fc53cf2c345f
+      - e119e46d-4bef-4d70-b47a-ee22f4696c87
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11987'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: null
     headers:
@@ -2215,7 +2412,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"25f6eecf-615f-4cef-9f33-f8417b293fc1","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"11d3bbd9-1364-49d3-b26c-70e8897fa6c3","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8a1f3303-edc2-46df-aafa-87d74eb4ecc2","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f2ed05bd-16c0-4a19-86f3-26f6e935e3ae","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f172c66-2195-49b8-b745-4fd11c577a5a","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a10d50ce-f05f-4d70-8fe6-716c6c12fca8","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"860e5cd3-486e-4fae-beb9-80318a6aae97","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"609ba9ec-69b7-4262-a958-f5226eafa72c","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7201e88c-0f20-4efa-b6b2-b9301d6fe220","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"88ce2acb-33c5-481e-bcae-9053d1737256","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8e097355-c513-4111-ad25-acacd0df3d48","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"f05ae970-e78f-42b3-ae13-b4122e3718bf","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cd22a9c8-937e-4ac8-a2f6-ddc1ee0aed1f","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"6dd0ac2d-2735-4b6e-beb0-68c580e05e3e","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"fdac2bd2-242b-4a49-a299-40ebdc9af442","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"88a0df7e-7d28-4fbe-a8a3-fc53cf2c345f","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"412a5655-4030-4e01-b59a-e873a9af3238","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6917b362-8fda-4c36-8d43-8241506b7139","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a46e23b6-b5f4-45b2-b7d3-0351fb8b133b","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f078a020-ae6d-4d54-b355-8c802965326d","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1b1d5e27-f0d1-4c35-b149-da7f3635473d","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"056b84a4-de49-4392-892f-29b0f174b75c","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e3a9ccc6-b76f-45f3-b82e-8e94951e84c2","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"cbedcc3d-d474-4c03-8d5a-4ce6fda6f66c","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"1f05df59-1342-4245-a2f3-d9f15916170a","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"48cc9d81-01bf-4ae8-a290-10cef2e6c921","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"8ddfbece-8b31-40d5-af29-978ce80ce3d5","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"bb856a14-247a-40be-a1d0-e5ddd5cb57d3","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cf4fc4c9-6a19-44ad-bcf5-cb77059e5121","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"97c5a2c1-3750-48c0-b23e-9a544d1477e4","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"bb611c46-06c0-4a2c-9c6c-a4f76d03c444","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e119e46d-4bef-4d70-b47a-ee22f4696c87","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -2224,7 +2421,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:25:34 GMT
+      - Wed, 22 Apr 2020 12:19:00 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -2238,9 +2435,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59912'
+      - '59966'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '495'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone5_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone5_Import.yaml
@@ -1,0 +1,2297 @@
+interactions:
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkNTZjOTM0Zi0yOGZjLTQ2OGYtOWRlYy0zODk3YzMzODY2OTQ=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:16 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkNTZjOTM0Zi0yOGZjLTQ2OGYtOWRlYy0zODk3YzMzODY2OTQ=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"647ad6d1-9ca0-4417-abd8-40172bde0823","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:46 GMT
+      etag:
+      - 647ad6d1-9ca0-4417-abd8-40172bde0823
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "hostmaster.zone5.com.", "serialNumber": 2003080800, "refreshTime":
+      43200, "retryTime": 900, "expireTime": 1814400, "minimumTtl": 10800}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '221'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"c5d58f47-9bf8-4a85-8e86-8de40805905f","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '584'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:47 GMT
+      etag:
+      - c5d58f47-9bf8-4a85-8e86-8de40805905f
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"608186d9-926c-45b6-8f22-2552331560a7","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '433'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:48 GMT
+      etag:
+      - 608186d9-926c-45b6-8f22-2552331560a7
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "0.1.2.3"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/default?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a71dd007-e2a6-454c-9dd3-86ed8069f2b1","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:49 GMT
+      etag:
+      - a71dd007-e2a6-454c-9dd3-86ed8069f2b1
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "test.zone5.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/tc?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"75fb2092-1300-4eba-b69a-93cd873e0ead","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '449'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:50 GMT
+      etag:
+      - 75fb2092-1300-4eba-b69a-93cd873e0ead
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "2.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0c356ae9-69ac-4f36-b6c8-8351556dced0","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '441'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:51 GMT
+      etag:
+      - 0c356ae9-69ac-4f36-b6c8-8351556dced0
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1.zone5.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f4a81d66-cecb-497b-aade-7b28b2dfe2ae","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '471'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:53 GMT
+      etag:
+      - f4a81d66-cecb-497b-aade-7b28b2dfe2ae
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "m1.zone5.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cfbd2481-2f39-40e1-98b9-e3a88e1446ec","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:54 GMT
+      etag:
+      - cfbd2481-2f39-40e1-98b9-e3a88e1446ec
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
+      "port": 3, "target": "srv1.zone5.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"84e369b7-5256-435a-8124-c91fdf81120c","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '498'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:55 GMT
+      etag:
+      - 84e369b7-5256-435a-8124-c91fdf81120c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"94bdd0e9-e6a9-43b5-bcdd-b27da2953dde","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:56 GMT
+      etag:
+      - 94bdd0e9-e6a9-43b5-bcdd-b27da2953dde
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "m1."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dc6ca673-3692-4371-a126-e26df29b5cf3","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '468'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:58 GMT
+      etag:
+      - dc6ca673-3692-4371-a126-e26df29b5cf3
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
+      "port": 3, "target": "srv1."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '105'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"71ea5fcd-3687-42cb-a949-0e95ea7bc8b6","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '491'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:58 GMT
+      etag:
+      - 71ea5fcd-3687-42cb-a949-0e95ea7bc8b6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "3.4.5.6"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/subzone?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3785e3c9-6b0e-4269-aeb6-1cd2688b3a9c","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:49:59 GMT
+      etag:
+      - 3785e3c9-6b0e-4269-aeb6-1cd2688b3a9c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "4.5.6.7"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www.subzone?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"fafd5244-1a08-4582-b6ac-2d62ee68f34c","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '465'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:50:00 GMT
+      etag:
+      - fafd5244-1a08-4582-b6ac-2d62ee68f34c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1.subzone.zone5.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '80'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname.subzone?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"81b99a93-a98d-4b24-8170-b1aa4a1fc7fb","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '503'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:50:01 GMT
+      etag:
+      - 81b99a93-a98d-4b24-8170-b1aa4a1fc7fb
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "bar.foo.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/record?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c0a1e716-0f32-4872-96e7-60d60ef3d8ed","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '458'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:50:03 GMT
+      etag:
+      - c0a1e716-0f32-4872-96e7-60d60ef3d8ed
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "7.8.9.0"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/test?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d3ece18d-aec1-400a-b284-c50b98774158","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '444'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:50:03 GMT
+      etag:
+      - d3ece18d-aec1-400a-b284-c50b98774158
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"608186d9-926c-45b6-8f22-2552331560a7","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"c5d58f47-9bf8-4a85-8e86-8de40805905f","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a71dd007-e2a6-454c-9dd3-86ed8069f2b1","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c0a1e716-0f32-4872-96e7-60d60ef3d8ed","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3785e3c9-6b0e-4269-aeb6-1cd2688b3a9c","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"81b99a93-a98d-4b24-8170-b1aa4a1fc7fb","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"fafd5244-1a08-4582-b6ac-2d62ee68f34c","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"75fb2092-1300-4eba-b69a-93cd873e0ead","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d3ece18d-aec1-400a-b284-c50b98774158","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f4a81d66-cecb-497b-aade-7b28b2dfe2ae","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"94bdd0e9-e6a9-43b5-bcdd-b27da2953dde","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cfbd2481-2f39-40e1-98b9-e3a88e1446ec","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dc6ca673-3692-4371-a126-e26df29b5cf3","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"84e369b7-5256-435a-8124-c91fdf81120c","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"71ea5fcd-3687-42cb-a949-0e95ea7bc8b6","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0c356ae9-69ac-4f36-b6c8-8351556dced0","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '7577'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:50:05 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59984'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"c5d58f47-9bf8-4a85-8e86-8de40805905f","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '596'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:50:05 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"608186d9-926c-45b6-8f22-2552331560a7","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"c5d58f47-9bf8-4a85-8e86-8de40805905f","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a71dd007-e2a6-454c-9dd3-86ed8069f2b1","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"c0a1e716-0f32-4872-96e7-60d60ef3d8ed","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3785e3c9-6b0e-4269-aeb6-1cd2688b3a9c","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"81b99a93-a98d-4b24-8170-b1aa4a1fc7fb","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"fafd5244-1a08-4582-b6ac-2d62ee68f34c","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"75fb2092-1300-4eba-b69a-93cd873e0ead","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"d3ece18d-aec1-400a-b284-c50b98774158","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"f4a81d66-cecb-497b-aade-7b28b2dfe2ae","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"94bdd0e9-e6a9-43b5-bcdd-b27da2953dde","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"cfbd2481-2f39-40e1-98b9-e3a88e1446ec","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"dc6ca673-3692-4371-a126-e26df29b5cf3","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"84e369b7-5256-435a-8124-c91fdf81120c","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"71ea5fcd-3687-42cb-a949-0e95ea7bc8b6","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0c356ae9-69ac-4f36-b6c8-8351556dced0","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '7577'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:50:05 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59964'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2Yzc1NGZjZC04MDc2LTQwZGEtYWE5YS1lYmI0OTQxMjIxNzM=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Thu, 16 Apr 2020 14:50:08 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2Yzc1NGZjZC04MDc2LTQwZGEtYWE5YS1lYmI0OTQxMjIxNzM=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2Yzc1NGZjZC04MDc2LTQwZGEtYWE5YS1lYmI0OTQxMjIxNzM=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:50:39 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkZjM1NjEyMi1mODk2LTQ3MjctYmIyNi01MjQ5NTQxN2E2ODI=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:06 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkZjM1NjEyMi1mODk2LTQ3MjctYmIyNi01MjQ5NTQxN2E2ODI=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"dc2ff631-edc1-4577-8ac7-5b7b96835e3a","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:37 GMT
+      etag:
+      - dc2ff631-edc1-4577-8ac7-5b7b96835e3a
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com","name":"zone5.com","type":"Microsoft.Network\/privateDnsZones","etag":"de74b176-2e86-4b2d-96fa-8a0fd6c98142","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:37 GMT
+      etag:
+      - de74b176-2e86-4b2d-96fa-8a0fd6c98142
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "hostmaster.zone5.com.", "serialNumber": 1, "refreshTime": 43200, "retryTime":
+      900, "expireTime": 1814400, "minimumTtl": 10800}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '212'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6787713c-2584-45a5-885b-e2cfc3f807ab","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '584'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:38 GMT
+      etag:
+      - 6787713c-2584-45a5-885b-e2cfc3f807ab
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0c84a0d5-af94-4ada-be9f-c58c90af8ac1","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '433'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:39 GMT
+      etag:
+      - 0c84a0d5-af94-4ada-be9f-c58c90af8ac1
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "0.1.2.3"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/default?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffbd5942-9c22-444f-9daf-e186fd615198","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:40 GMT
+      etag:
+      - ffbd5942-9c22-444f-9daf-e186fd615198
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11992'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "bar.foo.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/record?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"6c28d20e-7b62-474a-8c40-15b2d7b3d5c4","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '458'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:41 GMT
+      etag:
+      - 6c28d20e-7b62-474a-8c40-15b2d7b3d5c4
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "3.4.5.6"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/subzone?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7f46c9f4-0697-4609-ab8a-159a2b2961b8","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '453'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:42 GMT
+      etag:
+      - 7f46c9f4-0697-4609-ab8a-159a2b2961b8
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11993'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1.subzone.zone5.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '80'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname.subzone?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"bdfb6f84-a484-44aa-8883-59c7e41ba058","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '503'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:43 GMT
+      etag:
+      - bdfb6f84-a484-44aa-8883-59c7e41ba058
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "4.5.6.7"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www.subzone?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8e07a4e5-7a5f-4f59-abe3-cf105e0a6881","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '465'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:44 GMT
+      etag:
+      - 8e07a4e5-7a5f-4f59-abe3-cf105e0a6881
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "test.zone5.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/tc?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"86e125d8-6fef-407d-899e-016163ef9387","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '449'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:45 GMT
+      etag:
+      - 86e125d8-6fef-407d-899e-016163ef9387
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "7.8.9.0"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/test?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b5094d8a-93ec-4f6a-a135-7c3552fb76e6","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '444'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:47 GMT
+      etag:
+      - b5094d8a-93ec-4f6a-a135-7c3552fb76e6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1.zone5.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a536cd02-0840-41fe-a994-ead4dbe8ec53","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '471'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:48 GMT
+      etag:
+      - a536cd02-0840-41fe-a994-ead4dbe8ec53
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "r1."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/CNAME/test-cname2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"1fd7a236-2552-4d19-9b01-485e8e611e4b","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '464'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:48 GMT
+      etag:
+      - 1fd7a236-2552-4d19-9b01-485e8e611e4b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "m1.zone5.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"8f6a0bc4-9a4f-48bd-8597-ab319d830886","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:50 GMT
+      etag:
+      - 8f6a0bc4-9a4f-48bd-8597-ab319d830886
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 10, "exchange":
+      "m1."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/MX/test-mx2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"8da57a9c-3ce1-4dd7-8811-8526454a27e5","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '468'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:50 GMT
+      etag:
+      - 8da57a9c-3ce1-4dd7-8811-8526454a27e5
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
+      "port": 3, "target": "srv1.zone5.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b42986a1-4caf-47a1-b2a2-e67ad583f1b2","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '498'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:52 GMT
+      etag:
+      - b42986a1-4caf-47a1-b2a2-e67ad583f1b2
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
+      "port": 3, "target": "srv1."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '105'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/SRV/test-srv2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"179f2742-4cc3-4449-85ca-7f0ee76042e4","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '491'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:53 GMT
+      etag:
+      - 179f2742-4cc3-4449-85ca-7f0ee76042e4
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "2.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/A/www?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"410f273f-8ae6-4f52-afc9-1fd99b3f9ae7","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '441'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:53 GMT
+      etag:
+      - 410f273f-8ae6-4f52-afc9-1fd99b3f9ae7
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11992'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone5_import000001/providers/Microsoft.Network/privateDnsZones/zone5.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0c84a0d5-af94-4ada-be9f-c58c90af8ac1","properties":{"fqdn":"zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"6787713c-2584-45a5-885b-e2cfc3f807ab","properties":{"fqdn":"zone5.com.","ttl":3600,"soaRecord":{"email":"hostmaster.zone5.com.","expireTime":1814400,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":43200,"retryTime":900,"serialNumber":1,"minimumTtl":10800},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/default","name":"default","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ffbd5942-9c22-444f-9daf-e186fd615198","properties":{"fqdn":"default.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"0.1.2.3"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/record","name":"record","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"6c28d20e-7b62-474a-8c40-15b2d7b3d5c4","properties":{"fqdn":"record.zone5.com.","ttl":3600,"cnameRecord":{"cname":"bar.foo.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/subzone","name":"subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"7f46c9f4-0697-4609-ab8a-159a2b2961b8","properties":{"fqdn":"subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"3.4.5.6"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname.subzone","name":"test-cname.subzone","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"bdfb6f84-a484-44aa-8883-59c7e41ba058","properties":{"fqdn":"test-cname.subzone.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.subzone.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www.subzone","name":"www.subzone","type":"Microsoft.Network\/privateDnsZones\/A","etag":"8e07a4e5-7a5f-4f59-abe3-cf105e0a6881","properties":{"fqdn":"www.subzone.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"4.5.6.7"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/tc","name":"tc","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"86e125d8-6fef-407d-899e-016163ef9387","properties":{"fqdn":"tc.zone5.com.","ttl":3600,"cnameRecord":{"cname":"test.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/test","name":"test","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b5094d8a-93ec-4f6a-a135-7c3552fb76e6","properties":{"fqdn":"test.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"7.8.9.0"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname","name":"test-cname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a536cd02-0840-41fe-a994-ead4dbe8ec53","properties":{"fqdn":"test-cname.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1.zone5.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/CNAME\/test-cname2","name":"test-cname2","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"1fd7a236-2552-4d19-9b01-485e8e611e4b","properties":{"fqdn":"test-cname2.zone5.com.","ttl":3600,"cnameRecord":{"cname":"r1."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx","name":"test-mx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"8f6a0bc4-9a4f-48bd-8597-ab319d830886","properties":{"fqdn":"test-mx.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.zone5.com.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/MX\/test-mx2","name":"test-mx2","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"8da57a9c-3ce1-4dd7-8811-8526454a27e5","properties":{"fqdn":"test-mx2.zone5.com.","ttl":3600,"mxRecords":[{"exchange":"m1.","preference":10}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv","name":"test-srv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b42986a1-4caf-47a1-b2a2-e67ad583f1b2","properties":{"fqdn":"test-srv.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.zone5.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/SRV\/test-srv2","name":"test-srv2","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"179f2742-4cc3-4449-85ca-7f0ee76042e4","properties":{"fqdn":"test-srv2.zone5.com.","ttl":3600,"srvRecords":[{"port":3,"priority":1,"target":"srv1.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone5_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone5.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"410f273f-8ae6-4f52-afc9-1fd99b3f9ae7","properties":{"fqdn":"www.zone5.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '7577'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:51:54 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59966'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone6_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone6_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2MTI2ZDk0MC1iNzE1LTQ1YzktYTU4Yy05NmZjY2VlOTI2YzU=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjOGM4NDlkZC01M2UzLTQ4OGItYjk2MC05OWViOGExNGFlMGM=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:56:29 GMT
+      - Tue, 21 Apr 2020 05:26:00 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2MTI2ZDk0MC1iNzE1LTQ1YzktYTU4Yy05NmZjY2VlOTI2YzU=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjOGM4NDlkZC01M2UzLTQ4OGItYjk2MC05OWViOGExNGFlMGM=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -48,7 +48,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -70,20 +70,24 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2MTI2ZDk0MC1iNzE1LTQ1YzktYTU4Yy05NmZjY2VlOTI2YzU=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"status":"Succeeded"}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"caaba4c7-b613-4bc1-bad8-ecb490b5c86b","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
       content-length:
-      - '22'
+      - '594'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:56:59 GMT
+      - Tue, 21 Apr 2020 05:26:31 GMT
+      etag:
+      - caaba4c7-b613-4bc1-bad8-ecb490b5c86b
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -131,7 +135,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"2f0af6e3-8682-452c-9a78-b8394f538aa3","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5431e1b3-a277-46b1-be75-bcf95695a698","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -140,9 +144,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:57:02 GMT
+      - Tue, 21 Apr 2020 05:26:31 GMT
       etag:
-      - 2f0af6e3-8682-452c-9a78-b8394f538aa3
+      - 5431e1b3-a277-46b1-be75-bcf95695a698
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -156,7 +160,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -188,7 +192,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e39bcb45-ef00-4787-9bdb-38b2692c0bfb","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ae4f4d71-a61e-446c-a84f-39593edda55c","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -197,9 +201,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:57:03 GMT
+      - Tue, 21 Apr 2020 05:26:33 GMT
       etag:
-      - e39bcb45-ef00-4787-9bdb-38b2692c0bfb
+      - ae4f4d71-a61e-446c-a84f-39593edda55c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -209,7 +213,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -241,7 +245,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/www?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"df9c1d5f-8859-4422-954f-d3c1d1b548ba","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"04b054aa-dac5-4e8e-989d-bc4f9245cf77","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -250,9 +254,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:57:04 GMT
+      - Tue, 21 Apr 2020 05:26:33 GMT
       etag:
-      - df9c1d5f-8859-4422-954f-d3c1d1b548ba
+      - 04b054aa-dac5-4e8e-989d-bc4f9245cf77
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -262,7 +266,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11990'
+      - '11980'
       x-powered-by:
       - ASP.NET
     status:
@@ -290,7 +294,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e39bcb45-ef00-4787-9bdb-38b2692c0bfb","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"2f0af6e3-8682-452c-9a78-b8394f538aa3","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"df9c1d5f-8859-4422-954f-d3c1d1b548ba","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ae4f4d71-a61e-446c-a84f-39593edda55c","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5431e1b3-a277-46b1-be75-bcf95695a698","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"04b054aa-dac5-4e8e-989d-bc4f9245cf77","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -299,7 +303,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:57:05 GMT
+      - Tue, 21 Apr 2020 05:26:34 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -343,7 +347,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"2f0af6e3-8682-452c-9a78-b8394f538aa3","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5431e1b3-a277-46b1-be75-bcf95695a698","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -352,7 +356,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:57:07 GMT
+      - Tue, 21 Apr 2020 05:26:35 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -396,7 +400,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e39bcb45-ef00-4787-9bdb-38b2692c0bfb","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"2f0af6e3-8682-452c-9a78-b8394f538aa3","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"df9c1d5f-8859-4422-954f-d3c1d1b548ba","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ae4f4d71-a61e-446c-a84f-39593edda55c","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5431e1b3-a277-46b1-be75-bcf95695a698","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"04b054aa-dac5-4e8e-989d-bc4f9245cf77","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -405,7 +409,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:57:08 GMT
+      - Tue, 21 Apr 2020 05:26:36 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -419,109 +423,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59997'
+      - '59981'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com?api-version=2018-09-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs0MjY1NDkyNy0xZTA2LTRkYWItODExYy0yNzljZDg3NjljNGY=?api-version=2018-09-01
-      cache-control:
-      - private
-      content-length:
-      - '0'
-      date:
-      - Thu, 16 Apr 2020 14:57:11 GMT
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs0MjY1NDkyNy0xZTA2LTRkYWItODExYy0yNzljZDg3NjljNGY=?api-version=2018-09-01
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs0MjY1NDkyNy0xZTA2LTRkYWItODExYy0yNzljZDg3NjljNGY=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"Succeeded"}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '22'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:57:41 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -556,7 +460,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs4NTYxYTNjNi0xMGNhLTQ4Y2QtOTBmOC0zOTAzYTQ0OWUxYzE=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzYwNDU0Ny03NjBhLTQ5YzMtOWQ2YS1mYzBlYmZhNzk4ODg=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -564,9 +468,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:58:08 GMT
+      - Tue, 21 Apr 2020 05:26:39 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs4NTYxYTNjNi0xMGNhLTQ4Y2QtOTBmOC0zOTAzYTQ0OWUxYzE=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzYwNDU0Ny03NjBhLTQ5YzMtOWQ2YS1mYzBlYmZhNzk4ODg=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -576,7 +480,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -598,75 +502,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzYwNDU0Ny03NjBhLTQ5YzMtOWQ2YS1mYzBlYmZhNzk4ODg=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"809ddee6-7c83-4892-be00-d6fa4d9e48c1","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:58:38 GMT
-      etag:
-      - 809ddee6-7c83-4892-be00-d6fa4d9e48c1
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com","name":"zone6.com","type":"Microsoft.Network\/privateDnsZones","etag":"3ed857c8-63b0-45ed-b910-baf852f81f84","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '613'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 14:58:40 GMT
-      etag:
-      - 3ed857c8-63b0-45ed-b910-baf852f81f84
+      - Tue, 21 Apr 2020 05:27:09 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -714,7 +563,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"47d0e2f1-a1cf-45d4-ba2f-ca1a5c555a18","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"69a88fbb-15dc-47ee-9097-24c3c9b84bd7","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -723,9 +572,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:58:40 GMT
+      - Tue, 21 Apr 2020 05:27:10 GMT
       etag:
-      - 47d0e2f1-a1cf-45d4-ba2f-ca1a5c555a18
+      - 69a88fbb-15dc-47ee-9097-24c3c9b84bd7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -739,7 +588,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -771,7 +620,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"af2ae0d6-8fff-4f1f-b140-943d9b12407d","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2528e300-5c4a-4dff-8a25-ffbae94f4105","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -780,24 +629,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:58:41 GMT
+      - Tue, 21 Apr 2020 05:27:11 GMT
       etag:
-      - af2ae0d6-8fff-4f1f-b140-943d9b12407d
+      - 2528e300-5c4a-4dff-8a25-ffbae94f4105
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11990'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.1.1.1"}]}}'
     headers:
@@ -824,7 +677,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/www?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"72e07fce-3280-4043-ae40-5dc2d8587389","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a1688145-3274-45b6-8531-bcdbb83157b5","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -833,24 +686,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:58:42 GMT
+      - Tue, 21 Apr 2020 05:27:12 GMT
       etag:
-      - 72e07fce-3280-4043-ae40-5dc2d8587389
+      - a1688145-3274-45b6-8531-bcdbb83157b5
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -873,7 +730,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"af2ae0d6-8fff-4f1f-b140-943d9b12407d","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"47d0e2f1-a1cf-45d4-ba2f-ca1a5c555a18","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"72e07fce-3280-4043-ae40-5dc2d8587389","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2528e300-5c4a-4dff-8a25-ffbae94f4105","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"69a88fbb-15dc-47ee-9097-24c3c9b84bd7","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a1688145-3274-45b6-8531-bcdbb83157b5","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -882,7 +739,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:58:43 GMT
+      - Tue, 21 Apr 2020 05:27:12 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -896,9 +753,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59997'
+      - '59978'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '497'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone6_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone6_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjOGM4NDlkZC01M2UzLTQ4OGItYjk2MC05OWViOGExNGFlMGM=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1MWJmYWNjYi03NmU3LTRmNjktOTdmMS0wYjcyODU1MDhiNGM=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:26:00 GMT
+      - Wed, 22 Apr 2020 12:19:26 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtjOGM4NDlkZC01M2UzLTQ4OGItYjk2MC05OWViOGExNGFlMGM=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1MWJmYWNjYi03NmU3LTRmNjktOTdmMS0wYjcyODU1MDhiNGM=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -70,24 +70,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs1MWJmYWNjYi03NmU3LTRmNjktOTdmMS0wYjcyODU1MDhiNGM=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"caaba4c7-b613-4bc1-bad8-ecb490b5c86b","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:26:31 GMT
-      etag:
-      - caaba4c7-b613-4bc1-bad8-ecb490b5c86b
+      - Wed, 22 Apr 2020 12:19:56 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -101,7 +97,111 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '497'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com","name":"zone6.com","type":"Microsoft.Network\/privateDnsZones","etag":"950b1613-5de3-474d-b3c6-7e00c4906ec7","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:19:57 GMT
+      etag:
+      - 950b1613-5de3-474d-b3c6-7e00c4906ec7
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '487'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1fbf3b43-b248-4627-8b65-9e3786ef9501","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:19:57 GMT
+      etag:
+      - 1fbf3b43-b248-4627-8b65-9e3786ef9501
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '497'
       x-powered-by:
       - ASP.NET
     status:
@@ -135,7 +235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5431e1b3-a277-46b1-be75-bcf95695a698","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"9f2c2199-ba84-426f-9ff8-cbbe29b302af","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -144,9 +244,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:26:31 GMT
+      - Wed, 22 Apr 2020 12:19:58 GMT
       etag:
-      - 5431e1b3-a277-46b1-be75-bcf95695a698
+      - 9f2c2199-ba84-426f-9ff8-cbbe29b302af
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -192,7 +292,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ae4f4d71-a61e-446c-a84f-39593edda55c","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bfa43f2c-6e5b-4533-9f31-82b167cd1fd5","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -201,9 +301,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:26:33 GMT
+      - Wed, 22 Apr 2020 12:19:59 GMT
       etag:
-      - ae4f4d71-a61e-446c-a84f-39593edda55c
+      - bfa43f2c-6e5b-4533-9f31-82b167cd1fd5
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -213,7 +313,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -245,7 +345,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/www?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"04b054aa-dac5-4e8e-989d-bc4f9245cf77","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"083b3170-46da-4713-9a6d-9e8c963875bf","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -254,9 +354,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:26:33 GMT
+      - Wed, 22 Apr 2020 12:20:01 GMT
       etag:
-      - 04b054aa-dac5-4e8e-989d-bc4f9245cf77
+      - 083b3170-46da-4713-9a6d-9e8c963875bf
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -266,7 +366,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11980'
+      - '11991'
       x-powered-by:
       - ASP.NET
     status:
@@ -294,7 +394,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ae4f4d71-a61e-446c-a84f-39593edda55c","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5431e1b3-a277-46b1-be75-bcf95695a698","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"04b054aa-dac5-4e8e-989d-bc4f9245cf77","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bfa43f2c-6e5b-4533-9f31-82b167cd1fd5","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"9f2c2199-ba84-426f-9ff8-cbbe29b302af","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"083b3170-46da-4713-9a6d-9e8c963875bf","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -303,7 +403,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:26:34 GMT
+      - Wed, 22 Apr 2020 12:20:01 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -347,7 +447,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5431e1b3-a277-46b1-be75-bcf95695a698","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"9f2c2199-ba84-426f-9ff8-cbbe29b302af","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -356,7 +456,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:26:35 GMT
+      - Wed, 22 Apr 2020 12:20:03 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -400,7 +500,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"ae4f4d71-a61e-446c-a84f-39593edda55c","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"5431e1b3-a277-46b1-be75-bcf95695a698","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"04b054aa-dac5-4e8e-989d-bc4f9245cf77","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"bfa43f2c-6e5b-4533-9f31-82b167cd1fd5","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"9f2c2199-ba84-426f-9ff8-cbbe29b302af","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"083b3170-46da-4713-9a6d-9e8c963875bf","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -409,7 +509,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:26:36 GMT
+      - Wed, 22 Apr 2020 12:20:03 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -426,6 +526,106 @@ interactions:
       - '59981'
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTsyZGMwNjMxYy1mOTMzLTQwZTktODE3MS02ZGI4M2NhMWFhNjI=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Wed, 22 Apr 2020 12:20:05 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTsyZGMwNjMxYy1mOTMzLTQwZTktODE3MS02ZGI4M2NhMWFhNjI=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTsyZGMwNjMxYy1mOTMzLTQwZTktODE3MS02ZGI4M2NhMWFhNjI=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:20:36 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -460,7 +660,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzYwNDU0Ny03NjBhLTQ5YzMtOWQ2YS1mYzBlYmZhNzk4ODg=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyZmQyYzJhNi04MDY5LTRkNWItYWU2MS0wMWZhMjc4NjFmNjY=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -468,9 +668,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:26:39 GMT
+      - Wed, 22 Apr 2020 12:20:53 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzYwNDU0Ny03NjBhLTQ5YzMtOWQ2YS1mYzBlYmZhNzk4ODg=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyZmQyYzJhNi04MDY5LTRkNWItYWU2MS0wMWZhMjc4NjFmNjY=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -480,7 +680,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -503,7 +703,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2NzYwNDU0Ny03NjBhLTQ5YzMtOWQ2YS1mYzBlYmZhNzk4ODg=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTsyZmQyYzJhNi04MDY5LTRkNWItYWU2MS0wMWZhMjc4NjFmNjY=?api-version=2018-09-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -515,7 +715,111 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:27:09 GMT
+      - Wed, 22 Apr 2020 12:21:24 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com","name":"zone6.com","type":"Microsoft.Network\/privateDnsZones","etag":"66753c49-8d2d-4e00-9db7-4fb461a578c5","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:21:24 GMT
+      etag:
+      - 66753c49-8d2d-4e00-9db7-4fb461a578c5
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '492'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"3bde3c19-574d-4674-9094-b16e4d02a194","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:21:24 GMT
+      etag:
+      - 3bde3c19-574d-4674-9094-b16e4d02a194
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -563,7 +867,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"69a88fbb-15dc-47ee-9097-24c3c9b84bd7","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"88adafdb-96b2-482d-99ec-863edade93e6","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -572,9 +876,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:27:10 GMT
+      - Wed, 22 Apr 2020 12:21:25 GMT
       etag:
-      - 69a88fbb-15dc-47ee-9097-24c3c9b84bd7
+      - 88adafdb-96b2-482d-99ec-863edade93e6
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -620,7 +924,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2528e300-5c4a-4dff-8a25-ffbae94f4105","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cb2ae657-1750-4d46-a904-b1a18b3f034f","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -629,28 +933,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:27:11 GMT
+      - Wed, 22 Apr 2020 12:21:26 GMT
       etag:
-      - 2528e300-5c4a-4dff-8a25-ffbae94f4105
+      - cb2ae657-1750-4d46-a904-b1a18b3f034f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11990'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.1.1.1"}]}}'
     headers:
@@ -677,7 +977,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/www?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a1688145-3274-45b6-8531-bcdbb83157b5","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"65c3e38c-9d26-4121-9240-18e1ae0c327c","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -686,28 +986,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:27:12 GMT
+      - Wed, 22 Apr 2020 12:21:28 GMT
       etag:
-      - a1688145-3274-45b6-8531-bcdbb83157b5
+      - 65c3e38c-9d26-4121-9240-18e1ae0c327c
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: null
     headers:
@@ -730,7 +1026,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"2528e300-5c4a-4dff-8a25-ffbae94f4105","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"69a88fbb-15dc-47ee-9097-24c3c9b84bd7","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"a1688145-3274-45b6-8531-bcdbb83157b5","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"cb2ae657-1750-4d46-a904-b1a18b3f034f","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"88adafdb-96b2-482d-99ec-863edade93e6","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"65c3e38c-9d26-4121-9240-18e1ae0c327c","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -739,7 +1035,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:27:12 GMT
+      - Wed, 22 Apr 2020 12:21:29 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -753,9 +1049,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59978'
+      - '59997'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '497'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone6_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone6_Import.yaml
@@ -1,0 +1,907 @@
+interactions:
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2MTI2ZDk0MC1iNzE1LTQ1YzktYTU4Yy05NmZjY2VlOTI2YzU=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:56:29 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2MTI2ZDk0MC1iNzE1LTQ1YzktYTU4Yy05NmZjY2VlOTI2YzU=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs2MTI2ZDk0MC1iNzE1LTQ1YzktYTU4Yy05NmZjY2VlOTI2YzU=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:56:59 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "azuredns-hostmaster.microsoft.com.", "serialNumber": 1, "refreshTime":
+      3600, "retryTime": 300, "expireTime": 2419200, "minimumTtl": 300}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"2f0af6e3-8682-452c-9a78-b8394f538aa3","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:57:02 GMT
+      etag:
+      - 2f0af6e3-8682-452c-9a78-b8394f538aa3
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.1.1.1"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e39bcb45-ef00-4787-9bdb-38b2692c0bfb","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '433'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:57:03 GMT
+      etag:
+      - e39bcb45-ef00-4787-9bdb-38b2692c0bfb
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.1.1.1"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/www?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"df9c1d5f-8859-4422-954f-d3c1d1b548ba","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '441'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:57:04 GMT
+      etag:
+      - df9c1d5f-8859-4422-954f-d3c1d1b548ba
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11990'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e39bcb45-ef00-4787-9bdb-38b2692c0bfb","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"2f0af6e3-8682-452c-9a78-b8394f538aa3","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"df9c1d5f-8859-4422-954f-d3c1d1b548ba","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1482'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:57:05 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59997'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"2f0af6e3-8682-452c-9a78-b8394f538aa3","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '606'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:57:07 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"e39bcb45-ef00-4787-9bdb-38b2692c0bfb","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"2f0af6e3-8682-452c-9a78-b8394f538aa3","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"df9c1d5f-8859-4422-954f-d3c1d1b548ba","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1482'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:57:08 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59997'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs0MjY1NDkyNy0xZTA2LTRkYWItODExYy0yNzljZDg3NjljNGY=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Thu, 16 Apr 2020 14:57:11 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs0MjY1NDkyNy0xZTA2LTRkYWItODExYy0yNzljZDg3NjljNGY=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs0MjY1NDkyNy0xZTA2LTRkYWItODExYy0yNzljZDg3NjljNGY=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:57:41 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs4NTYxYTNjNi0xMGNhLTQ4Y2QtOTBmOC0zOTAzYTQ0OWUxYzE=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:58:08 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs4NTYxYTNjNi0xMGNhLTQ4Y2QtOTBmOC0zOTAzYTQ0OWUxYzE=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"809ddee6-7c83-4892-be00-d6fa4d9e48c1","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:58:38 GMT
+      etag:
+      - 809ddee6-7c83-4892-be00-d6fa4d9e48c1
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com","name":"zone6.com","type":"Microsoft.Network\/privateDnsZones","etag":"3ed857c8-63b0-45ed-b910-baf852f81f84","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:58:40 GMT
+      etag:
+      - 3ed857c8-63b0-45ed-b910-baf852f81f84
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "azuredns-hostmaster.microsoft.com.", "serialNumber": 1, "refreshTime":
+      3600, "retryTime": 300, "expireTime": 2419200, "minimumTtl": 300}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"47d0e2f1-a1cf-45d4-ba2f-ca1a5c555a18","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:58:40 GMT
+      etag:
+      - 47d0e2f1-a1cf-45d4-ba2f-ca1a5c555a18
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.1.1.1"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"af2ae0d6-8fff-4f1f-b140-943d9b12407d","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '433'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:58:41 GMT
+      etag:
+      - af2ae0d6-8fff-4f1f-b140-943d9b12407d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11992'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.1.1.1"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/A/www?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"72e07fce-3280-4043-ae40-5dc2d8587389","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '441'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:58:42 GMT
+      etag:
+      - 72e07fce-3280-4043-ae40-5dc2d8587389
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone6_import000001/providers/Microsoft.Network/privateDnsZones/zone6.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/A","etag":"af2ae0d6-8fff-4f1f-b140-943d9b12407d","properties":{"fqdn":"zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"47d0e2f1-a1cf-45d4-ba2f-ca1a5c555a18","properties":{"fqdn":"zone6.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone6_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone6.com\/A\/www","name":"www","type":"Microsoft.Network\/privateDnsZones\/A","etag":"72e07fce-3280-4043-ae40-5dc2d8587389","properties":{"fqdn":"www.zone6.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.1.1.1"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1482'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:58:43 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59997'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone7_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone7_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs3MTE3ZmJjYS01Yjc1LTQ0OTctYTQ5Yy1iZTY2OGI4OWE0YzE=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5Y2NjNmU5YS0xNDY2LTRjZTctOWJjYy0zMGMxMTA2MGZmMWY=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 14:59:42 GMT
+      - Tue, 21 Apr 2020 05:27:38 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs3MTE3ZmJjYS01Yjc1LTQ0OTctYTQ5Yy1iZTY2OGI4OWE0YzE=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5Y2NjNmU5YS0xNDY2LTRjZTctOWJjYy0zMGMxMTA2MGZmMWY=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -48,7 +48,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -76,7 +76,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"e036072f-dc20-493f-8baf-01fe449ec900","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"537e77d3-02b7-4b6c-b9d8-31e1a0c14c38","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -85,9 +85,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:00:13 GMT
+      - Tue, 21 Apr 2020 05:28:09 GMT
       etag:
-      - e036072f-dc20-493f-8baf-01fe449ec900
+      - 537e77d3-02b7-4b6c-b9d8-31e1a0c14c38
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -101,58 +101,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com","name":"zone7.com","type":"Microsoft.Network\/privateDnsZones","etag":"1292e347-9ff6-4136-ab36-1112739c10b9","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '613'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 15:00:13 GMT
-      etag:
-      - 1292e347-9ff6-4136-ab36-1112739c10b9
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -186,7 +135,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a05b5f09-909b-4f23-86af-2abb77bad012","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"666a3145-2f5b-4bc4-90c8-159b5e606e49","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -195,9 +144,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:00:14 GMT
+      - Tue, 21 Apr 2020 05:28:10 GMT
       etag:
-      - a05b5f09-909b-4f23-86af-2abb77bad012
+      - 666a3145-2f5b-4bc4-90c8-159b5e606e49
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -211,7 +160,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -243,7 +192,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a1f8ee0-799d-40e4-a294-7b32ad2dd50f","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"24615283-f62a-4963-8c3c-d27f828f2ae0","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -252,9 +201,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:00:15 GMT
+      - Tue, 21 Apr 2020 05:28:11 GMT
       etag:
-      - 9a1f8ee0-799d-40e4-a294-7b32ad2dd50f
+      - 24615283-f62a-4963-8c3c-d27f828f2ae0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -296,7 +245,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/txt1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f8e1d826-f229-4741-8795-e2aae72de90a","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4ca14fe9-bd81-465b-a8cb-2a7fce6e2389","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
         cd"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -306,9 +255,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:00:15 GMT
+      - Tue, 21 Apr 2020 05:28:13 GMT
       etag:
-      - f8e1d826-f229-4741-8795-e2aae72de90a
+      - 4ca14fe9-bd81-465b-a8cb-2a7fce6e2389
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -318,7 +267,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
@@ -350,7 +299,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/CNAME/cn1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"13fcb20c-e0e9-4ddf-a076-73a304d67ff9","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"68afe954-2843-46f0-aae4-700782155317","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -359,9 +308,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:00:17 GMT
+      - Tue, 21 Apr 2020 05:28:13 GMT
       etag:
-      - 13fcb20c-e0e9-4ddf-a076-73a304d67ff9
+      - 68afe954-2843-46f0-aae4-700782155317
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -371,7 +320,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -399,7 +348,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a05b5f09-909b-4f23-86af-2abb77bad012","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a1f8ee0-799d-40e4-a294-7b32ad2dd50f","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"13fcb20c-e0e9-4ddf-a076-73a304d67ff9","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f8e1d826-f229-4741-8795-e2aae72de90a","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"666a3145-2f5b-4bc4-90c8-159b5e606e49","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"24615283-f62a-4963-8c3c-d27f828f2ae0","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"68afe954-2843-46f0-aae4-700782155317","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4ca14fe9-bd81-465b-a8cb-2a7fce6e2389","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
         cd"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
@@ -409,7 +358,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:00:18 GMT
+      - Tue, 21 Apr 2020 05:28:14 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -453,7 +402,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a05b5f09-909b-4f23-86af-2abb77bad012","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"666a3145-2f5b-4bc4-90c8-159b5e606e49","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -462,7 +411,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:00:18 GMT
+      - Tue, 21 Apr 2020 05:28:14 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -478,7 +427,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59999'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -506,7 +455,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a05b5f09-909b-4f23-86af-2abb77bad012","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a1f8ee0-799d-40e4-a294-7b32ad2dd50f","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"13fcb20c-e0e9-4ddf-a076-73a304d67ff9","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f8e1d826-f229-4741-8795-e2aae72de90a","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"666a3145-2f5b-4bc4-90c8-159b5e606e49","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"24615283-f62a-4963-8c3c-d27f828f2ae0","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"68afe954-2843-46f0-aae4-700782155317","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4ca14fe9-bd81-465b-a8cb-2a7fce6e2389","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
         cd"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
@@ -516,7 +465,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:00:18 GMT
+      - Tue, 21 Apr 2020 05:28:15 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -531,106 +480,6 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59996'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2ZDhiMTFkOS1lNTE1LTRkYTctYTZmNC0yYjNjZTA1MTA1ZmE=?api-version=2018-09-01
-      cache-control:
-      - private
-      content-length:
-      - '0'
-      date:
-      - Thu, 16 Apr 2020 15:00:21 GMT
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2ZDhiMTFkOS1lNTE1LTRkYTctYTZmNC0yYjNjZTA1MTA1ZmE=?api-version=2018-09-01
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2ZDhiMTFkOS1lNTE1LTRkYTctYTZmNC0yYjNjZTA1MTA1ZmE=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"Succeeded"}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '22'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 15:00:52 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:
@@ -667,7 +516,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0NjBkODBjZi00YjEyLTQ0N2YtODFhNC03ODIzODRiMDNkY2I=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTszNjZhMDYwNS1mNTZlLTRlY2MtYTdjOS00MDg3YWJkNTdjNzI=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -675,9 +524,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:01:19 GMT
+      - Tue, 21 Apr 2020 05:28:17 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0NjBkODBjZi00YjEyLTQ0N2YtODFhNC03ODIzODRiMDNkY2I=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTszNjZhMDYwNS1mNTZlLTRlY2MtYTdjOS00MDg3YWJkNTdjNzI=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -709,24 +558,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5Y2NjNmU5YS0xNDY2LTRjZTctOWJjYy0zMGMxMTA2MGZmMWY=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4c417f17-1a97-4835-a2f8-ccb8140e1488","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:01:49 GMT
-      etag:
-      - 4c417f17-1a97-4835-a2f8-ccb8140e1488
+      - Tue, 21 Apr 2020 05:28:39 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -763,7 +608,58 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0NjBkODBjZi00YjEyLTQ0N2YtODFhNC03ODIzODRiMDNkY2I=?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com","name":"zone7.com","type":"Microsoft.Network\/privateDnsZones","etag":"d1538354-d9d2-4c5e-82a1-44babf0fc145","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":4,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:28:40 GMT
+      etag:
+      - d1538354-d9d2-4c5e-82a1-44babf0fc145
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTszNjZhMDYwNS1mNTZlLTRlY2MtYTdjOS00MDg3YWJkNTdjNzI=?api-version=2018-09-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -775,7 +671,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:01:50 GMT
+      - Tue, 21 Apr 2020 05:28:48 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -815,7 +711,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com","name":"zone7.com","type":"Microsoft.Network\/privateDnsZones","etag":"719ae3bf-3d86-430f-be49-ff833585396f","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com","name":"zone7.com","type":"Microsoft.Network\/privateDnsZones","etag":"d1538354-d9d2-4c5e-82a1-44babf0fc145","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":4,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -824,9 +720,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:01:51 GMT
+      - Tue, 21 Apr 2020 05:28:49 GMT
       etag:
-      - 719ae3bf-3d86-430f-be49-ff833585396f
+      - d1538354-d9d2-4c5e-82a1-44babf0fc145
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -840,7 +736,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '497'
       x-powered-by:
       - ASP.NET
     status:
@@ -874,7 +770,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"0bc881b0-bcd8-4366-966b-c4a925c68aeb","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b986789e-8faf-46d0-89f0-b58312ab2fc2","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -883,9 +779,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:01:51 GMT
+      - Tue, 21 Apr 2020 05:28:49 GMT
       etag:
-      - 0bc881b0-bcd8-4366-966b-c4a925c68aeb
+      - b986789e-8faf-46d0-89f0-b58312ab2fc2
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -899,7 +795,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -931,7 +827,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"66ef74ef-5bb6-4ba2-bdc1-5aa41a9491cc","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"223741ea-826d-4944-b721-bc34cee8df84","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -940,24 +836,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:01:52 GMT
+      - Tue, 21 Apr 2020 05:28:49 GMT
       etag:
-      - 66ef74ef-5bb6-4ba2-bdc1-5aa41a9491cc
+      - 223741ea-826d-4944-b721-bc34cee8df84
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "contoso.com."}}}'
     headers:
@@ -984,7 +884,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/CNAME/cn1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"9c20f540-653f-4a7f-b308-1dc193c97ffd","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"7a3cbad9-7aaa-4c80-be3e-caf054662670","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -993,24 +893,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:01:53 GMT
+      - Tue, 21 Apr 2020 05:28:52 GMT
       etag:
-      - 9c20f540-653f-4a7f-b308-1dc193c97ffd
+      - 7a3cbad9-7aaa-4c80-be3e-caf054662670
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["ab\\ cd"]}]}}'
     headers:
@@ -1037,7 +941,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/txt1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5584bd2a-1397-4611-afc3-e86430927b5c","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"689d37a2-e5f0-4f80-9d90-f06d742c2b0e","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
         cd"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -1047,24 +951,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:01:54 GMT
+      - Tue, 21 Apr 2020 05:28:52 GMT
       etag:
-      - 5584bd2a-1397-4611-afc3-e86430927b5c
+      - 689d37a2-e5f0-4f80-9d90-f06d742c2b0e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11988'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -1087,7 +995,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"0bc881b0-bcd8-4366-966b-c4a925c68aeb","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"66ef74ef-5bb6-4ba2-bdc1-5aa41a9491cc","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"9c20f540-653f-4a7f-b308-1dc193c97ffd","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5584bd2a-1397-4611-afc3-e86430927b5c","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b986789e-8faf-46d0-89f0-b58312ab2fc2","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"223741ea-826d-4944-b721-bc34cee8df84","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"7a3cbad9-7aaa-4c80-be3e-caf054662670","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"689d37a2-e5f0-4f80-9d90-f06d742c2b0e","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
         cd"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
@@ -1097,7 +1005,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:01:55 GMT
+      - Tue, 21 Apr 2020 05:28:53 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone7_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone7_Import.yaml
@@ -1,0 +1,1122 @@
+interactions:
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs3MTE3ZmJjYS01Yjc1LTQ0OTctYTQ5Yy1iZTY2OGI4OWE0YzE=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 14:59:42 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs3MTE3ZmJjYS01Yjc1LTQ0OTctYTQ5Yy1iZTY2OGI4OWE0YzE=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"e036072f-dc20-493f-8baf-01fe449ec900","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:00:13 GMT
+      etag:
+      - e036072f-dc20-493f-8baf-01fe449ec900
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com","name":"zone7.com","type":"Microsoft.Network\/privateDnsZones","etag":"1292e347-9ff6-4136-ab36-1112739c10b9","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:00:13 GMT
+      etag:
+      - 1292e347-9ff6-4136-ab36-1112739c10b9
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "azuredns-hostmaster.microsoft.com.", "serialNumber": 1, "refreshTime":
+      3600, "retryTime": 300, "expireTime": 2419200, "minimumTtl": 300}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a05b5f09-909b-4f23-86af-2abb77bad012","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:00:14 GMT
+      etag:
+      - a05b5f09-909b-4f23-86af-2abb77bad012
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 60, "txtRecords": [{"value": ["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a1f8ee0-799d-40e4-a294-7b32ad2dd50f","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '481'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:00:15 GMT
+      etag:
+      - 9a1f8ee0-799d-40e4-a294-7b32ad2dd50f
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["ab\\ cd"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/txt1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f8e1d826-f229-4741-8795-e2aae72de90a","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+        cd"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '446'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:00:15 GMT
+      etag:
+      - f8e1d826-f229-4741-8795-e2aae72de90a
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "contoso.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/CNAME/cn1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"13fcb20c-e0e9-4ddf-a076-73a304d67ff9","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '449'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:00:17 GMT
+      etag:
+      - 13fcb20c-e0e9-4ddf-a076-73a304d67ff9
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a05b5f09-909b-4f23-86af-2abb77bad012","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a1f8ee0-799d-40e4-a294-7b32ad2dd50f","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"13fcb20c-e0e9-4ddf-a076-73a304d67ff9","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f8e1d826-f229-4741-8795-e2aae72de90a","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+        cd"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1985'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:00:18 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59996'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a05b5f09-909b-4f23-86af-2abb77bad012","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '606'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:00:18 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a05b5f09-909b-4f23-86af-2abb77bad012","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"9a1f8ee0-799d-40e4-a294-7b32ad2dd50f","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"13fcb20c-e0e9-4ddf-a076-73a304d67ff9","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f8e1d826-f229-4741-8795-e2aae72de90a","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+        cd"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1985'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:00:18 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59996'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2ZDhiMTFkOS1lNTE1LTRkYTctYTZmNC0yYjNjZTA1MTA1ZmE=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Thu, 16 Apr 2020 15:00:21 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2ZDhiMTFkOS1lNTE1LTRkYTctYTZmNC0yYjNjZTA1MTA1ZmE=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs2ZDhiMTFkOS1lNTE1LTRkYTctYTZmNC0yYjNjZTA1MTA1ZmE=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:00:52 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0NjBkODBjZi00YjEyLTQ0N2YtODFhNC03ODIzODRiMDNkY2I=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:01:19 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0NjBkODBjZi00YjEyLTQ0N2YtODFhNC03ODIzODRiMDNkY2I=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"4c417f17-1a97-4835-a2f8-ccb8140e1488","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:01:49 GMT
+      etag:
+      - 4c417f17-1a97-4835-a2f8-ccb8140e1488
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0NjBkODBjZi00YjEyLTQ0N2YtODFhNC03ODIzODRiMDNkY2I=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:01:50 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com","name":"zone7.com","type":"Microsoft.Network\/privateDnsZones","etag":"719ae3bf-3d86-430f-be49-ff833585396f","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:01:51 GMT
+      etag:
+      - 719ae3bf-3d86-430f-be49-ff833585396f
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "azuredns-hostmaster.microsoft.com.", "serialNumber": 1, "refreshTime":
+      3600, "retryTime": 300, "expireTime": 2419200, "minimumTtl": 300}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"0bc881b0-bcd8-4366-966b-c4a925c68aeb","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:01:51 GMT
+      etag:
+      - 0bc881b0-bcd8-4366-966b-c4a925c68aeb
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 60, "txtRecords": [{"value": ["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"66ef74ef-5bb6-4ba2-bdc1-5aa41a9491cc","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '481'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:01:52 GMT
+      etag:
+      - 66ef74ef-5bb6-4ba2-bdc1-5aa41a9491cc
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "contoso.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/CNAME/cn1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"9c20f540-653f-4a7f-b308-1dc193c97ffd","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '449'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:01:53 GMT
+      etag:
+      - 9c20f540-653f-4a7f-b308-1dc193c97ffd
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["ab\\ cd"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/txt1?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5584bd2a-1397-4611-afc3-e86430927b5c","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+        cd"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '446'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:01:54 GMT
+      etag:
+      - 5584bd2a-1397-4611-afc3-e86430927b5c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"0bc881b0-bcd8-4366-966b-c4a925c68aeb","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"66ef74ef-5bb6-4ba2-bdc1-5aa41a9491cc","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"9c20f540-653f-4a7f-b308-1dc193c97ffd","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"5584bd2a-1397-4611-afc3-e86430927b5c","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+        cd"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1985'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:01:55 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59996'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone7_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone7_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5Y2NjNmU5YS0xNDY2LTRjZTctOWJjYy0zMGMxMTA2MGZmMWY=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0NWYwODE2Yi01NDZhLTRiYzItYjUyZC0zZmZlNjNkMThkODI=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:27:38 GMT
+      - Wed, 22 Apr 2020 12:21:55 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5Y2NjNmU5YS0xNDY2LTRjZTctOWJjYy0zMGMxMTA2MGZmMWY=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0NWYwODE2Yi01NDZhLTRiYzItYjUyZC0zZmZlNjNkMThkODI=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -70,13 +70,113 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs0NWYwODE2Yi01NDZhLTRiYzItYjUyZC0zZmZlNjNkMThkODI=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:22:26 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com","name":"zone7.com","type":"Microsoft.Network\/privateDnsZones","etag":"8f638b5d-9090-411a-a181-91f129f5b4ea","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 12:22:27 GMT
+      etag:
+      - 8f638b5d-9090-411a-a181-91f129f5b4ea
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '496'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"537e77d3-02b7-4b6c-b9d8-31e1a0c14c38","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"91c894c9-44a6-41a5-9636-b2f328f483c7","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -85,9 +185,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:28:09 GMT
+      - Wed, 22 Apr 2020 12:22:27 GMT
       etag:
-      - 537e77d3-02b7-4b6c-b9d8-31e1a0c14c38
+      - 91c894c9-44a6-41a5-9636-b2f328f483c7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -135,7 +235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"666a3145-2f5b-4bc4-90c8-159b5e606e49","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"07e77349-3b89-470e-b64b-a8c1f113f03f","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -144,9 +244,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:28:10 GMT
+      - Wed, 22 Apr 2020 12:22:28 GMT
       etag:
-      - 666a3145-2f5b-4bc4-90c8-159b5e606e49
+      - 07e77349-3b89-470e-b64b-a8c1f113f03f
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -160,7 +260,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -192,7 +292,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"24615283-f62a-4963-8c3c-d27f828f2ae0","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6066a2a2-f57d-454c-a6f5-6dba2f2499d1","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -201,9 +301,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:28:11 GMT
+      - Wed, 22 Apr 2020 12:22:29 GMT
       etag:
-      - 24615283-f62a-4963-8c3c-d27f828f2ae0
+      - 6066a2a2-f57d-454c-a6f5-6dba2f2499d1
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -213,7 +313,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
@@ -245,7 +345,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/txt1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4ca14fe9-bd81-465b-a8cb-2a7fce6e2389","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a74c891-16f4-4087-ae6e-e70f47bb53a7","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
         cd"]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
@@ -255,9 +355,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:28:13 GMT
+      - Wed, 22 Apr 2020 12:22:30 GMT
       etag:
-      - 4ca14fe9-bd81-465b-a8cb-2a7fce6e2389
+      - 6a74c891-16f4-4087-ae6e-e70f47bb53a7
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -267,7 +367,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11995'
       x-powered-by:
       - ASP.NET
     status:
@@ -299,7 +399,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/CNAME/cn1?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"68afe954-2843-46f0-aae4-700782155317","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a55099aa-deb0-4daf-956d-d0b3867c8922","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -308,9 +408,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:28:13 GMT
+      - Wed, 22 Apr 2020 12:22:32 GMT
       etag:
-      - 68afe954-2843-46f0-aae4-700782155317
+      - a55099aa-deb0-4daf-956d-d0b3867c8922
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -320,7 +420,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -348,7 +448,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"666a3145-2f5b-4bc4-90c8-159b5e606e49","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"24615283-f62a-4963-8c3c-d27f828f2ae0","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"68afe954-2843-46f0-aae4-700782155317","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4ca14fe9-bd81-465b-a8cb-2a7fce6e2389","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"07e77349-3b89-470e-b64b-a8c1f113f03f","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6066a2a2-f57d-454c-a6f5-6dba2f2499d1","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a55099aa-deb0-4daf-956d-d0b3867c8922","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a74c891-16f4-4087-ae6e-e70f47bb53a7","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
         cd"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
@@ -358,7 +458,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:28:14 GMT
+      - Wed, 22 Apr 2020 12:22:32 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -402,7 +502,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"666a3145-2f5b-4bc4-90c8-159b5e606e49","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"07e77349-3b89-470e-b64b-a8c1f113f03f","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -411,7 +511,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:28:14 GMT
+      - Wed, 22 Apr 2020 12:22:32 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -427,7 +527,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59999'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -455,7 +555,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"666a3145-2f5b-4bc4-90c8-159b5e606e49","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"24615283-f62a-4963-8c3c-d27f828f2ae0","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"68afe954-2843-46f0-aae4-700782155317","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"4ca14fe9-bd81-465b-a8cb-2a7fce6e2389","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"07e77349-3b89-470e-b64b-a8c1f113f03f","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6066a2a2-f57d-454c-a6f5-6dba2f2499d1","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a55099aa-deb0-4daf-956d-d0b3867c8922","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"6a74c891-16f4-4087-ae6e-e70f47bb53a7","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
         cd"]}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
@@ -465,7 +565,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:28:15 GMT
+      - Wed, 22 Apr 2020 12:22:33 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -488,45 +588,41 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": "global"}'
+    body: null
     headers:
       Accept:
       - application/json
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - network private-dns zone import
+      - network private-dns zone delete
       Connection:
       - keep-alive
       Content-Length:
-      - '22'
-      Content-Type:
-      - application/json; charset=utf-8
+      - '0'
       ParameterSetName:
-      - -n -g --file-name
+      - -g -n -y
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
       accept-language:
       - en-US
-    method: PUT
+    method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
   response:
     body:
-      string: '{}'
+      string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTszNjZhMDYwNS1mNTZlLTRlY2MtYTdjOS00MDg3YWJkNTdjNzI=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTszM2Q0YTk4Ni1lZjc0LTQwOGItYThkYy00MGNkM2Q5N2FlZTE=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
+      - '0'
       date:
-      - Tue, 21 Apr 2020 05:28:17 GMT
+      - Wed, 22 Apr 2020 12:22:36 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTszNjZhMDYwNS1mNTZlLTRlY2MtYTdjOS00MDg3YWJkNTdjNzI=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTszM2Q0YTk4Ni1lZjc0LTQwOGItYThkYy00MGNkM2Q5N2FlZTE=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -542,489 +638,4 @@ interactions:
     status:
       code: 202
       message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5Y2NjNmU5YS0xNDY2LTRjZTctOWJjYy0zMGMxMTA2MGZmMWY=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"Succeeded"}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '22'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:28:39 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com","name":"zone7.com","type":"Microsoft.Network\/privateDnsZones","etag":"d1538354-d9d2-4c5e-82a1-44babf0fc145","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":4,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '613'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:28:40 GMT
-      etag:
-      - d1538354-d9d2-4c5e-82a1-44babf0fc145
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTszNjZhMDYwNS1mNTZlLTRlY2MtYTdjOS00MDg3YWJkNTdjNzI=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"Succeeded"}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '22'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:28:48 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com","name":"zone7.com","type":"Microsoft.Network\/privateDnsZones","etag":"d1538354-d9d2-4c5e-82a1-44babf0fc145","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":4,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '613'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:28:49 GMT
-      etag:
-      - d1538354-d9d2-4c5e-82a1-44babf0fc145
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '497'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
-      "email": "azuredns-hostmaster.microsoft.com.", "serialNumber": 1, "refreshTime":
-      3600, "retryTime": 300, "expireTime": 2419200, "minimumTtl": 300}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '222'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/SOA/@?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b986789e-8faf-46d0-89f0-b58312ab2fc2","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '594'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:28:49 GMT
-      etag:
-      - b986789e-8faf-46d0-89f0-b58312ab2fc2
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 60, "txtRecords": [{"value": ["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '115'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/@?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"223741ea-826d-4944-b721-bc34cee8df84","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '481'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:28:49 GMT
-      etag:
-      - 223741ea-826d-4944-b721-bc34cee8df84
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "contoso.com."}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '71'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/CNAME/cn1?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"7a3cbad9-7aaa-4c80-be3e-caf054662670","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '449'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:28:52 GMT
-      etag:
-      - 7a3cbad9-7aaa-4c80-be3e-caf054662670
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["ab\\ cd"]}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '69'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/TXT/txt1?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"689d37a2-e5f0-4f80-9d90-f06d742c2b0e","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
-        cd"]}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '446'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:28:52 GMT
-      etag:
-      - 689d37a2-e5f0-4f80-9d90-f06d742c2b0e
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11988'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns record-set list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -z
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone7_import000001/providers/Microsoft.Network/privateDnsZones/zone7.com/ALL?api-version=2018-09-01
-  response:
-    body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b986789e-8faf-46d0-89f0-b58312ab2fc2","properties":{"fqdn":"zone7.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"223741ea-826d-4944-b721-bc34cee8df84","properties":{"fqdn":"zone7.com.","ttl":60,"txtRecords":[{"value":["a\\\\b\\255\\000\\;\\\"\\\"\\\"testtesttest\\\"\\\"\\\""]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/CNAME\/cn1","name":"cn1","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"7a3cbad9-7aaa-4c80-be3e-caf054662670","properties":{"fqdn":"cn1.zone7.com.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone7_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone7.com\/TXT\/txt1","name":"txt1","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"689d37a2-e5f0-4f80-9d90-f06d742c2b0e","properties":{"fqdn":"txt1.zone7.com.","ttl":3600,"txtRecords":[{"value":["ab\\
-        cd"]}],"isAutoRegistered":false}}]}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '1985'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 21 Apr 2020 05:28:53 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59996'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
 version: 1

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone8_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone8_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiZjE2M2I0NC01OGVmLTRjY2YtOWZkMS05ZTc4YmE0ZmQ3Yjg=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiNGRjMTBlMS1lYzcyLTQyYjMtYmVlMS0zNTQ4YjFjMDY2ZjA=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,494 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:02:37 GMT
+      - Tue, 21 Apr 2020 05:29:20 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiZjE2M2I0NC01OGVmLTRjY2YtOWZkMS05ZTc4YmE0ZmQ3Yjg=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiNGRjMTBlMS1lYzcyLTQyYjMtYmVlMS0zNTQ4YjFjMDY2ZjA=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11992'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"da0a7913-897a-472d-9b7e-fb79cd99ea18","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:29:51 GMT
+      etag:
+      - da0a7913-897a-472d-9b7e-fb79cd99ea18
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "azuredns-hostmaster.microsoft.com.", "serialNumber": 1, "refreshTime":
+      3600, "retryTime": 300, "expireTime": 2419200, "minimumTtl": 300}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"64df2c99-2248-4c90-9e7f-95766b974596","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:29:52 GMT
+      etag:
+      - 64df2c99-2248-4c90-9e7f-95766b974596
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 172800, "txtRecords": [{"value": ["ns1-03.azure-dns.com."]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/TXT/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01f4e700-114f-4c87-bbdf-16145a0011ff","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '451'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:29:53 GMT
+      etag:
+      - 01f4e700-114f-4c87-bbdf-16145a0011ff
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/A/ns?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"31c60e08-b469-43a8-9a8f-2a90008e4cc5","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '438'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:29:54 GMT
+      etag:
+      - 31c60e08-b469-43a8-9a8f-2a90008e4cc5
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11989'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "2.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/A/*?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"172a0f65-4b87-4ffd-a9a3-e9e1de631023","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '435'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:29:55 GMT
+      etag:
+      - 172a0f65-4b87-4ffd-a9a3-e9e1de631023
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11988'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"172a0f65-4b87-4ffd-a9a3-e9e1de631023","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"64df2c99-2248-4c90-9e7f-95766b974596","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01f4e700-114f-4c87-bbdf-16145a0011ff","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"31c60e08-b469-43a8-9a8f-2a90008e4cc5","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1933'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:29:56 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59908'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '494'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"64df2c99-2248-4c90-9e7f-95766b974596","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '606'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:29:56 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"172a0f65-4b87-4ffd-a9a3-e9e1de631023","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"64df2c99-2248-4c90-9e7f-95766b974596","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01f4e700-114f-4c87-bbdf-16145a0011ff","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"31c60e08-b469-43a8-9a8f-2a90008e4cc5","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1933'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:29:57 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59996'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmY2VkNDI4Zi1iMTIwLTQzM2UtOGQzNi1lYmZhY2I3MmRkM2Y=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:29:59 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmY2VkNDI4Zi1iMTIwLTQzM2UtOGQzNi1lYmZhY2I3MmRkM2Y=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -76,7 +561,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"3cba3a00-fe7b-4180-80eb-477ec1b0ac6b","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"64df2c99-2248-4c90-9e7f-95766b974596","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -85,9 +570,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:03:07 GMT
+      - Tue, 21 Apr 2020 05:30:29 GMT
       etag:
-      - 3cba3a00-fe7b-4180-80eb-477ec1b0ac6b
+      - 64df2c99-2248-4c90-9e7f-95766b974596
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -127,7 +612,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com","name":"zone8.com","type":"Microsoft.Network\/privateDnsZones","etag":"b3e053d1-1eca-48eb-b8f6-b89bbf2aafd5","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com","name":"zone8.com","type":"Microsoft.Network\/privateDnsZones","etag":"0891c6f0-e5ce-4c66-968d-465eb5db57d1","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":4,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -136,9 +621,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:03:08 GMT
+      - Tue, 21 Apr 2020 05:30:30 GMT
       etag:
-      - b3e053d1-1eca-48eb-b8f6-b89bbf2aafd5
+      - 0891c6f0-e5ce-4c66-968d-465eb5db57d1
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -152,7 +637,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '497'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -186,7 +671,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"880239e9-a3ad-4e9b-b570-66cd2685e6e6","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b3809be0-931a-452d-b157-2f744111d3df","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -195,9 +680,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:03:08 GMT
+      - Tue, 21 Apr 2020 05:30:30 GMT
       etag:
-      - 880239e9-a3ad-4e9b-b570-66cd2685e6e6
+      - b3809be0-931a-452d-b157-2f744111d3df
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -211,7 +696,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
@@ -243,7 +728,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/TXT/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7a8a7fa6-7f66-40b1-bf6f-5d02715368b4","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0483c5bb-921f-4079-9199-64d8d0524440","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -252,77 +737,28 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:03:09 GMT
+      - Tue, 21 Apr 2020 05:30:32 GMT
       etag:
-      - 7a8a7fa6-7f66-40b1-bf6f-5d02715368b4
+      - 0483c5bb-921f-4079-9199-64d8d0524440
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
-- request:
-    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}]}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '71'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/A/ns?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0084aadd-63d1-46e2-93d9-cdba90bad43b","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '438'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 15:03:11 GMT
-      etag:
-      - 0084aadd-63d1-46e2-93d9-cdba90bad43b
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "2.3.4.5"}]}}'
     headers:
@@ -349,7 +785,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/A/*?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"56e15933-0f03-40e3-90fc-3ab8932eeb22","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9e4de8f2-b379-4eee-bd59-52db6ee912aa","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -358,13 +794,17 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:03:11 GMT
+      - Tue, 21 Apr 2020 05:30:33 GMT
       etag:
-      - 56e15933-0f03-40e3-90fc-3ab8932eeb22
+      - 9e4de8f2-b379-4eee-bd59-52db6ee912aa
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
@@ -374,8 +814,65 @@ interactions:
       x-powered-by:
       - ASP.NET
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/A/ns?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3751dbb3-d464-4367-aae4-1dbe40fa601e","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '438'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 05:30:34 GMT
+      etag:
+      - 3751dbb3-d464-4367-aae4-1dbe40fa601e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11985'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -398,7 +895,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"56e15933-0f03-40e3-90fc-3ab8932eeb22","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"880239e9-a3ad-4e9b-b570-66cd2685e6e6","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7a8a7fa6-7f66-40b1-bf6f-5d02715368b4","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0084aadd-63d1-46e2-93d9-cdba90bad43b","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9e4de8f2-b379-4eee-bd59-52db6ee912aa","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b3809be0-931a-452d-b157-2f744111d3df","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0483c5bb-921f-4079-9199-64d8d0524440","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3751dbb3-d464-4367-aae4-1dbe40fa601e","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -407,7 +904,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 16 Apr 2020 15:03:13 GMT
+      - Tue, 21 Apr 2020 05:30:35 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -421,370 +918,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59993'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone export
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA?api-version=2018-09-01
-  response:
-    body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"880239e9-a3ad-4e9b-b570-66cd2685e6e6","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '606'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 15:03:13 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59999'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone export
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/ALL?api-version=2018-09-01
-  response:
-    body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"56e15933-0f03-40e3-90fc-3ab8932eeb22","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"880239e9-a3ad-4e9b-b570-66cd2685e6e6","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7a8a7fa6-7f66-40b1-bf6f-5d02715368b4","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0084aadd-63d1-46e2-93d9-cdba90bad43b","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '1933'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 15:03:13 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59992'
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com?api-version=2018-09-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZGVjNzczNC04MzIxLTRkZmYtYjI2Ny1mMzI2ZGFmN2YwNmY=?api-version=2018-09-01
-      cache-control:
-      - private
-      content-length:
-      - '0'
-      date:
-      - Thu, 16 Apr 2020 15:03:16 GMT
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZGVjNzczNC04MzIxLTRkZmYtYjI2Ny1mMzI2ZGFmN2YwNmY=?api-version=2018-09-01
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11998'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n -y
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZGVjNzczNC04MzIxLTRkZmYtYjI2Ny1mMzI2ZGFmN2YwNmY=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"Succeeded"}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '22'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 15:03:46 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '497'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location": "global"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '22'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com?api-version=2018-09-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5YTY5ODBjYS1jNGI2LTRlZjEtYTMwOC1hYTUwODI5OGVlZTc=?api-version=2018-09-01
-      cache-control:
-      - private
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 15:04:13 GMT
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5YTY5ODBjYS1jNGI2LTRlZjEtYTMwOC1hYTUwODI5OGVlZTc=?api-version=2018-09-01
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
-  response:
-    body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f23d6dec-9d95-4d6b-a30b-a39ef486506b","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '594'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 15:04:43 GMT
-      etag:
-      - f23d6dec-9d95-4d6b-a30b-a39ef486506b
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network private-dns zone import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --file-name
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5YTY5ODBjYS1jNGI2LTRlZjEtYTMwOC1hYTUwODI5OGVlZTc=?api-version=2018-09-01
-  response:
-    body:
-      string: '{"status":"Succeeded"}'
-    headers:
-      cache-control:
-      - private
-      content-length:
-      - '22'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 16 Apr 2020 15:04:43 GMT
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
+      - '59996'
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone8_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone8_Import.yaml
@@ -28,7 +28,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiNGRjMTBlMS1lYzcyLTQyYjMtYmVlMS0zNTQ4YjFjMDY2ZjA=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5NGNmYjczZC1hODE5LTQzYWEtYmYzMS0zOWExMjYyODk3Mzc=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -36,9 +36,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:29:20 GMT
+      - Wed, 22 Apr 2020 10:44:23 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiNGRjMTBlMS1lYzcyLTQyYjMtYmVlMS0zNTQ4YjFjMDY2ZjA=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5NGNmYjczZC1hODE5LTQzYWEtYmYzMS0zOWExMjYyODk3Mzc=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -48,12 +48,112 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11992'
+      - '11997'
       x-powered-by:
       - ASP.NET
     status:
       code: 202
       message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5NGNmYjczZC1hODE5LTQzYWEtYmYzMS0zOWExMjYyODk3Mzc=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 10:44:53 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com","name":"zone8.com","type":"Microsoft.Network\/privateDnsZones","etag":"eb2f7cf2-f397-4338-b2dd-e0bef8f2ad39","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 10:44:53 GMT
+      etag:
+      - eb2f7cf2-f397-4338-b2dd-e0bef8f2ad39
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '491'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -76,7 +176,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"da0a7913-897a-472d-9b7e-fb79cd99ea18","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"bb46f7a1-ab88-4020-907b-df156fb2ab59","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -85,9 +185,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:29:51 GMT
+      - Wed, 22 Apr 2020 10:44:54 GMT
       etag:
-      - da0a7913-897a-472d-9b7e-fb79cd99ea18
+      - bb46f7a1-ab88-4020-907b-df156fb2ab59
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -135,7 +235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"64df2c99-2248-4c90-9e7f-95766b974596","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1c35fc6b-cf4f-4e4f-b07c-05ea0f4644e8","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -144,9 +244,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:29:52 GMT
+      - Wed, 22 Apr 2020 10:44:55 GMT
       etag:
-      - 64df2c99-2248-4c90-9e7f-95766b974596
+      - 1c35fc6b-cf4f-4e4f-b07c-05ea0f4644e8
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -160,7 +260,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11994'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -192,7 +292,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/TXT/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01f4e700-114f-4c87-bbdf-16145a0011ff","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3c61ce48-712e-4820-9257-7c30cec11355","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -201,9 +301,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:29:53 GMT
+      - Wed, 22 Apr 2020 10:44:56 GMT
       etag:
-      - 01f4e700-114f-4c87-bbdf-16145a0011ff
+      - 3c61ce48-712e-4820-9257-7c30cec11355
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -213,7 +313,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -245,7 +345,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/A/ns?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"31c60e08-b469-43a8-9a8f-2a90008e4cc5","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"341799d9-dc72-41e6-b362-ad2c47b1e54a","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -254,9 +354,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:29:54 GMT
+      - Wed, 22 Apr 2020 10:44:57 GMT
       etag:
-      - 31c60e08-b469-43a8-9a8f-2a90008e4cc5
+      - 341799d9-dc72-41e6-b362-ad2c47b1e54a
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -266,7 +366,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11989'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
@@ -298,7 +398,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/A/*?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"172a0f65-4b87-4ffd-a9a3-e9e1de631023","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"13feaf7c-34d9-4712-a923-30893e5d8132","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -307,9 +407,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:29:55 GMT
+      - Wed, 22 Apr 2020 10:44:58 GMT
       etag:
-      - 172a0f65-4b87-4ffd-a9a3-e9e1de631023
+      - 13feaf7c-34d9-4712-a923-30893e5d8132
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -319,7 +419,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11988'
+      - '11996'
       x-powered-by:
       - ASP.NET
     status:
@@ -347,7 +447,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"172a0f65-4b87-4ffd-a9a3-e9e1de631023","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"64df2c99-2248-4c90-9e7f-95766b974596","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01f4e700-114f-4c87-bbdf-16145a0011ff","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"31c60e08-b469-43a8-9a8f-2a90008e4cc5","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"13feaf7c-34d9-4712-a923-30893e5d8132","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1c35fc6b-cf4f-4e4f-b07c-05ea0f4644e8","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3c61ce48-712e-4820-9257-7c30cec11355","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"341799d9-dc72-41e6-b362-ad2c47b1e54a","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -356,7 +456,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:29:56 GMT
+      - Wed, 22 Apr 2020 10:44:59 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -370,9 +470,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59908'
+      - '59992'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '494'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:
@@ -400,7 +500,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"64df2c99-2248-4c90-9e7f-95766b974596","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1c35fc6b-cf4f-4e4f-b07c-05ea0f4644e8","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -409,7 +509,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:29:56 GMT
+      - Wed, 22 Apr 2020 10:45:00 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -425,7 +525,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59999'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -453,7 +553,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"172a0f65-4b87-4ffd-a9a3-e9e1de631023","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"64df2c99-2248-4c90-9e7f-95766b974596","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"01f4e700-114f-4c87-bbdf-16145a0011ff","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"31c60e08-b469-43a8-9a8f-2a90008e4cc5","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"13feaf7c-34d9-4712-a923-30893e5d8132","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"1c35fc6b-cf4f-4e4f-b07c-05ea0f4644e8","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"3c61ce48-712e-4820-9257-7c30cec11355","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"341799d9-dc72-41e6-b362-ad2c47b1e54a","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -462,7 +562,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:29:57 GMT
+      - Wed, 22 Apr 2020 10:45:00 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -477,6 +577,106 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
       - '59996'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3NGFhMWI4Yy03NWJlLTRiYzMtODM0NC00OGE1NGJmNzliNDc=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Wed, 22 Apr 2020 10:45:03 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3NGFhMWI4Yy03NWJlLTRiYzMtODM0NC00OGE1NGJmNzliNDc=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3NGFhMWI4Yy03NWJlLTRiYzMtODM0NC00OGE1NGJmNzliNDc=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 10:45:33 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
       - '499'
       x-powered-by:
@@ -513,7 +713,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmY2VkNDI4Zi1iMTIwLTQzM2UtOGQzNi1lYmZhY2I3MmRkM2Y=?api-version=2018-09-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5NGI1NjU0ZC00YzgxLTQ5NDEtOGI4Yi0yODc4MjdmZDdlMTM=?api-version=2018-09-01
       cache-control:
       - private
       content-length:
@@ -521,9 +721,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:29:59 GMT
+      - Wed, 22 Apr 2020 10:46:01 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtmY2VkNDI4Zi1iMTIwLTQzM2UtOGQzNi1lYmZhY2I3MmRkM2Y=?api-version=2018-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5NGI1NjU0ZC00YzgxLTQ5NDEtOGI4Yi0yODc4MjdmZDdlMTM=?api-version=2018-09-01
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -555,24 +755,20 @@ interactions:
       User-Agent:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
         azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
-      accept-language:
-      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5NGI1NjU0ZC00YzgxLTQ5NDEtOGI4Yi0yODc4MjdmZDdlMTM=?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"64df2c99-2248-4c90-9e7f-95766b974596","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"status":"Succeeded"}'
     headers:
       cache-control:
       - private
       content-length:
-      - '594'
+      - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:30:29 GMT
-      etag:
-      - 64df2c99-2248-4c90-9e7f-95766b974596
+      - Wed, 22 Apr 2020 10:46:31 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -612,7 +808,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com","name":"zone8.com","type":"Microsoft.Network\/privateDnsZones","etag":"0891c6f0-e5ce-4c66-968d-465eb5db57d1","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":4,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com","name":"zone8.com","type":"Microsoft.Network\/privateDnsZones","etag":"0c04b97d-9ae0-4622-ae03-f03bdc8c0f67","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - private
@@ -621,9 +817,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:30:30 GMT
+      - Wed, 22 Apr 2020 10:46:32 GMT
       etag:
-      - 0891c6f0-e5ce-4c66-968d-465eb5db57d1
+      - 0c04b97d-9ae0-4622-ae03-f03bdc8c0f67
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -637,7 +833,60 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '492'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f30a1d36-255e-4376-ba36-df088fe4fa95","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 22 Apr 2020 10:46:33 GMT
+      etag:
+      - f30a1d36-255e-4376-ba36-df088fe4fa95
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -671,7 +920,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b3809be0-931a-452d-b157-2f744111d3df","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"8fdd59d2-99b3-4431-9101-867b087cc79e","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -680,9 +929,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:30:30 GMT
+      - Wed, 22 Apr 2020 10:46:33 GMT
       etag:
-      - b3809be0-931a-452d-b157-2f744111d3df
+      - 8fdd59d2-99b3-4431-9101-867b087cc79e
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -696,7 +945,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -728,7 +977,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/TXT/@?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0483c5bb-921f-4079-9199-64d8d0524440","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"023dc667-245b-4193-b5ab-68b066153ad9","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -737,28 +986,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:30:32 GMT
+      - Wed, 22 Apr 2020 10:46:34 GMT
       etag:
-      - 0483c5bb-921f-4079-9199-64d8d0524440
+      - 023dc667-245b-4193-b5ab-68b066153ad9
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11993'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "2.3.4.5"}]}}'
     headers:
@@ -785,7 +1030,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/A/*?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9e4de8f2-b379-4eee-bd59-52db6ee912aa","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"50791021-fe0e-45db-90e9-d1e9b5996047","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -794,28 +1039,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:30:33 GMT
+      - Wed, 22 Apr 2020 10:46:36 GMT
       etag:
-      - 9e4de8f2-b379-4eee-bd59-52db6ee912aa
+      - 50791021-fe0e-45db-90e9-d1e9b5996047
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11991'
+      - '11992'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}]}}'
     headers:
@@ -842,7 +1083,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/A/ns?api-version=2018-09-01
   response:
     body:
-      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3751dbb3-d464-4367-aae4-1dbe40fa601e","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b150831d-bb57-4180-8f1e-8bfd808df9d0","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
     headers:
       cache-control:
       - private
@@ -851,28 +1092,24 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:30:34 GMT
+      - Wed, 22 Apr 2020 10:46:37 GMT
       etag:
-      - 3751dbb3-d464-4367-aae4-1dbe40fa601e
+      - b150831d-bb57-4180-8f1e-8bfd808df9d0
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
       x-aspnet-version:
       - 4.0.30319
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11985'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
 - request:
     body: null
     headers:
@@ -895,7 +1132,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/ALL?api-version=2018-09-01
   response:
     body:
-      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"9e4de8f2-b379-4eee-bd59-52db6ee912aa","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"b3809be0-931a-452d-b157-2f744111d3df","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"0483c5bb-921f-4079-9199-64d8d0524440","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"3751dbb3-d464-4367-aae4-1dbe40fa601e","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"50791021-fe0e-45db-90e9-d1e9b5996047","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"8fdd59d2-99b3-4431-9101-867b087cc79e","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"023dc667-245b-4193-b5ab-68b066153ad9","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b150831d-bb57-4180-8f1e-8bfd808df9d0","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
     headers:
       cache-control:
       - private
@@ -904,7 +1141,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 05:30:35 GMT
+      - Wed, 22 Apr 2020 10:46:38 GMT
       server:
       - Microsoft-IIS/10.0
       strict-transport-security:
@@ -918,9 +1155,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-entities-read:
-      - '59996'
+      - '59992'
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '499'
+      - '498'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone8_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone8_Import.yaml
@@ -1,0 +1,795 @@
+interactions:
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiZjE2M2I0NC01OGVmLTRjY2YtOWZkMS05ZTc4YmE0ZmQ3Yjg=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:02:37 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtiZjE2M2I0NC01OGVmLTRjY2YtOWZkMS05ZTc4YmE0ZmQ3Yjg=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"3cba3a00-fe7b-4180-80eb-477ec1b0ac6b","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:03:07 GMT
+      etag:
+      - 3cba3a00-fe7b-4180-80eb-477ec1b0ac6b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com","name":"zone8.com","type":"Microsoft.Network\/privateDnsZones","etag":"b3e053d1-1eca-48eb-b8f6-b89bbf2aafd5","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '613'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:03:08 GMT
+      etag:
+      - b3e053d1-1eca-48eb-b8f6-b89bbf2aafd5
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '497'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "azuredns-hostmaster.microsoft.com.", "serialNumber": 1, "refreshTime":
+      3600, "retryTime": 300, "expireTime": 2419200, "minimumTtl": 300}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"880239e9-a3ad-4e9b-b570-66cd2685e6e6","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:03:08 GMT
+      etag:
+      - 880239e9-a3ad-4e9b-b570-66cd2685e6e6
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 172800, "txtRecords": [{"value": ["ns1-03.azure-dns.com."]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/TXT/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7a8a7fa6-7f66-40b1-bf6f-5d02715368b4","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '451'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:03:09 GMT
+      etag:
+      - 7a8a7fa6-7f66-40b1-bf6f-5d02715368b4
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "1.2.3.4"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/A/ns?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0084aadd-63d1-46e2-93d9-cdba90bad43b","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '438'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:03:11 GMT
+      etag:
+      - 0084aadd-63d1-46e2-93d9-cdba90bad43b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11992'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "2.3.4.5"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/A/*?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"56e15933-0f03-40e3-90fc-3ab8932eeb22","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '435'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:03:11 GMT
+      etag:
+      - 56e15933-0f03-40e3-90fc-3ab8932eeb22
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11991'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"56e15933-0f03-40e3-90fc-3ab8932eeb22","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"880239e9-a3ad-4e9b-b570-66cd2685e6e6","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7a8a7fa6-7f66-40b1-bf6f-5d02715368b4","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0084aadd-63d1-46e2-93d9-cdba90bad43b","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1933'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:03:13 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59993'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"880239e9-a3ad-4e9b-b570-66cd2685e6e6","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '606'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:03:13 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/*","name":"*","type":"Microsoft.Network\/privateDnsZones\/A","etag":"56e15933-0f03-40e3-90fc-3ab8932eeb22","properties":{"fqdn":"*.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"2.3.4.5"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"880239e9-a3ad-4e9b-b570-66cd2685e6e6","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/TXT\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"7a8a7fa6-7f66-40b1-bf6f-5d02715368b4","properties":{"fqdn":"zone8.com.","ttl":172800,"txtRecords":[{"value":["ns1-03.azure-dns.com."]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/A\/ns","name":"ns","type":"Microsoft.Network\/privateDnsZones\/A","etag":"0084aadd-63d1-46e2-93d9-cdba90bad43b","properties":{"fqdn":"ns.zone8.com.","ttl":3600,"aRecords":[{"ipv4Address":"1.2.3.4"}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '1933'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:03:13 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59992'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '498'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZGVjNzczNC04MzIxLTRkZmYtYjI2Ny1mMzI2ZGFmN2YwNmY=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Thu, 16 Apr 2020 15:03:16 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZGVjNzczNC04MzIxLTRkZmYtYjI2Ny1mMzI2ZGFmN2YwNmY=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs3ZGVjNzczNC04MzIxLTRkZmYtYjI2Ny1mMzI2ZGFmN2YwNmY=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:03:46 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '497'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5YTY5ODBjYS1jNGI2LTRlZjEtYTMwOC1hYTUwODI5OGVlZTc=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:04:13 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5YTY5ODBjYS1jNGI2LTRlZjEtYTMwOC1hYTUwODI5OGVlZTc=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsZones/zone8.com/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/c912f493-60bf-4b11-90e0-3395f2dbdb7c\/resourceGroups\/cli_private_dns_zone8_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone8.com\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"f23d6dec-9d95-4d6b-a30b-a39ef486506b","properties":{"fqdn":"zone8.com.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:04:43 GMT
+      etag:
+      - f23d6dec-9d95-4d6b-a30b-a39ef486506b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone8_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTs5YTY5ODBjYS1jNGI2LTRlZjEtYTMwOC1hYTUwODI5OGVlZTc=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 16 Apr 2020 15:04:43 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone_Local_Import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/recordings/test_Private_Dns_Zone_Local_Import.yaml
@@ -1,0 +1,2135 @@
+interactions:
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTthZTM4ZDFjYS1hZTM0LTQ4ZTYtOGU3Yi0wOWZlNGEzMzcwNDQ=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:01 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTthZTM4ZDFjYS1hZTM0LTQ4ZTYtOGU3Yi0wOWZlNGEzMzcwNDQ=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTthZTM4ZDFjYS1hZTM0LTQ4ZTYtOGU3Yi0wOWZlNGEzMzcwNDQ=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:31 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local","name":"zone.local","type":"Microsoft.Network\/privateDnsZones","etag":"23141642-c2b7-4b3b-8803-dd010e22622f","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '615'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:31 GMT
+      etag:
+      - 23141642-c2b7-4b3b-8803-dd010e22622f
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"a2cfdb6a-7fec-4c96-9e43-e23980959e0b","properties":{"fqdn":"zone.local.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '596'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:32 GMT
+      etag:
+      - a2cfdb6a-7fec-4c96-9e43-e23980959e0b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "azuredns-hostmaster.microsoft.com.", "serialNumber": 1, "refreshTime":
+      3600, "retryTime": 300, "expireTime": 2419200, "minimumTtl": 300}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"9fd9b0fb-b51d-4718-b30b-5b3427a0f83a","properties":{"fqdn":"zone.local.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '596'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:33 GMT
+      etag:
+      - 9fd9b0fb-b51d-4718-b30b-5b3427a0f83a
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 1, "exchange":
+      "mail.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/MX/mymx?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"4684111f-0749-4392-92cc-4135644e8cef","properties":{"fqdn":"mymx.zone.local.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '471'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:34 GMT
+      etag:
+      - 4684111f-0749-4392-92cc-4135644e8cef
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.0.0.10"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/A/manuala?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6073aacd-f45c-42b4-b61b-ce0fa9da48d5","properties":{"fqdn":"manuala.zone.local.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '457'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:35 GMT
+      etag:
+      - 6073aacd-f45c-42b4-b61b-ce0fa9da48d5
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 0, "aRecords": [{"ipv4Address": "10.0.1.0"}, {"ipv4Address":
+      "10.0.1.1"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/A/mya?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"62d7bb32-fc8a-464f-aaa0-3ae1d3ed2ea5","properties":{"fqdn":"mya.zone.local.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '468'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:37 GMT
+      etag:
+      - 62d7bb32-fc8a-464f-aaa0-3ae1d3ed2ea5
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/AAAA/myaaaa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"666a70eb-7840-461c-af64-6c82f34c9ec1","properties":{"fqdn":"myaaaa.zone.local.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '489'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:38 GMT
+      etag:
+      - 666a70eb-7840-461c-af64-6c82f34c9ec1
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "contoso.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/CNAME/mycname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"635e568c-3ad7-462a-bcac-d8cd6afa1f83","properties":{"fqdn":"mycname.zone.local.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:39 GMT
+      etag:
+      - 635e568c-3ad7-462a-bcac-d8cd6afa1f83
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "myptrdname"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/PTR/myname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"d8675b95-4123-4d8e-a39e-02c6a645f4ed","properties":{"fqdn":"myname.zone.local.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '458'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:40 GMT
+      etag:
+      - d8675b95-4123-4d8e-a39e-02c6a645f4ed
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "contoso.com"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/PTR/myptr?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"4943d27b-bfd1-44b8-a1b3-f42f2e384f2b","properties":{"fqdn":"myptr.zone.local.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '456'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:41 GMT
+      etag:
+      - 4943d27b-bfd1-44b8-a1b3-f42f2e384f2b
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["manualtxt"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/TXT/myname2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"61f36c31-398a-4b47-8d64-0358d7175284","properties":{"fqdn":"myname2.zone.local.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '459'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:43 GMT
+      etag:
+      - 61f36c31-398a-4b47-8d64-0358d7175284
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 7200, "txtRecords": [{"value": ["abc def"]}, {"value":
+      ["foo bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/TXT/mytxt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f0333331-9cad-4afc-9803-719c462c6d3c","properties":{"fqdn":"mytxt2.zone.local.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '476'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:44 GMT
+      etag:
+      - f0333331-9cad-4afc-9803-719c462c6d3c
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["hi"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '64'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/TXT/mytxtrs?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"03df2726-f9c1-49bb-8ef8-3f040eb1a8ee","properties":{"fqdn":"mytxtrs.zone.local.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:46 GMT
+      etag:
+      - 03df2726-f9c1-49bb-8ef8-3f040eb1a8ee
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
+      "port": 1234, "target": "target.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/SRV/mysrv?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"529473cd-dcea-455b-827a-97a20aecd970","properties":{"fqdn":"mysrv.zone.local.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '498'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:46 GMT
+      etag:
+      - 529473cd-dcea-455b-827a-97a20aecd970
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 100, "weight":
+      1, "port": 443, "target": "target.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/SRV/_sip._tls?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b91f243f-c6f6-4fcd-ae90-e33daedbcbe8","properties":{"fqdn":"_sip._tls.zone.local.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '511'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:47 GMT
+      etag:
+      - b91f243f-c6f6-4fcd-ae90-e33daedbcbe8
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"9fd9b0fb-b51d-4718-b30b-5b3427a0f83a","properties":{"fqdn":"zone.local.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b91f243f-c6f6-4fcd-ae90-e33daedbcbe8","properties":{"fqdn":"_sip._tls.zone.local.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6073aacd-f45c-42b4-b61b-ce0fa9da48d5","properties":{"fqdn":"manuala.zone.local.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"62d7bb32-fc8a-464f-aaa0-3ae1d3ed2ea5","properties":{"fqdn":"mya.zone.local.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"666a70eb-7840-461c-af64-6c82f34c9ec1","properties":{"fqdn":"myaaaa.zone.local.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"635e568c-3ad7-462a-bcac-d8cd6afa1f83","properties":{"fqdn":"mycname.zone.local.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"4684111f-0749-4392-92cc-4135644e8cef","properties":{"fqdn":"mymx.zone.local.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"d8675b95-4123-4d8e-a39e-02c6a645f4ed","properties":{"fqdn":"myname.zone.local.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"61f36c31-398a-4b47-8d64-0358d7175284","properties":{"fqdn":"myname2.zone.local.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"4943d27b-bfd1-44b8-a1b3-f42f2e384f2b","properties":{"fqdn":"myptr.zone.local.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"529473cd-dcea-455b-827a-97a20aecd970","properties":{"fqdn":"mysrv.zone.local.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f0333331-9cad-4afc-9803-719c462c6d3c","properties":{"fqdn":"mytxt2.zone.local.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"03df2726-f9c1-49bb-8ef8-3f040eb1a8ee","properties":{"fqdn":"mytxtrs.zone.local.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '6278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:49 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59987'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/SOA?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"9fd9b0fb-b51d-4718-b30b-5b3427a0f83a","properties":{"fqdn":"zone.local.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '608'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:49 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59999'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone export
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"9fd9b0fb-b51d-4718-b30b-5b3427a0f83a","properties":{"fqdn":"zone.local.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"b91f243f-c6f6-4fcd-ae90-e33daedbcbe8","properties":{"fqdn":"_sip._tls.zone.local.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"6073aacd-f45c-42b4-b61b-ce0fa9da48d5","properties":{"fqdn":"manuala.zone.local.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"62d7bb32-fc8a-464f-aaa0-3ae1d3ed2ea5","properties":{"fqdn":"mya.zone.local.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"666a70eb-7840-461c-af64-6c82f34c9ec1","properties":{"fqdn":"myaaaa.zone.local.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"635e568c-3ad7-462a-bcac-d8cd6afa1f83","properties":{"fqdn":"mycname.zone.local.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"4684111f-0749-4392-92cc-4135644e8cef","properties":{"fqdn":"mymx.zone.local.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"d8675b95-4123-4d8e-a39e-02c6a645f4ed","properties":{"fqdn":"myname.zone.local.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"61f36c31-398a-4b47-8d64-0358d7175284","properties":{"fqdn":"myname2.zone.local.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"4943d27b-bfd1-44b8-a1b3-f42f2e384f2b","properties":{"fqdn":"myptr.zone.local.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"529473cd-dcea-455b-827a-97a20aecd970","properties":{"fqdn":"mysrv.zone.local.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"f0333331-9cad-4afc-9803-719c462c6d3c","properties":{"fqdn":"mytxt2.zone.local.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"03df2726-f9c1-49bb-8ef8-3f040eb1a8ee","properties":{"fqdn":"mytxtrs.zone.local.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '6278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:08:49 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59987'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local?api-version=2018-09-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs5NWI1NjM0NS1hYTI0LTQzMTUtODQ2OC1kYTVlMTBmMmJlYmI=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '0'
+      date:
+      - Fri, 24 Apr 2020 04:08:52 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs5NWI1NjM0NS1hYTI0LTQzMTUtODQ2OC1kYTVlMTBmMmJlYmI=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -y
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtEZWxldGVQcml2YXRlRG5zWm9uZTs5NWI1NjM0NS1hYTI0LTQzMTUtODQ2OC1kYTVlMTBmMmJlYmI=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:09:23 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local?api-version=2018-09-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkMDRkMTgzYy1hZDBhLTQ2MmEtYjI1My05ZDJmNzliZGY0ZTU=?api-version=2018-09-01
+      cache-control:
+      - private
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:09:52 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsOperationResults/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkMDRkMTgzYy1hZDBhLTQ2MmEtYjI1My05ZDJmNzliZGY0ZTU=?api-version=2018-09-01
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsOperationStatuses/RnJvbnRFbmRBc3luY09wZXJhdGlvbjtVcHNlcnRQcml2YXRlRG5zWm9uZTtkMDRkMTgzYy1hZDBhLTQ2MmEtYjI1My05ZDJmNzliZGY0ZTU=?api-version=2018-09-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:23 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local","name":"zone.local","type":"Microsoft.Network\/privateDnsZones","etag":"f69d677f-ff87-4f6f-9484-0078b1decefd","location":"global","properties":{"maxNumberOfRecordSets":25000,"maxNumberOfVirtualNetworkLinks":1000,"maxNumberOfVirtualNetworkLinksWithRegistration":100,"numberOfRecordSets":1,"numberOfVirtualNetworkLinks":0,"numberOfVirtualNetworkLinksWithRegistration":0,"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '615'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:23 GMT
+      etag:
+      - f69d677f-ff87-4f6f-9484-0078b1decefd
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"475e63df-eedf-40c3-83f9-f52512c0d2e2","properties":{"fqdn":"zone.local.","ttl":3600,"soaRecord":{"email":"azureprivatedns-host.microsoft.com","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '596'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:25 GMT
+      etag:
+      - 475e63df-eedf-40c3-83f9-f52512c0d2e2
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "soaRecord": {"host": "azureprivatedns.net",
+      "email": "azuredns-hostmaster.microsoft.com.", "serialNumber": 1, "refreshTime":
+      3600, "retryTime": 300, "expireTime": 2419200, "minimumTtl": 300}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/SOA/@?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"82558f83-2880-4d24-bffc-abe781001dc0","properties":{"fqdn":"zone.local.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '596'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:27 GMT
+      etag:
+      - 82558f83-2880-4d24-bffc-abe781001dc0
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 100, "weight":
+      1, "port": 443, "target": "target.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/SRV/_sip._tls?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"f435ed25-917e-4074-a4f2-35f2d2c34c43","properties":{"fqdn":"_sip._tls.zone.local.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '511'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:28 GMT
+      etag:
+      - f435ed25-917e-4074-a4f2-35f2d2c34c43
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aRecords": [{"ipv4Address": "10.0.0.10"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/A/manuala?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5d12e462-5b8e-4606-926e-ec01edd45952","properties":{"fqdn":"manuala.zone.local.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '457'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:29 GMT
+      etag:
+      - 5d12e462-5b8e-4606-926e-ec01edd45952
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 0, "aRecords": [{"ipv4Address": "10.0.1.0"}, {"ipv4Address":
+      "10.0.1.1"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/A/mya?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b543d0e3-e42e-4924-8cf6-72ba7174f186","properties":{"fqdn":"mya.zone.local.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '468'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:30 GMT
+      etag:
+      - b543d0e3-e42e-4924-8cf6-72ba7174f186
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "aaaaRecords": [{"ipv6Address": "2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/AAAA/myaaaa?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"f34ce5b2-cacf-4ab0-adc7-523552af912d","properties":{"fqdn":"myaaaa.zone.local.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '489'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:31 GMT
+      etag:
+      - f34ce5b2-cacf-4ab0-adc7-523552af912d
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "cnameRecord": {"cname": "contoso.com."}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/CNAME/mycname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a914a259-6d2b-486e-b27b-c780bf3c4a12","properties":{"fqdn":"mycname.zone.local.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '463'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:33 GMT
+      etag:
+      - a914a259-6d2b-486e-b27b-c780bf3c4a12
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "mxRecords": [{"preference": 1, "exchange":
+      "mail.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/MX/mymx?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"73b9537f-38a8-46d1-8762-334a15ebb7df","properties":{"fqdn":"mymx.zone.local.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '471'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:34 GMT
+      etag:
+      - 73b9537f-38a8-46d1-8762-334a15ebb7df
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "myptrdname"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/PTR/myname?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"b6e5d57b-d914-417e-8c35-a62064b87d6e","properties":{"fqdn":"myname.zone.local.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '458'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:35 GMT
+      etag:
+      - b6e5d57b-d914-417e-8c35-a62064b87d6e
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["manualtxt"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/TXT/myname2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ff1a2cad-e5c6-46e7-aec4-c5f942a678b9","properties":{"fqdn":"myname2.zone.local.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '459'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:36 GMT
+      etag:
+      - ff1a2cad-e5c6-46e7-aec4-c5f942a678b9
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "ptrRecords": [{"ptrdname": "contoso.com"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/PTR/myptr?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8bf8b67b-02fb-42ad-aada-b694f2364074","properties":{"fqdn":"myptr.zone.local.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '456'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:37 GMT
+      etag:
+      - 8bf8b67b-02fb-42ad-aada-b694f2364074
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "srvRecords": [{"priority": 1, "weight": 2,
+      "port": 1234, "target": "target.contoso.com."}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/SRV/mysrv?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"c0b6f5cd-a483-4515-a343-e3a519944955","properties":{"fqdn":"mysrv.zone.local.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '498'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:39 GMT
+      etag:
+      - c0b6f5cd-a483-4515-a343-e3a519944955
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 7200, "txtRecords": [{"value": ["abc def"]}, {"value":
+      ["foo bar"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/TXT/mytxt2?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"57458539-fe52-4c2a-8691-7cd40ecfcb42","properties":{"fqdn":"mytxt2.zone.local.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '476'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:40 GMT
+      etag:
+      - 57458539-fe52-4c2a-8691-7cd40ecfcb42
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11998'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"ttl": 3600, "txtRecords": [{"value": ["hi"]}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns zone import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '64'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g --file-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/TXT/mytxtrs?api-version=2018-09-01
+  response:
+    body:
+      string: '{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"de82882f-99f2-4b76-b45f-4bd96a38f321","properties":{"fqdn":"mytxtrs.zone.local.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:41 GMT
+      etag:
+      - de82882f-99f2-4b76-b45f-4bd96a38f321
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-dns record-set list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -z
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+        azure-mgmt-privatedns/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_private_dns_zone_local_import000001/providers/Microsoft.Network/privateDnsZones/zone.local/ALL?api-version=2018-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SOA\/@","name":"@","type":"Microsoft.Network\/privateDnsZones\/SOA","etag":"82558f83-2880-4d24-bffc-abe781001dc0","properties":{"fqdn":"zone.local.","ttl":3600,"soaRecord":{"email":"azuredns-hostmaster.microsoft.com.","expireTime":2419200,"host":"azureprivatedns.net","minimumTTL":null,"refreshTime":3600,"retryTime":300,"serialNumber":1,"minimumTtl":300},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SRV\/_sip._tls","name":"_sip._tls","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"f435ed25-917e-4074-a4f2-35f2d2c34c43","properties":{"fqdn":"_sip._tls.zone.local.","ttl":3600,"srvRecords":[{"port":443,"priority":100,"target":"target.contoso.com.","weight":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/A\/manuala","name":"manuala","type":"Microsoft.Network\/privateDnsZones\/A","etag":"5d12e462-5b8e-4606-926e-ec01edd45952","properties":{"fqdn":"manuala.zone.local.","ttl":3600,"aRecords":[{"ipv4Address":"10.0.0.10"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/A\/mya","name":"mya","type":"Microsoft.Network\/privateDnsZones\/A","etag":"b543d0e3-e42e-4924-8cf6-72ba7174f186","properties":{"fqdn":"mya.zone.local.","ttl":0,"aRecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/privateDnsZones\/AAAA","etag":"f34ce5b2-cacf-4ab0-adc7-523552af912d","properties":{"fqdn":"myaaaa.zone.local.","ttl":3600,"aaaaRecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/privateDnsZones\/CNAME","etag":"a914a259-6d2b-486e-b27b-c780bf3c4a12","properties":{"fqdn":"mycname.zone.local.","ttl":3600,"cnameRecord":{"cname":"contoso.com."},"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/privateDnsZones\/MX","etag":"73b9537f-38a8-46d1-8762-334a15ebb7df","properties":{"fqdn":"mymx.zone.local.","ttl":3600,"mxRecords":[{"exchange":"mail.contoso.com.","preference":1}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/PTR\/myname","name":"myname","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"b6e5d57b-d914-417e-8c35-a62064b87d6e","properties":{"fqdn":"myname.zone.local.","ttl":3600,"ptrRecords":[{"ptrdname":"myptrdname"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"ff1a2cad-e5c6-46e7-aec4-c5f942a678b9","properties":{"fqdn":"myname2.zone.local.","ttl":3600,"txtRecords":[{"value":["manualtxt"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/privateDnsZones\/PTR","etag":"8bf8b67b-02fb-42ad-aada-b694f2364074","properties":{"fqdn":"myptr.zone.local.","ttl":3600,"ptrRecords":[{"ptrdname":"contoso.com"}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/privateDnsZones\/SRV","etag":"c0b6f5cd-a483-4515-a343-e3a519944955","properties":{"fqdn":"mysrv.zone.local.","ttl":3600,"srvRecords":[{"port":1234,"priority":1,"target":"target.contoso.com.","weight":2}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"57458539-fe52-4c2a-8691-7cd40ecfcb42","properties":{"fqdn":"mytxt2.zone.local.","ttl":7200,"txtRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}],"isAutoRegistered":false}},{"id":"\/subscriptions\/52bae96a-3806-426c-a5dc-1ae6016b5f15\/resourceGroups\/cli_private_dns_zone_local_import000001\/providers\/Microsoft.Network\/privateDnsZones\/zone.local\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/privateDnsZones\/TXT","etag":"de82882f-99f2-4b76-b45f-4bd96a38f321","properties":{"fqdn":"mytxtrs.zone.local.","ttl":3600,"txtRecords":[{"value":["hi"]}],"isAutoRegistered":false}}]}'
+    headers:
+      cache-control:
+      - private
+      content-length:
+      - '6278'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 24 Apr 2020 04:10:42 GMT
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-entities-read:
+      - '59987'
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
@@ -8,7 +8,7 @@ import os
 import unittest
 import time
 
-from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
+from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, live_only)
 from knack.log import get_logger
 from knack.util import CLIError
 from msrestazure.azure_exceptions import CloudError
@@ -898,6 +898,7 @@ class PrivateDnsRecordSetsTests(BaseScenarioTests):
         self.assertTrue(all(recordset in createdRecordsets for recordset in returnedRecordsets))
 
 
+@live_only()
 class PrivateDnsZoneImportTest(ScenarioTest):
 
     def _match_record(self, record_set, name, type):
@@ -935,9 +936,9 @@ class PrivateDnsZoneImportTest(ScenarioTest):
 
         # Export zone file and delete the zone
         self.cmd('network private-dns zone export -g {rg} -n {zone} --file-name "{export}"')
-        self.cmd('network private-dns zone delete -g {rg} -n {zone} -y')
+        # self.cmd('network private-dns zone delete -g {rg} -n {zone} -y')
         # 20 seconds should be enough for the zone delete to finish(Skipped under playback mode)
-        time.sleep(20)
+        # time.sleep(20)
 
         # Reimport zone file and verify both record sets are equivalent
         self.cmd('network private-dns zone import -n {zone} -g {rg} --file-name "{export}"')

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
@@ -937,6 +937,7 @@ class PrivateDnsZoneImportTest(ScenarioTest):
         # Export zone file and delete the zone
         self.cmd('network private-dns zone export -g {rg} -n {zone} --file-name "{export}"')
         self.cmd('network private-dns zone delete -g {rg} -n {zone} -y')
+        time.sleep(10)
 
         # Reimport zone file and verify both record sets are equivalent
         self.cmd('network private-dns zone import -n {zone} -g {rg} --file-name "{export}"')

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
@@ -898,6 +898,7 @@ class PrivateDnsRecordSetsTests(BaseScenarioTests):
         self.assertTrue(all(recordset in createdRecordsets for recordset in returnedRecordsets))
 
 
+# Running only live test because of this isue: Confusing error message if play count mismatches - https://github.com/kevin1024/vcrpy/issues/516
 @live_only()
 class PrivateDnsZoneImportTest(ScenarioTest):
 
@@ -977,6 +978,10 @@ class PrivateDnsZoneImportTest(ScenarioTest):
     @ResourceGroupPreparer(name_prefix='cli_private_dns_zone8_import')
     def test_Private_Dns_Zone8_Import(self, resource_group):
         self._test_PrivateDnsZone('zone8.com', 'zone8.txt')
+
+    @ResourceGroupPreparer(name_prefix='cli_private_dns_zone_local_import')
+    def test_Private_Dns_Zone_Local_Import(self, resource_group):
+        self._test_PrivateDnsZone('zone.local', 'zone.local.txt')
 
 
 if __name__ == '__main__':

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
@@ -6,6 +6,7 @@
 # pylint: disable=line-too-long
 import os
 import unittest
+import time
 
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer)
 from knack.log import get_logger
@@ -15,6 +16,8 @@ from msrestazure.azure_exceptions import CloudError
 logger = get_logger(__name__)
 # pylint: disable=line-too-long
 regexSubscription = '[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}}'
+
+TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
 
 def GeneratePrivateZoneName(self):
@@ -893,6 +896,87 @@ class PrivateDnsRecordSetsTests(BaseScenarioTests):
             self.check('length(@)', 8)
         ]).get_output_in_json()
         self.assertTrue(all(recordset in createdRecordsets for recordset in returnedRecordsets))
+
+
+class PrivateDnsZoneImportTest(ScenarioTest):
+
+    def _match_record(self, record_set, name, type):
+        matches = [x for x in record_set if x['name'] == name and x['type'] == type]
+        self.assertEqual(len(matches), 1)
+        return matches[0]
+
+    def _list_record_fqdns(self, val):
+        return tuple([x['fqdn'] for x in val])
+
+    def _check_records(self, records1, records2):
+        self.assertEqual(self._list_record_fqdns(records1), self._list_record_fqdns(records2))
+        for record in records1:
+            record_match = self._match_record(records2, record['name'], record['type'])
+            del record['etag']
+            del record_match['etag']
+            try:
+                self.assertDictEqual(record, record_match)
+            except AssertionError:
+                raise
+
+    def _test_PrivateDnsZone(self, zone_name, filename):
+        """ This tests that a zone file can be imported, exported, and re-imported without any changes to the
+            record sets. It does not test that the imported files meet any specific requirements. For that, run
+            additional checks in the individual zone file tests.
+        """
+        self.kwargs.update({
+            'zone': zone_name,
+            'path': os.path.join(TEST_DIR, 'zone_files', filename),
+            'export': os.path.join(TEST_DIR, 'zone_files', filename + '_export.txt')
+        })
+        # Import from zone file
+        self.cmd('network private-dns zone import -n {zone} -g {rg} --file-name "{path}"')
+        records1 = self.cmd('network private-dns record-set list -g {rg} -z {zone}').get_output_in_json()
+
+        # Export zone file and delete the zone
+        self.cmd('network private-dns zone export -g {rg} -n {zone} --file-name "{export}"')
+        self.cmd('network private-dns zone delete -g {rg} -n {zone} -y')
+        # 20 seconds should be enough for the zone delete to finish(Skipped under playback mode)
+        time.sleep(20)
+
+        # Reimport zone file and verify both record sets are equivalent
+        self.cmd('network private-dns zone import -n {zone} -g {rg} --file-name "{export}"')
+        records2 = self.cmd('network private-dns record-set list -g {rg} -z {zone}').get_output_in_json()
+
+        # verify that each record in the original import is unchanged after export/re-import
+        self._check_records(records1, records2)
+
+    @ResourceGroupPreparer(name_prefix='cli_private_dns_zone1_import')
+    def test_Private_Dns_Zone1_Import(self, resource_group):
+        self._test_PrivateDnsZone('zone1.com', 'zone1.txt')
+
+    @ResourceGroupPreparer(name_prefix='cli_private_dns_zone2_import')
+    def test_Private_Dns_Zone2_Import(self, resource_group):
+        self._test_PrivateDnsZone('zone2.com', 'zone2.txt')
+
+    @ResourceGroupPreparer(name_prefix='cli_private_dns_zone3_import')
+    def test_Private_Dns_Zone3_Import(self, resource_group):
+        self._test_PrivateDnsZone('zone3.com', 'zone3.txt')
+
+    @ResourceGroupPreparer(name_prefix='cli_private_dns_zone4_import')
+    def test_Private_Dns_Zone4_Import(self, resource_group):
+        self._test_PrivateDnsZone('zone4.com', 'zone4.txt')
+
+    @ResourceGroupPreparer(name_prefix='cli_private_dns_zone5_import')
+    def test_Private_Dns_Zone5_Import(self, resource_group):
+        self._test_PrivateDnsZone('zone5.com', 'zone5.txt')
+
+    @ResourceGroupPreparer(name_prefix='cli_private_dns_zone6_import')
+    def test_Private_Dns_Zone6_Import(self, resource_group):
+        self._test_PrivateDnsZone('zone6.com', 'zone6.txt')
+
+    @ResourceGroupPreparer(name_prefix='cli_private_dns_zone7_import')
+    def test_Private_Dns_Zone7_Import(self, resource_group):
+        self._test_PrivateDnsZone('zone7.com', 'zone7.txt')
+
+    @ResourceGroupPreparer(name_prefix='cli_private_dns_zone8_import')
+    def test_Private_Dns_Zone8_Import(self, resource_group):
+        self._test_PrivateDnsZone('zone8.com', 'zone8.txt')
 
 
 if __name__ == '__main__':

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
@@ -936,9 +936,7 @@ class PrivateDnsZoneImportTest(ScenarioTest):
 
         # Export zone file and delete the zone
         self.cmd('network private-dns zone export -g {rg} -n {zone} --file-name "{export}"')
-        # self.cmd('network private-dns zone delete -g {rg} -n {zone} -y')
-        # 20 seconds should be enough for the zone delete to finish(Skipped under playback mode)
-        # time.sleep(20)
+        self.cmd('network private-dns zone delete -g {rg} -n {zone} -y')
 
         # Reimport zone file and verify both record sets are equivalent
         self.cmd('network private-dns zone import -n {zone} -g {rg} --file-name "{export}"')

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone.local.txt
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone.local.txt
@@ -1,0 +1,16 @@
+$ORIGIN zone1.local.
+@ 3600 IN SOA azureprivatedns.net. azuredns-hostmaster.microsoft.com. ( 1 3600 300 2419200 300 )
+mymx 3600 MX 1 mail.contoso.com.
+manuala 3600 A 10.0.0.10
+mya 0 A 10.0.1.0
+mya 0 A 10.0.1.1
+myaaaa 3600 AAAA 2001:4898:e0:99:6dc4:6329:1c99:4e69
+mycname 3600 CNAME contoso.com.
+myname 3600 PTR myptrdname
+myptr 3600 PTR contoso.com
+myname2 3600 TXT "manualtxt"
+mytxt2 7200 TXT "abc def"
+mytxt2 7200 TXT "foo bar"
+mytxtrs 3600 TXT "hi"
+mysrv 3600 SRV 1 2 1234 target.contoso.com.
+_sip._tls.@ 3600 IN SRV 100 1 443 target.contoso.com.

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone1.txt
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone1.txt
@@ -1,0 +1,16 @@
+$ORIGIN zone1.com.
+@ 3600 IN SOA azureprivatedns.net. azuredns-hostmaster.microsoft.com. ( 1 3600 300 2419200 300 )
+mymx 3600 MX 1 mail.contoso.com.
+manuala 3600 A 10.0.0.10
+mya 0 A 10.0.1.0
+mya 0 A 10.0.1.1
+myaaaa 3600 AAAA 2001:4898:e0:99:6dc4:6329:1c99:4e69
+mycname 3600 CNAME contoso.com.
+myname 3600 PTR myptrdname
+myptr 3600 PTR contoso.com
+myname2 3600 TXT "manualtxt"
+mytxt2 7200 TXT "abc def"
+mytxt2 7200 TXT "foo bar"
+mytxtrs 3600 TXT "hi"
+mysrv 3600 SRV 1 2 1234 target.contoso.com.
+_sip._tls.@ 3600 IN SRV 100 1 443 target.contoso.com.

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone2.txt
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone2.txt
@@ -1,0 +1,99 @@
+;
+;  Database file mytestzone.com.dns for Default zone scope in zone mytestzone.com.
+;      Zone version:  10
+;
+
+@                       IN  SOA zone2.com. hostmaster. (
+                        		10           ; serial number
+                        		900          ; refresh
+                        		600          ; retry
+                        		86400        ; expire
+                        		3600       ) ; default TTL
+
+;
+;  Zone records
+;
+
+spaces TXT "  a  " ; should preserve all quoted spaces (length 5)
+
+a2                      A	1.2.3.4
+                        A	2.3.4.5
+aaaa2                   AAAA 2001:cafe:130::100
+                        AAAA 2001:cafe:130::101
+doozie                  TXT	( "abcdefghijklmnopqrstuvwxyz" ; test comment
+                              "1234567890"
+                        	  "abcdefghijklmnopqrstuvwxyz"
+							  "1234567890" ; another comment
+                        	  "abcdefghijklmnopqrstuvwxyz"
+							  "1234567890" ) ; comments
+fee2                    CNAME	bar.com.
+                        CNAME	bar. ; This should be ignored and a warning given
+mail                    MX	10	mail1.mymail.com.
+                        MX	11	flooble.
+sip.tcp                 SRV	10 20 30	foobar.
+                        SRV 55 66 77	zoo.
+test-txt2               TXT "string 1"
+                        TXT "string 2"
+						
+aa	100	A 4.5.6.7  ; A record
+    200 A 6.7.8.9  ; Another A record, same record set, use the lower of the two TTLs
+	300 MX 1 foo.com ; MX record with name 'aa', TTL 300
+200		A 7.8.9.0	; A record with name 200
+
+longtxt  999 TXT "this is a super long txt record...wow, it is really really long!  And I even used copy and paste to make it longer....this is a super long txt record...wow, it is really really long!  And I even used copy and paste to make it longer....this is a super long txt record...wow, it is really really long!  And I even used copy and paste to make it longer....this is a super long txt record...wow, it is really really long!  And I even used copy and paste to make it longer....this is a super long txt record...wow, it is really really long!  And I even used copy and paste to make it longer....this is a super long txt record...wow, it is really really long!  And I even used copy and paste to make it longer....this is a super long txt record...wow, it is really really long!  And I even used copy and paste to make it longer....this is a super long txt record...wow, it is really really long!  And I even used copy and paste to make it longer...."
+longtxt2 100 TXT "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+
+myspf 100 SPF "this is an SPF record! Convert to TXT on import"
+@ 200 TXT "this is another SPF, this time as TXT"
+
+; PTR tests
+160.1                   PTR        foo.com.
+
+160.2                   PTR        foobar.com.
+160.2                   PTR        bar.com.
+
+160.3                   PTR        foo.com.
+						PTR        bar.com.
+
+; semicolon tests
+; single string, foobar
+t1                            TXT         foobar
+t2                            TXT         "foobar"
+
+; two strings
+t3                            TXT         "foo" "bar"
+
+; semicolon in string value
+t4                            TXT         "foo;bar"
+t5                            TXT         foo\;bar
+t6                            TXT         "foo\;bar"
+
+; string with quotes
+t7                            TXT         "\"quoted string\""
+
+; two strings, no quotes
+t8                            TXT         foo bar
+
+; multi-line
+t9                            TXT         ( "foo"
+                                                 "barr" )
+
+; with comments
+t10                          TXT         "foo bar"              ; comment
+t11                          TXT         foobar                  ; comment
+
+@                       TXT        ( "v=spf1 mx ip4:14.14.22.0/23 a:mail.trum.ch mx:mese.ch include:spf.mapp.com ?all" )
+
+base                   3600        A        194.124.202.114
+
+                        MX        10        be.xpiler.de.
+
+                        TXT        ( "v=spf1 mx include:_spf4.xcaign.de include:_spf6.xcaign.de -all" )
+
+                        TXT        ( "spf2.0/mfrom,pra mx ip4:15.19.14.0/24 ip4:8.8.11.4/27 ip4:9.16.20.19/26 -all" )
+
+even                   A        194.124.202.114
+
+                        MX        10        be.xpiler.de.
+
+                        TXT        ( "v=spf1 mx include:_spf4.xgn.de include:_spf6.xgn.de -all" )

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone3.txt
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone3.txt
@@ -1,0 +1,65 @@
+; This zone file assumes the zone name is 'zone3.com'
+$ORIGIN zone3.com.
+
+; Note, first record must be SOA. Override default TTL
+@ 1d IN SOA ns1.zone3.com. hostmaster (
+			2003080800 ; se = serial number
+			12h ; ref = refresh
+			15m ; ret = update retry
+			3w ; ex = expiry
+			3h ; min = minimum
+			)
+
+
+; Check each type
+test-a IN A 1.2.3.4
+test-aaaa IN AAAA 2001:cafe:130::100
+test-cname IN CNAME target.com.
+test-cname2 IN CNAME target.org
+test-mx IN MX 10 mail.com.
+_sip._tcp.test-srv IN SRV 1 2 3 target.com.
+test-txt IN TXT "string 1" ; Note, text is enclosed in quotes
+
+; Check that missing name means re-use previous name
+d1 IN A 12.1.2.3
+   IN A 12.2.3.4 ; Same record set 'd1.zone3.com.'
+   IN TXT "fishfishfish" ; New record set, same name but type == TXT
+
+$ORIGIN d1.zone3.com.
+@ IN A 12.3.4.5 ; Same record set d1 as above
+  IN A 12.4.5.6 ; Same record set again
+
+; Check for non-adjacent records in same record set
+$ORIGIN zone3.com.
+f1 IN A 11.1.2.3
+f2 IN A 11.2.3.4
+f1 IN A 11.2.3.3 ; Same record set as f1 above
+
+$ORIGIN f2.zone3.com.
+@ IN A 11.5.6.7 ; Same record set as f2 above
+
+; Multi-line records (see also SOA example above)
+$ORIGIN zone3.com.
+_sip._tcp IN SRV ( 10
+		   20
+		   30
+		   foo.com.) ; SRV with priority 10, weight 20, port 30, target foo.com.
+mail IN MX (100
+	    mail.test.com.) ; MX record
+
+; Missing class
+noclass A 1.2.3.4
+	A 2.3.4.5
+
+; noclass CNAME bar.com
+
+; Multi-string TXT records
+txt1 TXT "string 1 only"
+txt2 TXT "string1" "string2" ; Concatenate to "string1string2" (no separator)
+txt3 TXT ("this is a very long string with lots of text, in fact is has 74 characters"
+	  "this is a very long string with lots of text, in fact is has 74 characters"
+ 	  "this is a very long string with lots of text, in fact is has 74 characters"
+	  "this is a very long string with lots of text, in fact is has 74 characters"
+	 ) ; Concatentate, and divide into 255 character strings
+
+txt3 TXT "string;string;string" ; String with ';' inside

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone4.txt
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone4.txt
@@ -1,0 +1,60 @@
+; This zone file assumes the zone name is 'zone4.com'
+; Note, first record must be SOA.
+
+@ IN SOA ns1.zone4.com. hostmaster (
+			2003080800 ; se = serial number
+			12h ; ref = refresh
+			15m ; ret = update retry
+			3w ; ex = expiry
+			3h ; min = minimum
+			) ; Should have default TTL of 3600
+
+; Check $TTL is observed
+$ttl 300
+ttl-300 IN A 10.1.2.3 ; Should have TTL 300
+
+$TTL 0
+ttl-0 IN A 10.2.3.4 ; Should have TTL 0
+
+; Check $TTL can be overridden
+ttl-60 60 IN A 10.3.4.5 ; Should have TTL 60
+
+; Check various $TTL formats, cases
+$TTL 1w
+ttl-1w IN A 10.3.4.5 ; Should have TTL 1 week (604800)
+
+$TTL 1D
+ttl-1d IN A 10.7.8.9 ; Should have TTL 1 day (86400)
+
+$TTL 1h
+ttl-1h IN A 10.4.5.6 ; Should have TTL 1 hour (3600)
+
+$TTL 99S
+ttl-99s IN A 10.5.6.7 ; Should have TTL 99 seconds
+
+$TTL 100
+ttl-100 IN A 10.6.7.8 ; Should have TTL 100 seconds
+
+$TTL 6m
+ttl-6m IN A 10.8.9.0 ; Should have TTL 6 minutes (360)
+
+$TTL 1W2d3h4M5
+ttl-mix IN A 10.8.9.0 ; Should have TTL of 788645
+
+; Now repeat, specifying TTL on records instead of using $TTL
+xttl-1w 1w IN A 10.3.4.5 ; Should have TTL 1 week (604800)
+xttl-1d 1D IN A 10.7.8.9 ; Should have TTL 1 day (86400)
+xttl-1h 1h IN A 10.4.5.6 ; Should have TTL 1 hour (3600)
+xttl-99s 99s IN A 10.5.6.7 ; Should have TTL 99 seconds
+xttl-100 100 IN A 10.6.7.8 ; Should have TTL 100 seconds
+xttl-6m 6M IN A 10.8.9.0 ; Should have TTL 6 minutes (360)
+xttl-mix 2d1W3h4M5 IN A 10.9.9.9 ; Should have TTL of 788645
+
+; Check for conflicting TTLs on records with the same name
+c1 10 IN A 11.1.2.3
+c1 20 IN A 11.2.3.3 ; Same record set as c1 above, should use TTL 10 and give warning
+c2 10 IN A 11.2.3.4 ; Will have TTL of 5 because of the below record...
+
+$ORIGIN c2.zone4.com.
+$TTL 5
+@ IN A 11.5.6.7 ; Same record set as c2 above, should use TTL 5 for entire record set and give warning

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone5.txt
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone5.txt
@@ -1,0 +1,45 @@
+; This zone file assumes the zone name is 'zone5.com'
+
+; Before setting $ORIGIN, create a couple of records to check the default
+; $ORIGIN matches the zone name. Note, first record must be SOA.
+@ IN SOA ns1.zone5.com. hostmaster (
+			2003080800 ; se = serial number
+			12h ; ref = refresh
+			15m ; ret = update retry
+			3w ; ex = expiry
+			3h ; min = minimum
+			) ; Should give email 'hostmaster.zone5.com.'
+
+default IN A 0.1.2.3 ; Should give default.zone5.com. A 0.1.2.3
+tc IN CNAME test ; Should give tc.zone5.com. CNAME test.zone5.com.
+
+; Test that $ORIGIN is substituted into non-fully qualified names
+$ORIGIN zone5.com.
+@ IN A 1.2.3.4 ; fqdn = zone5.com.
+www IN A 2.3.4.5 ; fqdn = www.zone5.com.
+
+; Check both record names and RDATA (across record types as appropriate)
+test-cname IN CNAME r1 ; Should give test-cname.zone5.com. CNAME r1.zone5.com.
+test-mx IN MX 10 m1 ; Should give test-mx.zone5.com MX 10 m1.zone5.com.
+test-srv IN SRV 1 2 3 srv1 ; Should give test-srv.zone5.com SRV 1 2 3 srv1.zone5.com.
+
+; And repeat the above, this time with fully-qualified targets
+test-cname2 IN CNAME r1. ; Should give test-cname2.zone5.com. CNAME r1.
+test-mx2 IN MX 10 m1. ; Should give test-mx2.zone5.com MX 10 m1.
+test-ns2 IN NS ns1. ; Should give test-ns2.zone5.com NS ns1.
+test-srv2 IN SRV 1 2 3 srv1. ; Should give test-srv2.zone5.com SRV 1 2 3 srv1.
+
+; Check that changes to $ORIGIN are picked up
+$ORIGIN subzone.zone5.com.
+@ IN A 3.4.5.6 ; fqdn = subzone.zone5.com.
+www IN A 4.5.6.7 ; fqdn = www.subzone.zone5.com.
+test-cname IN CNAME r1 ; Should give test-cname.subzone.zone5.com.
+
+; CNAME r1.subzone.zone5.com.
+; Check $ORIGIN from outside zone is permitted (but not for record names)
+; Also check that $ORIGIN without '.' terminator has one added (and a warning)
+$ORIGIN foo.com
+record.zone5.com. IN CNAME bar ; Should give record.zone5.com. CNAME bar.foo.com.
+
+; A fully-qualified name that is within the zone should work OK
+test.zone5.com. IN A 7.8.9.0 ; Should work OK

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone6.txt
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone6.txt
@@ -1,0 +1,19 @@
+; Exported zone file from Azure DNS
+; Resource Group Name: TheOne
+; Zone name: zone6.com
+; Date and time (UTC): Mon Jan 22 2018 09:09:43 GMT+0000
+
+$TTL 3600
+$ORIGIN zone6.com.
+
+@ 3600 IN SOA ns1-03.azure-dns.com. azuredns-hostmaster.microsoft.com. (
+                                1
+                                3600
+                                300
+                                2419200
+                                300
+                                )
+
+@ 3600 IN A 1.1.1.1
+
+www 3600 IN A 1.1.1.1

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone7.txt
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone7.txt
@@ -1,0 +1,20 @@
+; Exported zone file from Azure DNS
+; Resource Group Name: TheOne
+; Zone name: zone7.com
+; Date and time (UTC): Mon Jan 22 2018 09:09:43 GMT+0000
+
+$TTL 3600
+$ORIGIN zone7.com.
+
+@ 3600 IN SOA ns1-03.azure-dns.com. azuredns-hostmaster.microsoft.com. (
+                                1
+                                3600
+                                300
+                                2419200
+                                300
+                                )
+
+@ 60 IN TXT "a\\b\255\000\;" "\"\"\"testtesttest\"\"\"" ; "some test record
+
+txt1 TXT ab\ cd
+cn1 CNAME contoso.com.;comment1;comment2;comment3

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone8.txt
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/zone_files/zone8.txt
@@ -1,0 +1,15 @@
+$TTL 300
+$ORIGIN zone8.com.
+    
+@ 3600 IN SOA ns1-03.azure-dns.com. azuredns-hostmaster.microsoft.com. (
+              1 ; serial
+              3600 ; refresh
+              300 ; retry
+              2419200 ; expire
+              300 ; minimum
+              )
+
+  172800 IN TXT ns1-03.azure-dns.com.
+;
+ns 3600 IN A 1.2.3.4
+* 3600 IN A 2.3.4.5


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR contains the changes for importing and exporting zone files to private dns zone. This is added as new feature in private dns zone. This feature was already present in public Azure DNS, incorporating similar changes for Private DNS zone.

**Testing Guide**  
<!--Example commands with explanations.-->
az network private-dns zone import -g MyResourceGroup -n MyZone -f /path/to/zone/file

 az network private-dns zone export -g MyResourceGroup -n www.mysite.com -f mysite_com_zone.txt

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
