### PR TITLE
[ARO] az aro: Fix table output

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_format.py
@@ -15,11 +15,13 @@ def aro_list_table_format(results):
 def aro_show_table_format(result):
     parts = parse_resource_id(result['id'])
 
+    worker_profiles = result['workerProfiles'] or []
+
     return collections.OrderedDict(
         Name=result['name'],
         ResourceGroup=parts['resource_group'],
         Location=result['location'],
         ProvisioningState=result['provisioningState'],
-        WorkerCount=sum(wp['count'] for wp in result['workerProfiles']),
+        WorkerCount=sum(wp['count'] or 0 for wp in worker_profiles),
         URL=result['consoleProfile']['url'],
     )

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_show.yaml
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_show.yaml
@@ -5178,4 +5178,81 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subscription
+      User-Agent:
+      - python/3.6.9 (Linux-4.15.0-76-generic-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.11
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.3.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004\"\
+        ,\n    \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\"\
+        ,\n    \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"show\"\
+        \n    },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\"\
+        ,\n        \"clusterProfile\": {\n            \"domain\": \"4ft6di6t\",\n\
+        \            \"version\": \"4.3.9\",\n            \"resourceGroupId\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-4ft6di6t\"\
+        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.4ft6di6t.eastus.aroapp.io/\"\
+        \n        },\n        \"servicePrincipalProfile\": {\n            \"clientId\"\
+        : \"576bc7e1-3881-41d6-ab31-370a96fadaa8\"\n        },\n        \"networkProfile\"\
+        : {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\"\
+        : \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n          \
+        \  \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
+        \n        },\n        \"workerProfiles\": [\n            {\n             \
+        \   \"name\": \"aro-worker-eastus1\",\n                \"vmSize\": \"Standard_D2s_v3\"\
+        ,\n                \"diskSizeGB\": 128,\n                \"subnetId\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\n                \"count\": 1\n            },\n            {\n         \
+        \       \"name\": \"aro-worker-eastus2\",\n                \"vmSize\": \"\
+        Standard_D2s_v3\",\n                \"diskSizeGB\": 128,\n               \
+        \ \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\n                \"count\": 1\n            },\n            {\n         \
+        \       \"name\": \"aro-worker-eastus3\",\n                \"vmSize\": \"\
+        Standard_D2s_v3\",\n                \"diskSizeGB\": 128,\n               \
+        \ \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\n                \"count\": 1\n            }\n        ],\n        \"apiserverProfile\"\
+        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.4ft6di6t.eastus.aroapp.io:6443/\"\
+        ,\n            \"ip\": \"40.88.21.177\"\n        },\n        \"ingressProfiles\"\
+        : [\n            {\n                \"name\": \"default\",\n             \
+        \   \"visibility\": \"Public\",\n                \"ip\": \"40.71.235.172\"\
+        \n            }\n        ]\n    }\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2812'
+      content-type:
+      - application/json
+      date:
+      - Fri, 10 Apr 2020 07:22:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/test_aro_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/test_aro_commands.py
@@ -10,7 +10,8 @@ from random import randint
 
 from knack.log import get_logger
 from azure_devtools.scenario_tests import AllowLargeResponse
-from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, RoleBasedServicePrincipalPreparer
+from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
+from azure.cli.testsdk.checkers import StringContainCheck
 
 logger = get_logger(__name__)
 
@@ -93,8 +94,9 @@ class AroScenarioTests(ScenarioTest):
         master_subnet = self.create_random_name('dev_master', 14)
         worker_subnet = self.create_random_name('dev_worker', 14)
 
+        name = self.create_random_name('aro', 14)
         self.kwargs.update({
-            'name': self.create_random_name('aro', 14),
+            'name': name,
             'resource_group': resource_group,
             'subscription': subscription,
             'master_subnet': master_subnet,
@@ -116,6 +118,12 @@ class AroScenarioTests(ScenarioTest):
             self.check('name', '{name}'),
             self.check_pattern('id', '.*{name}'),
             self.check('resourceGroup', '{rg}')
+        ])
+        self.cmd('aro show -g {rg} -n {name} --subscription {subscription} --output table', checks=[
+            StringContainCheck(name),
+            StringContainCheck(resource_group),
+            StringContainCheck('eastus'),
+            StringContainCheck('Succeeded'),
         ])
 
     @AllowLargeResponse()


### PR DESCRIPTION
**Description**

Fixes a bug in `az aro {command} --output table` (`az aro list --output table`, for example) when the comamnd fails due to not taking into account potential `None` values in data in some edge cases table output currently fails. For example:

* When there are no worker profiles (cluster only has masters or we failed to get data from API server)
* When a worker profile does not have count (machine set was scaled to 0)

**Testing Guide**  

Create an ARO cluster, scale all machine sets to 0 and try to run `az aro list --output table`.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARO] az aro: Fix table output

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
