### PR TITLE
{REST} az rest: Refine help

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -553,7 +553,7 @@ def check_connectivity(url='https://example.org', max_retries=5, timeout=1):
     return success
 
 
-def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
                      body=None, skip_authorization_header=False, resource=None, output_file=None,
                      generated_client_request_id_name='x-ms-client-request-id'):
     import uuid
@@ -616,26 +616,26 @@ def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  #
             result[key] = value
     uri_parameters = result or None
 
-    # If uri is an ARM resource ID, like /subscriptions/xxx/resourcegroups/xxx?api-version=2019-07-01,
+    # If url is an ARM resource ID, like /subscriptions/xxx/resourcegroups/xxx?api-version=2019-07-01,
     # default to Azure Resource Manager.
     # https://management.azure.com/ + subscriptions/xxx/resourcegroups/xxx?api-version=2019-07-01
-    if '://' not in uri:
-        uri = cli_ctx.cloud.endpoints.resource_manager + uri.lstrip('/')
+    if '://' not in url:
+        url = cli_ctx.cloud.endpoints.resource_manager + url.lstrip('/')
 
     # Replace common tokens with real values. It is for smooth experience if users copy and paste the url from
     # Azure Rest API doc
     from azure.cli.core._profile import Profile
     profile = Profile()
-    if '{subscriptionId}' in uri:
-        uri = uri.replace('{subscriptionId}', profile.get_subscription_id())
+    if '{subscriptionId}' in url:
+        url = url.replace('{subscriptionId}', profile.get_subscription_id())
 
-    if not skip_authorization_header and uri.lower().startswith('https://'):
+    if not skip_authorization_header and url.lower().startswith('https://'):
         if not resource:
             endpoints = cli_ctx.cloud.endpoints
-            # If uri starts with ARM endpoint, like https://management.azure.com/,
+            # If url starts with ARM endpoint, like https://management.azure.com/,
             # use active_directory_resource_id for resource.
             # This follows the same behavior as azure.cli.core.commands.client_factory._get_mgmt_service_client
-            if uri.lower().startswith(endpoints.resource_manager.rstrip('/')):
+            if url.lower().startswith(endpoints.resource_manager.rstrip('/')):
                 resource = endpoints.active_directory_resource_id
             else:
                 from azure.cli.core.cloud import CloudEndpointNotSetException
@@ -644,7 +644,7 @@ def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  #
                         value = getattr(endpoints, p)
                     except CloudEndpointNotSetException:
                         continue
-                    if isinstance(value, six.string_types) and uri.lower().startswith(value.lower()):
+                    if isinstance(value, six.string_types) and url.lower().startswith(value.lower()):
                         resource = value
                         break
         if resource:
@@ -659,7 +659,7 @@ def send_raw_request(cli_ctx, method, uri, headers=None, uri_parameters=None,  #
     try:
         # https://requests.readthedocs.io/en/latest/user/advanced/#prepared-requests
         s = Session()
-        req = Request(method=method, url=uri, headers=headers, params=uri_parameters, data=body)
+        req = Request(method=method, url=url, headers=headers, params=uri_parameters, data=body)
         prepped = s.prepare_request(req)
 
         # Merge environment settings into session

--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -1850,7 +1850,7 @@ long-summary: >
     attaches header `Authorization: Bearer <token>`, where `<token>` is retrieved from AAD. The target resource of the
     token is derived from --url if --url starts with an endpoint from `az cloud show --query endpoints`. You may also
     use --resource for a custom resource.
-    
+
     If Content-Type header is not set and --body is a valid JSON string, Content-Type header will default to
     application/json.
 examples:

--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -1844,7 +1844,15 @@ examples:
 
 helps['rest'] = """
 type: command
-short-summary: invoke a custom request
+short-summary: Invoke a custom request.
+long-summary: >
+    This command automatically authenticates using the credential logged in: If Authorization header is not set, it
+    attaches header `Authorization: Bearer <token>`, where `<token>` is retrieved from AAD. The target resource of the
+    token is derived from --url if --url starts with an endpoint from `az cloud show --query endpoints`. You may also
+    use --resource for a custom resource.
+    
+    If Content-Type header is not set and --body is a valid JSON string, Content-Type header will default to
+    application/json.
 examples:
   - name: Get Audit log through Microsoft Graph
     text: >

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -421,14 +421,16 @@ def load_arguments(self, _):
     with self.argument_context('rest') as c:
         c.argument('method', options_list=['--method', '-m'], arg_type=get_enum_type(['head', 'get', 'put', 'post', 'delete', 'options', 'patch'], default='get'),
                    help='HTTP request method')
-        c.argument('uri', options_list=['--uri', '-u'], help='request uri. For uri without host, CLI will assume "https://management.azure.com/". '
-                   "Common token '{subscriptionId}' will be replaced with the current subscription ID specified by 'az account set'")
+        c.argument('uri', options_list=['--url', '--uri', '-u'], help='Request URL. If it doesn\'t start with a host, '
+                   'CLI assumes it as an Azure resource ID and prefixes it with the ARM endpoint of the current '
+                   'cloud shown by `az cloud show --query endpoints.resourceManager`. Common token {subscriptionId} '
+                   'will be replaced with the current subscription ID specified by `az account set`')
         c.argument('headers', nargs='+', help="Space-separated headers in KEY=VALUE format or JSON string. Use @{file} to load from a file")
         c.argument('uri_parameters', nargs='+', help='Space-separated queries in KEY=VALUE format or JSON string. Use @{file} to load from a file')
-        c.argument('skip_authorization_header', action='store_true', help='do not auto append "Authorization" header')
-        c.argument('body', options_list=['--body', '-b'], help='request body. Use @{file} to load from a file')
+        c.argument('skip_authorization_header', action='store_true', help='Do not auto-append Authorization header')
+        c.argument('body', options_list=['--body', '-b'], help='Request body. Use @{file} to load from a file. For quoting issues in different terminals, see https://github.com/Azure/azure-cli/blob/dev/doc/use_cli_effectively.md#quoting-issues')
         c.argument('output_file', help='save response payload to a file')
-        c.argument('resource', help='Resource url for which CLI should acquire a token in order to access '
-                   'the service. The token will be placed in the "Authorization" header. By default, '
-                   'CLI can figure this out based on "--url" argument, unless you use ones not in the list '
+        c.argument('resource', help='Resource url for which CLI should acquire a token from AAD in order to access '
+                   'the service. The token will be placed in the Authorization header. By default, '
+                   'CLI can figure this out based on --url argument, unless you use ones not in the list '
                    'of "az cloud show --query endpoints"')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Refine the help doc of `az rest`.

Also use the correct name `URL` instead of `URI` for the HTTP request. See [What is the difference between a URI, a URL and a URN?](https://stackoverflow.com/questions/176264/what-is-the-difference-between-a-uri-a-url-and-a-urn).

**Testing Guide**  
```
az rest --help
```
