### PR TITLE
[Web App] Web app and plan different rgs

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -165,7 +165,7 @@ def load_arguments(self, _):
         c.argument('generate_ssh_keys', action='store_true', validator=validate_create_parameters)
         c.argument('node_vm_size', options_list=['--node-vm-size', '-s'], completer=get_vm_size_completion_list)
         c.argument('nodepool_name', type=str, default='nodepool1',
-                   help='Node pool name, upto 12 alphanumeric characters', validator=validate_nodepool_name)
+                   help='Node pool name, up to 12 alphanumeric characters', validator=validate_nodepool_name)
         c.argument('ssh_key_value', required=False, type=file_type, default=os.path.join('~', '.ssh', 'id_rsa.pub'),
                    completer=FilesCompleter(), validator=validate_ssh_key)
         c.argument('aad_client_app_id')
@@ -281,7 +281,7 @@ def load_arguments(self, _):
 
     with self.argument_context('aks scale') as c:
         c.argument('nodepool_name', type=str,
-                   help='Node pool name, upto 12 alphanumeric characters', validator=validate_nodepool_name)
+                   help='Node pool name, up to 12 alphanumeric characters', validator=validate_nodepool_name)
 
     with self.argument_context('aks nodepool') as c:
         c.argument('cluster_name', type=str, help='The cluster name.')

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -120,6 +120,7 @@ def load_arguments(self, _):
         c.argument('plan', options_list=['--plan', '-p'], configured_default='appserviceplan',
                    completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'),
                    help="name or resource id of the app service plan. Use 'appservice plan create' to get one")
+        c.argument('plan_resource_group', options_list=['--plan-resource-group'], help='resource group where the plan is located. Needed only is plan is in differente rg than webapp will be created')
         c.ignore('language')
         c.ignore('using_webapp_up')
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -80,7 +80,7 @@ def create_webapp(cmd, resource_group_name, name, plan, runtime=None, startup_fi
         raise CLIError('usage error: --deployment-source-url <url> | --deployment-local-git')
 
     docker_registry_server_url = parse_docker_image_name(deployment_container_image_name)
-    
+  
     client = web_client_factory(cmd.cli_ctx)
     if is_valid_resource_id(plan):
         parse_result = parse_resource_id(plan)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -86,7 +86,7 @@ def create_webapp(cmd, resource_group_name, name, plan, runtime=None, startup_fi
         parse_result = parse_resource_id(plan)
         plan_info = client.app_service_plans.get(parse_result['resource_group'], parse_result['name'])
     else:
-        plan_info = client.app_service_plans.get(resource_group_name, plan)
+        plan_info = _get_plan_by_name(client, plan)
     if not plan_info:
         raise CLIError("The plan '{}' doesn't exist".format(plan))
     is_linux = plan_info.reserved
@@ -3529,3 +3529,13 @@ def _verify_hostname_binding(cmd, resource_group_name, name, hostname, slot=None
             verified_hostname_found = True
 
     return verified_hostname_found
+
+def _get_plan_by_name(client, plan):
+    plan_info = None
+    plan_list = client.app_service_plans.list()
+    if plan_list:
+        candidate_plans = list(filter(lambda x: x.name == plan, plan_list))
+        if candidate_plans:
+            plan_info = candidate_plans[0]
+
+    return plan_info

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3532,14 +3532,3 @@ def _verify_hostname_binding(cmd, resource_group_name, name, hostname, slot=None
             verified_hostname_found = True
 
     return verified_hostname_found
-
-
-def _get_plan_by_name(client, plan):
-    plan_info = None
-    plan_list = client.app_service_plans.list()
-    if plan_list:
-        candidate_plans = list(filter(lambda x: x.name == plan, plan_list))
-        if candidate_plans:
-            plan_info = candidate_plans[0]
-
-    return plan_info

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3530,6 +3530,7 @@ def _verify_hostname_binding(cmd, resource_group_name, name, hostname, slot=None
 
     return verified_hostname_found
 
+
 def _get_plan_by_name(client, plan):
     plan_info = None
     plan_list = client.app_service_plans.list()

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -73,20 +73,23 @@ def create_webapp(cmd, resource_group_name, name, plan, runtime=None, startup_fi
                   deployment_container_image_name=None, deployment_source_url=None, deployment_source_branch='master',
                   deployment_local_git=None, docker_registry_server_password=None, docker_registry_server_user=None,
                   multicontainer_config_type=None, multicontainer_config_file=None, tags=None,
-                  using_webapp_up=False, language=None):
+                  using_webapp_up=False, language=None, plan_resource_group=None):
     SiteConfig, SkuDescription, Site, NameValuePair = cmd.get_models(
         'SiteConfig', 'SkuDescription', 'Site', 'NameValuePair')
     if deployment_source_url and deployment_local_git:
         raise CLIError('usage error: --deployment-source-url <url> | --deployment-local-git')
 
     docker_registry_server_url = parse_docker_image_name(deployment_container_image_name)
-
+    
     client = web_client_factory(cmd.cli_ctx)
     if is_valid_resource_id(plan):
         parse_result = parse_resource_id(plan)
         plan_info = client.app_service_plans.get(parse_result['resource_group'], parse_result['name'])
     else:
-        plan_info = _get_plan_by_name(client, plan)
+        if plan_resource_group:
+            plan_info = client.app_service_plans.get(plan_resource_group, plan)
+        else:
+            plan_info = client.app_service_plans.get(resource_group_name, plan)
     if not plan_info:
         raise CLIError("The plan '{}' doesn't exist".format(plan))
     is_linux = plan_info.reserved


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR adds the possibility of creating a web app in a resource group that is different from the plan you are trying to create

**Testing Guide**  
<!--Example commands with explanations.-->
In order to test this PR, you should follow the instructions on this [issue ](https://github.com/Azure/azure-cli/issues/12090 )that explain how to reproduce it. You should run:
```
$APP_SERVICE_PLAN_NAME = "appserviceplan"
$PLAN_RESOURCE_GROUP_NAME = "appservice-plan-group"
$APP_RESOURCE_GROUP_NAME = "webapp-group"

az group create --name $PLAN_RESOURCE_GROUP_NAME --location australiaeast --subscription $SUBSCRIPTION_ID

az group create --name $APP_RESOURCE_GROUP_NAME --location australiaeast --subscription $SUBSCRIPTION_ID

az appservice plan create --name $APP_SERVICE_PLAN_NAME --resource-group $PLAN_RESOURCE_GROUP_NAME --sku B1 --is-linux

$WEBAPP_NAME = [System.Guid]::NewGuid().ToString()

az webapp create --name $WEBAPP_NAME --resource-group $APP_RESOURCE_GROUP_NAME --plan $APP_SERVICE_PLAN_NAME --runtime """python|3.6""" --query id
```


**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
