### PR TITLE
[Compute] az vmss disk detach: fix data disk NoneType issue

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -2808,6 +2808,9 @@ def detach_disk_from_vmss(cmd, resource_group_name, vmss_name, lun, instance_id=
         vmss_vm = client.virtual_machine_scale_set_vms.get(resource_group_name, vmss_name, instance_id)
         data_disks = vmss_vm.storage_profile.data_disks
 
+    if not data_disks:
+        raise CLIError("Data disk doesn't exist")
+
     leftovers = [d for d in data_disks if d.lun != lun]
     if len(data_disks) == len(leftovers):
         raise CLIError("Could not find the data disk with lun '{}'".format(lun))


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR is to fix #11144

When we try to detach lun from a vmss without data disk, we will meet a NoneType exception.

I add a check here for data disk, and will raise `Data disk doesn't exist` error for this case.


**Testing Guide**  
`az vmss create -g RG -n vmssName --image UbuntuLTS --load-balancer ""`
`az vmss disk detach -g RG --vmss-name vmssName --lun 0` (prompt error instead of exception)

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
