### PR TITLE
[IoT] Update the IoT command module first run extension awareness message to the accurate, non-deprecated modern Id `azure-iot`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/__init__.py
@@ -14,13 +14,13 @@ from azure.cli.core.extension import extension_exists
 def handler(ctx, **kwargs):
     cmd = kwargs.get('command', None)
     if cmd and cmd.startswith('iot'):
-        if not extension_exists('azure-cli-iot-ext'):
+        if not extension_exists('azure-iot'):
             ran_before = ctx.config.getboolean('iot', 'first_run', fallback=False)
             if not ran_before:
                 extension_text = """
 Comprehensive IoT data-plane functionality is available in the Azure IoT CLI Extension.
 
-To install the extension, run: "az extension add --name azure-cli-iot-ext"
+To install the extension, run: "az extension add --name azure-iot"
 
 For more info and install guide go to: https://github.com/Azure/azure-iot-cli-extension
 """

--- a/src/azure-cli/azure/cli/command_modules/iot/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/__init__.py
@@ -18,7 +18,7 @@ def handler(ctx, **kwargs):
             ran_before = ctx.config.getboolean('iot', 'first_run', fallback=False)
             if not ran_before:
                 extension_text = """
-Comprehensive IoT data-plane functionality is available in the Azure IoT CLI Extension.
+Comprehensive IoT functionality is available in the Azure IoT CLI Extension.
 
 To install the extension, run: "az extension add --name azure-iot"
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

We need to remove and replace the deprecated IoT extension Id `azure-cli-iot-ext`  with the modern/current extension Id `azure-iot`.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[IoT] az iot: Update the IoT command module first run extension awareness message to the accurate, non-deprecated modern Id `azure-iot`. 



