### PR TITLE
[AppService] az webapp|functionapp config ssl import: Lookup key vault across resources groups in subscription and improve help and examples.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -326,6 +326,8 @@ short-summary: Import an SSL certificate to a function app from Key Vault.
 examples:
   - name: Import an SSL certificate to a function app from Key Vault.
     text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
+  - name: Import an SSL certificate to a function app from Key Vault using resource id (typically if Key Vault is in another subscription).
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName
 """
 
 helps['functionapp config ssl create'] = """
@@ -1186,6 +1188,8 @@ short-summary: Import an SSL certificate to a web app from Key Vault.
 examples:
   - name: Import an SSL certificate to a web app from Key Vault.
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
+  - name: Import an SSL certificate to a web app from Key Vault using resource id (typically if Key Vault is in another subscription).
+    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName
 """
 
 helps['webapp config ssl create'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2136,7 +2136,26 @@ def import_ssl_cert(cmd, resource_group_name, name, key_vault, key_vault_certifi
         raise CLIError("'{}' app doesn't exist in resource group {}".format(name, resource_group_name))
     server_farm_id = webapp.server_farm_id
     location = webapp.location
-    kv_id = _format_key_vault_id(cmd.cli_ctx, key_vault, resource_group_name)
+    kv_id = None
+    if not is_valid_resource_id(key_vault):
+        kv_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_KEYVAULT)
+        key_vaults = kv_client.vaults.list_by_subscription()
+        for kv in key_vaults:
+            if key_vault == kv.name:
+                kv_id = kv.id
+                break
+    else:
+        kv_id = key_vault
+
+    if kv_id is None:
+        kv_msg = 'The Key Vault {0} was not found in the subscription in context. ' \
+                 'If your Key Vault is in a different subscription, please specify the full Resource ID: ' \
+                 '\naz .. ssl import -n {1} -g {2} --key-vault-certificate-name {3} ' \
+                 '--key-vault /subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/' \
+                 'vaults/{0}'.format(key_vault, name, resource_group_name, key_vault_certificate_name)
+        logger.warning(kv_msg)
+        return
+
     kv_id_parts = parse_resource_id(kv_id)
     kv_name = kv_id_parts['name']
     kv_resource_group_name = kv_id_parts['resource_group']

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import.yaml
@@ -13,15 +13,15 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-04-03T06:45:41Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-04-21T06:36:05Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 03 Apr 2020 06:45:50 GMT
+      - Tue, 21 Apr 2020 06:36:19 GMT
       expires:
       - '-1'
       pragma:
@@ -63,8 +63,8 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: POST
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:45:51 GMT
+      - Tue, 21 Apr 2020 06:36:20 GMT
       expires:
       - '-1'
       pragma:
@@ -98,7 +98,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1194'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -118,15 +118,15 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-04-03T06:45:41Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-04-21T06:36:05Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -135,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 03 Apr 2020 06:45:51 GMT
+      - Tue, 21 Apr 2020 06:36:21 GMT
       expires:
       - '-1'
       pragma:
@@ -168,8 +168,8 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: PUT
@@ -177,8 +177,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":13271,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"04b0639d-85d8-445a-bada-8da78e50ff30","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-309_13271","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":26380,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-297_26380","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:46:05 GMT
+      - Tue, 21 Apr 2020 06:36:29 GMT
       expires:
       - '-1'
       pragma:
@@ -205,7 +205,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1195'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -225,8 +225,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
@@ -234,8 +234,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":13271,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"04b0639d-85d8-445a-bada-8da78e50ff30","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-309_13271","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":26380,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-297_26380","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -244,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:46:06 GMT
+      - Tue, 21 Apr 2020 06:36:30 GMT
       expires:
       - '-1'
       pragma:
@@ -285,8 +285,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: POST
@@ -302,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:46:08 GMT
+      - Tue, 21 Apr 2020 06:36:30 GMT
       expires:
       - '-1'
       pragma:
@@ -320,7 +320,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1194'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -340,8 +340,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
@@ -349,8 +349,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":13271,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"04b0639d-85d8-445a-bada-8da78e50ff30","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-309_13271","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":26380,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-297_26380","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +359,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:46:08 GMT
+      - Tue, 21 Apr 2020 06:36:31 GMT
       expires:
       - '-1'
       pragma:
@@ -399,8 +399,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: POST
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:46:09 GMT
+      - Tue, 21 Apr 2020 06:36:31 GMT
       expires:
       - '-1'
       pragma:
@@ -460,8 +460,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: PUT
@@ -469,18 +469,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-309.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-03T06:46:14.6333333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"C3E7C05FE8A97695B3AE08C1935F4251C48E338FE439627B2E788D9D718C8A70","kind":"app","inboundIpAddress":"13.69.68.42","possibleInboundIpAddresses":"13.69.68.42","outboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211","possibleOutboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211,13.81.108.29,13.81.60.108,13.94.135.163,40.68.255.234,52.174.23.159","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-309","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:36:35.47","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3586'
+      - '3571'
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:46:32 GMT
+      - Tue, 21 Apr 2020 06:36:51 GMT
       etag:
-      - '"1D60983920F0A75"'
+      - '"1D617A7347FA70B"'
       expires:
       - '-1'
       pragma:
@@ -522,8 +522,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: POST
@@ -532,17 +532,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000003 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="ekJmRYC6dmpPipihDwcQwCfJzbnTZphHm4WPRhxqkPfNKqG5veiA4Gcsun6q"
+        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-309.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="ekJmRYC6dmpPipihDwcQwCfJzbnTZphHm4WPRhxqkPfNKqG5veiA4Gcsun6q"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-297.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-309dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="ekJmRYC6dmpPipihDwcQwCfJzbnTZphHm4WPRhxqkPfNKqG5veiA4Gcsun6q"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-297dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 03 Apr 2020 06:46:33 GMT
+      - Tue, 21 Apr 2020 06:36:53 GMT
       expires:
       - '-1'
       pragma:
@@ -568,7 +568,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11993'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:
@@ -588,15 +588,15 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-04-03T06:45:41Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-04-21T06:36:05Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -605,7 +605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 03 Apr 2020 06:46:36 GMT
+      - Tue, 21 Apr 2020 06:36:53 GMT
       expires:
       - '-1'
       pragma:
@@ -629,7 +629,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
         azure-graphrbac/0.60.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -637,46 +637,47 @@ interactions:
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"96aab2b1-c4e2-4163-b9c9-3eb33e9e2ae9","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":["65cc641f-cccd-4643-97e0-a17e3045e541","e26c2fcc-ab91-4a61-b35c-03cdc8dddf66","46129a58-a698-46f0-aa5b-17f6586297d9","6db1f1db-2b46-403f-be40-e39395f08dbb","6dc145d6-95dd-4191-b9c3-185575ee6f6b","41fcdd7d-4733-4863-9cf4-c65b83ce2df4","2f442157-a11c-46b9-ae5b-6e39ff4e5849","c4801e8a-cb58-4c35-aca6-f2dcc106f287","0898bdbb-73b0-471a-81e5-20f1fe4dd66e","617b097b-4b93-4ede-83de-5f075bb5fb2f","33c4f319-9bdd-48d6-9c4d-410b750a4a5a","4828c8ec-dc2e-4779-b502-87ac9ce28ab7","3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"],"skuId":"c7df2760-2c81-4ef7-b578-5b5392b571df"},{"disabledPlans":["39b5c996-467e-4e60-bd62-46066f572726"],"skuId":"90d8b3f8-712e-4f7b-aa1e-62e7ae6cbe96"},{"disabledPlans":["e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72"],"skuId":"09015f9f-377f-4538-bbb5-f75ceb09358a"},{"disabledPlans":[],"skuId":"f30db892-07e9-47e9-837c-80727f46fd3d"},{"disabledPlans":[],"skuId":"26a18e8f-4d14-46f8-835a-ed3ba424a961"},{"disabledPlans":[],"skuId":"412ce1a7-a499-41b3-8eb6-b38f2bbc5c3f"},{"disabledPlans":[],"skuId":"488ba24a-39a9-4473-8ee5-19291e71b002"},{"disabledPlans":[],"skuId":"b05e124f-c7cc-45a0-a6aa-8cf78c946968"},{"disabledPlans":["0b03f40b-c404-40c3-8651-2aceb74365fa","b650d915-9886-424b-a08d-633cede56f57","e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72","fe71d6c3-a2ea-4499-9778-da042bf08063","fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"],"skuId":"ea126fc5-a19e-42e2-a731-da9d437bffcf"},{"disabledPlans":[],"skuId":"c5928f49-12ba-48f7-ada3-0d743a3601d5"}],"assignedPlans":[{"assignedTimestamp":"2020-03-12T07:22:11Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2020-03-12T07:22:11Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2020-03-12T07:22:11Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2020-03-12T07:22:11Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"},{"assignedTimestamp":"2019-11-05T07:17:44Z","capabilityStatus":"Enabled","service":"WhiteboardServices","servicePlanId":"4a51bca5-1eff-43f5-878c-177680f191af"},{"assignedTimestamp":"2019-10-14T22:50:50Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"5136a095-5cf0-4aff-bec3-e84448b38ea5"},{"assignedTimestamp":"2019-10-14T22:50:50Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb0351d-3b08-4503-993d-383af8de41e3"},{"assignedTimestamp":"2019-08-09T03:49:48Z","capabilityStatus":"Enabled","service":"MicrosoftFormsProTest","servicePlanId":"97f29a83-1a20-44ff-bf48-5e4ad11f3e51"},{"assignedTimestamp":"2019-05-23T13:18:01Z","capabilityStatus":"Enabled","service":"DYN365AISERVICEINSIGHTS","servicePlanId":"1412cdc1-d593-4ad1-9050-40c30ad0b023"},{"assignedTimestamp":"2019-05-10T01:49:15Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"199a5c09-e0ca-4e37-8f7c-b05d533e1ea2"},{"assignedTimestamp":"2019-04-02T17:59:51Z","capabilityStatus":"Enabled","service":"ProjectProgramsAndPortfolios","servicePlanId":"818523f5-016b-4355-9be8-ed6944946ea7"},{"assignedTimestamp":"2019-04-02T17:59:51Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"fa200448-008c-4acb-abd4-ea106ed2199d"},{"assignedTimestamp":"2019-04-02T17:59:51Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"50554c47-71d9-49fd-bc54-42a2765c555c"},{"assignedTimestamp":"2018-10-29T07:15:04Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"50e68c76-46c6-4674-81f9-75456511b170"},{"assignedTimestamp":"2018-10-29T07:15:04Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"17ab22cd-a0b3-4536-910a-cb6eb12696c0"},{"assignedTimestamp":"2018-09-24T16:02:18Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"018fb91e-cee3-418c-9063-d7562978bdaf"},{"assignedTimestamp":"2018-09-24T16:02:16Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"ca4be917-fbce-4b52-839e-6647467a1668"},{"assignedTimestamp":"2018-09-24T16:02:15Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"b1188c4c-1b36-4018-b48b-ee07604f6feb"},{"assignedTimestamp":"2018-09-24T16:02:15Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"4828c8ec-dc2e-4779-b502-87ac9ce28ab7"},{"assignedTimestamp":"2018-09-24T16:02:15Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"},{"assignedTimestamp":"2018-08-30T00:03:54Z","capabilityStatus":"Enabled","service":"Sway","servicePlanId":"a23b959c-7ce8-4e57-9140-b90eb88a9e97"},{"assignedTimestamp":"2018-08-30T00:03:54Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"bea4c11e-220a-4e6d-8eb8-8ea15d019f90"},{"assignedTimestamp":"2018-08-30T00:03:54Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"6c57d4b6-3b23-47a5-9bc9-69f17b4947b3"},{"assignedTimestamp":"2018-08-30T00:03:54Z","capabilityStatus":"Deleted","service":"OfficeForms","servicePlanId":"159f4cd6-e380-449f-a816-af1a9ef76344"},{"assignedTimestamp":"2018-04-24T05:55:12Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2018-04-24T05:55:12Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"2125cfd7-2110-4567-83c4-c1cd5275163d"},{"assignedTimestamp":"2018-04-24T05:55:12Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2018-04-24T05:55:12Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"c4048e79-4474-4c74-ba9b-c31ff225e511"},{"assignedTimestamp":"2018-03-22T04:15:07Z","capabilityStatus":"Deleted","service":"MicrosoftStream","servicePlanId":"acffdce6-c30f-4dc2-81c0-372e33c515ec"},{"assignedTimestamp":"2018-03-17T13:09:02Z","capabilityStatus":"Enabled","service":"WindowsDefenderATP","servicePlanId":"871d91ec-ec1a-452b-a83f-bd76c7d770ef"},{"assignedTimestamp":"2018-03-17T13:09:02Z","capabilityStatus":"Enabled","service":"AzureAdvancedThreatAnalytics","servicePlanId":"14ab5db5-e6c4-4b20-b4bc-13e36fd2227f"},{"assignedTimestamp":"2018-03-17T13:09:02Z","capabilityStatus":"Enabled","service":"Windows","servicePlanId":"e7c91390-7625-45be-94e0-e16907e03118"},{"assignedTimestamp":"2018-01-08T22:38:03Z","capabilityStatus":"Enabled","service":"ProjectWorkManagement","servicePlanId":"b737dad2-2f6c-4c65-90e3-ca563267e8b9"},{"assignedTimestamp":"2018-01-01T02:00:47Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"41781fb2-bc02-4b7c-bd55-b576c07bb09d"},{"assignedTimestamp":"2018-01-01T02:00:47Z","capabilityStatus":"Enabled","service":"MultiFactorService","servicePlanId":"8a256a2b-b617-496d-b51b-e76466e88db0"},{"assignedTimestamp":"2017-12-31T11:05:47Z","capabilityStatus":"Deleted","service":"Adallom","servicePlanId":"932ad362-64a8-4783-9106-97849a1a30b9"},{"assignedTimestamp":"2017-12-16T06:45:17Z","capabilityStatus":"Enabled","service":"To-Do","servicePlanId":"3fb82609-8c27-4f7b-bd51-30634711ee67"},{"assignedTimestamp":"2017-12-16T06:45:17Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"5689bec4-755d-4753-8b61-40975025187c"},{"assignedTimestamp":"2017-12-16T06:45:17Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"2e2ddb96-6af9-4b1d-a3f0-d6ecfd22edb2"},{"assignedTimestamp":"2016-10-29T16:48:25Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"8c098270-9dd4-4350-9b30-ba4703f3b36b"},{"assignedTimestamp":"2017-10-07T06:41:14Z","capabilityStatus":"Enabled","service":"Netbreeze","servicePlanId":"03acaee3-9492-4f40-aed4-bcb6b32981b6"},{"assignedTimestamp":"2017-10-07T06:41:14Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"d56f3deb-50d8-465a-bedb-f079817ccac1"},{"assignedTimestamp":"2017-08-13T13:55:28Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"e212cbc7-0961-4c40-9825-01117710dcb1"},{"assignedTimestamp":"2017-06-11T03:39:10Z","capabilityStatus":"Enabled","service":"MicrosoftStream","servicePlanId":"6c6042f5-6f01-4d67-b8c1-eb99d36eed3e"},{"assignedTimestamp":"2017-06-11T03:39:10Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"eec0eb4f-6444-4f95-aba0-50c24d67f998"},{"assignedTimestamp":"2017-06-11T03:39:10Z","capabilityStatus":"Enabled","service":"SCO","servicePlanId":"c1ec4a95-1f05-45b3-a911-aa3fa01094f5"},{"assignedTimestamp":"2017-05-08T18:10:22Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb87545-963c-4e0d-99df-69c6916d9eb0"},{"assignedTimestamp":"2017-05-08T18:10:22Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"34c0d7a0-a70f-4668-9238-47f9fc208882"},{"assignedTimestamp":"2017-05-08T18:10:22Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"9f431833-0334-42de-a7dc-70aa40db46db"},{"assignedTimestamp":"2017-05-08T18:10:22Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"8e0c0a52-6a6c-4d40-8370-dd62790dcd70"},{"assignedTimestamp":"2017-02-22T00:14:27Z","capabilityStatus":"Enabled","service":"Deskless","servicePlanId":"8c7d2df8-86f0-4902-b2ed-a0458298f3b3"},{"assignedTimestamp":"2016-12-14T14:10:26Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"07699545-9485-468e-95b6-2fca3738be01"},{"assignedTimestamp":"2016-12-14T14:10:26Z","capabilityStatus":"Enabled","service":"TeamspaceAPI","servicePlanId":"57ff2da0-773e-42df-b2af-ffb7a2317929"},{"assignedTimestamp":"2016-12-14T14:10:26Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"9c0dab89-a30c-4117-86e7-97bda240acd2"},{"assignedTimestamp":"2016-10-29T16:48:25Z","capabilityStatus":"Enabled","service":"PowerBI","servicePlanId":"70d33638-9c74-4d01-bfd3-562de28bd4ba"},{"assignedTimestamp":"2016-10-29T16:48:25Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"4de31727-a228-4ec3-a5bf-8e45b5ca48cc"},{"assignedTimestamp":"2016-10-29T16:48:25Z","capabilityStatus":"Enabled","service":"YammerEnterprise","servicePlanId":"7547a3fe-08ee-4ccb-b430-5077c5041653"},{"assignedTimestamp":"2016-10-29T16:48:25Z","capabilityStatus":"Deleted","service":"PowerBI","servicePlanId":"fc0a60aa-feee-4746-a0e3-aecfe81a38dd"},{"assignedTimestamp":"2016-10-29T16:48:25Z","capabilityStatus":"Deleted","service":"AzureAnalysis","servicePlanId":"2049e525-b859-401b-b2a0-e0a31c4b1fe4"},{"assignedTimestamp":"2016-10-29T16:48:25Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"0feaeb32-d00e-4d66-bd5a-43b5b83db82c"},{"assignedTimestamp":"2016-10-29T16:48:25Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"43de0ff5-c92c-492b-9116-175376d08c38"},{"assignedTimestamp":"2015-12-21T11:10:12Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"663a804f-1c30-4ff0-9915-9db84f0d1cea"}],"city":null,"companyName":"MICROSOFT","consentProvidedForMinor":null,"country":null,"createdDateTime":null,"creationType":null,"department":"App
-        Service","dirSyncEnabled":true,"displayName":"Kota Sudhakar Reddy (TECH MAHINDRA
-        LTD.)","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Kota
-        Sudhakar","immutableId":"870796","isCompromised":null,"jobTitle":null,"lastDirSyncTime":"2020-04-01T10:47:38Z","legalAgeGroupClassification":null,"mail":"v-kotred@microsoft.com","mailNickname":"v-kotred","mobile":null,"onPremisesDistinguishedName":"CN=Kota
-        Sudhakar Reddy (TECH MAHINDRA LTD.),OU=UserAccounts,DC=fareast,DC=corp,DC=microsoft,DC=com","onPremisesSecurityIdentifier":"S-1-5-21-2146773085-903363285-719344707-2044577","otherMails":[],"passwordPolicies":"DisablePasswordExpiration","passwordProfile":null,"physicalDeliveryOfficeName":"No
-        WorkSpace","postalCode":null,"preferredLanguage":null,"provisionedPlans":[{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Adallom"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Netbreeze"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"microsoftcommunicationsonline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"}],"provisioningErrors":[],"proxyAddresses":["X500:/o=MMS/ou=External
-        (FYDIBOHF25SPDLT)/cn=Recipients/cn=23c56835d74b4f51bd574a10c499a399","X500:/o=Nokia/ou=Exchange
-        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=Kota Sudhakar Reddyd2e","X500:/o=microsoft/ou=Exchange
-        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=Kota Sudhakar Reddycfa","X500:/o=microsoft/ou=Exchange
-        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=7fca2d893c8f49e0b059ed41772b7cbd-Kota
-        Sudhakar","X500:/o=ExchangeLabs/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=a1fcc628b0d5433f8f9b264649356587-Kota
-        Sudhak","SMTP:v-kotred@microsoft.com","smtp:v-kotred@service.microsoft.com","smtp:v-kotred@microsoft.onmicrosoft.com","X500:/o=microsoft/ou=Exchange
-        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=Kota Sudhakar Reddycf3"],"refreshTokensValidFromDateTime":"2020-04-01T10:38:22Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":"v-kotred@microsoft.com","state":null,"streetAddress":null,"surname":"Reddy","telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/96aab2b1-c4e2-4163-b9c9-3eb33e9e2ae9/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":"SG","userIdentities":[],"userPrincipalName":"v-kotred@microsoft.com","userState":null,"userStateChangedOn":null,"userType":"Member","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToPersonnelNbr":"340857","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToFullName":"Panchagnula,
-        Sisira P","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToEmailName":"SISIRAP","extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10180740","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10180740","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"91917521","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1010","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"NO
-        WORKSPACE","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"99997","extension_18e31482d3fb4a8ea958aa96b662f508_PersonnelNumber":"870796"}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":["65cc641f-cccd-4643-97e0-a17e3045e541","e26c2fcc-ab91-4a61-b35c-03cdc8dddf66","46129a58-a698-46f0-aa5b-17f6586297d9","6db1f1db-2b46-403f-be40-e39395f08dbb","6dc145d6-95dd-4191-b9c3-185575ee6f6b","41fcdd7d-4733-4863-9cf4-c65b83ce2df4","2f442157-a11c-46b9-ae5b-6e39ff4e5849","c4801e8a-cb58-4c35-aca6-f2dcc106f287","0898bdbb-73b0-471a-81e5-20f1fe4dd66e","617b097b-4b93-4ede-83de-5f075bb5fb2f","33c4f319-9bdd-48d6-9c4d-410b750a4a5a","4828c8ec-dc2e-4779-b502-87ac9ce28ab7","3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"],"skuId":"c7df2760-2c81-4ef7-b578-5b5392b571df"},{"disabledPlans":["39b5c996-467e-4e60-bd62-46066f572726"],"skuId":"90d8b3f8-712e-4f7b-aa1e-62e7ae6cbe96"},{"disabledPlans":["e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72"],"skuId":"09015f9f-377f-4538-bbb5-f75ceb09358a"},{"disabledPlans":[],"skuId":"dcb1a3ae-b33f-4487-846a-a640262fadf4"},{"disabledPlans":[],"skuId":"f30db892-07e9-47e9-837c-80727f46fd3d"},{"disabledPlans":[],"skuId":"26a18e8f-4d14-46f8-835a-ed3ba424a961"},{"disabledPlans":[],"skuId":"412ce1a7-a499-41b3-8eb6-b38f2bbc5c3f"},{"disabledPlans":[],"skuId":"488ba24a-39a9-4473-8ee5-19291e71b002"},{"disabledPlans":[],"skuId":"b05e124f-c7cc-45a0-a6aa-8cf78c946968"},{"disabledPlans":["0b03f40b-c404-40c3-8651-2aceb74365fa","b650d915-9886-424b-a08d-633cede56f57","e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72","fe71d6c3-a2ea-4499-9778-da042bf08063","fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"],"skuId":"ea126fc5-a19e-42e2-a731-da9d437bffcf"},{"disabledPlans":[],"skuId":"c5928f49-12ba-48f7-ada3-0d743a3601d5"},{"disabledPlans":[],"skuId":"87bbbc60-4754-4998-8c88-227dca264858"}],"assignedPlans":[{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"},{"assignedTimestamp":"2019-11-04T20:02:03Z","capabilityStatus":"Enabled","service":"WhiteboardServices","servicePlanId":"4a51bca5-1eff-43f5-878c-177680f191af"},{"assignedTimestamp":"2019-10-15T04:17:14Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"5136a095-5cf0-4aff-bec3-e84448b38ea5"},{"assignedTimestamp":"2019-10-15T04:17:14Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb0351d-3b08-4503-993d-383af8de41e3"},{"assignedTimestamp":"2019-08-08T23:29:37Z","capabilityStatus":"Enabled","service":"MicrosoftFormsProTest","servicePlanId":"97f29a83-1a20-44ff-bf48-5e4ad11f3e51"},{"assignedTimestamp":"2019-05-23T01:47:36Z","capabilityStatus":"Enabled","service":"DYN365AISERVICEINSIGHTS","servicePlanId":"1412cdc1-d593-4ad1-9050-40c30ad0b023"},{"assignedTimestamp":"2019-05-09T22:32:19Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"199a5c09-e0ca-4e37-8f7c-b05d533e1ea2"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"ProjectProgramsAndPortfolios","servicePlanId":"818523f5-016b-4355-9be8-ed6944946ea7"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"fa200448-008c-4acb-abd4-ea106ed2199d"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"50554c47-71d9-49fd-bc54-42a2765c555c"},{"assignedTimestamp":"2018-11-18T17:43:28Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"d20bfa21-e9ae-43fc-93c2-20783f0840c3"},{"assignedTimestamp":"2018-11-18T17:43:28Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"d5368ca3-357e-4acb-9c21-8495fb025d1f"},{"assignedTimestamp":"2018-11-17T17:45:51Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"50e68c76-46c6-4674-81f9-75456511b170"},{"assignedTimestamp":"2018-11-17T17:45:51Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"17ab22cd-a0b3-4536-910a-cb6eb12696c0"},{"assignedTimestamp":"2018-10-11T18:25:27Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"018fb91e-cee3-418c-9063-d7562978bdaf"},{"assignedTimestamp":"2018-10-11T18:25:26Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"ca4be917-fbce-4b52-839e-6647467a1668"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"b1188c4c-1b36-4018-b48b-ee07604f6feb"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"4828c8ec-dc2e-4779-b502-87ac9ce28ab7"},{"assignedTimestamp":"2018-08-29T07:16:06Z","capabilityStatus":"Enabled","service":"Sway","servicePlanId":"a23b959c-7ce8-4e57-9140-b90eb88a9e97"},{"assignedTimestamp":"2018-08-29T07:16:06Z","capabilityStatus":"Deleted","service":"OfficeForms","servicePlanId":"159f4cd6-e380-449f-a816-af1a9ef76344"},{"assignedTimestamp":"2018-04-26T17:45:50Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"bea4c11e-220a-4e6d-8eb8-8ea15d019f90"},{"assignedTimestamp":"2018-04-26T17:45:50Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"6c57d4b6-3b23-47a5-9bc9-69f17b4947b3"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"2125cfd7-2110-4567-83c4-c1cd5275163d"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"c4048e79-4474-4c74-ba9b-c31ff225e511"},{"assignedTimestamp":"2018-03-20T15:10:18Z","capabilityStatus":"Deleted","service":"MicrosoftStream","servicePlanId":"acffdce6-c30f-4dc2-81c0-372e33c515ec"},{"assignedTimestamp":"2018-03-17T08:10:29Z","capabilityStatus":"Enabled","service":"WindowsDefenderATP","servicePlanId":"871d91ec-ec1a-452b-a83f-bd76c7d770ef"},{"assignedTimestamp":"2018-03-17T08:10:29Z","capabilityStatus":"Enabled","service":"Windows","servicePlanId":"e7c91390-7625-45be-94e0-e16907e03118"},{"assignedTimestamp":"2018-03-17T02:35:48Z","capabilityStatus":"Enabled","service":"AzureAdvancedThreatAnalytics","servicePlanId":"14ab5db5-e6c4-4b20-b4bc-13e36fd2227f"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"CRM","servicePlanId":"bf36ca64-95c6-4918-9275-eb9f4ce2c04f"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"PowerAppsService","servicePlanId":"874fc546-6efe-4d22-90b8-5c4e7aa59f4b"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"ProcessSimple","servicePlanId":"7e6d7d78-73de-46ba-83b1-6d25117334ba"},{"assignedTimestamp":"2018-01-09T00:28:58Z","capabilityStatus":"Enabled","service":"ProjectWorkManagement","servicePlanId":"b737dad2-2f6c-4c65-90e3-ca563267e8b9"},{"assignedTimestamp":"2017-12-31T23:10:50Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"41781fb2-bc02-4b7c-bd55-b576c07bb09d"},{"assignedTimestamp":"2017-12-31T23:10:50Z","capabilityStatus":"Enabled","service":"MultiFactorService","servicePlanId":"8a256a2b-b617-496d-b51b-e76466e88db0"},{"assignedTimestamp":"2017-12-31T06:32:41Z","capabilityStatus":"Deleted","service":"Adallom","servicePlanId":"932ad362-64a8-4783-9106-97849a1a30b9"},{"assignedTimestamp":"2017-12-16T19:57:33Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"5689bec4-755d-4753-8b61-40975025187c"},{"assignedTimestamp":"2017-12-16T19:57:33Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"2e2ddb96-6af9-4b1d-a3f0-d6ecfd22edb2"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"8c098270-9dd4-4350-9b30-ba4703f3b36b"},{"assignedTimestamp":"2017-11-12T20:20:22Z","capabilityStatus":"Enabled","service":"To-Do","servicePlanId":"3fb82609-8c27-4f7b-bd51-30634711ee67"},{"assignedTimestamp":"2017-10-07T01:41:03Z","capabilityStatus":"Enabled","service":"Netbreeze","servicePlanId":"03acaee3-9492-4f40-aed4-bcb6b32981b6"},{"assignedTimestamp":"2017-10-07T01:41:03Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"d56f3deb-50d8-465a-bedb-f079817ccac1"},{"assignedTimestamp":"2017-06-26T10:50:26Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"e212cbc7-0961-4c40-9825-01117710dcb1"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"MicrosoftStream","servicePlanId":"6c6042f5-6f01-4d67-b8c1-eb99d36eed3e"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"eec0eb4f-6444-4f95-aba0-50c24d67f998"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"SCO","servicePlanId":"c1ec4a95-1f05-45b3-a911-aa3fa01094f5"},{"assignedTimestamp":"2017-05-13T01:11:22Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"8e0c0a52-6a6c-4d40-8370-dd62790dcd70"},{"assignedTimestamp":"2017-02-21T21:53:31Z","capabilityStatus":"Enabled","service":"Deskless","servicePlanId":"8c7d2df8-86f0-4902-b2ed-a0458298f3b3"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"07699545-9485-468e-95b6-2fca3738be01"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"TeamspaceAPI","servicePlanId":"57ff2da0-773e-42df-b2af-ffb7a2317929"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"9c0dab89-a30c-4117-86e7-97bda240acd2"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"PowerBI","servicePlanId":"70d33638-9c74-4d01-bfd3-562de28bd4ba"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"34c0d7a0-a70f-4668-9238-47f9fc208882"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"9f431833-0334-42de-a7dc-70aa40db46db"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"4de31727-a228-4ec3-a5bf-8e45b5ca48cc"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"YammerEnterprise","servicePlanId":"7547a3fe-08ee-4ccb-b430-5077c5041653"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Deleted","service":"AzureAnalysis","servicePlanId":"2049e525-b859-401b-b2a0-e0a31c4b1fe4"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Deleted","service":"PowerBI","servicePlanId":"fc0a60aa-feee-4746-a0e3-aecfe81a38dd"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"43de0ff5-c92c-492b-9116-175376d08c38"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"0feaeb32-d00e-4d66-bd5a-43b5b83db82c"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb87545-963c-4e0d-99df-69c6916d9eb0"},{"assignedTimestamp":"2012-10-18T11:17:30Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"663a804f-1c30-4ff0-9915-9db84f0d1cea"},{"assignedTimestamp":"2015-12-14T08:31:18Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"e61a2945-1d4e-4523-b6e7-30ba39d20f32"},{"assignedTimestamp":"2016-06-30T05:43:33Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"2c4ec2dc-c62d-4167-a966-52a3e6374015"},{"assignedTimestamp":"2016-06-30T05:43:33Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"0b4346bb-8dc3-4079-9dfc-513696f56039"}],"city":"Kongens
+        Lyngby","companyName":"DENMARK","consentProvidedForMinor":null,"country":null,"createdDateTime":null,"creationType":null,"department":"DK-EPG
+        COGS Solution Architect-Azure","dirSyncEnabled":true,"displayName":"Mads Damg\u00e5rd","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Mads","immutableId":"301328","isCompromised":null,"jobTitle":"SR
+        CLOUD SOLUTION ARCHITECT","lastDirSyncTime":"2020-04-16T19:15:38Z","legalAgeGroupClassification":null,"mail":"madsd@microsoft.com","mailNickname":"madsd","mobile":"+4551578136","onPremisesDistinguishedName":"CN=Mads
+        Damg\u00e5rd,OU=UserAccounts,DC=europe,DC=corp,DC=microsoft,DC=com","onPremisesSecurityIdentifier":"S-1-5-21-1721254763-462695806-1538882281-2655010","otherMails":[],"passwordPolicies":"DisablePasswordExpiration","passwordProfile":null,"physicalDeliveryOfficeName":"LYNGBY/Mobile","postalCode":null,"preferredLanguage":null,"provisionedPlans":[{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Adallom"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Netbreeze"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"microsoftcommunicationsonline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"}],"provisioningErrors":[],"proxyAddresses":["smtp:madsd@sales.microsoft.com","x500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=user01a2850e","SMTP:madsd@microsoft.com","x500:/o=microsoft/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=userff21d3b0","x500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=madsd_microsoft.comc37e77e4","x500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=user31cebcc7e1b7241a","X500:/o=MMS/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=user77aa8516","x500:/o=microsoft/ou=First
+        Administrative Group/cn=Recipients/cn=madsd","x500:/o=SDF/ou=Exchange Administrative
+        Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=contact46dc0812","x500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=madsddf0a188e10","x500:/O=microsoft/OU=europe/cn=Recipients/cn=madsd","x500:/O=Nokia/OU=HUB/cn=Recipients/cn=madsd","x500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=51490-madsd_9845154d95","x500:/o=MSNBC/ou=Servers/cn=Recipients/cn=madsd","smtp:MADSD@service.microsoft.com"],"refreshTokensValidFromDateTime":"2019-11-16T08:17:12Z","showInAddressList":true,"signInNames":[],"sipProxyAddress":"madsd@microsoft.com","state":null,"streetAddress":null,"surname":"Damg\u00e5rd","telephoneNumber":"+45
+        (45) 678476","thumbnailPhoto@odata.mediaEditLink":"directoryObjects/0b9188a0-540d-4262-9311-61bb1a0235ef/Microsoft.DirectoryServices.User/thumbnailPhoto","thumbnailPhoto@odata.mediaContentType":"image/Jpeg","usageLocation":"DK","userIdentities":[],"userPrincipalName":"madsd@microsoft.com","userState":null,"userStateChangedOn":null,"userType":null,"extension_18e31482d3fb4a8ea958aa96b662f508_SupervisorInd":"N","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToPersonnelNbr":"218748","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToFullName":"Schioldan,
+        Morten","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToEmailName":"MORTENS","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"MOBILE","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"99998","extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10084905","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10084905","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1023","extension_18e31482d3fb4a8ea958aa96b662f508_LocationAreaCode":"DK","extension_18e31482d3fb4a8ea958aa96b662f508_PersonnelNumber":"301328","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"49025387"}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '17007'
+      - '18997'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 03 Apr 2020 06:46:39 GMT
+      - Tue, 21 Apr 2020 06:36:55 GMT
       duration:
-      - '1657492'
+      - '1129856'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - T6IDWO2NCaBvgJvavUofmNEK1DqvLOJ39maolQNXmmg=
+      - JM6VhjMuUiaZENNEm9cD89HT+0vtv/U/AyNndwvom1g=
       ocp-aad-session-key:
-      - u4--76Z_2j7Mr6IitzhNxHMHBzsyo-TbjfS9ju7WUK6sLmwX8rTLK7g9htvwxRrDmst2y60EEENcMQ8ZNe8Z_GZIzYf7ZqraSiPecr3uvWtMXzBngJFxlkGAMO1GuTzH.C6U1Yf3n1cdog9urSx9alt2V8PMm5qyEArlAJtwpsO0
+      - Rsge2uqOLgMZsTPRQ6ZjDzviVhGKH7EKCV5Y-yK5zAyJBQRYOTW0UHxDuczI_KShfaxhsHSfUiuXW2-OWZsj53sJDlzcoyUvt3j2Ab8eOQtP_uNYxG7T5SJIofkfYhJp.O268mE4sQVpgVazomE3hq268OuefW_B1OVb7Jj-K-AE
       pragma:
       - no-cache
       request-id:
-      - a3cb715f-80cf-4ce6-8c69-35b01dfa773e
+      - 6e2af8eb-8a80-4727-b028-03a02f2890a5
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -691,7 +692,7 @@ interactions:
 - request:
     body: '{"location": "westeurope", "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
       "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
-      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "96aab2b1-c4e2-4163-b9c9-3eb33e9e2ae9",
+      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "0b9188a0-540d-4262-9311-61bb1a0235ef",
       "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
       "backup", "restore", "recover"], "secrets": ["get", "list", "set", "delete",
       "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
@@ -717,15 +718,15 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"96aab2b1-c4e2-4163-b9c9-3eb33e9e2ae9","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net","provisioningState":"RegisteringDns"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net","provisioningState":"RegisteringDns"}}'
     headers:
       cache-control:
       - no-cache
@@ -734,7 +735,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 03 Apr 2020 06:46:48 GMT
+      - Tue, 21 Apr 2020 06:36:59 GMT
       expires:
       - '-1'
       pragma:
@@ -754,7 +755,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.276
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1193'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -774,13 +775,13 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"96aab2b1-c4e2-4163-b9c9-3eb33e9e2ae9","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -789,7 +790,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 03 Apr 2020 06:47:21 GMT
+      - Tue, 21 Apr 2020 06:37:29 GMT
       expires:
       - '-1'
       pragma:
@@ -823,7 +824,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
         azure-graphrbac/0.60.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -849,19 +850,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 03 Apr 2020 06:47:22 GMT
+      - Tue, 21 Apr 2020 06:37:29 GMT
       duration:
-      - '1294419'
+      - '548647'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 4OeuXTvEGuvenDTmachtJqTCCIwvtQOhIrf/BRyt5dA=
+      - lcUiHqF+JaQXTPH0KEWC/V5ZITB+YUarCo2tbQoAdl8=
       ocp-aad-session-key:
-      - ZSMiOwa2DdzQRXF-EKBQ-rGBBVXkdwqh501eeZfx7QkanQmNwowRAYN4z4uB8NOGLm_0411sz2E3j6hOs5_t1DmPcLDlujeDpcOzWcUixQvZsIU9ovi0xl1jv5L_TQ7k.YnjBoLh0-q0RLQihH5L-v25Hjq03flTde9cewEFfhrc
+      - 47ZMCV-6PSXzGQ-lli2tKELUMG1D6d1gAASB7ZszAzGzE30HjI9Y_SmEGUk7znXnhn-x_Wzh-iQKfZ-8QQANYClZouBVu-PtvH8MyLMEpJvJWb6u20y3oVTenmL0jQZS.2zVJtVuOjGcLNB2V5RclsqY5QVy_cUp9Le8HqEYB3LI
       pragma:
       - no-cache
       request-id:
-      - 81b0a746-7a39-499a-9186-0575256008ca
+      - 5a8eb1d9-e033-46a7-a021-2f1787f0fcee
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -887,15 +888,15 @@ interactions:
       ParameterSetName:
       - -g --name --spn --secret-permissions
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"96aab2b1-c4e2-4163-b9c9-3eb33e9e2ae9","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -904,7 +905,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 03 Apr 2020 06:47:25 GMT
+      - Tue, 21 Apr 2020 06:37:31 GMT
       expires:
       - '-1'
       pragma:
@@ -931,7 +932,7 @@ interactions:
 - request:
     body: '{"location": "westeurope", "tags": {}, "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
       "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
-      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "96aab2b1-c4e2-4163-b9c9-3eb33e9e2ae9",
+      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "0b9188a0-540d-4262-9311-61bb1a0235ef",
       "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
       "backup", "restore", "recover"], "secrets": ["get", "list", "set", "delete",
       "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
@@ -958,15 +959,15 @@ interactions:
       ParameterSetName:
       - -g --name --spn --secret-permissions
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"96aab2b1-c4e2-4163-b9c9-3eb33e9e2ae9","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -975,7 +976,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 03 Apr 2020 06:47:25 GMT
+      - Tue, 21 Apr 2020 06:37:31 GMT
       expires:
       - '-1'
       pragma:
@@ -995,7 +996,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.276
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1192'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -1015,7 +1016,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
         azure-keyvault/7.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -1033,7 +1034,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 03 Apr 2020 06:47:27 GMT
+      - Tue, 21 Apr 2020 06:37:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1050,7 +1051,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=103.49.206.62;act_addr_fam=InterNetwork;
+      - addr=185.107.14.16;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
@@ -1076,7 +1077,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
         azure-keyvault/7.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -1084,7 +1085,7 @@ interactions:
     uri: https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/import?api-version=7.0
   response:
     body:
-      string: '{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/6aff8427755c474fa585a3e7c835d3ac","kid":"https://kv-ssl-test000004.vault.azure.net/keys/test-cert/6aff8427755c474fa585a3e7c835d3ac","sid":"https://kv-ssl-test000004.vault.azure.net/secrets/test-cert/6aff8427755c474fa585a3e7c835d3ac","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1585896451,"updated":1585896451,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1585896451,"updated":1585896451}}}'
+      string: '{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/c704d25df9034f34bf0fa818dbf17354","kid":"https://kv-ssl-test000004.vault.azure.net/keys/test-cert/c704d25df9034f34bf0fa818dbf17354","sid":"https://kv-ssl-test000004.vault.azure.net/secrets/test-cert/c704d25df9034f34bf0fa818dbf17354","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1587451053,"updated":1587451053,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1587451053,"updated":1587451053}}}'
     headers:
       cache-control:
       - no-cache
@@ -1093,7 +1094,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 03 Apr 2020 06:47:31 GMT
+      - Tue, 21 Apr 2020 06:37:33 GMT
       expires:
       - '-1'
       pragma:
@@ -1107,7 +1108,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=103.49.206.62;act_addr_fam=InterNetwork;
+      - addr=185.107.14.16;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
@@ -1131,8 +1132,8 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
@@ -1140,18 +1141,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-309.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-03T06:46:14.9833333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"C3E7C05FE8A97695B3AE08C1935F4251C48E338FE439627B2E788D9D718C8A70","kind":"app","inboundIpAddress":"13.69.68.42","possibleInboundIpAddresses":"13.69.68.42","outboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211","possibleOutboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211,13.81.108.29,13.81.60.108,13.94.135.163,40.68.255.234,52.174.23.159","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-309","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:36:36.1766667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3584'
+      - '3574'
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:47:32 GMT
+      - Tue, 21 Apr 2020 06:37:34 GMT
       etag:
-      - '"1D60983920F0A75"'
+      - '"1D617A7347FA70B"'
       expires:
       - '-1'
       pragma:
@@ -1187,24 +1188,24 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"96aab2b1-c4e2-4163-b9c9-3eb33e9e2ae9","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/certs/providers/Microsoft.KeyVault/vaults/tb-certs","name":"tb-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"6b244528-5604-411e-9ff1-5df31b00f93a","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"013244e3-a217-4ca4-bf2a-e65b263959cd","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"4dbab725-22a4-44d5-ad44-c267ca38a954","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"21bf1420-2ed9-48b9-bf6d-ece1337d4fd1","permissions":{"keys":[],"secrets":["Get"],"certificates":["Get"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"],"keys":[],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"ed47c2a1-bd23-4341-b39c-f4fd69138dd3","permissions":{"secrets":["Get","Set","Delete"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://tb-certs.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tbsbwe-integration/providers/Microsoft.KeyVault/vaults/apim-certs","name":"apim-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"vaultUri":"https://apim-certs.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/webapp-global/providers/Microsoft.KeyVault/vaults/madsd-cert","name":"madsd-cert","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["get"],"certificates":[],"storage":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"vaultUri":"https://madsd-cert.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=ServiceBased,ZDJWaVlYQndMV2RzYjJKaGJIeHRZV1J6WkMxalpYSjA="}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1317'
+      - '6092'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 03 Apr 2020 06:47:34 GMT
+      - Tue, 21 Apr 2020 06:37:34 GMT
       expires:
       - '-1'
       pragma:
@@ -1242,17 +1243,72 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/96aab2b1-c4e2-4163-b9c9-3eb33e9e2ae9?api-version=1.6
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1317'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 21 Apr 2020 06:37:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.276
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.4.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/0b9188a0-540d-4262-9311-61bb1a0235ef?api-version=1.6
   response:
     body:
       string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
-        ''96aab2b1-c4e2-4163-b9c9-3eb33e9e2ae9'' does not exist or one of its queried
-        reference-property objects are not present."},"requestId":"ed4895ee-d31b-4535-b694-a1574077a318","date":"2020-04-03T06:47:37"}}'
+        ''0b9188a0-540d-4262-9311-61bb1a0235ef'' does not exist or one of its queried
+        reference-property objects are not present."},"requestId":"231272df-9149-4d83-8be7-8bb445cf4a5f","date":"2020-04-21T06:37:36"}}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1265,19 +1321,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 03 Apr 2020 06:47:36 GMT
+      - Tue, 21 Apr 2020 06:37:36 GMT
       duration:
-      - '1341656'
+      - '557560'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 2xhGPX15ZWVNU1RddsOoDGYfmcoPumQYeMzN4JhJc7E=
+      - sLztrgZ8JSDnWz4frtQ4NvPpSD8rFSiENpbTNRku9OY=
       ocp-aad-session-key:
-      - 9CvbuUXoz9EMFxVUXYZaiZxIvUbbJYAUI9tesa91WlnXJbsRcZjldD12mDnYQr3A9TnhHvyQzqE5Xnu5CO7Zdhqb7sI6j8onRPm2xm8B4hcihN1ECjynht-mqjSdF_Lv.RSjDP9k0f-SH4Wh9qa2tOSXHavUkA4XWAps26sLmPu0
+      - AwqM7zPC7PFfPjeBrgJ6P1PTw5UOaTsfSmmz6C6BDMUy0ulACcqZ2Ip-8RfzU-Sf6dZnU5rEc4COxLzgvpz3gsE3qvKXI1sNcfXJON85Rfmt2Mzm7_YENSDjLNDFaiSs._tkJf22K976osocJIgPHbY84T7-4nLmSYqlTKEYlqNk
       pragma:
       - no-cache
       request-id:
-      - ed4895ee-d31b-4535-b694-a1574077a318
+      - 231272df-9149-4d83-8be7-8bb445cf4a5f
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1303,8 +1359,8 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
@@ -1329,19 +1385,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 03 Apr 2020 06:47:37 GMT
+      - Tue, 21 Apr 2020 06:37:36 GMT
       duration:
-      - '1433210'
+      - '673080'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 4OeuXTvEGuvenDTmachtJqTCCIwvtQOhIrf/BRyt5dA=
+      - 2tT8IJLYLAl4WiEBvtldRBzIBH40hdQ2CjGxgGCHWGg=
       ocp-aad-session-key:
-      - ZGqgukNttNkk5pFjn2re8Nm_V-WwcHZxO_HIELnXc0X10jlUOyWmRQWjMr49VBKZ05UnJ-P_QNbGJrxZJg2v7LV6F3I1-zAbLuVtJ0vqzLZYQCV50ClLM68_hqGn0diA.26EQsgTsc5HpObC_sBJg_72QqTjnPMwVLIxPFBwnbF8
+      - LL2KJ_yWhlYwXcI536AAONVy545XeFGzDXOPh-9dLDWa9omAZyC0CilMthqb7L0c_Rkx2C0V1CE0H1k8WvL7dsmp0UlzmzOjFka_7ODnFIWl2Dy3Wg_Bq5Euo_uKuJRi.59z2oVWwYPRGzMFdAgjWEnHtOJ7rZjZRXDJJu33Ld5o
       pragma:
       - no-cache
       request-id:
-      - 685f46c0-0b9c-4954-988f-1c37326a0076
+      - 1316f388-3127-474e-b8ef-45abf8faf0c9
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1373,8 +1429,8 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: PUT
@@ -1391,7 +1447,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:47:44 GMT
+      - Tue, 21 Apr 2020 06:37:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1412,7 +1468,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1189'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -1432,8 +1488,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
@@ -1441,18 +1497,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-309.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-03T06:46:14.9833333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"C3E7C05FE8A97695B3AE08C1935F4251C48E338FE439627B2E788D9D718C8A70","kind":"app","inboundIpAddress":"13.69.68.42","possibleInboundIpAddresses":"13.69.68.42","outboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211","possibleOutboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211,13.81.108.29,13.81.60.108,13.94.135.163,40.68.255.234,52.174.23.159","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-309","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:36:36.1766667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3584'
+      - '3574'
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:47:45 GMT
+      - Tue, 21 Apr 2020 06:37:39 GMT
       etag:
-      - '"1D60983920F0A75"'
+      - '"1D617A7347FA70B"'
       expires:
       - '-1'
       pragma:
@@ -1488,8 +1544,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
@@ -1497,18 +1553,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-309.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-03T06:46:14.9833333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"C3E7C05FE8A97695B3AE08C1935F4251C48E338FE439627B2E788D9D718C8A70","kind":"app","inboundIpAddress":"13.69.68.42","possibleInboundIpAddresses":"13.69.68.42","outboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211","possibleOutboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211,13.81.108.29,13.81.60.108,13.94.135.163,40.68.255.234,52.174.23.159","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-309","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:36:36.1766667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3584'
+      - '3574'
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:47:46 GMT
+      - Tue, 21 Apr 2020 06:37:40 GMT
       etag:
-      - '"1D60983920F0A75"'
+      - '"1D617A7347FA70B"'
       expires:
       - '-1'
       pragma:
@@ -1544,8 +1600,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
@@ -1562,7 +1618,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:47:47 GMT
+      - Tue, 21 Apr 2020 06:37:40 GMT
       expires:
       - '-1'
       pragma:
@@ -1598,8 +1654,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
@@ -1616,9 +1672,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:47:49 GMT
+      - Tue, 21 Apr 2020 06:37:41 GMT
       etag:
-      - '"1D60983920F0A75"'
+      - '"1D617A7347FA70B"'
       expires:
       - '-1'
       pragma:
@@ -1661,8 +1717,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: PUT
@@ -1670,18 +1726,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-309.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-03T06:47:51.36","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"C3E7C05FE8A97695B3AE08C1935F4251C48E338FE439627B2E788D9D718C8A70","kind":"app","inboundIpAddress":"13.69.68.42","possibleInboundIpAddresses":"13.69.68.42","outboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211","possibleOutboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211,13.81.108.29,13.81.60.108,13.94.135.163,40.68.255.234,52.174.23.159","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-309","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:37:43.0166667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3621'
+      - '3616'
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:47:53 GMT
+      - Tue, 21 Apr 2020 06:37:43 GMT
       etag:
-      - '"1D60983920F0A75"'
+      - '"1D617A7347FA70B"'
       expires:
       - '-1'
       pragma:
@@ -1699,7 +1755,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '498'
+      - '499'
       x-powered-by:
       - ASP.NET
     status:
@@ -1719,8 +1775,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: GET
@@ -1728,18 +1784,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-309.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-03T06:47:51.36","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"C3E7C05FE8A97695B3AE08C1935F4251C48E338FE439627B2E788D9D718C8A70","kind":"app","inboundIpAddress":"13.69.68.42","possibleInboundIpAddresses":"13.69.68.42","outboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211","possibleOutboundIpAddresses":"13.69.68.42,13.95.8.34,52.174.20.232,52.174.23.121,137.116.220.211,13.81.108.29,13.81.60.108,13.94.135.163,40.68.255.234,52.174.23.159","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-309","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:37:43.0166667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3619'
+      - '3614'
       content-type:
       - application/json
       date:
-      - Fri, 03 Apr 2020 06:47:55 GMT
+      - Tue, 21 Apr 2020 06:37:44 GMT
       etag:
-      - '"1D60983CB80F400"'
+      - '"1D617A75C56A08B"'
       expires:
       - '-1'
       pragma:
@@ -1779,8 +1835,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.7.6 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.3.1
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
       accept-language:
       - en-US
     method: POST
@@ -1789,17 +1845,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000003 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="ekJmRYC6dmpPipihDwcQwCfJzbnTZphHm4WPRhxqkPfNKqG5veiA4Gcsun6q"
+        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-309.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="ekJmRYC6dmpPipihDwcQwCfJzbnTZphHm4WPRhxqkPfNKqG5veiA4Gcsun6q"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-297.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-309dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="ekJmRYC6dmpPipihDwcQwCfJzbnTZphHm4WPRhxqkPfNKqG5veiA4Gcsun6q"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-297dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -1811,7 +1867,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 03 Apr 2020 06:47:58 GMT
+      - Tue, 21 Apr 2020 06:37:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1825,7 +1881,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11995'
+      - '11999'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:13Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:10Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:07:19 GMT
+      - Tue, 12 May 2020 19:31:15 GMT
       expires:
       - '-1'
       pragma:
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:20 GMT
+      - Tue, 12 May 2020 19:31:17 GMT
       expires:
       - '-1'
       pragma:
@@ -126,7 +126,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:13Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:10Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -135,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:07:21 GMT
+      - Tue, 12 May 2020 19:31:17 GMT
       expires:
       - '-1'
       pragma:
@@ -177,8 +177,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":31600,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-161_31600","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31247,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31247","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:29 GMT
+      - Tue, 12 May 2020 19:31:25 GMT
       expires:
       - '-1'
       pragma:
@@ -234,8 +234,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":31600,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-161_31600","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31247,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31247","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -244,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:30 GMT
+      - Tue, 12 May 2020 19:31:26 GMT
       expires:
       - '-1'
       pragma:
@@ -302,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:31 GMT
+      - Tue, 12 May 2020 19:31:27 GMT
       expires:
       - '-1'
       pragma:
@@ -349,8 +349,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":31600,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-161_31600","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31247,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31247","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +359,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:33 GMT
+      - Tue, 12 May 2020 19:31:28 GMT
       expires:
       - '-1'
       pragma:
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:34 GMT
+      - Tue, 12 May 2020 19:31:29 GMT
       expires:
       - '-1'
       pragma:
@@ -469,18 +469,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:37.26","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:32.7966667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3723'
+      - '3725'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:54 GMT
+      - Tue, 12 May 2020 19:31:49 GMT
       etag:
-      - '"1D6281B41635AAB"'
+      - '"1D62893F18F1D00"'
       expires:
       - '-1'
       pragma:
@@ -532,17 +532,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000003 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
+        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-161dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 12 May 2020 05:07:55 GMT
+      - Tue, 12 May 2020 19:31:49 GMT
       expires:
       - '-1'
       pragma:
@@ -596,7 +596,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:13Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:10Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -605,7 +605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:07:56 GMT
+      - Tue, 12 May 2020 19:31:51 GMT
       expires:
       - '-1'
       pragma:
@@ -665,19 +665,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:07:58 GMT
+      - Tue, 12 May 2020 19:31:51 GMT
       duration:
-      - '1121706'
+      - '757920'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - C9HzIAu8sf3ZdxROmT8HhmxgHchIgClb0lVlCryzFUI=
+      - xsKs6kcygFymxnFIvb6Zu9yFcc/0RKWgC8AUyuRFnTk=
       ocp-aad-session-key:
-      - jU0uA9IyihSP8o9bPpTy5fSDQq01aS-j74eor7jqq-6mdx3WcMiWGu73JQSCx1qLJ4HWu43aab0r_2XlI3a_25V93e3J9V18WIZAMbGwOwYoU7p0kxD3Wwc2T98tGvGI.My3_qyGveo17ucNGTaWXYGZp_D1msQo8N2uRVmOAzBI
+      - en4lIjHpAi4du5Dbe3DAjO5JT6bm0p65I1MMTw6gCwL-o3mntX-900IzSGD8K_lrUnjqsjosN4naiLxCuWrkZuZG_NTWgXCVIk06Li4jT0P732PgNoChOiOOo3m6vDwl.NsGbFe5Q2ohjIJRF6BY_Ux3KDdFeAWlAwhE2WPJvLEI
       pragma:
       - no-cache
       request-id:
-      - 5d2a9442-26d3-412d-8639-3ae10bc0804f
+      - 2452d4c1-f179-411f-b3f8-652d3a896911
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -734,7 +734,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:01 GMT
+      - Tue, 12 May 2020 19:31:55 GMT
       expires:
       - '-1'
       pragma:
@@ -789,7 +789,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:33 GMT
+      - Tue, 12 May 2020 19:32:26 GMT
       expires:
       - '-1'
       pragma:
@@ -849,19 +849,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:08:35 GMT
+      - Tue, 12 May 2020 19:32:27 GMT
       duration:
-      - '1520250'
+      - '543027'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - kRuloLn7w9ZM2KqLmZGPpy3rrvNTiCwdCWz+CJa/570=
+      - DTbc+ix7+LLHlTTkVueMm+LsccsKsJNfJqnQvKw39+w=
       ocp-aad-session-key:
-      - cdZ17VboG4LyAiDCMMHA2b63QEPpP4ETQ2vFxqCSEwYYl3YoEB_erAL14c7uEiRSYQz1kgdKh7GmKOQnPi7-rsTXOfc5vRkdb1Y5bVnYjfDLCPIK3gO6zCrLpE7SLd4I.4J4glO6fiRtttEPWCFhdpjlVmA-kjcES2i_prWkFrP4
+      - 0rP77jEwPG4eMv6iBqbbs-Jbn0aZYGMP4Bn6l4ln3_HXFcW53gv2kha_hMqigMqmiDIhvgpLfWt8Ac0wx9lrD_Q0EdpOKGtYmBrY6eB3YVTOye0ACFrwwpFj4KiaxkDV.-5UteEmsvA0JCp4zsxlTEujA9VYiyx1cAwLvZLr2Ovw
       pragma:
       - no-cache
       request-id:
-      - 47609fe6-5a04-48c4-8f83-595f7030de5c
+      - 141ce193-3a67-4960-a14f-e77464466cb9
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -904,7 +904,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:35 GMT
+      - Tue, 12 May 2020 19:32:27 GMT
       expires:
       - '-1'
       pragma:
@@ -975,7 +975,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:36 GMT
+      - Tue, 12 May 2020 19:32:27 GMT
       expires:
       - '-1'
       pragma:
@@ -995,7 +995,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.278
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-powered-by:
       - ASP.NET
     status:
@@ -1033,7 +1033,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:37 GMT
+      - Tue, 12 May 2020 19:32:29 GMT
       expires:
       - '-1'
       pragma:
@@ -1084,7 +1084,7 @@ interactions:
     uri: https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/import?api-version=7.0
   response:
     body:
-      string: '{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/a42da491666540dc91cee15391963254","kid":"https://kv-ssl-test000004.vault.azure.net/keys/test-cert/a42da491666540dc91cee15391963254","sid":"https://kv-ssl-test000004.vault.azure.net/secrets/test-cert/a42da491666540dc91cee15391963254","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589260118,"updated":1589260118,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589260118,"updated":1589260118}}}'
+      string: '{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/a6b72fe4059346ac8a34e873af0713aa","kid":"https://kv-ssl-test000004.vault.azure.net/keys/test-cert/a6b72fe4059346ac8a34e873af0713aa","sid":"https://kv-ssl-test000004.vault.azure.net/secrets/test-cert/a6b72fe4059346ac8a34e873af0713aa","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589311950,"updated":1589311950,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589311950,"updated":1589311950}}}'
     headers:
       cache-control:
       - no-cache
@@ -1093,7 +1093,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:39 GMT
+      - Tue, 12 May 2020 19:32:30 GMT
       expires:
       - '-1'
       pragma:
@@ -1140,18 +1140,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.0266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:33.2","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3726'
+      - '3717'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:39 GMT
+      - Tue, 12 May 2020 19:32:31 GMT
       etag:
-      - '"1D6281B41635AAB"'
+      - '"1D62893F18F1D00"'
       expires:
       - '-1'
       pragma:
@@ -1195,16 +1195,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who","name":"madsd-who","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"88d52f7a-b7b2-4ccb-80a5-e4bab463396d","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who2","name":"madsd-who2","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who2.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who3","name":"madsd-who3","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://madsd-who3.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who4","name":"madsd-who4","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who4.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/certs/providers/Microsoft.KeyVault/vaults/tb-certs","name":"tb-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"6b244528-5604-411e-9ff1-5df31b00f93a","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"013244e3-a217-4ca4-bf2a-e65b263959cd","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"4dbab725-22a4-44d5-ad44-c267ca38a954","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"21bf1420-2ed9-48b9-bf6d-ece1337d4fd1","permissions":{"keys":[],"secrets":["Get"],"certificates":["Get"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"],"keys":[],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"ed47c2a1-bd23-4341-b39c-f4fd69138dd3","permissions":{"secrets":["Get","Set","Delete"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://tb-certs.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM="}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who","name":"madsd-who","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"88d52f7a-b7b2-4ccb-80a5-e4bab463396d","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who2","name":"madsd-who2","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who2.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who3","name":"madsd-who3","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://madsd-who3.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who4","name":"madsd-who4","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who4.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/certs/providers/Microsoft.KeyVault/vaults/tb-certs","name":"tb-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"6b244528-5604-411e-9ff1-5df31b00f93a","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"013244e3-a217-4ca4-bf2a-e65b263959cd","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"4dbab725-22a4-44d5-ad44-c267ca38a954","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"21bf1420-2ed9-48b9-bf6d-ece1337d4fd1","permissions":{"keys":[],"secrets":["Get"],"certificates":["Get"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"],"keys":[],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"ed47c2a1-bd23-4341-b39c-f4fd69138dd3","permissions":{"secrets":["Get","Set","Delete"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://tb-certs.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=ServiceBased,Tm9uZSxZMlZ5ZEhOOGRHSXRZMlZ5ZEhNPQ=="}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '7630'
+      - '7659'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:41 GMT
+      - Tue, 12 May 2020 19:32:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1247,19 +1247,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM=
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=ServiceBased,Tm9uZSxZMlZ5ZEhOOGRHSXRZMlZ5ZEhNPQ==
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgcnudntyhmvoeiyqtlcpn2yancwt7apjg2vgwtzgef5ea77yvd3qlxmtacdhee3fvb/providers/Microsoft.KeyVault/vaults/kv-ssl-testbb6qd4kxn","name":"kv-ssl-testbb6qd4kxn","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testbb6qd4kxn.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgx4rt26hzocre327frzultmovguawysetpl4k45efmie45x5h5ncwr2hcw6d2pvxsh/providers/Microsoft.KeyVault/vaults/kv-ssl-testjjfy5fv7k","name":"kv-ssl-testjjfy5fv7k","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testjjfy5fv7k.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2xpdGVzdC5yZ3g0cnQyNmh6b2NyZTMyN2ZyenVsdG1vdmd1YXd5c2V0cGw0azQ1ZWZtaWU0NXg1aDVuY3dyMmhjdzZkMnB2eHNofGt2LXNzbC10ZXN0ampmeTVmdjdr"}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgdeeybdgaon4bzatidwejnuguq3p25is2dqltzu4dgfxfizamnele32hom2hur6hyf/providers/Microsoft.KeyVault/vaults/kv-ssl-testbizfzvmi6","name":"kv-ssl-testbizfzvmi6","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testbizfzvmi6.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=ServiceBased,Tm9uZSxZMnhwZEdWemRDNXlaMmxoTm1ObE4yOTZabTFwY0cwMmVUWmlkbkl5ZVRkdk4zbHJkR1UyYWpOelkzQnFkbkptWVdNemJIZG5hMjl2Y3pkbVpUZHpjSFowWldSbmIzWnFObUpqZkd0MkxYTnpiQzEwWlhOMGFYZDNZV2w1ZUc5NA=="}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4161'
+      - '2940'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:41 GMT
+      - Tue, 12 May 2020 19:32:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1314,7 +1314,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:42 GMT
+      - Tue, 12 May 2020 19:32:33 GMT
       expires:
       - '-1'
       pragma:
@@ -1362,7 +1362,7 @@ interactions:
     body:
       string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
         ''0b9188a0-540d-4262-9311-61bb1a0235ef'' does not exist or one of its queried
-        reference-property objects are not present."},"requestId":"d6ae8b16-f939-41bc-b768-4a2e5aa286e1","date":"2020-05-12T05:08:42"}}'
+        reference-property objects are not present."},"requestId":"d1b6a798-673a-48e6-893a-82617372f83a","date":"2020-05-12T19:32:34"}}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1375,19 +1375,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:08:42 GMT
+      - Tue, 12 May 2020 19:32:33 GMT
       duration:
-      - '543030'
+      - '683244'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - nXlz28L4mvclWaIr6aYrPLvkq+aZFBTjRwfxg/IAWtA=
+      - CrKpb+/O96f7HIobOieq3ywuuUZ6uBiwPAqn3NvIBs0=
       ocp-aad-session-key:
-      - oFNSeTsAQIok1jZ6VrVSvfT3_tKsv4mTWWXAnGqpsHDWqjyveGr6Oi0-i9f3nWqlVXMQdASXVSgixXXiUF7p7j2Jo5kXbuGz_8Xjz71TOtP5troYL2kD69zyH0soKJk-.ZEaASJyLOv3Ce2ML0orrf9P67v9RIZQg7LnAD0b03tk
+      - 04kaLK7tp8fErcBZwhHpfDQGQMvSrofqXZ3hZFXl72JMmROGtGrPnhMM3Qg32WQhv5z0GnaIp45Uk7OB0ZC_aNjh6L572A5PNSEuctTxXSOscd5T_ZJl884RJdtVJ628.WQrzQ6iu1J9BqzlH9oC8BID1Zze4y90w7p7OrKdgPGU
       pragma:
       - no-cache
       request-id:
-      - d6ae8b16-f939-41bc-b768-4a2e5aa286e1
+      - d1b6a798-673a-48e6-893a-82617372f83a
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1439,19 +1439,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:08:43 GMT
+      - Tue, 12 May 2020 19:32:34 GMT
       duration:
-      - '530767'
+      - '583720'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - SG5zWAheXepBmH7JdRXr60mHGY06RS13iatxT8gotGU=
+      - DTbc+ix7+LLHlTTkVueMm+LsccsKsJNfJqnQvKw39+w=
       ocp-aad-session-key:
-      - BThoi0sHkCf1KLfA8xpRfFsOVlXkeov6tszYMuWAfULB1xA1KXWy89pbCQBrYdePBWJQXuoLqQrmbf9cYyw7lJuOd57-aeb8KnTAUc40xotjbIjn6aN48kXNhpTHzmBY.djxsg-AUVM7X05-nIfk8aAyUKmDVh9T7H6M_wjvCg4c
+      - N6hAei84H4-8u41K1z25rZ3EPBBftcZlbPGjMrVuwM_A8OAJv_4Vrhl5yxcOfi9UMdkx84_ztM1roa2jjRSiYWdgpV_Cdyv-9aBDrURDeSI9Nn9xMk4HimfOB-JmcSDs.wiZ7Ik8KboD_ZC8zMyaXYsdDlb0H0CdmYv159vfs-e0
       pragma:
       - no-cache
       request-id:
-      - 3e555653-3a19-47f4-a43a-2ffd09480c0b
+      - 050c744d-0775-4abf-8623-8ad7b56551c3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1501,7 +1501,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:45 GMT
+      - Tue, 12 May 2020 19:32:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1551,18 +1551,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.0266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:33.2","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3726'
+      - '3717'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:46 GMT
+      - Tue, 12 May 2020 19:32:38 GMT
       etag:
-      - '"1D6281B41635AAB"'
+      - '"1D62893F18F1D00"'
       expires:
       - '-1'
       pragma:
@@ -1607,18 +1607,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.0266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:33.2","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3726'
+      - '3717'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:47 GMT
+      - Tue, 12 May 2020 19:32:39 GMT
       etag:
-      - '"1D6281B41635AAB"'
+      - '"1D62893F18F1D00"'
       expires:
       - '-1'
       pragma:
@@ -1672,7 +1672,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:47 GMT
+      - Tue, 12 May 2020 19:32:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1726,9 +1726,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:47 GMT
+      - Tue, 12 May 2020 19:32:40 GMT
       etag:
-      - '"1D6281B41635AAB"'
+      - '"1D62893F18F1D00"'
       expires:
       - '-1'
       pragma:
@@ -1780,18 +1780,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:50.3733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:32:42.6033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3768'
+      - '3765'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:51 GMT
+      - Tue, 12 May 2020 19:32:43 GMT
       etag:
-      - '"1D6281B41635AAB"'
+      - '"1D62893F18F1D00"'
       expires:
       - '-1'
       pragma:
@@ -1838,18 +1838,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:50.3733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:32:42.6033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3766'
+      - '3763'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:51 GMT
+      - Tue, 12 May 2020 19:32:43 GMT
       etag:
-      - '"1D6281B6C829455"'
+      - '"1D628941AED38B5"'
       expires:
       - '-1'
       pragma:
@@ -1899,17 +1899,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000003 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
+        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-161dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -1921,7 +1921,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 12 May 2020 05:08:52 GMT
+      - Tue, 12 May 2020 19:32:44 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:10Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-13T05:37:27Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:31:15 GMT
+      - Wed, 13 May 2020 05:37:32 GMT
       expires:
       - '-1'
       pragma:
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:17 GMT
+      - Wed, 13 May 2020 05:37:34 GMT
       expires:
       - '-1'
       pragma:
@@ -126,7 +126,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:10Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-13T05:37:27Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -135,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:31:17 GMT
+      - Wed, 13 May 2020 05:37:34 GMT
       expires:
       - '-1'
       pragma:
@@ -177,8 +177,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":31247,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31247","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":33961,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-231_33961","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:25 GMT
+      - Wed, 13 May 2020 05:37:42 GMT
       expires:
       - '-1'
       pragma:
@@ -234,8 +234,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":31247,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31247","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":33961,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-231_33961","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -244,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:26 GMT
+      - Wed, 13 May 2020 05:37:48 GMT
       expires:
       - '-1'
       pragma:
@@ -302,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:27 GMT
+      - Wed, 13 May 2020 05:37:49 GMT
       expires:
       - '-1'
       pragma:
@@ -349,8 +349,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":31247,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31247","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":33961,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-231_33961","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +359,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:28 GMT
+      - Wed, 13 May 2020 05:37:50 GMT
       expires:
       - '-1'
       pragma:
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:29 GMT
+      - Wed, 13 May 2020 05:37:51 GMT
       expires:
       - '-1'
       pragma:
@@ -469,18 +469,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:32.7966667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-231.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:37:55.2","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.137.106.13","possibleInboundIpAddresses":"51.137.106.13","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-231.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115","possibleOutboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115,23.97.138.9,168.63.98.31,51.144.82.49","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-231","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3725'
+      - '3729'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:49 GMT
+      - Wed, 13 May 2020 05:38:12 GMT
       etag:
-      - '"1D62893F18F1D00"'
+      - '"1D628E8A75DAEAB"'
       expires:
       - '-1'
       pragma:
@@ -532,17 +532,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000003 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
+        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="8fRe3cd2bdY2rE6wj55KppMdzxGyuCK7SetiRa1vop1s2KWm3bchjfAQvTZy"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-231.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="8fRe3cd2bdY2rE6wj55KppMdzxGyuCK7SetiRa1vop1s2KWm3bchjfAQvTZy"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-231dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="8fRe3cd2bdY2rE6wj55KppMdzxGyuCK7SetiRa1vop1s2KWm3bchjfAQvTZy"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 12 May 2020 19:31:49 GMT
+      - Wed, 13 May 2020 05:38:12 GMT
       expires:
       - '-1'
       pragma:
@@ -596,7 +596,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:10Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-13T05:37:27Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -605,7 +605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:31:51 GMT
+      - Wed, 13 May 2020 05:38:15 GMT
       expires:
       - '-1'
       pragma:
@@ -665,19 +665,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 19:31:51 GMT
+      - Wed, 13 May 2020 05:38:16 GMT
       duration:
-      - '757920'
+      - '1105184'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - xsKs6kcygFymxnFIvb6Zu9yFcc/0RKWgC8AUyuRFnTk=
+      - HA51yM5VLGWqlsr+MKUciJ18FR464COzZqLyBqIgdmk=
       ocp-aad-session-key:
-      - en4lIjHpAi4du5Dbe3DAjO5JT6bm0p65I1MMTw6gCwL-o3mntX-900IzSGD8K_lrUnjqsjosN4naiLxCuWrkZuZG_NTWgXCVIk06Li4jT0P732PgNoChOiOOo3m6vDwl.NsGbFe5Q2ohjIJRF6BY_Ux3KDdFeAWlAwhE2WPJvLEI
+      - 4bz4xNWXZRVwDc-QHm2NlyIItLjKJweSE62TLa-Gsslt9VStE_McUI1KB8nXo5iu6s9ijkHZFk2uQn189d98HQhLnDMpPaKlbIxwHDMtkkQr7b28ClT5GkQWauqurIPo.A8ZAZCdq2EBNHB2awZtfX_CCLtx0uSGg-qTuAYUk1Hk
       pragma:
       - no-cache
       request-id:
-      - 2452d4c1-f179-411f-b3f8-652d3a896911
+      - 25744b1b-c01a-4bb9-aff0-76fba8ce5fe4
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -734,7 +734,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:31:55 GMT
+      - Wed, 13 May 2020 05:38:19 GMT
       expires:
       - '-1'
       pragma:
@@ -789,7 +789,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:26 GMT
+      - Wed, 13 May 2020 05:38:49 GMT
       expires:
       - '-1'
       pragma:
@@ -849,19 +849,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 19:32:27 GMT
+      - Wed, 13 May 2020 05:38:52 GMT
       duration:
-      - '543027'
+      - '703632'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - DTbc+ix7+LLHlTTkVueMm+LsccsKsJNfJqnQvKw39+w=
+      - vyaB9+uzNmJCCt/ra5+noSb0zb6oSP5oVO18uV/JFh0=
       ocp-aad-session-key:
-      - 0rP77jEwPG4eMv6iBqbbs-Jbn0aZYGMP4Bn6l4ln3_HXFcW53gv2kha_hMqigMqmiDIhvgpLfWt8Ac0wx9lrD_Q0EdpOKGtYmBrY6eB3YVTOye0ACFrwwpFj4KiaxkDV.-5UteEmsvA0JCp4zsxlTEujA9VYiyx1cAwLvZLr2Ovw
+      - mQG3mw86iQ7C_WBR0cL_ZAK0DxmNAyAg6_J8BPJgzdjf9VdNaBufg2QWh2MMI7VjBpm0WRbxp-YcQSNT_XGn3kJPzrPycAx7ERbUBRA5EDdFkukpccKp7-6SI7Hbnkuo.PIsAueTkSU1REOeyRqvHcy-RgBSDT5eS_0OdeGraOO8
       pragma:
       - no-cache
       request-id:
-      - 141ce193-3a67-4960-a14f-e77464466cb9
+      - 5eb70516-a828-4ce8-a350-8e8f206beef5
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -904,7 +904,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:27 GMT
+      - Wed, 13 May 2020 05:38:52 GMT
       expires:
       - '-1'
       pragma:
@@ -975,7 +975,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:27 GMT
+      - Wed, 13 May 2020 05:38:52 GMT
       expires:
       - '-1'
       pragma:
@@ -995,7 +995,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.278
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -1033,7 +1033,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:29 GMT
+      - Wed, 13 May 2020 05:38:54 GMT
       expires:
       - '-1'
       pragma:
@@ -1050,7 +1050,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=185.107.14.16;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=80.199.117.23;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
@@ -1084,7 +1084,7 @@ interactions:
     uri: https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/import?api-version=7.0
   response:
     body:
-      string: '{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/a6b72fe4059346ac8a34e873af0713aa","kid":"https://kv-ssl-test000004.vault.azure.net/keys/test-cert/a6b72fe4059346ac8a34e873af0713aa","sid":"https://kv-ssl-test000004.vault.azure.net/secrets/test-cert/a6b72fe4059346ac8a34e873af0713aa","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589311950,"updated":1589311950,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589311950,"updated":1589311950}}}'
+      string: '{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/bfb1278490cb41f6b047635519d6d5ee","kid":"https://kv-ssl-test000004.vault.azure.net/keys/test-cert/bfb1278490cb41f6b047635519d6d5ee","sid":"https://kv-ssl-test000004.vault.azure.net/secrets/test-cert/bfb1278490cb41f6b047635519d6d5ee","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589348336,"updated":1589348336,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589348336,"updated":1589348336}}}'
     headers:
       cache-control:
       - no-cache
@@ -1093,7 +1093,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:30 GMT
+      - Wed, 13 May 2020 05:38:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1107,7 +1107,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=185.107.14.16;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=80.199.117.23;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
@@ -1140,18 +1140,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:33.2","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-231.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:37:55.9466667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.137.106.13","possibleInboundIpAddresses":"51.137.106.13","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-231.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115","possibleOutboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115,23.97.138.9,168.63.98.31,51.144.82.49","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-231","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3717'
+      - '3733'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:31 GMT
+      - Wed, 13 May 2020 05:38:57 GMT
       etag:
-      - '"1D62893F18F1D00"'
+      - '"1D628E8A75DAEAB"'
       expires:
       - '-1'
       pragma:
@@ -1195,16 +1195,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who","name":"madsd-who","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"88d52f7a-b7b2-4ccb-80a5-e4bab463396d","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who2","name":"madsd-who2","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who2.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who3","name":"madsd-who3","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://madsd-who3.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who4","name":"madsd-who4","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who4.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/certs/providers/Microsoft.KeyVault/vaults/tb-certs","name":"tb-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"6b244528-5604-411e-9ff1-5df31b00f93a","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"013244e3-a217-4ca4-bf2a-e65b263959cd","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"4dbab725-22a4-44d5-ad44-c267ca38a954","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"21bf1420-2ed9-48b9-bf6d-ece1337d4fd1","permissions":{"keys":[],"secrets":["Get"],"certificates":["Get"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"],"keys":[],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"ed47c2a1-bd23-4341-b39c-f4fd69138dd3","permissions":{"secrets":["Get","Set","Delete"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://tb-certs.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=ServiceBased,Tm9uZSxZMlZ5ZEhOOGRHSXRZMlZ5ZEhNPQ=="}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who","name":"madsd-who","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"88d52f7a-b7b2-4ccb-80a5-e4bab463396d","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who2","name":"madsd-who2","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who2.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who3","name":"madsd-who3","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://madsd-who3.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who4","name":"madsd-who4","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who4.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/certs/providers/Microsoft.KeyVault/vaults/tb-certs","name":"tb-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"6b244528-5604-411e-9ff1-5df31b00f93a","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"013244e3-a217-4ca4-bf2a-e65b263959cd","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"4dbab725-22a4-44d5-ad44-c267ca38a954","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"21bf1420-2ed9-48b9-bf6d-ece1337d4fd1","permissions":{"keys":[],"secrets":["Get"],"certificates":["Get"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"],"keys":[],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"ed47c2a1-bd23-4341-b39c-f4fd69138dd3","permissions":{"secrets":["Get","Set","Delete"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://tb-certs.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM="}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '7659'
+      - '7630'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:32 GMT
+      - Wed, 13 May 2020 05:38:57 GMT
       expires:
       - '-1'
       pragma:
@@ -1247,19 +1247,74 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=ServiceBased,Tm9uZSxZMlZ5ZEhOOGRHSXRZMlZ5ZEhNPQ==
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM=
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgdeeybdgaon4bzatidwejnuguq3p25is2dqltzu4dgfxfizamnele32hom2hur6hyf/providers/Microsoft.KeyVault/vaults/kv-ssl-testbizfzvmi6","name":"kv-ssl-testbizfzvmi6","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testbizfzvmi6.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=ServiceBased,Tm9uZSxZMnhwZEdWemRDNXlaMmxoTm1ObE4yOTZabTFwY0cwMmVUWmlkbkl5ZVRkdk4zbHJkR1UyYWpOelkzQnFkbkptWVdNemJIZG5hMjl2Y3pkbVpUZHpjSFowWldSbmIzWnFObUpqZkd0MkxYTnpiQzEwWlhOMGFYZDNZV2w1ZUc5NA=="}'
+      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2xpdGVzdC5yZ2lhNmNlN296Zm1pcG02eTZidnIyeTdvN3lrdGU2ajNzY3BqdnJmYWMzbHdna29vczdmZTdzcHZ0ZWRnb3ZqNmJjfGt2LXNzbC10ZXN0aXd3YWl5eG94"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2940'
+      - '304'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:32 GMT
+      - Wed, 13 May 2020 05:38:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2xpdGVzdC5yZ2lhNmNlN296Zm1pcG02eTZidnIyeTdvN3lrdGU2ajNzY3BqdnJmYWMzbHdna29vczdmZTdzcHZ0ZWRnb3ZqNmJjfGt2LXNzbC10ZXN0aXd3YWl5eG94
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgpebygg6denaownx3ewwp3ebafnzhdfqdi2nho5zjwtxyhjsxs7kaorzx37vs4xehz/providers/Microsoft.KeyVault/vaults/kv-ssl-testcc4lknf5s","name":"kv-ssl-testcc4lknf5s","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testcc4lknf5s.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2xpdGVzdC5yZ3g0cnQyNmh6b2NyZTMyN2ZyenVsdG1vdmd1YXd5c2V0cGw0azQ1ZWZtaWU0NXg1aDVuY3dyMmhjdzZkMnB2eHNofGt2LXNzbC10ZXN0ampmeTVmdjdr"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2875'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 13 May 2020 05:38:58 GMT
       expires:
       - '-1'
       pragma:
@@ -1314,7 +1369,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:33 GMT
+      - Wed, 13 May 2020 05:38:59 GMT
       expires:
       - '-1'
       pragma:
@@ -1362,7 +1417,7 @@ interactions:
     body:
       string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
         ''0b9188a0-540d-4262-9311-61bb1a0235ef'' does not exist or one of its queried
-        reference-property objects are not present."},"requestId":"d1b6a798-673a-48e6-893a-82617372f83a","date":"2020-05-12T19:32:34"}}'
+        reference-property objects are not present."},"requestId":"92802133-6f8c-4f83-8a4c-988cfac0a459","date":"2020-05-13T05:39:00"}}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1375,19 +1430,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 19:32:33 GMT
+      - Wed, 13 May 2020 05:38:59 GMT
       duration:
-      - '683244'
+      - '622397'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - CrKpb+/O96f7HIobOieq3ywuuUZ6uBiwPAqn3NvIBs0=
+      - A0I+8kJwgN1zJUPshFGq3UbFlmzMA3hx23rZo+7kr7E=
       ocp-aad-session-key:
-      - 04kaLK7tp8fErcBZwhHpfDQGQMvSrofqXZ3hZFXl72JMmROGtGrPnhMM3Qg32WQhv5z0GnaIp45Uk7OB0ZC_aNjh6L572A5PNSEuctTxXSOscd5T_ZJl884RJdtVJ628.WQrzQ6iu1J9BqzlH9oC8BID1Zze4y90w7p7OrKdgPGU
+      - QjXJ70jIBr__YL5x1nNIOgiEDYjNYZsMb6zGKtdhaMf78XKtsYGO3u2VPH6AEPN-lSJ1M9n3Ej4sgwoDh5QF6nOqfmoucKuKlgjZeItdfDUAR9y_xaODt7qQDDqmsP-p.AtUD5PRHR4eHh1YgXIsu7SftVSuz442yTDDFR6LCLFY
       pragma:
       - no-cache
       request-id:
-      - d1b6a798-673a-48e6-893a-82617372f83a
+      - 92802133-6f8c-4f83-8a4c-988cfac0a459
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1439,19 +1494,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 19:32:34 GMT
+      - Wed, 13 May 2020 05:38:59 GMT
       duration:
-      - '583720'
+      - '648590'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - DTbc+ix7+LLHlTTkVueMm+LsccsKsJNfJqnQvKw39+w=
+      - NCLikt5gA/KhTFVr9i6W+Ah7pWAcW54TIy83Z9kJVH0=
       ocp-aad-session-key:
-      - N6hAei84H4-8u41K1z25rZ3EPBBftcZlbPGjMrVuwM_A8OAJv_4Vrhl5yxcOfi9UMdkx84_ztM1roa2jjRSiYWdgpV_Cdyv-9aBDrURDeSI9Nn9xMk4HimfOB-JmcSDs.wiZ7Ik8KboD_ZC8zMyaXYsdDlb0H0CdmYv159vfs-e0
+      - dm6p9V0on5vLuReMidn9Xj2ldc46g8hMp1WQX7MKHhpGs45ZYmips6spzMw6ZarxIt8gtgVqE-mpTqEtNbuJufqQ2KfslLS9OwB1EcMZFSLY6wDyozRgApvYteXyYDTr.rjtUMSPEJK-gnik3UYsKA1LtlbbkD9-4f4UPqP6pcag
       pragma:
       - no-cache
       request-id:
-      - 050c744d-0775-4abf-8623-8ad7b56551c3
+      - d20d8aa5-f75d-49a6-9376-3e800b18e819
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1501,7 +1556,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:37 GMT
+      - Wed, 13 May 2020 05:39:02 GMT
       expires:
       - '-1'
       pragma:
@@ -1551,18 +1606,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:33.2","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-231.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:37:55.9466667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.137.106.13","possibleInboundIpAddresses":"51.137.106.13","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-231.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115","possibleOutboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115,23.97.138.9,168.63.98.31,51.144.82.49","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-231","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3717'
+      - '3733'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:38 GMT
+      - Wed, 13 May 2020 05:39:03 GMT
       etag:
-      - '"1D62893F18F1D00"'
+      - '"1D628E8A75DAEAB"'
       expires:
       - '-1'
       pragma:
@@ -1607,18 +1662,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:33.2","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-231.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:37:55.9466667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.137.106.13","possibleInboundIpAddresses":"51.137.106.13","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-231.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115","possibleOutboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115,23.97.138.9,168.63.98.31,51.144.82.49","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-231","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3717'
+      - '3733'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:39 GMT
+      - Wed, 13 May 2020 05:39:04 GMT
       etag:
-      - '"1D62893F18F1D00"'
+      - '"1D628E8A75DAEAB"'
       expires:
       - '-1'
       pragma:
@@ -1672,7 +1727,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:39 GMT
+      - Wed, 13 May 2020 05:39:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1726,9 +1781,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:40 GMT
+      - Wed, 13 May 2020 05:39:13 GMT
       etag:
-      - '"1D62893F18F1D00"'
+      - '"1D628E8A75DAEAB"'
       expires:
       - '-1'
       pragma:
@@ -1780,18 +1835,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:32:42.6033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-231.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:39:15.2666667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.137.106.13","possibleInboundIpAddresses":"51.137.106.13","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-231.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115","possibleOutboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115,23.97.138.9,168.63.98.31,51.144.82.49","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-231","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3765'
+      - '3775'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:43 GMT
+      - Wed, 13 May 2020 05:39:15 GMT
       etag:
-      - '"1D62893F18F1D00"'
+      - '"1D628E8A75DAEAB"'
       expires:
       - '-1'
       pragma:
@@ -1838,18 +1893,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:32:42.6033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-231.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:39:15.2666667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.137.106.13","possibleInboundIpAddresses":"51.137.106.13","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-231.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115","possibleOutboundIpAddresses":"51.137.106.13,23.97.143.58,104.46.35.14,40.91.195.130,104.46.56.115,23.97.138.9,168.63.98.31,51.144.82.49","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-231","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3763'
+      - '3773'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:43 GMT
+      - Wed, 13 May 2020 05:39:17 GMT
       etag:
-      - '"1D628941AED38B5"'
+      - '"1D628E8D6A4F42B"'
       expires:
       - '-1'
       pragma:
@@ -1899,17 +1954,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000003 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
+        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="8fRe3cd2bdY2rE6wj55KppMdzxGyuCK7SetiRa1vop1s2KWm3bchjfAQvTZy"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-231.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="8fRe3cd2bdY2rE6wj55KppMdzxGyuCK7SetiRa1vop1s2KWm3bchjfAQvTZy"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="QxP61fSPvX2kmuejeuTWN1gg7kpeJQvuyYqcW75BFjE05ii7zwguA06aeKcQ"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-231dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="8fRe3cd2bdY2rE6wj55KppMdzxGyuCK7SetiRa1vop1s2KWm3bchjfAQvTZy"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -1921,7 +1976,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 12 May 2020 19:32:44 GMT
+      - Wed, 13 May 2020 05:39:18 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import.yaml
@@ -14,14 +14,14 @@ interactions:
       - -g -n --sku
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-04-21T06:36:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:13Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 06:36:19 GMT
+      - Tue, 12 May 2020 05:07:19 GMT
       expires:
       - '-1'
       pragma:
@@ -64,7 +64,7 @@ interactions:
       - -g -n --sku
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: POST
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:36:20 GMT
+      - Tue, 12 May 2020 05:07:20 GMT
       expires:
       - '-1'
       pragma:
@@ -119,14 +119,14 @@ interactions:
       - -g -n --sku
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-04-21T06:36:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:13Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -135,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 06:36:21 GMT
+      - Tue, 12 May 2020 05:07:21 GMT
       expires:
       - '-1'
       pragma:
@@ -169,7 +169,7 @@ interactions:
       - -g -n --sku
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
@@ -177,8 +177,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":26380,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-297_26380","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31600,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-161_31600","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:36:29 GMT
+      - Tue, 12 May 2020 05:07:29 GMT
       expires:
       - '-1'
       pragma:
@@ -226,7 +226,7 @@ interactions:
       - -g -n --plan
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -234,8 +234,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":26380,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-297_26380","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31600,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-161_31600","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -244,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:36:30 GMT
+      - Tue, 12 May 2020 05:07:30 GMT
       expires:
       - '-1'
       pragma:
@@ -286,7 +286,7 @@ interactions:
       - -g -n --plan
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: POST
@@ -302,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:36:30 GMT
+      - Tue, 12 May 2020 05:07:31 GMT
       expires:
       - '-1'
       pragma:
@@ -341,7 +341,7 @@ interactions:
       - -g -n --plan
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -349,8 +349,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":26380,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-297_26380","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31600,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-161_31600","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +359,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:36:31 GMT
+      - Tue, 12 May 2020 05:07:33 GMT
       expires:
       - '-1'
       pragma:
@@ -400,7 +400,7 @@ interactions:
       - -g -n --plan
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: POST
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:36:31 GMT
+      - Tue, 12 May 2020 05:07:34 GMT
       expires:
       - '-1'
       pragma:
@@ -461,7 +461,7 @@ interactions:
       - -g -n --plan
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
@@ -469,18 +469,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:36:35.47","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:37.26","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3571'
+      - '3723'
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:36:51 GMT
+      - Tue, 12 May 2020 05:07:54 GMT
       etag:
-      - '"1D617A7347FA70B"'
+      - '"1D6281B41635AAB"'
       expires:
       - '-1'
       pragma:
@@ -523,7 +523,7 @@ interactions:
       - -g -n --plan
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: POST
@@ -532,17 +532,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000003 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
+        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-297.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-297dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-161dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 21 Apr 2020 06:36:53 GMT
+      - Tue, 12 May 2020 05:07:55 GMT
       expires:
       - '-1'
       pragma:
@@ -589,14 +589,14 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-04-21T06:36:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:13Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -605,7 +605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 06:36:53 GMT
+      - Tue, 12 May 2020 05:07:56 GMT
       expires:
       - '-1'
       pragma:
@@ -638,9 +638,9 @@ interactions:
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":["65cc641f-cccd-4643-97e0-a17e3045e541","e26c2fcc-ab91-4a61-b35c-03cdc8dddf66","46129a58-a698-46f0-aa5b-17f6586297d9","6db1f1db-2b46-403f-be40-e39395f08dbb","6dc145d6-95dd-4191-b9c3-185575ee6f6b","41fcdd7d-4733-4863-9cf4-c65b83ce2df4","2f442157-a11c-46b9-ae5b-6e39ff4e5849","c4801e8a-cb58-4c35-aca6-f2dcc106f287","0898bdbb-73b0-471a-81e5-20f1fe4dd66e","617b097b-4b93-4ede-83de-5f075bb5fb2f","33c4f319-9bdd-48d6-9c4d-410b750a4a5a","4828c8ec-dc2e-4779-b502-87ac9ce28ab7","3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"],"skuId":"c7df2760-2c81-4ef7-b578-5b5392b571df"},{"disabledPlans":["39b5c996-467e-4e60-bd62-46066f572726"],"skuId":"90d8b3f8-712e-4f7b-aa1e-62e7ae6cbe96"},{"disabledPlans":["e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72"],"skuId":"09015f9f-377f-4538-bbb5-f75ceb09358a"},{"disabledPlans":[],"skuId":"dcb1a3ae-b33f-4487-846a-a640262fadf4"},{"disabledPlans":[],"skuId":"f30db892-07e9-47e9-837c-80727f46fd3d"},{"disabledPlans":[],"skuId":"26a18e8f-4d14-46f8-835a-ed3ba424a961"},{"disabledPlans":[],"skuId":"412ce1a7-a499-41b3-8eb6-b38f2bbc5c3f"},{"disabledPlans":[],"skuId":"488ba24a-39a9-4473-8ee5-19291e71b002"},{"disabledPlans":[],"skuId":"b05e124f-c7cc-45a0-a6aa-8cf78c946968"},{"disabledPlans":["0b03f40b-c404-40c3-8651-2aceb74365fa","b650d915-9886-424b-a08d-633cede56f57","e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72","fe71d6c3-a2ea-4499-9778-da042bf08063","fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"],"skuId":"ea126fc5-a19e-42e2-a731-da9d437bffcf"},{"disabledPlans":[],"skuId":"c5928f49-12ba-48f7-ada3-0d743a3601d5"},{"disabledPlans":[],"skuId":"87bbbc60-4754-4998-8c88-227dca264858"}],"assignedPlans":[{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"},{"assignedTimestamp":"2019-11-04T20:02:03Z","capabilityStatus":"Enabled","service":"WhiteboardServices","servicePlanId":"4a51bca5-1eff-43f5-878c-177680f191af"},{"assignedTimestamp":"2019-10-15T04:17:14Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"5136a095-5cf0-4aff-bec3-e84448b38ea5"},{"assignedTimestamp":"2019-10-15T04:17:14Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb0351d-3b08-4503-993d-383af8de41e3"},{"assignedTimestamp":"2019-08-08T23:29:37Z","capabilityStatus":"Enabled","service":"MicrosoftFormsProTest","servicePlanId":"97f29a83-1a20-44ff-bf48-5e4ad11f3e51"},{"assignedTimestamp":"2019-05-23T01:47:36Z","capabilityStatus":"Enabled","service":"DYN365AISERVICEINSIGHTS","servicePlanId":"1412cdc1-d593-4ad1-9050-40c30ad0b023"},{"assignedTimestamp":"2019-05-09T22:32:19Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"199a5c09-e0ca-4e37-8f7c-b05d533e1ea2"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"ProjectProgramsAndPortfolios","servicePlanId":"818523f5-016b-4355-9be8-ed6944946ea7"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"fa200448-008c-4acb-abd4-ea106ed2199d"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"50554c47-71d9-49fd-bc54-42a2765c555c"},{"assignedTimestamp":"2018-11-18T17:43:28Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"d20bfa21-e9ae-43fc-93c2-20783f0840c3"},{"assignedTimestamp":"2018-11-18T17:43:28Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"d5368ca3-357e-4acb-9c21-8495fb025d1f"},{"assignedTimestamp":"2018-11-17T17:45:51Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"50e68c76-46c6-4674-81f9-75456511b170"},{"assignedTimestamp":"2018-11-17T17:45:51Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"17ab22cd-a0b3-4536-910a-cb6eb12696c0"},{"assignedTimestamp":"2018-10-11T18:25:27Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"018fb91e-cee3-418c-9063-d7562978bdaf"},{"assignedTimestamp":"2018-10-11T18:25:26Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"ca4be917-fbce-4b52-839e-6647467a1668"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"b1188c4c-1b36-4018-b48b-ee07604f6feb"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"4828c8ec-dc2e-4779-b502-87ac9ce28ab7"},{"assignedTimestamp":"2018-08-29T07:16:06Z","capabilityStatus":"Enabled","service":"Sway","servicePlanId":"a23b959c-7ce8-4e57-9140-b90eb88a9e97"},{"assignedTimestamp":"2018-08-29T07:16:06Z","capabilityStatus":"Deleted","service":"OfficeForms","servicePlanId":"159f4cd6-e380-449f-a816-af1a9ef76344"},{"assignedTimestamp":"2018-04-26T17:45:50Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"bea4c11e-220a-4e6d-8eb8-8ea15d019f90"},{"assignedTimestamp":"2018-04-26T17:45:50Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"6c57d4b6-3b23-47a5-9bc9-69f17b4947b3"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"2125cfd7-2110-4567-83c4-c1cd5275163d"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"c4048e79-4474-4c74-ba9b-c31ff225e511"},{"assignedTimestamp":"2018-03-20T15:10:18Z","capabilityStatus":"Deleted","service":"MicrosoftStream","servicePlanId":"acffdce6-c30f-4dc2-81c0-372e33c515ec"},{"assignedTimestamp":"2018-03-17T08:10:29Z","capabilityStatus":"Enabled","service":"WindowsDefenderATP","servicePlanId":"871d91ec-ec1a-452b-a83f-bd76c7d770ef"},{"assignedTimestamp":"2018-03-17T08:10:29Z","capabilityStatus":"Enabled","service":"Windows","servicePlanId":"e7c91390-7625-45be-94e0-e16907e03118"},{"assignedTimestamp":"2018-03-17T02:35:48Z","capabilityStatus":"Enabled","service":"AzureAdvancedThreatAnalytics","servicePlanId":"14ab5db5-e6c4-4b20-b4bc-13e36fd2227f"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"CRM","servicePlanId":"bf36ca64-95c6-4918-9275-eb9f4ce2c04f"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"PowerAppsService","servicePlanId":"874fc546-6efe-4d22-90b8-5c4e7aa59f4b"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"ProcessSimple","servicePlanId":"7e6d7d78-73de-46ba-83b1-6d25117334ba"},{"assignedTimestamp":"2018-01-09T00:28:58Z","capabilityStatus":"Enabled","service":"ProjectWorkManagement","servicePlanId":"b737dad2-2f6c-4c65-90e3-ca563267e8b9"},{"assignedTimestamp":"2017-12-31T23:10:50Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"41781fb2-bc02-4b7c-bd55-b576c07bb09d"},{"assignedTimestamp":"2017-12-31T23:10:50Z","capabilityStatus":"Enabled","service":"MultiFactorService","servicePlanId":"8a256a2b-b617-496d-b51b-e76466e88db0"},{"assignedTimestamp":"2017-12-31T06:32:41Z","capabilityStatus":"Deleted","service":"Adallom","servicePlanId":"932ad362-64a8-4783-9106-97849a1a30b9"},{"assignedTimestamp":"2017-12-16T19:57:33Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"5689bec4-755d-4753-8b61-40975025187c"},{"assignedTimestamp":"2017-12-16T19:57:33Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"2e2ddb96-6af9-4b1d-a3f0-d6ecfd22edb2"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"8c098270-9dd4-4350-9b30-ba4703f3b36b"},{"assignedTimestamp":"2017-11-12T20:20:22Z","capabilityStatus":"Enabled","service":"To-Do","servicePlanId":"3fb82609-8c27-4f7b-bd51-30634711ee67"},{"assignedTimestamp":"2017-10-07T01:41:03Z","capabilityStatus":"Enabled","service":"Netbreeze","servicePlanId":"03acaee3-9492-4f40-aed4-bcb6b32981b6"},{"assignedTimestamp":"2017-10-07T01:41:03Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"d56f3deb-50d8-465a-bedb-f079817ccac1"},{"assignedTimestamp":"2017-06-26T10:50:26Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"e212cbc7-0961-4c40-9825-01117710dcb1"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"MicrosoftStream","servicePlanId":"6c6042f5-6f01-4d67-b8c1-eb99d36eed3e"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"eec0eb4f-6444-4f95-aba0-50c24d67f998"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"SCO","servicePlanId":"c1ec4a95-1f05-45b3-a911-aa3fa01094f5"},{"assignedTimestamp":"2017-05-13T01:11:22Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"8e0c0a52-6a6c-4d40-8370-dd62790dcd70"},{"assignedTimestamp":"2017-02-21T21:53:31Z","capabilityStatus":"Enabled","service":"Deskless","servicePlanId":"8c7d2df8-86f0-4902-b2ed-a0458298f3b3"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"07699545-9485-468e-95b6-2fca3738be01"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"TeamspaceAPI","servicePlanId":"57ff2da0-773e-42df-b2af-ffb7a2317929"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"9c0dab89-a30c-4117-86e7-97bda240acd2"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"PowerBI","servicePlanId":"70d33638-9c74-4d01-bfd3-562de28bd4ba"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"34c0d7a0-a70f-4668-9238-47f9fc208882"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"9f431833-0334-42de-a7dc-70aa40db46db"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"4de31727-a228-4ec3-a5bf-8e45b5ca48cc"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"YammerEnterprise","servicePlanId":"7547a3fe-08ee-4ccb-b430-5077c5041653"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Deleted","service":"AzureAnalysis","servicePlanId":"2049e525-b859-401b-b2a0-e0a31c4b1fe4"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Deleted","service":"PowerBI","servicePlanId":"fc0a60aa-feee-4746-a0e3-aecfe81a38dd"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"43de0ff5-c92c-492b-9116-175376d08c38"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"0feaeb32-d00e-4d66-bd5a-43b5b83db82c"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb87545-963c-4e0d-99df-69c6916d9eb0"},{"assignedTimestamp":"2012-10-18T11:17:30Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"663a804f-1c30-4ff0-9915-9db84f0d1cea"},{"assignedTimestamp":"2015-12-14T08:31:18Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"e61a2945-1d4e-4523-b6e7-30ba39d20f32"},{"assignedTimestamp":"2016-06-30T05:43:33Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"2c4ec2dc-c62d-4167-a966-52a3e6374015"},{"assignedTimestamp":"2016-06-30T05:43:33Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"0b4346bb-8dc3-4079-9dfc-513696f56039"}],"city":"Kongens
-        Lyngby","companyName":"DENMARK","consentProvidedForMinor":null,"country":null,"createdDateTime":null,"creationType":null,"department":"DK-EPG
-        COGS Solution Architect-Azure","dirSyncEnabled":true,"displayName":"Mads Damg\u00e5rd","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Mads","immutableId":"301328","isCompromised":null,"jobTitle":"SR
-        CLOUD SOLUTION ARCHITECT","lastDirSyncTime":"2020-04-16T19:15:38Z","legalAgeGroupClassification":null,"mail":"madsd@microsoft.com","mailNickname":"madsd","mobile":"+4551578136","onPremisesDistinguishedName":"CN=Mads
+        Lyngby","companyName":"DENMARK","consentProvidedForMinor":null,"country":null,"createdDateTime":null,"creationType":null,"department":"Global
+        CSA Denmark COGS","dirSyncEnabled":true,"displayName":"Mads Damg\u00e5rd","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Mads","immutableId":"301328","isCompromised":null,"jobTitle":"SR
+        CLOUD SOLUTION ARCHITECT","lastDirSyncTime":"2020-04-29T08:59:58Z","legalAgeGroupClassification":null,"mail":"madsd@microsoft.com","mailNickname":"madsd","mobile":"+4551578136","onPremisesDistinguishedName":"CN=Mads
         Damg\u00e5rd,OU=UserAccounts,DC=europe,DC=corp,DC=microsoft,DC=com","onPremisesSecurityIdentifier":"S-1-5-21-1721254763-462695806-1538882281-2655010","otherMails":[],"passwordPolicies":"DisablePasswordExpiration","passwordProfile":null,"physicalDeliveryOfficeName":"LYNGBY/Mobile","postalCode":null,"preferredLanguage":null,"provisionedPlans":[{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Adallom"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Netbreeze"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"microsoftcommunicationsonline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"}],"provisioningErrors":[],"proxyAddresses":["smtp:madsd@sales.microsoft.com","x500:/o=ExchangeLabs/ou=Exchange
         Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=user01a2850e","SMTP:madsd@microsoft.com","x500:/o=microsoft/ou=Exchange
         Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=userff21d3b0","x500:/o=SDF/ou=Exchange
@@ -651,33 +651,33 @@ interactions:
         Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=contact46dc0812","x500:/o=ExchangeLabs/ou=Exchange
         Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=madsddf0a188e10","x500:/O=microsoft/OU=europe/cn=Recipients/cn=madsd","x500:/O=Nokia/OU=HUB/cn=Recipients/cn=madsd","x500:/o=SDF/ou=Exchange
         Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=51490-madsd_9845154d95","x500:/o=MSNBC/ou=Servers/cn=Recipients/cn=madsd","smtp:MADSD@service.microsoft.com"],"refreshTokensValidFromDateTime":"2019-11-16T08:17:12Z","showInAddressList":true,"signInNames":[],"sipProxyAddress":"madsd@microsoft.com","state":null,"streetAddress":null,"surname":"Damg\u00e5rd","telephoneNumber":"+45
-        (45) 678476","thumbnailPhoto@odata.mediaEditLink":"directoryObjects/0b9188a0-540d-4262-9311-61bb1a0235ef/Microsoft.DirectoryServices.User/thumbnailPhoto","thumbnailPhoto@odata.mediaContentType":"image/Jpeg","usageLocation":"DK","userIdentities":[],"userPrincipalName":"madsd@microsoft.com","userState":null,"userStateChangedOn":null,"userType":null,"extension_18e31482d3fb4a8ea958aa96b662f508_SupervisorInd":"N","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToPersonnelNbr":"218748","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToFullName":"Schioldan,
-        Morten","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToEmailName":"MORTENS","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"MOBILE","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"99998","extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10084905","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10084905","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1023","extension_18e31482d3fb4a8ea958aa96b662f508_LocationAreaCode":"DK","extension_18e31482d3fb4a8ea958aa96b662f508_PersonnelNumber":"301328","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"49025387"}'
+        (45) 678476","thumbnailPhoto@odata.mediaEditLink":"directoryObjects/0b9188a0-540d-4262-9311-61bb1a0235ef/Microsoft.DirectoryServices.User/thumbnailPhoto","thumbnailPhoto@odata.mediaContentType":"image/Jpeg","usageLocation":"DK","userIdentities":[],"userPrincipalName":"madsd@microsoft.com","userState":null,"userStateChangedOn":null,"userType":null,"extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"MOBILE","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"99998","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToPersonnelNbr":"1184534","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToFullName":"Coffin,
+        Callum D","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToEmailName":"CALCOF","extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10212147","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"91890670","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10212147","extension_18e31482d3fb4a8ea958aa96b662f508_SupervisorInd":"N","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1023","extension_18e31482d3fb4a8ea958aa96b662f508_LocationAreaCode":"DK","extension_18e31482d3fb4a8ea958aa96b662f508_PersonnelNumber":"301328"}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '18997'
+      - '18983'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 21 Apr 2020 06:36:55 GMT
+      - Tue, 12 May 2020 05:07:58 GMT
       duration:
-      - '1129856'
+      - '1121706'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - JM6VhjMuUiaZENNEm9cD89HT+0vtv/U/AyNndwvom1g=
+      - C9HzIAu8sf3ZdxROmT8HhmxgHchIgClb0lVlCryzFUI=
       ocp-aad-session-key:
-      - Rsge2uqOLgMZsTPRQ6ZjDzviVhGKH7EKCV5Y-yK5zAyJBQRYOTW0UHxDuczI_KShfaxhsHSfUiuXW2-OWZsj53sJDlzcoyUvt3j2Ab8eOQtP_uNYxG7T5SJIofkfYhJp.O268mE4sQVpgVazomE3hq268OuefW_B1OVb7Jj-K-AE
+      - jU0uA9IyihSP8o9bPpTy5fSDQq01aS-j74eor7jqq-6mdx3WcMiWGu73JQSCx1qLJ4HWu43aab0r_2XlI3a_25V93e3J9V18WIZAMbGwOwYoU7p0kxD3Wwc2T98tGvGI.My3_qyGveo17ucNGTaWXYGZp_D1msQo8N2uRVmOAzBI
       pragma:
       - no-cache
       request-id:
-      - 6e2af8eb-8a80-4727-b028-03a02f2890a5
+      - 5d2a9442-26d3-412d-8639-3ae10bc0804f
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -699,9 +699,8 @@ interactions:
       "import", "update", "managecontacts", "getissuers", "listissuers", "setissuers",
       "deleteissuers", "manageissuers", "recover"], "storage": ["get", "list", "delete",
       "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}}],
-      "softDeleteRetentionInDays": 90, "enableRbacAuthorization": false, "networkAcls":
-      {"bypass": "AzureServices", "defaultAction": "Allow", "ipRules": [], "virtualNetworkRules":
-      []}}}'
+      "softDeleteRetentionInDays": 90, "networkAcls": {"bypass": "AzureServices",
+      "defaultAction": "Allow", "ipRules": [], "virtualNetworkRules": []}}}'
     headers:
       Accept:
       - application/json
@@ -712,30 +711,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '929'
+      - '895'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g -n
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net","provisioningState":"RegisteringDns"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net","provisioningState":"RegisteringDns"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1185'
+      - '1153'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 06:36:59 GMT
+      - Tue, 12 May 2020 05:08:01 GMT
       expires:
       - '-1'
       pragma:
@@ -753,7 +752,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.0.276
+      - 1.1.0.278
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-powered-by:
@@ -776,21 +775,21 @@ interactions:
       - -g -n
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1181'
+      - '1149'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 06:37:29 GMT
+      - Tue, 12 May 2020 05:08:33 GMT
       expires:
       - '-1'
       pragma:
@@ -808,7 +807,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.0.276
+      - 1.1.0.278
       x-powered-by:
       - ASP.NET
     status:
@@ -850,19 +849,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 21 Apr 2020 06:37:29 GMT
+      - Tue, 12 May 2020 05:08:35 GMT
       duration:
-      - '548647'
+      - '1520250'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - lcUiHqF+JaQXTPH0KEWC/V5ZITB+YUarCo2tbQoAdl8=
+      - kRuloLn7w9ZM2KqLmZGPpy3rrvNTiCwdCWz+CJa/570=
       ocp-aad-session-key:
-      - 47ZMCV-6PSXzGQ-lli2tKELUMG1D6d1gAASB7ZszAzGzE30HjI9Y_SmEGUk7znXnhn-x_Wzh-iQKfZ-8QQANYClZouBVu-PtvH8MyLMEpJvJWb6u20y3oVTenmL0jQZS.2zVJtVuOjGcLNB2V5RclsqY5QVy_cUp9Le8HqEYB3LI
+      - cdZ17VboG4LyAiDCMMHA2b63QEPpP4ETQ2vFxqCSEwYYl3YoEB_erAL14c7uEiRSYQz1kgdKh7GmKOQnPi7-rsTXOfc5vRkdb1Y5bVnYjfDLCPIK3gO6zCrLpE7SLd4I.4J4glO6fiRtttEPWCFhdpjlVmA-kjcES2i_prWkFrP4
       pragma:
       - no-cache
       request-id:
-      - 5a8eb1d9-e033-46a7-a021-2f1787f0fcee
+      - 47609fe6-5a04-48c4-8f83-595f7030de5c
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -889,23 +888,23 @@ interactions:
       - -g --name --spn --secret-permissions
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1181'
+      - '1149'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 06:37:31 GMT
+      - Tue, 12 May 2020 05:08:35 GMT
       expires:
       - '-1'
       pragma:
@@ -923,7 +922,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.0.276
+      - 1.1.0.278
       x-powered-by:
       - ASP.NET
     status:
@@ -942,7 +941,7 @@ interactions:
       {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "f8daea97-62e7-4026-becf-13c2ea98e8b4",
       "permissions": {"secrets": ["get"]}}], "vaultUri": "https://kv-ssl-test000004.vault.azure.net/",
       "enabledForDeployment": false, "enableSoftDelete": true, "softDeleteRetentionInDays":
-      90, "enableRbacAuthorization": false}}'
+      90}}'
     headers:
       Accept:
       - application/json
@@ -953,30 +952,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1090'
+      - '1056'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g --name --spn --secret-permissions
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1317'
+      - '1285'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 06:37:31 GMT
+      - Tue, 12 May 2020 05:08:36 GMT
       expires:
       - '-1'
       pragma:
@@ -994,7 +993,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.0.276
+      - 1.1.0.278
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-powered-by:
@@ -1034,7 +1033,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 06:37:31 GMT
+      - Tue, 12 May 2020 05:08:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1051,11 +1050,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=185.107.14.16;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=185.107.14.16;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
-      - 1.1.0.898
+      - 1.1.3.0
       x-powered-by:
       - ASP.NET
     status:
@@ -1085,7 +1084,7 @@ interactions:
     uri: https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/import?api-version=7.0
   response:
     body:
-      string: '{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/c704d25df9034f34bf0fa818dbf17354","kid":"https://kv-ssl-test000004.vault.azure.net/keys/test-cert/c704d25df9034f34bf0fa818dbf17354","sid":"https://kv-ssl-test000004.vault.azure.net/secrets/test-cert/c704d25df9034f34bf0fa818dbf17354","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1587451053,"updated":1587451053,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1587451053,"updated":1587451053}}}'
+      string: '{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/a42da491666540dc91cee15391963254","kid":"https://kv-ssl-test000004.vault.azure.net/keys/test-cert/a42da491666540dc91cee15391963254","sid":"https://kv-ssl-test000004.vault.azure.net/secrets/test-cert/a42da491666540dc91cee15391963254","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589260118,"updated":1589260118,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589260118,"updated":1589260118}}}'
     headers:
       cache-control:
       - no-cache
@@ -1094,7 +1093,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 06:37:33 GMT
+      - Tue, 12 May 2020 05:08:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1108,11 +1107,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - addr=185.107.14.16;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=185.107.14.16;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
-      - 1.1.0.898
+      - 1.1.3.0
       x-powered-by:
       - ASP.NET
     status:
@@ -1133,7 +1132,7 @@ interactions:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -1141,18 +1140,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:36:36.1766667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.0266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3574'
+      - '3726'
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:37:34 GMT
+      - Tue, 12 May 2020 05:08:39 GMT
       etag:
-      - '"1D617A7347FA70B"'
+      - '"1D6281B41635AAB"'
       expires:
       - '-1'
       pragma:
@@ -1189,23 +1188,23 @@ interactions:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/certs/providers/Microsoft.KeyVault/vaults/tb-certs","name":"tb-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"6b244528-5604-411e-9ff1-5df31b00f93a","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"013244e3-a217-4ca4-bf2a-e65b263959cd","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"4dbab725-22a4-44d5-ad44-c267ca38a954","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"21bf1420-2ed9-48b9-bf6d-ece1337d4fd1","permissions":{"keys":[],"secrets":["Get"],"certificates":["Get"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"],"keys":[],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"ed47c2a1-bd23-4341-b39c-f4fd69138dd3","permissions":{"secrets":["Get","Set","Delete"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://tb-certs.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tbsbwe-integration/providers/Microsoft.KeyVault/vaults/apim-certs","name":"apim-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"vaultUri":"https://apim-certs.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/webapp-global/providers/Microsoft.KeyVault/vaults/madsd-cert","name":"madsd-cert","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["get"],"certificates":[],"storage":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"vaultUri":"https://madsd-cert.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=ServiceBased,ZDJWaVlYQndMV2RzYjJKaGJIeHRZV1J6WkMxalpYSjA="}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who","name":"madsd-who","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"88d52f7a-b7b2-4ccb-80a5-e4bab463396d","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who2","name":"madsd-who2","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who2.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who3","name":"madsd-who3","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://madsd-who3.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who4","name":"madsd-who4","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who4.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/certs/providers/Microsoft.KeyVault/vaults/tb-certs","name":"tb-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"6b244528-5604-411e-9ff1-5df31b00f93a","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"013244e3-a217-4ca4-bf2a-e65b263959cd","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"4dbab725-22a4-44d5-ad44-c267ca38a954","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"21bf1420-2ed9-48b9-bf6d-ece1337d4fd1","permissions":{"keys":[],"secrets":["Get"],"certificates":["Get"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"],"keys":[],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"ed47c2a1-bd23-4341-b39c-f4fd69138dd3","permissions":{"secrets":["Get","Set","Delete"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://tb-certs.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM="}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '6092'
+      - '7630'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 06:37:34 GMT
+      - Tue, 12 May 2020 05:08:41 GMT
       expires:
       - '-1'
       pragma:
@@ -1223,7 +1222,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.0.276
+      - 1.1.0.278
       x-powered-by:
       - ASP.NET
     status:
@@ -1244,23 +1243,78 @@ interactions:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM=
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgcnudntyhmvoeiyqtlcpn2yancwt7apjg2vgwtzgef5ea77yvd3qlxmtacdhee3fvb/providers/Microsoft.KeyVault/vaults/kv-ssl-testbb6qd4kxn","name":"kv-ssl-testbb6qd4kxn","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testbb6qd4kxn.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgx4rt26hzocre327frzultmovguawysetpl4k45efmie45x5h5ncwr2hcw6d2pvxsh/providers/Microsoft.KeyVault/vaults/kv-ssl-testjjfy5fv7k","name":"kv-ssl-testjjfy5fv7k","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testjjfy5fv7k.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2xpdGVzdC5yZ3g0cnQyNmh6b2NyZTMyN2ZyenVsdG1vdmd1YXd5c2V0cGw0azQ1ZWZtaWU0NXg1aDVuY3dyMmhjdzZkMnB2eHNofGt2LXNzbC10ZXN0ampmeTVmdjdr"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4161'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 12 May 2020 05:08:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1317'
+      - '1285'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 21 Apr 2020 06:37:35 GMT
+      - Tue, 12 May 2020 05:08:42 GMT
       expires:
       - '-1'
       pragma:
@@ -1278,7 +1332,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.0.276
+      - 1.1.0.278
       x-powered-by:
       - ASP.NET
     status:
@@ -1299,7 +1353,7 @@ interactions:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -1308,7 +1362,7 @@ interactions:
     body:
       string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
         ''0b9188a0-540d-4262-9311-61bb1a0235ef'' does not exist or one of its queried
-        reference-property objects are not present."},"requestId":"231272df-9149-4d83-8be7-8bb445cf4a5f","date":"2020-04-21T06:37:36"}}'
+        reference-property objects are not present."},"requestId":"d6ae8b16-f939-41bc-b768-4a2e5aa286e1","date":"2020-05-12T05:08:42"}}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1321,19 +1375,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 21 Apr 2020 06:37:36 GMT
+      - Tue, 12 May 2020 05:08:42 GMT
       duration:
-      - '557560'
+      - '543030'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - sLztrgZ8JSDnWz4frtQ4NvPpSD8rFSiENpbTNRku9OY=
+      - nXlz28L4mvclWaIr6aYrPLvkq+aZFBTjRwfxg/IAWtA=
       ocp-aad-session-key:
-      - AwqM7zPC7PFfPjeBrgJ6P1PTw5UOaTsfSmmz6C6BDMUy0ulACcqZ2Ip-8RfzU-Sf6dZnU5rEc4COxLzgvpz3gsE3qvKXI1sNcfXJON85Rfmt2Mzm7_YENSDjLNDFaiSs._tkJf22K976osocJIgPHbY84T7-4nLmSYqlTKEYlqNk
+      - oFNSeTsAQIok1jZ6VrVSvfT3_tKsv4mTWWXAnGqpsHDWqjyveGr6Oi0-i9f3nWqlVXMQdASXVSgixXXiUF7p7j2Jo5kXbuGz_8Xjz71TOtP5troYL2kD69zyH0soKJk-.ZEaASJyLOv3Ce2ML0orrf9P67v9RIZQg7LnAD0b03tk
       pragma:
       - no-cache
       request-id:
-      - 231272df-9149-4d83-8be7-8bb445cf4a5f
+      - d6ae8b16-f939-41bc-b768-4a2e5aa286e1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1360,7 +1414,7 @@ interactions:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -1385,19 +1439,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 21 Apr 2020 06:37:36 GMT
+      - Tue, 12 May 2020 05:08:43 GMT
       duration:
-      - '673080'
+      - '530767'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 2tT8IJLYLAl4WiEBvtldRBzIBH40hdQ2CjGxgGCHWGg=
+      - SG5zWAheXepBmH7JdRXr60mHGY06RS13iatxT8gotGU=
       ocp-aad-session-key:
-      - LL2KJ_yWhlYwXcI536AAONVy545XeFGzDXOPh-9dLDWa9omAZyC0CilMthqb7L0c_Rkx2C0V1CE0H1k8WvL7dsmp0UlzmzOjFka_7ODnFIWl2Dy3Wg_Bq5Euo_uKuJRi.59z2oVWwYPRGzMFdAgjWEnHtOJ7rZjZRXDJJu33Ld5o
+      - BThoi0sHkCf1KLfA8xpRfFsOVlXkeov6tszYMuWAfULB1xA1KXWy89pbCQBrYdePBWJQXuoLqQrmbf9cYyw7lJuOd57-aeb8KnTAUc40xotjbIjn6aN48kXNhpTHzmBY.djxsg-AUVM7X05-nIfk8aAyUKmDVh9T7H6M_wjvCg4c
       pragma:
       - no-cache
       request-id:
-      - 1316f388-3127-474e-b8ef-45abf8faf0c9
+      - 3e555653-3a19-47f4-a43a-2ffd09480c0b
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1430,7 +1484,7 @@ interactions:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
@@ -1447,7 +1501,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:37:38 GMT
+      - Tue, 12 May 2020 05:08:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1468,7 +1522,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-powered-by:
       - ASP.NET
     status:
@@ -1489,7 +1543,7 @@ interactions:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -1497,18 +1551,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:36:36.1766667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.0266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3574'
+      - '3726'
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:37:39 GMT
+      - Tue, 12 May 2020 05:08:46 GMT
       etag:
-      - '"1D617A7347FA70B"'
+      - '"1D6281B41635AAB"'
       expires:
       - '-1'
       pragma:
@@ -1545,7 +1599,7 @@ interactions:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -1553,18 +1607,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:36:36.1766667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.0266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3574'
+      - '3726'
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:37:40 GMT
+      - Tue, 12 May 2020 05:08:47 GMT
       etag:
-      - '"1D617A7347FA70B"'
+      - '"1D6281B41635AAB"'
       expires:
       - '-1'
       pragma:
@@ -1601,7 +1655,7 @@ interactions:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -1618,7 +1672,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:37:40 GMT
+      - Tue, 12 May 2020 05:08:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1655,7 +1709,7 @@ interactions:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -1672,9 +1726,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:37:41 GMT
+      - Tue, 12 May 2020 05:08:47 GMT
       etag:
-      - '"1D617A7347FA70B"'
+      - '"1D6281B41635AAB"'
       expires:
       - '-1'
       pragma:
@@ -1718,7 +1772,7 @@ interactions:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
@@ -1726,18 +1780,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:37:43.0166667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:50.3733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3616'
+      - '3768'
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:37:43 GMT
+      - Tue, 12 May 2020 05:08:51 GMT
       etag:
-      - '"1D617A7347FA70B"'
+      - '"1D6281B41635AAB"'
       expires:
       - '-1'
       pragma:
@@ -1776,7 +1830,7 @@ interactions:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -1784,18 +1838,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-297.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-04-21T06:37:43.0166667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.23","possibleInboundIpAddresses":"13.69.68.23","outboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17","possibleOutboundIpAddresses":"13.69.68.23,13.94.236.45,13.80.30.234,13.80.27.167,13.94.238.17,13.93.8.230,13.80.25.191,13.69.30.55,40.115.26.112,13.69.29.185","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-297","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-WestEuropewebspace","selfLink":"https://waws-prod-am2-161.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestEuropewebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:50.3733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.178.75.200","possibleInboundIpAddresses":"52.178.75.200","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167","possibleOutboundIpAddresses":"52.178.75.200,52.178.94.222,52.178.102.126,52.178.88.128,52.178.91.167,52.178.91.4,52.178.91.42","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-161","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3614'
+      - '3766'
       content-type:
       - application/json
       date:
-      - Tue, 21 Apr 2020 06:37:44 GMT
+      - Tue, 12 May 2020 05:08:51 GMT
       etag:
-      - '"1D617A75C56A08B"'
+      - '"1D6281B6C829455"'
       expires:
       - '-1'
       pragma:
@@ -1836,7 +1890,7 @@ interactions:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
       - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.4.0
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: POST
@@ -1845,17 +1899,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000003 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
+        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-297.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-161.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-297dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="Fhd2nrmGBBkt0umfp8rfKn7tL67xirHd9EpLqKBne4g2308HBJ7A8vnml9RB"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-161dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="fFrFgEhEui72GdYdqPT4YAck1uGbn90pbBftvgWzR5e6ATPBcRw3SqL3theu"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -1867,7 +1921,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 21 Apr 2020 06:37:45 GMT
+      - Tue, 12 May 2020 05:08:52 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_crossrg.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_crossrg.yaml
@@ -1,0 +1,1992 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-08T07:30:27Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '432'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:30:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "ssl-test-plan000003", "type": "Microsoft.Web/serverfarms", "location":
+      "westeurope", "properties": {"skuName": "B1", "capacity": 1}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --sku
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/validate?api-version=2019-08-01
+  response:
+    body:
+      string: '{"status":"Success","error":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '33'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:30:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-08T07:30:27Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '432'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:30:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westeurope", "properties": {"perSiteScaling": false, "isXenon":
+      false}, "sku": {"name": "B1", "tier": "BASIC", "capacity": 1}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '140'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --sku
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        Europe","properties":{"serverFarmId":27032,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-253_27032","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1536'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:30:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        Europe","properties":{"serverFarmId":27032,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-253_27032","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1536'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:30:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"name": "web-ssl-test000004", "type": "Microsoft.Web/sites", "location":
+      "West Europe", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003"}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '329'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/validate?api-version=2019-08-01
+  response:
+    body:
+      string: '{"status":"Success","error":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '33'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:30:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        Europe","properties":{"serverFarmId":27032,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-253_27032","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1536'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:30:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "web-ssl-test000004", "type": "Site"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/checknameavailability?api-version=2019-08-01
+  response:
+    body:
+      string: '{"nameAvailable":true,"reason":"","message":""}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '47'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:30:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"location": "West Europe", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003",
+      "reserved": false, "isXenon": false, "hyperV": false, "siteConfig": {"netFrameworkVersion":
+      "v4.6", "appSettings": [{"name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "10.14"}],
+      "localMySqlEnabled": false, "http20Enabled": true}, "scmSiteAlsoStopped": false,
+      "httpsOnly": false}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '544'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:30:44.7933333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3737'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:31:01 GMT
+      etag:
+      - '"1D6250A96434520"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004/publishxml?api-version=2019-08-01
+  response:
+    body:
+      string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
+        publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-253dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile></publishData>
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1678'
+      content-type:
+      - application/xml
+      date:
+      - Fri, 08 May 2020 07:31:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-08T07:30:21Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '432'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:31:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":["65cc641f-cccd-4643-97e0-a17e3045e541","e26c2fcc-ab91-4a61-b35c-03cdc8dddf66","46129a58-a698-46f0-aa5b-17f6586297d9","6db1f1db-2b46-403f-be40-e39395f08dbb","6dc145d6-95dd-4191-b9c3-185575ee6f6b","41fcdd7d-4733-4863-9cf4-c65b83ce2df4","2f442157-a11c-46b9-ae5b-6e39ff4e5849","c4801e8a-cb58-4c35-aca6-f2dcc106f287","0898bdbb-73b0-471a-81e5-20f1fe4dd66e","617b097b-4b93-4ede-83de-5f075bb5fb2f","33c4f319-9bdd-48d6-9c4d-410b750a4a5a","4828c8ec-dc2e-4779-b502-87ac9ce28ab7","3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"],"skuId":"c7df2760-2c81-4ef7-b578-5b5392b571df"},{"disabledPlans":["39b5c996-467e-4e60-bd62-46066f572726"],"skuId":"90d8b3f8-712e-4f7b-aa1e-62e7ae6cbe96"},{"disabledPlans":["e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72"],"skuId":"09015f9f-377f-4538-bbb5-f75ceb09358a"},{"disabledPlans":[],"skuId":"dcb1a3ae-b33f-4487-846a-a640262fadf4"},{"disabledPlans":[],"skuId":"f30db892-07e9-47e9-837c-80727f46fd3d"},{"disabledPlans":[],"skuId":"26a18e8f-4d14-46f8-835a-ed3ba424a961"},{"disabledPlans":[],"skuId":"412ce1a7-a499-41b3-8eb6-b38f2bbc5c3f"},{"disabledPlans":[],"skuId":"488ba24a-39a9-4473-8ee5-19291e71b002"},{"disabledPlans":[],"skuId":"b05e124f-c7cc-45a0-a6aa-8cf78c946968"},{"disabledPlans":["0b03f40b-c404-40c3-8651-2aceb74365fa","b650d915-9886-424b-a08d-633cede56f57","e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72","fe71d6c3-a2ea-4499-9778-da042bf08063","fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"],"skuId":"ea126fc5-a19e-42e2-a731-da9d437bffcf"},{"disabledPlans":[],"skuId":"c5928f49-12ba-48f7-ada3-0d743a3601d5"},{"disabledPlans":[],"skuId":"87bbbc60-4754-4998-8c88-227dca264858"}],"assignedPlans":[{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"},{"assignedTimestamp":"2019-11-04T20:02:03Z","capabilityStatus":"Enabled","service":"WhiteboardServices","servicePlanId":"4a51bca5-1eff-43f5-878c-177680f191af"},{"assignedTimestamp":"2019-10-15T04:17:14Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"5136a095-5cf0-4aff-bec3-e84448b38ea5"},{"assignedTimestamp":"2019-10-15T04:17:14Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb0351d-3b08-4503-993d-383af8de41e3"},{"assignedTimestamp":"2019-08-08T23:29:37Z","capabilityStatus":"Enabled","service":"MicrosoftFormsProTest","servicePlanId":"97f29a83-1a20-44ff-bf48-5e4ad11f3e51"},{"assignedTimestamp":"2019-05-23T01:47:36Z","capabilityStatus":"Enabled","service":"DYN365AISERVICEINSIGHTS","servicePlanId":"1412cdc1-d593-4ad1-9050-40c30ad0b023"},{"assignedTimestamp":"2019-05-09T22:32:19Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"199a5c09-e0ca-4e37-8f7c-b05d533e1ea2"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"ProjectProgramsAndPortfolios","servicePlanId":"818523f5-016b-4355-9be8-ed6944946ea7"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"fa200448-008c-4acb-abd4-ea106ed2199d"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"50554c47-71d9-49fd-bc54-42a2765c555c"},{"assignedTimestamp":"2018-11-18T17:43:28Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"d20bfa21-e9ae-43fc-93c2-20783f0840c3"},{"assignedTimestamp":"2018-11-18T17:43:28Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"d5368ca3-357e-4acb-9c21-8495fb025d1f"},{"assignedTimestamp":"2018-11-17T17:45:51Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"50e68c76-46c6-4674-81f9-75456511b170"},{"assignedTimestamp":"2018-11-17T17:45:51Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"17ab22cd-a0b3-4536-910a-cb6eb12696c0"},{"assignedTimestamp":"2018-10-11T18:25:27Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"018fb91e-cee3-418c-9063-d7562978bdaf"},{"assignedTimestamp":"2018-10-11T18:25:26Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"ca4be917-fbce-4b52-839e-6647467a1668"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"b1188c4c-1b36-4018-b48b-ee07604f6feb"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"4828c8ec-dc2e-4779-b502-87ac9ce28ab7"},{"assignedTimestamp":"2018-08-29T07:16:06Z","capabilityStatus":"Enabled","service":"Sway","servicePlanId":"a23b959c-7ce8-4e57-9140-b90eb88a9e97"},{"assignedTimestamp":"2018-08-29T07:16:06Z","capabilityStatus":"Deleted","service":"OfficeForms","servicePlanId":"159f4cd6-e380-449f-a816-af1a9ef76344"},{"assignedTimestamp":"2018-04-26T17:45:50Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"bea4c11e-220a-4e6d-8eb8-8ea15d019f90"},{"assignedTimestamp":"2018-04-26T17:45:50Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"6c57d4b6-3b23-47a5-9bc9-69f17b4947b3"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"2125cfd7-2110-4567-83c4-c1cd5275163d"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"c4048e79-4474-4c74-ba9b-c31ff225e511"},{"assignedTimestamp":"2018-03-20T15:10:18Z","capabilityStatus":"Deleted","service":"MicrosoftStream","servicePlanId":"acffdce6-c30f-4dc2-81c0-372e33c515ec"},{"assignedTimestamp":"2018-03-17T08:10:29Z","capabilityStatus":"Enabled","service":"WindowsDefenderATP","servicePlanId":"871d91ec-ec1a-452b-a83f-bd76c7d770ef"},{"assignedTimestamp":"2018-03-17T08:10:29Z","capabilityStatus":"Enabled","service":"Windows","servicePlanId":"e7c91390-7625-45be-94e0-e16907e03118"},{"assignedTimestamp":"2018-03-17T02:35:48Z","capabilityStatus":"Enabled","service":"AzureAdvancedThreatAnalytics","servicePlanId":"14ab5db5-e6c4-4b20-b4bc-13e36fd2227f"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"CRM","servicePlanId":"bf36ca64-95c6-4918-9275-eb9f4ce2c04f"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"PowerAppsService","servicePlanId":"874fc546-6efe-4d22-90b8-5c4e7aa59f4b"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"ProcessSimple","servicePlanId":"7e6d7d78-73de-46ba-83b1-6d25117334ba"},{"assignedTimestamp":"2018-01-09T00:28:58Z","capabilityStatus":"Enabled","service":"ProjectWorkManagement","servicePlanId":"b737dad2-2f6c-4c65-90e3-ca563267e8b9"},{"assignedTimestamp":"2017-12-31T23:10:50Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"41781fb2-bc02-4b7c-bd55-b576c07bb09d"},{"assignedTimestamp":"2017-12-31T23:10:50Z","capabilityStatus":"Enabled","service":"MultiFactorService","servicePlanId":"8a256a2b-b617-496d-b51b-e76466e88db0"},{"assignedTimestamp":"2017-12-31T06:32:41Z","capabilityStatus":"Deleted","service":"Adallom","servicePlanId":"932ad362-64a8-4783-9106-97849a1a30b9"},{"assignedTimestamp":"2017-12-16T19:57:33Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"5689bec4-755d-4753-8b61-40975025187c"},{"assignedTimestamp":"2017-12-16T19:57:33Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"2e2ddb96-6af9-4b1d-a3f0-d6ecfd22edb2"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"8c098270-9dd4-4350-9b30-ba4703f3b36b"},{"assignedTimestamp":"2017-11-12T20:20:22Z","capabilityStatus":"Enabled","service":"To-Do","servicePlanId":"3fb82609-8c27-4f7b-bd51-30634711ee67"},{"assignedTimestamp":"2017-10-07T01:41:03Z","capabilityStatus":"Enabled","service":"Netbreeze","servicePlanId":"03acaee3-9492-4f40-aed4-bcb6b32981b6"},{"assignedTimestamp":"2017-10-07T01:41:03Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"d56f3deb-50d8-465a-bedb-f079817ccac1"},{"assignedTimestamp":"2017-06-26T10:50:26Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"e212cbc7-0961-4c40-9825-01117710dcb1"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"MicrosoftStream","servicePlanId":"6c6042f5-6f01-4d67-b8c1-eb99d36eed3e"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"eec0eb4f-6444-4f95-aba0-50c24d67f998"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"SCO","servicePlanId":"c1ec4a95-1f05-45b3-a911-aa3fa01094f5"},{"assignedTimestamp":"2017-05-13T01:11:22Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"8e0c0a52-6a6c-4d40-8370-dd62790dcd70"},{"assignedTimestamp":"2017-02-21T21:53:31Z","capabilityStatus":"Enabled","service":"Deskless","servicePlanId":"8c7d2df8-86f0-4902-b2ed-a0458298f3b3"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"07699545-9485-468e-95b6-2fca3738be01"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"TeamspaceAPI","servicePlanId":"57ff2da0-773e-42df-b2af-ffb7a2317929"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"9c0dab89-a30c-4117-86e7-97bda240acd2"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"PowerBI","servicePlanId":"70d33638-9c74-4d01-bfd3-562de28bd4ba"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"34c0d7a0-a70f-4668-9238-47f9fc208882"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"9f431833-0334-42de-a7dc-70aa40db46db"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"4de31727-a228-4ec3-a5bf-8e45b5ca48cc"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"YammerEnterprise","servicePlanId":"7547a3fe-08ee-4ccb-b430-5077c5041653"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Deleted","service":"AzureAnalysis","servicePlanId":"2049e525-b859-401b-b2a0-e0a31c4b1fe4"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Deleted","service":"PowerBI","servicePlanId":"fc0a60aa-feee-4746-a0e3-aecfe81a38dd"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"43de0ff5-c92c-492b-9116-175376d08c38"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"0feaeb32-d00e-4d66-bd5a-43b5b83db82c"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb87545-963c-4e0d-99df-69c6916d9eb0"},{"assignedTimestamp":"2012-10-18T11:17:30Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"663a804f-1c30-4ff0-9915-9db84f0d1cea"},{"assignedTimestamp":"2015-12-14T08:31:18Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"e61a2945-1d4e-4523-b6e7-30ba39d20f32"},{"assignedTimestamp":"2016-06-30T05:43:33Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"2c4ec2dc-c62d-4167-a966-52a3e6374015"},{"assignedTimestamp":"2016-06-30T05:43:33Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"0b4346bb-8dc3-4079-9dfc-513696f56039"}],"city":"Kongens
+        Lyngby","companyName":"DENMARK","consentProvidedForMinor":null,"country":null,"createdDateTime":null,"creationType":null,"department":"Global
+        CSA Denmark COGS","dirSyncEnabled":true,"displayName":"Mads Damg\u00e5rd","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Mads","immutableId":"301328","isCompromised":null,"jobTitle":"SR
+        CLOUD SOLUTION ARCHITECT","lastDirSyncTime":"2020-04-29T08:59:58Z","legalAgeGroupClassification":null,"mail":"madsd@microsoft.com","mailNickname":"madsd","mobile":"+4551578136","onPremisesDistinguishedName":"CN=Mads
+        Damg\u00e5rd,OU=UserAccounts,DC=europe,DC=corp,DC=microsoft,DC=com","onPremisesSecurityIdentifier":"S-1-5-21-1721254763-462695806-1538882281-2655010","otherMails":[],"passwordPolicies":"DisablePasswordExpiration","passwordProfile":null,"physicalDeliveryOfficeName":"LYNGBY/Mobile","postalCode":null,"preferredLanguage":null,"provisionedPlans":[{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Adallom"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Netbreeze"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"microsoftcommunicationsonline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"}],"provisioningErrors":[],"proxyAddresses":["smtp:madsd@sales.microsoft.com","x500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=user01a2850e","SMTP:madsd@microsoft.com","x500:/o=microsoft/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=userff21d3b0","x500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=madsd_microsoft.comc37e77e4","x500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=user31cebcc7e1b7241a","X500:/o=MMS/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=user77aa8516","x500:/o=microsoft/ou=First
+        Administrative Group/cn=Recipients/cn=madsd","x500:/o=SDF/ou=Exchange Administrative
+        Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=contact46dc0812","x500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=madsddf0a188e10","x500:/O=microsoft/OU=europe/cn=Recipients/cn=madsd","x500:/O=Nokia/OU=HUB/cn=Recipients/cn=madsd","x500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=51490-madsd_9845154d95","x500:/o=MSNBC/ou=Servers/cn=Recipients/cn=madsd","smtp:MADSD@service.microsoft.com"],"refreshTokensValidFromDateTime":"2019-11-16T08:17:12Z","showInAddressList":true,"signInNames":[],"sipProxyAddress":"madsd@microsoft.com","state":null,"streetAddress":null,"surname":"Damg\u00e5rd","telephoneNumber":"+45
+        (45) 678476","thumbnailPhoto@odata.mediaEditLink":"directoryObjects/0b9188a0-540d-4262-9311-61bb1a0235ef/Microsoft.DirectoryServices.User/thumbnailPhoto","thumbnailPhoto@odata.mediaContentType":"image/Jpeg","usageLocation":"DK","userIdentities":[],"userPrincipalName":"madsd@microsoft.com","userState":null,"userStateChangedOn":null,"userType":null,"extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"MOBILE","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"99998","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToPersonnelNbr":"1184534","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToFullName":"Coffin,
+        Callum D","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToEmailName":"CALCOF","extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10212147","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"91890670","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10212147","extension_18e31482d3fb4a8ea958aa96b662f508_SupervisorInd":"N","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1023","extension_18e31482d3fb4a8ea958aa96b662f508_LocationAreaCode":"DK","extension_18e31482d3fb4a8ea958aa96b662f508_PersonnelNumber":"301328"}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '18983'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 08 May 2020 07:31:03 GMT
+      duration:
+      - '1276497'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - tKzm60xV0/ARMk4TibFT6s6b4D0EK9FgLAcLhsU9Zdo=
+      ocp-aad-session-key:
+      - oUdnGdgbwmXtoVOeIWhz46pUBMk4gATBwQrp4-96REURKB7_qKHH2PMOmU1HSXRzLMcvlTy-H5493hgsWoafo6NqjOcqX6Gjhow0LSrf5Qj36XAY59JJ16rgqCNQ7gCP.E-H-H6mqRUA4XErHJneancLn1GfGw7iwtOcEG-wtv7U
+      pragma:
+      - no-cache
+      request-id:
+      - 7ccd296b-ad8b-4b47-af32-83347f36750a
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westeurope", "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+      "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
+      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "0b9188a0-540d-4262-9311-61bb1a0235ef",
+      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
+      "backup", "restore", "recover"], "secrets": ["get", "list", "set", "delete",
+      "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
+      "import", "update", "managecontacts", "getissuers", "listissuers", "setissuers",
+      "deleteissuers", "manageissuers", "recover"], "storage": ["get", "list", "delete",
+      "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}}],
+      "softDeleteRetentionInDays": 90, "networkAcls": {"bypass": "AzureServices",
+      "defaultAction": "Allow", "ipRules": [], "virtualNetworkRules": []}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '895'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net","provisioningState":"RegisteringDns"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1153'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:31:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1149'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:31:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27Microsoft.Azure.WebSites%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
+        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft.Azure.WebSites","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access all the APIs registered with App Service","adminConsentDisplayName":"Access
+        APIs registered with App Service","id":"e0ea806b-d128-49dc-ac08-2bf18f7874d8","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access all the APIs registered with App Service","userConsentDisplayName":"Access
+        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["Microsoft.Azure.WebSites","abfa0a7c-a6b6-4736-8310-5855508787cd"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1677'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 08 May 2020 07:31:38 GMT
+      duration:
+      - '654488'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - 3jmX5tYejN2H7PQhIIYrRvojJnfbj/hiLvLd/lJX/Lw=
+      ocp-aad-session-key:
+      - aPPVDTzHdNVEA7qDA6cm9cHJ_r-yQzAz0eOjJ3bFv0z0pI0BEpfJRbp2eMMXOo9-ipgHlTyXgZy5jPvHgHlMVJBAM-6jUJhNgQH_RkbFITmL8Q1baZeZSOgNIKHQOVYE.Bpb7VxeEl6oNlIGLVvaVjWt4-guyE6K_qCzXmx_UFf8
+      pragma:
+      - no-cache
+      request-id:
+      - 8fb60fdd-a404-4dc3-bd79-8cdc8f36e6fd
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault set-policy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --spn --secret-permissions
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1149'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:31:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westeurope", "tags": {}, "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+      "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
+      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "0b9188a0-540d-4262-9311-61bb1a0235ef",
+      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
+      "backup", "restore", "recover"], "secrets": ["get", "list", "set", "delete",
+      "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
+      "import", "update", "managecontacts", "getissuers", "listissuers", "setissuers",
+      "deleteissuers", "manageissuers", "recover"], "storage": ["get", "list", "delete",
+      "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}},
+      {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "f8daea97-62e7-4026-becf-13c2ea98e8b4",
+      "permissions": {"secrets": ["get"]}}], "vaultUri": "https://kv-ssl-test000005.vault.azure.net/",
+      "enabledForDeployment": false, "enableSoftDelete": true, "softDeleteRetentionInDays":
+      90}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault set-policy
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1056'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g --name --spn --secret-permissions
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:31:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - 0
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-keyvault/7.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/import?api-version=7.0
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
+        or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '87'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:31:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=85.191.83.80;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westeurope
+      x-ms-keyvault-service-version:
+      - 1.1.3.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"value": "MIIKYgIBAzCCCh4GCSqGSIb3DQEHAaCCCg8EggoLMIIKBzCCBggGCSqGSIb3DQEHAaCCBfkEggX1MIIF8TCCBe0GCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAiXDoyN14zikgICB9AEggTYczAG9RXE6P9dZzKEkuAB3zAoIpepICAcTQO38wV1z2dd3E1p7vBI+RYv1Td3965af6LUHeW7iHwE1h+qUntxAQtW7vVI7cUFa9iP0Heu/ijuZraY1lmKQEzFWffCE1XIgwcH3yHpi88Ow1Au64PfaaYPlrAgklPQ69DPIwM9JuhBd5qXW1XDe6XQ1msu6kvEFR1SNLN4Ul6BfKSPvzhVPKVnq33Lbt/QsVkZ3DtabLz8sW6qVYjEa5R8uW2Z7OaBtBbQWGkM6vnuaUpnE0pXxo815RTsvHXVlZkfgSCeOakmGIAygU/EU8BGvubAWx7WNo6RWFCOiT25tJspW6VY9JEse5ESvc4QnUQm1f0C3YPCcCDUCwEt3ZatGSr4MnJHN2Y1OEf1aWjewz0Se1bP2o/SwihyBNqXXZ3QzjxC8vrR+l6E7fPX3UVPJG5hHZfn2q5aofU/OyrPLUUDCaRlrM5oBADouQBy+t77/pobdvShgdYhiy/QCD6mJGalk6OEdfvp35uoL4jgo2irh4i9C3oOzSXFADUjivG66ZsVIN0k43boaO+JueqVso4GNYB8Zz4FIRlPQOZNCXHcuqvhnU0SGhujeb+H0LSXw53xmiwpWwB7xdv7b/qacaoOV1S3C8ZTM6FkJ8oKmNRMIWiIyfgyXQpmqaMND6nCVkcKkYbmVgNQZdWmbiKg1NGm66Q8rLtSUdIlyyCYzmxngLAa4zEbqPqgMwP4LIyCnxKn7hguBeyLsDvYRk029pgLnVVl5fl+Ijk4w2Noor/Axn3yD2gXCy5h9Xel1iXUqr4JtaJnWOoELx5KFwGhXeHdmRUjRVigbVN+nNd2AdtLih2eBimKpRm2NoBCrfGg9KUDpSi8eSTmbXW/enBWkdGrlu9lVTpgK3tlXW3VUveJh15rtwxTUagsee3G06w6YOu0ZRmT4hNfV2FWmjCuB4VCkY+KeFndsRLdC52odvO2z0u2nwBlvRjFrzErpAJdHWWv+XQ/fuOOjBbP5mvV1+gPEEA8QY4tvi/ac1n5S8L2oVNhaF39+QYlwMdcpLFy2BAw2PN7OnNAQMKViTu4iqVA6861oDa22D9EVufpyvSQj4Y0UoGhs8kS8aT8qsHUvabPlrjqslSuaIDB3H2kVSXXVW9kmMLmRNlhqm7Kowa4jjobr2lNY5dZFjJKy3wD2lsBdRHvsGrC35/vakI6Qy0WHcgA1YM7JwJl808lCQ9fi5Jcd/3tjfyhRv6AvZ6Na2VMZwg2bNOCJfhMKgTyssqRLy5us9zRXRvDFI8IQHmoNcliDnQZIcaVApPx095wQOOm4n8dqfw0AFSSRpgdQT6yQRxlNUyqhQbaUzlUKxxf9F6iVvpDMizmDbCB2/wapF+1/6M4HZfHT0JV4nnOtjr96Yfm1pUYN6jkcsyyeYypOFMKcbaTe9UtU9XU/AxJnkBOl2U7YRuffu3ElkZv0pZggWaNeQ3sCE5scVrFsi8+/AFz1O264knbXyw07leoal/JKIiAquq1Hx6QMzShgz/ympyGVHcC2DJBqjOQ/E8b/34WjUaBMop+JNMStUZnoJqL68rQcxkRdWAEj27f+A2c9nagz0TyCXLB5s/LQu3mbknXQzDbH7qJQxOidFg675fqaTrhekaR7psnJDGB2zATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEEAYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwB0AHIAbwBuAGcAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMGUGCSqGSIb3DQEJFDFYHlYAUAB2AGsAVABtAHAAOgAzAGUAYQAxADIAYQBiADcALQBjAGMAYgA4AC0ANAA3ADcAZAAtAGEAYQBlADQALQA5ADgAZQA1AGYAZgAzAGEANgA4ADcAZjCCA/cGCSqGSIb3DQEHBqCCA+gwggPkAgEAMIID3QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQII49JHcCo5YoCAgfQgIIDsNAp0Fem6ktVE6yy8cO2q9jHI94QEA5Xu4T5v/RWz1VJJ2SdSCBXvrCYdhldYVSoXbSbeLTBsULmi/6ST1VkMETbtrl8RlW8DzzDFeYisyeZtOuxbHcVX8ByqDFo/Ro/vydvx7CRx11IstHIeg64qeVsofMU9NRS3rCGU9CwCjJ4aV9QFgZa0vEnROAZnaI1uRWOuMuHT98Kvv/wJ93xZJq2voAASyysePaZq/pUlzmRuyC/Pz2uXdNIoOu8BykMjvXw4kFzDCWt1DljYaijTLX9hGgzgxdbAOw1/2RSlEaYXpxPrhaYxOTFLGByyO2F1arn3btiMGTxBh61/2Gswg+gpUWX9J3jlT77pXXgyHgZ4YBJ45cWkTCmSSOqjyjdP6buSRInPlfTKDfQGi0riI32qdcO77gCvJdMOcN5HTleglaCDvQyFfYRAzWQ+EQ4N0WfnfDYe8v7+o136wht8cxxKQmo4/FbfOMURe6L1Hlj/hOie6yUD8+lqNMF3oFW42/rMUke5OWZZEIqDeN8tg08f/h7T2i10HW5zuDwAMllqwSdcfNZOESpcbAGbZn76wvvG2sYMXmT3lZvel4iWD8yOZTWIaCKv1+p5GqKTIiIpVOl7iXS4QTwbuNaMJl4a92zuCrnWxTJgw+ZCsmEvpC4u/OUivv7l1R7eJgbo/gdbtuaZWr3Ei4jaOlQj7W6OOGjJDAzzzY1MndsoBA+6HC3KsOCmP9aoXjp8g6hTMNnWZVehPE3Bq4AjHPoP3YXYFHfqqetUhYxnajYd6AB0JPiM9anCMTgbqUHhCTK8B+smPMCijRAGESbrP3EDcmSEJ2mjobV4SllM0qbfKBvU9ZdbUGaOHSytD/fplWpH4oc6SBvHyhK/WPzBz+o7uwgzD70Spl9OiqhsitQTw1asjWKRCs3rrby5tpAfbD0V0lSgLa9ac9bOP/B82LwRe5V7bG/TY+oE5hrN+d50rYl+FBzGsh0lZ//b9lbJIylFhNKz+C2zEobd846u90tYfBvbHgo8RSbIN082uGLo3Vi3d0g/uhkhSMqLNQdYkBku2akqPcPIVrgdaT1ezCgoxX61q5UTjtdRuZv1d9u1ZhOA8iO7Gqi0C/9MQAQhk9uhbHg+88gLE5VFeRgt7H+fI2OjvFqSkq6Xk8Tio4RCQp54wnZ9cyOl7i5mZ7pqEZBUPxbXS6ssQYjuFi67Bl4BqYdIIV11mEYCccDAuyzNmoRy6LnvKFF4JUfEWZvO09PSU7qMDswHzAHBgUrDgMCGgQUSM2AwxMfBXKBH7nTqtFwI2zPF/0EFN4t6/m7IFHS48s+ZjArJodRXSNNAgIH0A==\n",
+      "pwd": "test", "policy": {"secret_props": {"contentType": "application/x-pkcs12"}},
+      "attributes": {"enabled": true, "nbf": 1514790000, "exp": 4701913200}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3722'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-keyvault/7.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/import?api-version=7.0
+  response:
+    body:
+      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/c74f5290b60b4ffb9b6079cc82ebf47b","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/c74f5290b60b4ffb9b6079cc82ebf47b","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/c74f5290b60b4ffb9b6079cc82ebf47b","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1588923101,"updated":1588923101,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1588923101,"updated":1588923101}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:31:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=85.191.83.80;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westeurope
+      x-ms-keyvault-service-version:
+      - 1.1.3.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:30:45.49","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3730'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:31:43 GMT
+      etag:
+      - '"1D6250A96434520"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who","name":"madsd-who","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"88d52f7a-b7b2-4ccb-80a5-e4bab463396d","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who2","name":"madsd-who2","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who2.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who3","name":"madsd-who3","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://madsd-who3.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who4","name":"madsd-who4","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who4.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/certs/providers/Microsoft.KeyVault/vaults/tb-certs","name":"tb-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"6b244528-5604-411e-9ff1-5df31b00f93a","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"013244e3-a217-4ca4-bf2a-e65b263959cd","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"4dbab725-22a4-44d5-ad44-c267ca38a954","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"21bf1420-2ed9-48b9-bf6d-ece1337d4fd1","permissions":{"keys":[],"secrets":["Get"],"certificates":["Get"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"],"keys":[],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"ed47c2a1-bd23-4341-b39c-f4fd69138dd3","permissions":{"secrets":["Get","Set","Delete"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://tb-certs.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM="}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7630'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:31:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM=
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tbsbwe-integration/providers/Microsoft.KeyVault/vaults/apim-certs","name":"apim-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"vaultUri":"https://apim-certs.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/webapp-global/providers/Microsoft.KeyVault/vaults/madsd-cert","name":"madsd-cert","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["get"],"certificates":[],"storage":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"vaultUri":"https://madsd-cert.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/who-kv/providers/Microsoft.KeyVault/vaults/madsd-who-kv","name":"madsd-who-kv","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":[],"secrets":[],"certificates":["Import"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"aff4c9f9-46ea-41e2-9df7-e36758965ef1","permissions":{"secrets":["Get"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://madsd-who-kv.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=d2hvLWt2fG1hZHNkLXdoby1rdg=="}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '4716'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:31:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
+  response:
+    body:
+      string: '{"error":{"code":"GatewayTimeout","message":"The gateway did not receive
+        a response from ''Microsoft.KeyVault'' within the specified time period."}}'
+    headers:
+      cache-control:
+      - no-cache
+      connection:
+      - close
+      content-length:
+      - '146'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:32:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - service
+    status:
+      code: 504
+      message: Gateway Timeout
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 08 May 2020 07:32:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/0b9188a0-540d-4262-9311-61bb1a0235ef?api-version=1.6
+  response:
+    body:
+      string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
+        ''0b9188a0-540d-4262-9311-61bb1a0235ef'' does not exist or one of its queried
+        reference-property objects are not present."},"requestId":"754a83b5-7433-4794-8597-4e831d0aaf7f","date":"2020-05-08T07:32:06"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '294'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 08 May 2020 07:32:05 GMT
+      duration:
+      - '583254'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - MMQrQrViRv0Bc3c4iUCyC/u3NCggY7UtseN0uz/06Pk=
+      ocp-aad-session-key:
+      - iSgEwO4NJMQvNsz_0rXqFK9RNSbEJma27uwjVUj4l6aNWHOtApTfuwJ0AteG5FVKU7B4NR10TCD5JTHolp8D1Dp0T4kqlV5ELbB2C_b_-Dl6o-yoLGmGLMGxozRn0RD4.5APszI2MutZS4uv_Ix5hhltbwym5Umv9jOS3QjU7DFs
+      pragma:
+      - no-cache
+      request-id:
+      - 754a83b5-7433-4794-8597-4e831d0aaf7f
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/f8daea97-62e7-4026-becf-13c2ea98e8b4?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
+        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft.Azure.WebSites","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access all the APIs registered with App Service","adminConsentDisplayName":"Access
+        APIs registered with App Service","id":"e0ea806b-d128-49dc-ac08-2bf18f7874d8","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access all the APIs registered with App Service","userConsentDisplayName":"Access
+        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["Microsoft.Azure.WebSites","abfa0a7c-a6b6-4736-8310-5855508787cd"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1674'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Fri, 08 May 2020 07:32:06 GMT
+      duration:
+      - '690138'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - XULeFld9KOmyFfWKBdSX9DqwT8n32mIyA053GG6sPcE=
+      ocp-aad-session-key:
+      - 8CQ75YvOJIh2TjjuUHu4r2SlXsXzPZV2oHYEskIHhM9fOWAPmRmT7t3i_KfZRm3w1fKR65vHHseKg4H5KAI_J7bN1f3A08WARQVWVvePl-WidAVXzVHnl5HEXitXpyLD.SBgV3EM_Q9oMJhDu9JhA_zulHp9Wccl2nN-3YBEdylo
+      pragma:
+      - no-cache
+      request-id:
+      - 0c97f177-5ed6-429e-8315-1b1c6cd4ba31
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''b\''{"location": "West Europe", "properties": {"password": "", "keyVaultId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005",
+      "keyVaultSecretName": "test-cert", "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003"}}\'''''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '534'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/certificates/clitest.rg000002-kv-ssl-test000005-test-cert?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/certificates/clitest.rg000002-kv-ssl-test000005-test-cert","name":"clitest.rg000002-kv-ssl-test000005-test-cert","type":"Microsoft.Web/certificates","location":"West
+        Europe","properties":{"friendlyName":"","subjectName":"*.azurewebsites.net","hostNames":["*.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"*.azurewebsites.net","issueDate":"2018-01-01T07:00:00+00:00","expirationDate":"2118-12-31T07:00:00+00:00","password":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.keyvault/vaults/kv-ssl-test000005","keyVaultSecretName":"test-cert","keyVaultSecretStatus":"Initialized","webSpace":"clitest.rg000002-WestEuropewebspace","serverFarmId":null,"tags":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1361'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:32:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      warning:
+      - 199 Some of the uploaded certificates are either self-signed or expired.,199
+        Some of the uploaded certificates cannot be validated to a trusted CA
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:30:45.49","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3730'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:32:08 GMT
+      etag:
+      - '"1D6250A96434520"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:30:45.49","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3730'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:32:09 GMT
+      etag:
+      - '"1D6250A96434520"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/certificates?api-version=2019-08-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/certificates/clitest.rg000002-kv-ssl-test000005-test-cert","name":"clitest.rg000002-kv-ssl-test000005-test-cert","type":"Microsoft.Web/certificates","location":"West
+        Europe","properties":{"friendlyName":"","subjectName":"*.azurewebsites.net","hostNames":["*.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"*.azurewebsites.net","issueDate":"2018-01-01T07:00:00+00:00","expirationDate":"2118-12-31T07:00:00+00:00","password":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.keyvault/vaults/kv-ssl-test000005","keyVaultSecretName":"test-cert","keyVaultSecretStatus":"Initialized","webSpace":"clitest.rg000002-WestEuropewebspace","serverFarmId":null,"tags":null}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1399'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:32:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004/hostNameBindings?api-version=2019-08-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004/hostNameBindings/web-ssl-test000004.azurewebsites.net","name":"web-ssl-test000004/web-ssl-test000004.azurewebsites.net","type":"Microsoft.Web/sites/hostNameBindings","location":"West
+        Europe","properties":{"siteName":"web-ssl-test000004","domainId":null,"hostNameType":"Verified"}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '527'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:32:10 GMT
+      etag:
+      - '"1D6250A96434520"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "West Europe", "properties": {"hostNameSslStates": [{"name":
+      "web-ssl-test000004.azurewebsites.net", "sslState": "SniEnabled", "thumbprint":
+      "9E9735C45C792B03B3FFCCA614852B32EE71AD6B", "toUpdate": true}], "reserved":
+      false, "isXenon": false, "hyperV": false, "scmSiteAlsoStopped": false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '303'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:32:11.6033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3777'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:32:11 GMT
+      etag:
+      - '"1D6250A96434520"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:32:11.6033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3775'
+      content-type:
+      - application/json
+      date:
+      - Fri, 08 May 2020 07:32:12 GMT
+      etag:
+      - '"1D6250AC9971F35"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004/publishxml?api-version=2019-08-01
+  response:
+    body:
+      string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
+        publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-253dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile></publishData>
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1678'
+      content-type:
+      - application/xml
+      date:
+      - Fri, 08 May 2020 07:32:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_crossrg.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_crossrg.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:17Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:13Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:07:19 GMT
+      - Tue, 12 May 2020 19:31:17 GMT
       expires:
       - '-1'
       pragma:
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:21 GMT
+      - Tue, 12 May 2020 19:31:18 GMT
       expires:
       - '-1'
       pragma:
@@ -126,7 +126,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:17Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:13Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -135,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:07:22 GMT
+      - Tue, 12 May 2020 19:31:18 GMT
       expires:
       - '-1'
       pragma:
@@ -177,8 +177,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":31187,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31187","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":32408,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-147_32408","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:29 GMT
+      - Tue, 12 May 2020 19:31:27 GMT
       expires:
       - '-1'
       pragma:
@@ -234,8 +234,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":31187,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31187","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":32408,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-147_32408","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -244,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:32 GMT
+      - Tue, 12 May 2020 19:31:28 GMT
       expires:
       - '-1'
       pragma:
@@ -302,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:33 GMT
+      - Tue, 12 May 2020 19:31:29 GMT
       expires:
       - '-1'
       pragma:
@@ -349,8 +349,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":31187,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31187","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":32408,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-147_32408","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +359,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:33 GMT
+      - Tue, 12 May 2020 19:31:30 GMT
       expires:
       - '-1'
       pragma:
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:34 GMT
+      - Tue, 12 May 2020 19:31:31 GMT
       expires:
       - '-1'
       pragma:
@@ -469,18 +469,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:37.88","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:35.83","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3720'
+      - '3728'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:54 GMT
+      - Tue, 12 May 2020 19:31:53 GMT
       etag:
-      - '"1D6281B4186F540"'
+      - '"1D62893F399FB2B"'
       expires:
       - '-1'
       pragma:
@@ -532,17 +532,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-147dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 12 May 2020 05:07:55 GMT
+      - Tue, 12 May 2020 19:31:54 GMT
       expires:
       - '-1'
       pragma:
@@ -596,7 +596,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:13Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:10Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -605,7 +605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:07:56 GMT
+      - Tue, 12 May 2020 19:31:55 GMT
       expires:
       - '-1'
       pragma:
@@ -665,19 +665,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:07:58 GMT
+      - Tue, 12 May 2020 19:31:55 GMT
       duration:
-      - '961899'
+      - '869199'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - GLNTgkYWQOipiLSC2Yo0OhZro3lYCsGi4Ph5h6hB5lc=
+      - D5pMLIHvUfLf4s9vGZaMgRtRx0iHO79vDEvM2XNpWmc=
       ocp-aad-session-key:
-      - FTdlNgiCCRpRC-H3MHyqJwnHnB3O3TdVR7Lr78aD2EjL1-54HHPOracZu0V_yrtZaKbxugTCd8sRhU7JMnR9zZs2kYcIcx2_-E84G2OqLxpgzgS0tx5D5q_vZoIZDNnz.J3ME47UVoxBwX2Uy1yBIs-3u98PxWK6Cod6eqIPBH7g
+      - kBsyDu5dx6wg-L81f3kdbXeTlk9ZpD5cn8e5ykLris345S-U618IyMLD39lDXBcwjc3GFpF3zlLI6Dv5dGpF5rCF1oj4JiG3bRrUAc6rcKi3PHVWE_AKQqiq8jnq1ke9.tgoKi-3cKcgVSBbwovw-6_zZ6EpiD5T-hBtCe4Ceveg
       pragma:
       - no-cache
       request-id:
-      - 17c484e4-36c3-4f7d-81c6-7fa73b2bddc9
+      - 97c04691-ae7a-496f-8630-31f881e28028
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -734,7 +734,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:01 GMT
+      - Tue, 12 May 2020 19:31:58 GMT
       expires:
       - '-1'
       pragma:
@@ -789,7 +789,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:35 GMT
+      - Tue, 12 May 2020 19:32:29 GMT
       expires:
       - '-1'
       pragma:
@@ -849,19 +849,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:08:36 GMT
+      - Tue, 12 May 2020 19:32:30 GMT
       duration:
-      - '751948'
+      - '622419'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - PBkMK3FkczqRu4AwwSbI/9dG21Fq1SkcWqiQ0d0toIg=
+      - P3gpvpkk4BW1wM5zPSDPdzHqefqAwFg/M+le4NtwIt4=
       ocp-aad-session-key:
-      - IfDi4iCirHWUdmkOCh8dHvPddSD9WKEjQNF9TgRqiufGN4ZRTeDVILcU1ypzvgAqG7hkCWF8bT9411ZHrBaMo1ib69ZZPu_IircmsXYqNXmn6KCV3CfdIzFxnE7ytxkO.PA-F5NgUVwkviU8LIhBen7eMrqKiPYmiegv4Xslf_3s
+      - d7lG1muSvWtFVxpxH5NVzDSY-cOpsi29hMy_2oO6OBba7VuvzH3l5Yo0xDAert4fXa1hbu7zkm3QuzAWRwzIidHW5G5KYFy8gFDID7aOGhlYd8K0BhKaR5aBNLfyMXOQ.8FbmgUM5VlZmwu5jlWScmvbmKv7lsU70y1M3r3ohrR8
       pragma:
       - no-cache
       request-id:
-      - 00551788-1e4c-4f9b-8c38-90fe38b3dfe0
+      - d150e429-8e45-4bc1-a5c5-941577ac995f
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -904,7 +904,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:36 GMT
+      - Tue, 12 May 2020 19:32:31 GMT
       expires:
       - '-1'
       pragma:
@@ -975,7 +975,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:37 GMT
+      - Tue, 12 May 2020 19:32:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1033,7 +1033,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:38 GMT
+      - Tue, 12 May 2020 19:32:33 GMT
       expires:
       - '-1'
       pragma:
@@ -1084,7 +1084,7 @@ interactions:
     uri: https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/import?api-version=7.0
   response:
     body:
-      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/9c9bc1949fe64ee2bc5838ea60fc5d4c","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/9c9bc1949fe64ee2bc5838ea60fc5d4c","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/9c9bc1949fe64ee2bc5838ea60fc5d4c","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589260119,"updated":1589260119,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589260119,"updated":1589260119}}}'
+      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/3b384f3e5f84423fb82acfed634d9425","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/3b384f3e5f84423fb82acfed634d9425","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/3b384f3e5f84423fb82acfed634d9425","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589311954,"updated":1589311954,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589311954,"updated":1589311954}}}'
     headers:
       cache-control:
       - no-cache
@@ -1093,7 +1093,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:39 GMT
+      - Tue, 12 May 2020 19:32:34 GMT
       expires:
       - '-1'
       pragma:
@@ -1140,18 +1140,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.26","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:36.6266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3718'
+      - '3731'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:40 GMT
+      - Tue, 12 May 2020 19:32:35 GMT
       etag:
-      - '"1D6281B4186F540"'
+      - '"1D62893F399FB2B"'
       expires:
       - '-1'
       pragma:
@@ -1204,7 +1204,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:41 GMT
+      - Tue, 12 May 2020 19:32:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1250,16 +1250,71 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM=
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgl757xpw2ypb35hnluslx4e5ajjokipqhtzw6uqtfgvloecz72m5y4bz6sz7fwijoi/providers/Microsoft.KeyVault/vaults/kv-ssl-testwrns4igag","name":"kv-ssl-testwrns4igag","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testwrns4igag.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgx4rt26hzocre327frzultmovguawysetpl4k45efmie45x5h5ncwr2hcw6d2pvxsh/providers/Microsoft.KeyVault/vaults/kv-ssl-testjjfy5fv7k","name":"kv-ssl-testjjfy5fv7k","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testjjfy5fv7k.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2xpdGVzdC5yZ3g0cnQyNmh6b2NyZTMyN2ZyenVsdG1vdmd1YXd5c2V0cGw0azQ1ZWZtaWU0NXg1aDVuY3dyMmhjdzZkMnB2eHNofGt2LXNzbC10ZXN0ampmeTVmdjdr"}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg3knc3zrtivfa7ivx7itsjomlwkjr6esid6ycems2ick6xtjda7nwcrpwvgvltg6ui/providers/Microsoft.KeyVault/vaults/kv-ssl-testtnrmsbbvx","name":"kv-ssl-testtnrmsbbvx","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testtnrmsbbvx.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgdeeybdgaon4bzatidwejnuguq3p25is2dqltzu4dgfxfizamnele32hom2hur6hyf/providers/Microsoft.KeyVault/vaults/kv-ssl-testbizfzvmi6","name":"kv-ssl-testbizfzvmi6","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testbizfzvmi6.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2xpdGVzdC5yZ2lhNmNlN296Zm1pcG02eTZidnIyeTdvN3lrdGU2ajNzY3BqdnJmYWMzbHdna29vczdmZTdzcHZ0ZWRnb3ZqNmJjfGt2LXNzbC10ZXN0aXd3YWl5eG94"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4161'
+      - '2875'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:41 GMT
+      - Tue, 12 May 2020 19:32:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2xpdGVzdC5yZ2lhNmNlN296Zm1pcG02eTZidnIyeTdvN3lrdGU2ajNzY3BqdnJmYWMzbHdna29vczdmZTdzcHZ0ZWRnb3ZqNmJjfGt2LXNzbC10ZXN0aXd3YWl5eG94
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tbsbwe-integration/providers/Microsoft.KeyVault/vaults/apim-certs","name":"apim-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"vaultUri":"https://apim-certs.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=dGJzYndlLWludGVncmF0aW9ufGFwaW0tY2VydHM="}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2636'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 12 May 2020 19:32:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1314,7 +1369,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:42 GMT
+      - Tue, 12 May 2020 19:32:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1362,7 +1417,7 @@ interactions:
     body:
       string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
         ''0b9188a0-540d-4262-9311-61bb1a0235ef'' does not exist or one of its queried
-        reference-property objects are not present."},"requestId":"2bc02b6c-3b2a-4551-8243-249da700db7b","date":"2020-05-12T05:08:42"}}'
+        reference-property objects are not present."},"requestId":"d222b9ef-7b72-41f9-90d0-d1d982e8cf3c","date":"2020-05-12T19:32:38"}}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1375,19 +1430,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:08:42 GMT
+      - Tue, 12 May 2020 19:32:38 GMT
       duration:
-      - '487032'
+      - '489239'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - siXUS+nNA4qUT85mJNDhvqLqXzTugQrTvBpFIeRfE04=
+      - A0I+8kJwgN1zJUPshFGq3UbFlmzMA3hx23rZo+7kr7E=
       ocp-aad-session-key:
-      - hf-b2WVXqCPCOJZqSlF96NH01Qmr__UMuNd5ltjfgqHWs9FPTWI_BnAVral06YvEwigbzLIdg3BM0EJ6t0iEmuyMYzZmHxRS0AIz-QAdbxkSiC6TKXqXIYwHuN7torqS.6ShkaoA8e-x0Mcl-jc9QkEdw7LwaxkJ879xNMzSaodk
+      - VbvcMXbp4zDRnV0_1A8joPYmVxFx6NqUyoH-QNyoEioflXsRYThaXMA30AvGvcYePHddceXrlx5Dv4TwRKvh_83SdbCkKntBvOBC3gFTPfOGx4SlinyhC58l2_RN4Ds7.Ufy-o0Cl0Oy-qj3lkQT8af6BodyjmgR8I-XTzgTLyFE
       pragma:
       - no-cache
       request-id:
-      - 2bc02b6c-3b2a-4551-8243-249da700db7b
+      - d222b9ef-7b72-41f9-90d0-d1d982e8cf3c
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1439,19 +1494,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:08:42 GMT
+      - Tue, 12 May 2020 19:32:38 GMT
       duration:
-      - '627875'
+      - '633646'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - BLNkFyTT3HZfihAMH1Qcyp+q8lyela4bZDlNA38ZB3U=
+      - 2ctXlTqEryFKnal+2Em76ZTSxA5ECrPwzTAoILgTDZM=
       ocp-aad-session-key:
-      - 4io_Gayw5O076ECs7xj__YbokQ8IXz9poo8eCkNHv7uRVfBzX3tN4fECVm6PnYkMRUDeG8YfoAaWs_jIBcKeCFTpn1iWcRxDzKcsHIOFo3MF0nTiWKoe8kvJ5IPRnVCR.q6H-W6F4VygO38zEQs8CK9X9qHY0ToUMiGEAQ052G_c
+      - bDNXJXTPG_D47oLlufIgxD05UQ0sjPCNMBnH-1w8svQa8xqpdQaquBxZU-16cHa6Ti2qIXyydhkmgB0cNCRyTPFWdBVrATNBYOAvNPVJoAA0yYaWBfpFyjRISV-CgRJy.UlnOXIOVhecHcP7D7CyD98nnjaFQwQuWbr4d6uDUnL0
       pragma:
       - no-cache
       request-id:
-      - 33f7554f-ff3c-4c08-8df2-e280c845fe97
+      - 6f2737d8-6795-44a5-8624-ce7347bda11d
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1501,7 +1556,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:45 GMT
+      - Tue, 12 May 2020 19:32:40 GMT
       expires:
       - '-1'
       pragma:
@@ -1522,7 +1577,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -1551,18 +1606,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.26","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:36.6266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3718'
+      - '3731'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:46 GMT
+      - Tue, 12 May 2020 19:32:42 GMT
       etag:
-      - '"1D6281B4186F540"'
+      - '"1D62893F399FB2B"'
       expires:
       - '-1'
       pragma:
@@ -1607,18 +1662,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.26","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:36.6266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3718'
+      - '3731'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:46 GMT
+      - Tue, 12 May 2020 19:32:43 GMT
       etag:
-      - '"1D6281B4186F540"'
+      - '"1D62893F399FB2B"'
       expires:
       - '-1'
       pragma:
@@ -1672,7 +1727,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:47 GMT
+      - Tue, 12 May 2020 19:32:43 GMT
       expires:
       - '-1'
       pragma:
@@ -1726,9 +1781,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:48 GMT
+      - Tue, 12 May 2020 19:32:44 GMT
       etag:
-      - '"1D6281B4186F540"'
+      - '"1D62893F399FB2B"'
       expires:
       - '-1'
       pragma:
@@ -1780,18 +1835,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:50.06","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:32:46.4733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3760'
+      - '3773'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:50 GMT
+      - Tue, 12 May 2020 19:32:46 GMT
       etag:
-      - '"1D6281B4186F540"'
+      - '"1D62893F399FB2B"'
       expires:
       - '-1'
       pragma:
@@ -1838,18 +1893,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:50.06","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:32:46.4733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3758'
+      - '3771'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:50 GMT
+      - Tue, 12 May 2020 19:32:48 GMT
       etag:
-      - '"1D6281B6C52C4C0"'
+      - '"1D628941D3BBC95"'
       expires:
       - '-1'
       pragma:
@@ -1899,17 +1954,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-147dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -1921,7 +1976,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 12 May 2020 05:08:52 GMT
+      - Tue, 12 May 2020 19:32:48 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_crossrg.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_crossrg.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-08T07:30:27Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:17Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:30:29 GMT
+      - Tue, 12 May 2020 05:07:19 GMT
       expires:
       - '-1'
       pragma:
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:30:30 GMT
+      - Tue, 12 May 2020 05:07:21 GMT
       expires:
       - '-1'
       pragma:
@@ -126,7 +126,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-08T07:30:27Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:17Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -135,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:30:30 GMT
+      - Tue, 12 May 2020 05:07:22 GMT
       expires:
       - '-1'
       pragma:
@@ -177,8 +177,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":27032,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-253_27032","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31187,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31187","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:30:39 GMT
+      - Tue, 12 May 2020 05:07:29 GMT
       expires:
       - '-1'
       pragma:
@@ -234,8 +234,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":27032,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-253_27032","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31187,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31187","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -244,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:30:40 GMT
+      - Tue, 12 May 2020 05:07:32 GMT
       expires:
       - '-1'
       pragma:
@@ -302,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:30:40 GMT
+      - Tue, 12 May 2020 05:07:33 GMT
       expires:
       - '-1'
       pragma:
@@ -349,8 +349,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":27032,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-253_27032","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31187,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-139_31187","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +359,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:30:40 GMT
+      - Tue, 12 May 2020 05:07:33 GMT
       expires:
       - '-1'
       pragma:
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:30:41 GMT
+      - Tue, 12 May 2020 05:07:34 GMT
       expires:
       - '-1'
       pragma:
@@ -469,18 +469,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:30:44.7933333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:37.88","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3737'
+      - '3720'
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:31:01 GMT
+      - Tue, 12 May 2020 05:07:54 GMT
       etag:
-      - '"1D6250A96434520"'
+      - '"1D6281B4186F540"'
       expires:
       - '-1'
       pragma:
@@ -532,17 +532,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-253dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 08 May 2020 07:31:02 GMT
+      - Tue, 12 May 2020 05:07:55 GMT
       expires:
       - '-1'
       pragma:
@@ -596,7 +596,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-08T07:30:21Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:13Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -605,7 +605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:31:03 GMT
+      - Tue, 12 May 2020 05:07:56 GMT
       expires:
       - '-1'
       pragma:
@@ -665,19 +665,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 08 May 2020 07:31:03 GMT
+      - Tue, 12 May 2020 05:07:58 GMT
       duration:
-      - '1276497'
+      - '961899'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - tKzm60xV0/ARMk4TibFT6s6b4D0EK9FgLAcLhsU9Zdo=
+      - GLNTgkYWQOipiLSC2Yo0OhZro3lYCsGi4Ph5h6hB5lc=
       ocp-aad-session-key:
-      - oUdnGdgbwmXtoVOeIWhz46pUBMk4gATBwQrp4-96REURKB7_qKHH2PMOmU1HSXRzLMcvlTy-H5493hgsWoafo6NqjOcqX6Gjhow0LSrf5Qj36XAY59JJ16rgqCNQ7gCP.E-H-H6mqRUA4XErHJneancLn1GfGw7iwtOcEG-wtv7U
+      - FTdlNgiCCRpRC-H3MHyqJwnHnB3O3TdVR7Lr78aD2EjL1-54HHPOracZu0V_yrtZaKbxugTCd8sRhU7JMnR9zZs2kYcIcx2_-E84G2OqLxpgzgS0tx5D5q_vZoIZDNnz.J3ME47UVoxBwX2Uy1yBIs-3u98PxWK6Cod6eqIPBH7g
       pragma:
       - no-cache
       request-id:
-      - 7ccd296b-ad8b-4b47-af32-83347f36750a
+      - 17c484e4-36c3-4f7d-81c6-7fa73b2bddc9
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -734,7 +734,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:31:06 GMT
+      - Tue, 12 May 2020 05:08:01 GMT
       expires:
       - '-1'
       pragma:
@@ -789,7 +789,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:31:35 GMT
+      - Tue, 12 May 2020 05:08:35 GMT
       expires:
       - '-1'
       pragma:
@@ -849,19 +849,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 08 May 2020 07:31:38 GMT
+      - Tue, 12 May 2020 05:08:36 GMT
       duration:
-      - '654488'
+      - '751948'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 3jmX5tYejN2H7PQhIIYrRvojJnfbj/hiLvLd/lJX/Lw=
+      - PBkMK3FkczqRu4AwwSbI/9dG21Fq1SkcWqiQ0d0toIg=
       ocp-aad-session-key:
-      - aPPVDTzHdNVEA7qDA6cm9cHJ_r-yQzAz0eOjJ3bFv0z0pI0BEpfJRbp2eMMXOo9-ipgHlTyXgZy5jPvHgHlMVJBAM-6jUJhNgQH_RkbFITmL8Q1baZeZSOgNIKHQOVYE.Bpb7VxeEl6oNlIGLVvaVjWt4-guyE6K_qCzXmx_UFf8
+      - IfDi4iCirHWUdmkOCh8dHvPddSD9WKEjQNF9TgRqiufGN4ZRTeDVILcU1ypzvgAqG7hkCWF8bT9411ZHrBaMo1ib69ZZPu_IircmsXYqNXmn6KCV3CfdIzFxnE7ytxkO.PA-F5NgUVwkviU8LIhBen7eMrqKiPYmiegv4Xslf_3s
       pragma:
       - no-cache
       request-id:
-      - 8fb60fdd-a404-4dc3-bd79-8cdc8f36e6fd
+      - 00551788-1e4c-4f9b-8c38-90fe38b3dfe0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -904,7 +904,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:31:38 GMT
+      - Tue, 12 May 2020 05:08:36 GMT
       expires:
       - '-1'
       pragma:
@@ -975,7 +975,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:31:39 GMT
+      - Tue, 12 May 2020 05:08:37 GMT
       expires:
       - '-1'
       pragma:
@@ -995,7 +995,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.278
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -1033,7 +1033,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:31:40 GMT
+      - Tue, 12 May 2020 05:08:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1050,7 +1050,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=85.191.83.80;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=185.107.14.16;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
@@ -1084,7 +1084,7 @@ interactions:
     uri: https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/import?api-version=7.0
   response:
     body:
-      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/c74f5290b60b4ffb9b6079cc82ebf47b","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/c74f5290b60b4ffb9b6079cc82ebf47b","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/c74f5290b60b4ffb9b6079cc82ebf47b","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1588923101,"updated":1588923101,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1588923101,"updated":1588923101}}}'
+      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/9c9bc1949fe64ee2bc5838ea60fc5d4c","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/9c9bc1949fe64ee2bc5838ea60fc5d4c","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/9c9bc1949fe64ee2bc5838ea60fc5d4c","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589260119,"updated":1589260119,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589260119,"updated":1589260119}}}'
     headers:
       cache-control:
       - no-cache
@@ -1093,7 +1093,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:31:42 GMT
+      - Tue, 12 May 2020 05:08:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1107,7 +1107,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=85.191.83.80;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=185.107.14.16;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
@@ -1140,18 +1140,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:30:45.49","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.26","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3730'
+      - '3718'
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:31:43 GMT
+      - Tue, 12 May 2020 05:08:40 GMT
       etag:
-      - '"1D6250A96434520"'
+      - '"1D6281B4186F540"'
       expires:
       - '-1'
       pragma:
@@ -1204,7 +1204,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:31:44 GMT
+      - Tue, 12 May 2020 05:08:41 GMT
       expires:
       - '-1'
       pragma:
@@ -1250,16 +1250,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM=
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tbsbwe-integration/providers/Microsoft.KeyVault/vaults/apim-certs","name":"apim-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"vaultUri":"https://apim-certs.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/webapp-global/providers/Microsoft.KeyVault/vaults/madsd-cert","name":"madsd-cert","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["get"],"certificates":[],"storage":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"vaultUri":"https://madsd-cert.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/who-kv/providers/Microsoft.KeyVault/vaults/madsd-who-kv","name":"madsd-who-kv","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":[],"secrets":[],"certificates":["Import"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"aff4c9f9-46ea-41e2-9df7-e36758965ef1","permissions":{"secrets":["Get"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://madsd-who-kv.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=d2hvLWt2fG1hZHNkLXdoby1rdg=="}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgl757xpw2ypb35hnluslx4e5ajjokipqhtzw6uqtfgvloecz72m5y4bz6sz7fwijoi/providers/Microsoft.KeyVault/vaults/kv-ssl-testwrns4igag","name":"kv-ssl-testwrns4igag","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testwrns4igag.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgx4rt26hzocre327frzultmovguawysetpl4k45efmie45x5h5ncwr2hcw6d2pvxsh/providers/Microsoft.KeyVault/vaults/kv-ssl-testjjfy5fv7k","name":"kv-ssl-testjjfy5fv7k","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testjjfy5fv7k.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2xpdGVzdC5yZ3g0cnQyNmh6b2NyZTMyN2ZyenVsdG1vdmd1YXd5c2V0cGw0azQ1ZWZtaWU0NXg1aDVuY3dyMmhjdzZkMnB2eHNofGt2LXNzbC10ZXN0ampmeTVmdjdr"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4716'
+      - '4161'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:31:45 GMT
+      - Tue, 12 May 2020 05:08:41 GMT
       expires:
       - '-1'
       pragma:
@@ -1305,54 +1305,6 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
   response:
     body:
-      string: '{"error":{"code":"GatewayTimeout","message":"The gateway did not receive
-        a response from ''Microsoft.KeyVault'' within the specified time period."}}'
-    headers:
-      cache-control:
-      - no-cache
-      connection:
-      - close
-      content-length:
-      - '146'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 08 May 2020 07:32:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-failure-cause:
-      - service
-    status:
-      code: 504
-      message: Gateway Timeout
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp config ssl import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --key-vault --key-vault-certificate-name
-      User-Agent:
-      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
-  response:
-    body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
@@ -1362,7 +1314,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 08 May 2020 07:32:05 GMT
+      - Tue, 12 May 2020 05:08:42 GMT
       expires:
       - '-1'
       pragma:
@@ -1410,7 +1362,7 @@ interactions:
     body:
       string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
         ''0b9188a0-540d-4262-9311-61bb1a0235ef'' does not exist or one of its queried
-        reference-property objects are not present."},"requestId":"754a83b5-7433-4794-8597-4e831d0aaf7f","date":"2020-05-08T07:32:06"}}'
+        reference-property objects are not present."},"requestId":"2bc02b6c-3b2a-4551-8243-249da700db7b","date":"2020-05-12T05:08:42"}}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1423,19 +1375,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 08 May 2020 07:32:05 GMT
+      - Tue, 12 May 2020 05:08:42 GMT
       duration:
-      - '583254'
+      - '487032'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - MMQrQrViRv0Bc3c4iUCyC/u3NCggY7UtseN0uz/06Pk=
+      - siXUS+nNA4qUT85mJNDhvqLqXzTugQrTvBpFIeRfE04=
       ocp-aad-session-key:
-      - iSgEwO4NJMQvNsz_0rXqFK9RNSbEJma27uwjVUj4l6aNWHOtApTfuwJ0AteG5FVKU7B4NR10TCD5JTHolp8D1Dp0T4kqlV5ELbB2C_b_-Dl6o-yoLGmGLMGxozRn0RD4.5APszI2MutZS4uv_Ix5hhltbwym5Umv9jOS3QjU7DFs
+      - hf-b2WVXqCPCOJZqSlF96NH01Qmr__UMuNd5ltjfgqHWs9FPTWI_BnAVral06YvEwigbzLIdg3BM0EJ6t0iEmuyMYzZmHxRS0AIz-QAdbxkSiC6TKXqXIYwHuN7torqS.6ShkaoA8e-x0Mcl-jc9QkEdw7LwaxkJ879xNMzSaodk
       pragma:
       - no-cache
       request-id:
-      - 754a83b5-7433-4794-8597-4e831d0aaf7f
+      - 2bc02b6c-3b2a-4551-8243-249da700db7b
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1487,19 +1439,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 08 May 2020 07:32:06 GMT
+      - Tue, 12 May 2020 05:08:42 GMT
       duration:
-      - '690138'
+      - '627875'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - XULeFld9KOmyFfWKBdSX9DqwT8n32mIyA053GG6sPcE=
+      - BLNkFyTT3HZfihAMH1Qcyp+q8lyela4bZDlNA38ZB3U=
       ocp-aad-session-key:
-      - 8CQ75YvOJIh2TjjuUHu4r2SlXsXzPZV2oHYEskIHhM9fOWAPmRmT7t3i_KfZRm3w1fKR65vHHseKg4H5KAI_J7bN1f3A08WARQVWVvePl-WidAVXzVHnl5HEXitXpyLD.SBgV3EM_Q9oMJhDu9JhA_zulHp9Wccl2nN-3YBEdylo
+      - 4io_Gayw5O076ECs7xj__YbokQ8IXz9poo8eCkNHv7uRVfBzX3tN4fECVm6PnYkMRUDeG8YfoAaWs_jIBcKeCFTpn1iWcRxDzKcsHIOFo3MF0nTiWKoe8kvJ5IPRnVCR.q6H-W6F4VygO38zEQs8CK9X9qHY0ToUMiGEAQ052G_c
       pragma:
       - no-cache
       request-id:
-      - 0c97f177-5ed6-429e-8315-1b1c6cd4ba31
+      - 33f7554f-ff3c-4c08-8df2-e280c845fe97
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1549,7 +1501,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:32:07 GMT
+      - Tue, 12 May 2020 05:08:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1599,18 +1551,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:30:45.49","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.26","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3730'
+      - '3718'
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:32:08 GMT
+      - Tue, 12 May 2020 05:08:46 GMT
       etag:
-      - '"1D6250A96434520"'
+      - '"1D6281B4186F540"'
       expires:
       - '-1'
       pragma:
@@ -1655,18 +1607,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:30:45.49","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:38.26","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3730'
+      - '3718'
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:32:09 GMT
+      - Tue, 12 May 2020 05:08:46 GMT
       etag:
-      - '"1D6250A96434520"'
+      - '"1D6281B4186F540"'
       expires:
       - '-1'
       pragma:
@@ -1720,7 +1672,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:32:09 GMT
+      - Tue, 12 May 2020 05:08:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1774,9 +1726,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:32:10 GMT
+      - Tue, 12 May 2020 05:08:48 GMT
       etag:
-      - '"1D6250A96434520"'
+      - '"1D6281B4186F540"'
       expires:
       - '-1'
       pragma:
@@ -1828,18 +1780,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:32:11.6033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:50.06","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3777'
+      - '3760'
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:32:11 GMT
+      - Tue, 12 May 2020 05:08:50 GMT
       etag:
-      - '"1D6250A96434520"'
+      - '"1D6281B4186F540"'
       expires:
       - '-1'
       pragma:
@@ -1886,18 +1838,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-253.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-08T07:32:11.6033333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.69.68.1","possibleInboundIpAddresses":"13.69.68.1","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212","possibleOutboundIpAddresses":"13.69.68.1,104.47.161.32,104.47.142.248,40.115.59.104,104.47.144.212,104.47.161.137,104.47.143.150,104.47.161.68","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-253","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-139.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:50.06","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.174.235.29","possibleInboundIpAddresses":"52.174.235.29","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234","possibleOutboundIpAddresses":"52.174.235.29,52.174.57.123,52.174.56.29,52.174.61.120,52.178.71.234,52.174.62.82,52.174.58.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-139","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3775'
+      - '3758'
       content-type:
       - application/json
       date:
-      - Fri, 08 May 2020 07:32:12 GMT
+      - Tue, 12 May 2020 05:08:50 GMT
       etag:
-      - '"1D6250AC9971F35"'
+      - '"1D6281B6C52C4C0"'
       expires:
       - '-1'
       pragma:
@@ -1947,17 +1899,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-253.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-253dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="fp3rsawipMbylf5tykJaN4tm02YbhGXyb3iqyk17q8Y7He1mkLbXxphnToaY"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-139dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="s1k0LwZclkK5oj4kmy7icmQscXRLTfkbQeBx8wLsE0628AQx9oC0dKWb8QHq"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -1969,7 +1921,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 08 May 2020 07:32:13 GMT
+      - Tue, 12 May 2020 05:08:52 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_crossrg.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_crossrg.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:13Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-13T05:37:30Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:31:17 GMT
+      - Wed, 13 May 2020 05:37:32 GMT
       expires:
       - '-1'
       pragma:
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:18 GMT
+      - Wed, 13 May 2020 05:37:34 GMT
       expires:
       - '-1'
       pragma:
@@ -126,7 +126,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:13Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-13T05:37:30Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -135,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:31:18 GMT
+      - Wed, 13 May 2020 05:37:34 GMT
       expires:
       - '-1'
       pragma:
@@ -177,8 +177,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":32408,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-147_32408","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":44078,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-197_44078","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:27 GMT
+      - Wed, 13 May 2020 05:37:43 GMT
       expires:
       - '-1'
       pragma:
@@ -234,8 +234,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":32408,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-147_32408","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":44078,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-197_44078","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -244,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:28 GMT
+      - Wed, 13 May 2020 05:37:49 GMT
       expires:
       - '-1'
       pragma:
@@ -302,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:29 GMT
+      - Wed, 13 May 2020 05:37:50 GMT
       expires:
       - '-1'
       pragma:
@@ -349,8 +349,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":32408,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-147_32408","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":44078,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-197_44078","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +359,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:30 GMT
+      - Wed, 13 May 2020 05:37:51 GMT
       expires:
       - '-1'
       pragma:
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:31 GMT
+      - Wed, 13 May 2020 05:37:52 GMT
       expires:
       - '-1'
       pragma:
@@ -469,18 +469,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:35.83","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-197.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:37:56.2","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.144.107.53","possibleInboundIpAddresses":"51.144.107.53","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-197.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50","possibleOutboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50,51.144.105.68,51.144.109.204,51.144.230.67","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-197","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3728'
+      - '3738'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:31:53 GMT
+      - Wed, 13 May 2020 05:38:12 GMT
       etag:
-      - '"1D62893F399FB2B"'
+      - '"1D628E8A829A435"'
       expires:
       - '-1'
       pragma:
@@ -532,17 +532,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="DAgvnhjvPzC3FMn3dL7brQeHMEDThhrJKmT2Bbb69cf0726Csh9qtcQHnhR5"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-197.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="DAgvnhjvPzC3FMn3dL7brQeHMEDThhrJKmT2Bbb69cf0726Csh9qtcQHnhR5"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-147dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-197dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="DAgvnhjvPzC3FMn3dL7brQeHMEDThhrJKmT2Bbb69cf0726Csh9qtcQHnhR5"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -554,7 +554,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 12 May 2020 19:31:54 GMT
+      - Wed, 13 May 2020 05:38:13 GMT
       expires:
       - '-1'
       pragma:
@@ -596,7 +596,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:10Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-13T05:37:27Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -605,7 +605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:31:55 GMT
+      - Wed, 13 May 2020 05:38:15 GMT
       expires:
       - '-1'
       pragma:
@@ -665,19 +665,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 19:31:55 GMT
+      - Wed, 13 May 2020 05:38:16 GMT
       duration:
-      - '869199'
+      - '1269440'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - D5pMLIHvUfLf4s9vGZaMgRtRx0iHO79vDEvM2XNpWmc=
+      - hQWS2o2W04cZxTdCr8JjCJzZ0tPH18CHKzaXXj9zMk4=
       ocp-aad-session-key:
-      - kBsyDu5dx6wg-L81f3kdbXeTlk9ZpD5cn8e5ykLris345S-U618IyMLD39lDXBcwjc3GFpF3zlLI6Dv5dGpF5rCF1oj4JiG3bRrUAc6rcKi3PHVWE_AKQqiq8jnq1ke9.tgoKi-3cKcgVSBbwovw-6_zZ6EpiD5T-hBtCe4Ceveg
+      - t_9WjUUIaBhA5hP09oANviu_U7ydDfmE4bl8T-T4fZPLQ8i6Jwmt4vFnoIkpbf6izPwS0KCbrNr7N-ljg12OD9T6KixwSVsho5L_nmP7PM847XqafS4K4EHizjR-XUxp.Rq9pxkyDLGN-Cj0iqzKSP6-cumKQK4WXSeH1JclgSpk
       pragma:
       - no-cache
       request-id:
-      - 97c04691-ae7a-496f-8630-31f881e28028
+      - 4ed2d114-96eb-4216-ae40-f78768a0482f
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -734,7 +734,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:31:58 GMT
+      - Wed, 13 May 2020 05:38:19 GMT
       expires:
       - '-1'
       pragma:
@@ -789,7 +789,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:29 GMT
+      - Wed, 13 May 2020 05:38:49 GMT
       expires:
       - '-1'
       pragma:
@@ -849,19 +849,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 19:32:30 GMT
+      - Wed, 13 May 2020 05:38:52 GMT
       duration:
-      - '622419'
+      - '733541'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - P3gpvpkk4BW1wM5zPSDPdzHqefqAwFg/M+le4NtwIt4=
+      - 9nbvFA0YKQGLLgQ1KBlm+aPN2low+a4YeInBcWnBjKY=
       ocp-aad-session-key:
-      - d7lG1muSvWtFVxpxH5NVzDSY-cOpsi29hMy_2oO6OBba7VuvzH3l5Yo0xDAert4fXa1hbu7zkm3QuzAWRwzIidHW5G5KYFy8gFDID7aOGhlYd8K0BhKaR5aBNLfyMXOQ.8FbmgUM5VlZmwu5jlWScmvbmKv7lsU70y1M3r3ohrR8
+      - i9EB8AKqz6vF5Ed3q1iVkYtMRUIhtXF6xKxHEg6f0T56YVprwmcTuIVbG1oIwtcY7AHQKVOyQnvMN-iusNpunYWZXUDME058Es0-LMdU-HaAAdYSnZT6E5MylON0SC3y.eNMfCJfRXcA_Y8jNUXtvDFAFZPWLcBk5NEnEKEllnmc
       pragma:
       - no-cache
       request-id:
-      - d150e429-8e45-4bc1-a5c5-941577ac995f
+      - 8aebbd83-b310-4d3c-a181-63e67f42bd0b
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -904,7 +904,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:31 GMT
+      - Wed, 13 May 2020 05:38:52 GMT
       expires:
       - '-1'
       pragma:
@@ -975,7 +975,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:31 GMT
+      - Wed, 13 May 2020 05:38:53 GMT
       expires:
       - '-1'
       pragma:
@@ -995,7 +995,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.278
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-powered-by:
       - ASP.NET
     status:
@@ -1033,7 +1033,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:33 GMT
+      - Wed, 13 May 2020 05:38:55 GMT
       expires:
       - '-1'
       pragma:
@@ -1050,7 +1050,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=185.107.14.16;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=80.199.117.23;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
@@ -1084,7 +1084,7 @@ interactions:
     uri: https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/import?api-version=7.0
   response:
     body:
-      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/3b384f3e5f84423fb82acfed634d9425","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/3b384f3e5f84423fb82acfed634d9425","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/3b384f3e5f84423fb82acfed634d9425","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589311954,"updated":1589311954,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589311954,"updated":1589311954}}}'
+      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/2bc036f433db408b8240e6c9758d3df4","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/2bc036f433db408b8240e6c9758d3df4","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/2bc036f433db408b8240e6c9758d3df4","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589348336,"updated":1589348336,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589348336,"updated":1589348336}}}'
     headers:
       cache-control:
       - no-cache
@@ -1093,7 +1093,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:34 GMT
+      - Wed, 13 May 2020 05:38:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1107,7 +1107,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=185.107.14.16;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=80.199.117.23;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
@@ -1140,18 +1140,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:36.6266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-197.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:37:57.2833333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.144.107.53","possibleInboundIpAddresses":"51.144.107.53","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-197.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50","possibleOutboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50,51.144.105.68,51.144.109.204,51.144.230.67","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-197","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3731'
+      - '3742'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:35 GMT
+      - Wed, 13 May 2020 05:38:58 GMT
       etag:
-      - '"1D62893F399FB2B"'
+      - '"1D628E8A829A435"'
       expires:
       - '-1'
       pragma:
@@ -1168,171 +1168,6 @@ interactions:
       - 4.0.30319
       x-content-type-options:
       - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp config ssl import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --key-vault --key-vault-certificate-name
-      User-Agent:
-      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who","name":"madsd-who","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"88d52f7a-b7b2-4ccb-80a5-e4bab463396d","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who2","name":"madsd-who2","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who2.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who3","name":"madsd-who3","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"enableRbacAuthorization":false,"vaultUri":"https://madsd-who3.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/appgw-test/providers/Microsoft.KeyVault/vaults/madsd-who4","name":"madsd-who4","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"d3c36c86-431b-4715-adcd-1198ea24d457","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://madsd-who4.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/certs/providers/Microsoft.KeyVault/vaults/tb-certs","name":"tb-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"6b244528-5604-411e-9ff1-5df31b00f93a","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"013244e3-a217-4ca4-bf2a-e65b263959cd","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"4dbab725-22a4-44d5-ad44-c267ca38a954","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"21bf1420-2ed9-48b9-bf6d-ece1337d4fd1","permissions":{"keys":[],"secrets":["Get"],"certificates":["Get"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"],"storage":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"],"keys":[],"certificates":[]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"ed47c2a1-bd23-4341-b39c-f4fd69138dd3","permissions":{"secrets":["Get","Set","Delete"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://tb-certs.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM="}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '7630'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 12 May 2020 19:32:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-service-version:
-      - 1.1.0.278
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp config ssl import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --key-vault --key-vault-certificate-name
-      User-Agent:
-      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2VydHN8dGItY2VydHM=
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg3knc3zrtivfa7ivx7itsjomlwkjr6esid6ycems2ick6xtjda7nwcrpwvgvltg6ui/providers/Microsoft.KeyVault/vaults/kv-ssl-testtnrmsbbvx","name":"kv-ssl-testtnrmsbbvx","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testtnrmsbbvx.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgdeeybdgaon4bzatidwejnuguq3p25is2dqltzu4dgfxfizamnele32hom2hur6hyf/providers/Microsoft.KeyVault/vaults/kv-ssl-testbizfzvmi6","name":"kv-ssl-testbizfzvmi6","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-testbizfzvmi6.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2xpdGVzdC5yZ2lhNmNlN296Zm1pcG02eTZidnIyeTdvN3lrdGU2ajNzY3BqdnJmYWMzbHdna29vczdmZTdzcHZ0ZWRnb3ZqNmJjfGt2LXNzbC10ZXN0aXd3YWl5eG94"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '2875'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 12 May 2020 19:32:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-service-version:
-      - 1.1.0.278
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp config ssl import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --key-vault --key-vault-certificate-name
-      User-Agent:
-      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=Y2xpdGVzdC5yZ2lhNmNlN296Zm1pcG02eTZidnIyeTdvN3lrdGU2ajNzY3BqdnJmYWMzbHdna29vczdmZTdzcHZ0ZWRnb3ZqNmJjfGt2LXNzbC10ZXN0aXd3YWl5eG94
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tbsbwe-integration/providers/Microsoft.KeyVault/vaults/apim-certs","name":"apim-certs","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"2f21f1cf-4d63-4dca-9702-096934001a42","permissions":{"secrets":["List","Get"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"vaultUri":"https://apim-certs.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&$skiptoken=dGJzYndlLWludGVncmF0aW9ufGFwaW0tY2VydHM="}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '2636'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 12 May 2020 19:32:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-keyvault-service-version:
-      - 1.1.0.278
       x-powered-by:
       - ASP.NET
     status:
@@ -1369,7 +1204,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 19:32:37 GMT
+      - Wed, 13 May 2020 05:38:58 GMT
       expires:
       - '-1'
       pragma:
@@ -1417,7 +1252,7 @@ interactions:
     body:
       string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
         ''0b9188a0-540d-4262-9311-61bb1a0235ef'' does not exist or one of its queried
-        reference-property objects are not present."},"requestId":"d222b9ef-7b72-41f9-90d0-d1d982e8cf3c","date":"2020-05-12T19:32:38"}}'
+        reference-property objects are not present."},"requestId":"d83eb08b-4ba9-48ac-bab5-28faeed811b7","date":"2020-05-13T05:38:59"}}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1430,19 +1265,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 19:32:38 GMT
+      - Wed, 13 May 2020 05:38:58 GMT
       duration:
-      - '489239'
+      - '538533'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - A0I+8kJwgN1zJUPshFGq3UbFlmzMA3hx23rZo+7kr7E=
+      - jJF9TOo1F0uhlT6sw5TDP2Ob9dpbdc2I9QNv3vUfDbM=
       ocp-aad-session-key:
-      - VbvcMXbp4zDRnV0_1A8joPYmVxFx6NqUyoH-QNyoEioflXsRYThaXMA30AvGvcYePHddceXrlx5Dv4TwRKvh_83SdbCkKntBvOBC3gFTPfOGx4SlinyhC58l2_RN4Ds7.Ufy-o0Cl0Oy-qj3lkQT8af6BodyjmgR8I-XTzgTLyFE
+      - EX8zmnq6HSGOq5r7ZzbzfFs1C8xoaCijntuFAOKA3HerGVakFaDeuUv0CuxhGJLDVZIF2kJIP1lD_Lf8xg3cEvVHbCAgO29H-AXoi2iFQd27XPYsVMyE3dLqY12F5cp1.-S7Gib-2aOb5Fp0Ntm81mXHS8kU6ynPJacx0nh43Cnw
       pragma:
       - no-cache
       request-id:
-      - d222b9ef-7b72-41f9-90d0-d1d982e8cf3c
+      - d83eb08b-4ba9-48ac-bab5-28faeed811b7
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1494,19 +1329,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 19:32:38 GMT
+      - Wed, 13 May 2020 05:38:59 GMT
       duration:
-      - '633646'
+      - '625499'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 2ctXlTqEryFKnal+2Em76ZTSxA5ECrPwzTAoILgTDZM=
+      - 2sGLsVOhO3to8LazNPF6gLmWjWEMnxAt/p8+qpX3j+Q=
       ocp-aad-session-key:
-      - bDNXJXTPG_D47oLlufIgxD05UQ0sjPCNMBnH-1w8svQa8xqpdQaquBxZU-16cHa6Ti2qIXyydhkmgB0cNCRyTPFWdBVrATNBYOAvNPVJoAA0yYaWBfpFyjRISV-CgRJy.UlnOXIOVhecHcP7D7CyD98nnjaFQwQuWbr4d6uDUnL0
+      - NrLAAHD7-n4k0BEO1i79NRGbdeqmYfhloi4RFJ7duCQUXcu3UnGMPj5CeMlHNaO3dQbplSwc75r8nH6s2Sngzu2TeARASxGErIlQIj9EMO-WcgVbSUef9gqm2EmCRje-.UwgE-vUf1CW0WUB9s_W2PvLnskI9eqrwQ3w_L_sFSjc
       pragma:
       - no-cache
       request-id:
-      - 6f2737d8-6795-44a5-8624-ce7347bda11d
+      - 657aaeca-625c-481d-9b01-0f7231aa16e3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1556,7 +1391,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:40 GMT
+      - Wed, 13 May 2020 05:39:02 GMT
       expires:
       - '-1'
       pragma:
@@ -1606,18 +1441,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:36.6266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-197.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:37:57.2833333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.144.107.53","possibleInboundIpAddresses":"51.144.107.53","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-197.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50","possibleOutboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50,51.144.105.68,51.144.109.204,51.144.230.67","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-197","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3731'
+      - '3742'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:42 GMT
+      - Wed, 13 May 2020 05:39:03 GMT
       etag:
-      - '"1D62893F399FB2B"'
+      - '"1D628E8A829A435"'
       expires:
       - '-1'
       pragma:
@@ -1662,18 +1497,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:36.6266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-197.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:37:57.2833333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.144.107.53","possibleInboundIpAddresses":"51.144.107.53","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-197.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50","possibleOutboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50,51.144.105.68,51.144.109.204,51.144.230.67","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-197","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3731'
+      - '3742'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:43 GMT
+      - Wed, 13 May 2020 05:39:04 GMT
       etag:
-      - '"1D62893F399FB2B"'
+      - '"1D628E8A829A435"'
       expires:
       - '-1'
       pragma:
@@ -1727,7 +1562,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:43 GMT
+      - Wed, 13 May 2020 05:39:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1781,9 +1616,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:44 GMT
+      - Wed, 13 May 2020 05:39:12 GMT
       etag:
-      - '"1D62893F399FB2B"'
+      - '"1D628E8A829A435"'
       expires:
       - '-1'
       pragma:
@@ -1835,18 +1670,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:32:46.4733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-197.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:39:15.2366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.144.107.53","possibleInboundIpAddresses":"51.144.107.53","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-197.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50","possibleOutboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50,51.144.105.68,51.144.109.204,51.144.230.67","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-197","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3773'
+      - '3784'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:46 GMT
+      - Wed, 13 May 2020 05:39:15 GMT
       etag:
-      - '"1D62893F399FB2B"'
+      - '"1D628E8A829A435"'
       expires:
       - '-1'
       pragma:
@@ -1893,18 +1728,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-147.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:32:46.4733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.119.99","possibleInboundIpAddresses":"52.166.119.99","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152","possibleOutboundIpAddresses":"52.166.119.99,52.166.119.196,52.233.176.113,23.100.14.211,23.100.11.152,52.166.64.201,52.166.64.192","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-147","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-197.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-13T05:39:15.2366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"51.144.107.53","possibleInboundIpAddresses":"51.144.107.53","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-197.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50","possibleOutboundIpAddresses":"51.144.107.53,52.136.233.250,51.145.156.41,51.145.130.2,52.136.233.50,51.144.105.68,51.144.109.204,51.144.230.67","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-197","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3771'
+      - '3782'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 19:32:48 GMT
+      - Wed, 13 May 2020 05:39:16 GMT
       etag:
-      - '"1D628941D3BBC95"'
+      - '"1D628E8D6A0604B"'
       expires:
       - '-1'
       pragma:
@@ -1954,17 +1789,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="DAgvnhjvPzC3FMn3dL7brQeHMEDThhrJKmT2Bbb69cf0726Csh9qtcQHnhR5"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-147.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-197.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="DAgvnhjvPzC3FMn3dL7brQeHMEDThhrJKmT2Bbb69cf0726Csh9qtcQHnhR5"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-147dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="GbJ4HoHxGp8f9p76iGvEJyNwH5B1Cue4cP84WKw2hl3SoBtrmpMLHrqCjB9R"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-197dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="DAgvnhjvPzC3FMn3dL7brQeHMEDThhrJKmT2Bbb69cf0726Csh9qtcQHnhR5"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -1976,7 +1811,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 12 May 2020 19:32:48 GMT
+      - Wed, 13 May 2020 05:39:17 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_resource_id.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_resource_id.yaml
@@ -21,7 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:17Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:07:19 GMT
+      - Tue, 12 May 2020 19:31:18 GMT
       expires:
       - '-1'
       pragma:
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:21 GMT
+      - Tue, 12 May 2020 19:31:19 GMT
       expires:
       - '-1'
       pragma:
@@ -126,7 +126,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:17Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -135,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:07:21 GMT
+      - Tue, 12 May 2020 19:31:20 GMT
       expires:
       - '-1'
       pragma:
@@ -177,8 +177,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":29997,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-129_29997","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31206,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-151_31206","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:31 GMT
+      - Tue, 12 May 2020 19:31:28 GMT
       expires:
       - '-1'
       pragma:
@@ -234,8 +234,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":29997,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-129_29997","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31206,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-151_31206","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -244,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:33 GMT
+      - Tue, 12 May 2020 19:31:30 GMT
       expires:
       - '-1'
       pragma:
@@ -302,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:34 GMT
+      - Tue, 12 May 2020 19:31:31 GMT
       expires:
       - '-1'
       pragma:
@@ -349,8 +349,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":29997,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-129_29997","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":31206,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-151_31206","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +359,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:35 GMT
+      - Tue, 12 May 2020 19:31:31 GMT
       expires:
       - '-1'
       pragma:
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:36 GMT
+      - Tue, 12 May 2020 19:31:32 GMT
       expires:
       - '-1'
       pragma:
@@ -469,20 +469,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:39.9266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
-        all","description":"Allow all access"}],"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
-        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-151.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:36.64","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.95.93.152","possibleInboundIpAddresses":"13.95.93.152","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-151.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156","possibleOutboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156,13.94.244.42,13.94.246.37","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-151","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5634'
+      - '3718'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:07:56 GMT
+      - Tue, 12 May 2020 19:31:53 GMT
       etag:
-      - '"1D6281B42FB45C0"'
+      - '"1D62893F3FCA795"'
       expires:
       - '-1'
       pragma:
@@ -534,17 +532,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="EhXn1hhwdLwN0NaKZvHkGl0c5hSoGmhTZFw3oZXEvwqEcSBg4pMdsMstwmWg"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-151.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="EhXn1hhwdLwN0NaKZvHkGl0c5hSoGmhTZFw3oZXEvwqEcSBg4pMdsMstwmWg"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-129dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-151dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="EhXn1hhwdLwN0NaKZvHkGl0c5hSoGmhTZFw3oZXEvwqEcSBg4pMdsMstwmWg"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -556,7 +554,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 12 May 2020 05:07:57 GMT
+      - Tue, 12 May 2020 19:31:54 GMT
       expires:
       - '-1'
       pragma:
@@ -598,7 +596,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:13Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T19:31:10Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -607,7 +605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:07:59 GMT
+      - Tue, 12 May 2020 19:31:55 GMT
       expires:
       - '-1'
       pragma:
@@ -667,19 +665,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:08:01 GMT
+      - Tue, 12 May 2020 19:31:56 GMT
       duration:
-      - '868363'
+      - '908947'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - dusSHMGp8AHql3T0nao3jfF854LW2KCS83LdNeRhCpA=
+      - L9f9I9ocpvSBVm40jLNLuD0XOW+Mi6xe+xAqA6+Jkl8=
       ocp-aad-session-key:
-      - 7l6PxrW6ku37Z98X_ya-cHprwlCS8wHMARY7VpcV5qA6cRn7PaVD87AflFeYeaoU-9UFPoT0ZK8IqKAn0085HHz3gOoAGCbE4Zrdtla4VuE6DsxRCUqjCprDa_Fb5GJN.whq2Uq7_Rvy20ky1Mxuifvvb27Iski-uvTP4yRNFBU8
+      - YjTzb2No1P-FCgQ2DbgX8RGtLRIVKxd-z_e7kPRR24yHPIKpbNm1_6PfMtQ63SKswKlj6qk-gUbWC2RS2K2nr9FiK0coveGMwLQyQgsunScN2GJZ02GfVuPEuXlhZ6lx.0WcP6T_231XRuClPpA_EpRne3icxbHOjWQQZHrdhqSI
       pragma:
       - no-cache
       request-id:
-      - a48f4b0b-c47b-4819-bd57-231a0e4d3d94
+      - 8a8747c0-d788-426b-82d9-e3b06c3a1274
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -736,7 +734,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:05 GMT
+      - Tue, 12 May 2020 19:31:58 GMT
       expires:
       - '-1'
       pragma:
@@ -756,7 +754,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.278
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-powered-by:
       - ASP.NET
     status:
@@ -791,7 +789,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:36 GMT
+      - Tue, 12 May 2020 19:32:28 GMT
       expires:
       - '-1'
       pragma:
@@ -851,19 +849,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:08:38 GMT
+      - Tue, 12 May 2020 19:32:30 GMT
       duration:
-      - '597140'
+      - '872255'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - +mFhW3zfNlL3MqkQdNCdtnQrkmSB0OaKpcrtrJZMtTY=
+      - tig9LfZj3s29ygFZVQtm0nWR8oG5C2HMc7apOOtdSJI=
       ocp-aad-session-key:
-      - xFmd30BJeaztQgte0MtqpTpv7_sf9BTPFw9Q2DIx7LesoFUhSyCPWgcoz04y9GwNpOiC-9tGgwlxY2e6bf8hJFkO3V2FHnrSof-IWdrrkZrPKoSxTjhfjRu1_s4OFHjg.HjFTPFr-rdLTEPnAqElPlYbJT7dBrqrcpwP1fEXzPog
+      - MM0qrpIroiqudD7Q5CBpG8_-jCd4KNlTd8BeSLLT29KlC8UswtL6CgmhDp04T1xFztBHNUG0meoMR-PLKUhiK7bNkGxHQ52w7Y_p880tcEtohNIJHZMXvC_Gqv7MhcWk.-i5JhA_Bhp2ifH4IAo4Rabwi_otnJFMV5ByOgJQxtZ4
       pragma:
       - no-cache
       request-id:
-      - 94a84400-3980-4f12-9106-dfab3febacf7
+      - 29e2ab5a-5cd1-4d50-b051-c0ab5f3ac37d
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -906,7 +904,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:38 GMT
+      - Tue, 12 May 2020 19:32:31 GMT
       expires:
       - '-1'
       pragma:
@@ -977,7 +975,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:39 GMT
+      - Tue, 12 May 2020 19:32:31 GMT
       expires:
       - '-1'
       pragma:
@@ -997,7 +995,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.278
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -1035,7 +1033,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:40 GMT
+      - Tue, 12 May 2020 19:32:33 GMT
       expires:
       - '-1'
       pragma:
@@ -1086,7 +1084,7 @@ interactions:
     uri: https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/import?api-version=7.0
   response:
     body:
-      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/f91c346dff034e0f89e40366db1fdd80","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/f91c346dff034e0f89e40366db1fdd80","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/f91c346dff034e0f89e40366db1fdd80","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589260122,"updated":1589260122,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589260122,"updated":1589260122}}}'
+      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/ea599e7f630b485e8699dcd6e94feaeb","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/ea599e7f630b485e8699dcd6e94feaeb","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/ea599e7f630b485e8699dcd6e94feaeb","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589311955,"updated":1589311955,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589311955,"updated":1589311955}}}'
     headers:
       cache-control:
       - no-cache
@@ -1095,7 +1093,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:42 GMT
+      - Tue, 12 May 2020 19:32:34 GMT
       expires:
       - '-1'
       pragma:
@@ -1142,18 +1140,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:40.7","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-151.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:37.2733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.95.93.152","possibleInboundIpAddresses":"13.95.93.152","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-151.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156","possibleOutboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156,13.94.244.42,13.94.246.37","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-151","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5428'
+      - '3721'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:43 GMT
+      - Tue, 12 May 2020 19:32:36 GMT
       etag:
-      - '"1D6281B42FB45C0"'
+      - '"1D62893F3FCA795"'
       expires:
       - '-1'
       pragma:
@@ -1206,7 +1204,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 12 May 2020 05:08:44 GMT
+      - Tue, 12 May 2020 19:32:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1254,7 +1252,7 @@ interactions:
     body:
       string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
         ''0b9188a0-540d-4262-9311-61bb1a0235ef'' does not exist or one of its queried
-        reference-property objects are not present."},"requestId":"f94db2b7-8254-48e9-bdce-4ce9a99988f2","date":"2020-05-12T05:08:45"}}'
+        reference-property objects are not present."},"requestId":"b0bd544a-a5de-4ef5-a91c-6ffbbe19682e","date":"2020-05-12T19:32:38"}}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1267,19 +1265,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:08:44 GMT
+      - Tue, 12 May 2020 19:32:37 GMT
       duration:
-      - '590574'
+      - '582921'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - b9ASSZteLM8czm9V1W7BZ5NF7ky+34pVlnCiBkefH2U=
+      - IA+f26hykHGFjqbb0zO6E7kkIcADwfInsfAi7FFANSA=
       ocp-aad-session-key:
-      - Gd2jTvEdU6_NMAZI-dUkiypom6oQIzqpHRmcvaFES-kJbdsPluS46_LTA6HyKfb5ZYrz6p1zHoYPTRu252OB6aEqZgwwWzNgwuBDqXXUAtrufRDDz1Ezf0m3BS8w83-0._S_uX9Ofi1SEZ6qZSk35Tp4BzIJQmCf1eY1uWGejstE
+      - ja-AW6RZQXRuUzIhQr4QWZ1sfvRnPKLv6G5LR6VwvoKfeuaDaF7uIYfyzJHmGiJ3pJxfeXCrju5im6zV1bPg0kyE1ULuIuCJ4_VNnB42_-06msVuHlpKs-VyxqFqjeJT.D6Ykx21XnKcIdm9JHPkm5O651FqFAXNrtH3b9ceV9g0
       pragma:
       - no-cache
       request-id:
-      - f94db2b7-8254-48e9-bdce-4ce9a99988f2
+      - b0bd544a-a5de-4ef5-a91c-6ffbbe19682e
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1331,19 +1329,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 12 May 2020 05:08:45 GMT
+      - Tue, 12 May 2020 19:32:37 GMT
       duration:
-      - '632852'
+      - '784750'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - iYxoT8fSWWhlxJc2rGBuP3JOC8UJ+1n2qF9+WsQLam4=
+      - mG4tzi+r14oyWd6xDxeA2UPg1mYjls3jKglBI+YMfzQ=
       ocp-aad-session-key:
-      - R5lguPe1VmhOzvwLO1XWuZJpuR-IjfRZX4IW9B28libZpUTIpFo5XGQV6gmffxdqUTW7MEhwpF85-cnYWZgi_Q-U8oV_qVZx2UCssCuBJEwg5JyN8GE7RIORvFKBbXzN.ASWvp9pCgdjaBphQTU7I06QIxA32waRm0hl1JVMgTHw
+      - 7tHglW3nGVGuxri3EWnsSOmlV35vJcHF7QBMa5CIz0xlqUUnWHE0cO5U7L3YA9gJNeuZHvFqO928Tb2QIx6JancB2XUIrAkYdL7tan4Wt8PwDGfX14cYUxMJIfgUh5Sd.2pTgVTbwAaG_sobXWzoeEtHvqpt51OZLnp4KK8PfzjI
       pragma:
       - no-cache
       request-id:
-      - 6d4f5d3b-883a-4b1f-9ca2-4b5d2b7a8ccd
+      - 5666567a-26c9-4bf4-b4c6-954caf3a268d
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1393,7 +1391,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:47 GMT
+      - Tue, 12 May 2020 19:32:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1443,18 +1441,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:40.7","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-151.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:37.2733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.95.93.152","possibleInboundIpAddresses":"13.95.93.152","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-151.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156","possibleOutboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156,13.94.244.42,13.94.246.37","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-151","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5428'
+      - '3721'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:49 GMT
+      - Tue, 12 May 2020 19:32:41 GMT
       etag:
-      - '"1D6281B42FB45C0"'
+      - '"1D62893F3FCA795"'
       expires:
       - '-1'
       pragma:
@@ -1499,18 +1497,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:40.7","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-151.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:31:37.2733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.95.93.152","possibleInboundIpAddresses":"13.95.93.152","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-151.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156","possibleOutboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156,13.94.244.42,13.94.246.37","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-151","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5428'
+      - '3721'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:49 GMT
+      - Tue, 12 May 2020 19:32:42 GMT
       etag:
-      - '"1D6281B42FB45C0"'
+      - '"1D62893F3FCA795"'
       expires:
       - '-1'
       pragma:
@@ -1564,7 +1562,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:49 GMT
+      - Tue, 12 May 2020 19:32:43 GMT
       expires:
       - '-1'
       pragma:
@@ -1618,9 +1616,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:50 GMT
+      - Tue, 12 May 2020 19:32:44 GMT
       etag:
-      - '"1D6281B42FB45C0"'
+      - '"1D62893F3FCA795"'
       expires:
       - '-1'
       pragma:
@@ -1672,20 +1670,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:52.65","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
-        all","description":"Allow all access"}],"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
-        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-151.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:32:46.1633333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.95.93.152","possibleInboundIpAddresses":"13.95.93.152","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-151.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156","possibleOutboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156,13.94.244.42,13.94.246.37","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-151","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5669'
+      - '3763'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:53 GMT
+      - Tue, 12 May 2020 19:32:47 GMT
       etag:
-      - '"1D6281B42FB45C0"'
+      - '"1D62893F3FCA795"'
       expires:
       - '-1'
       pragma:
@@ -1732,18 +1728,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:52.65","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-151.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T19:32:46.1633333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":null,"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"13.95.93.152","possibleInboundIpAddresses":"13.95.93.152","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-151.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156","possibleOutboundIpAddresses":"13.95.93.152,13.94.247.233,52.174.98.160,104.40.144.74,13.94.243.156,13.94.244.42,13.94.246.37","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-151","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5469'
+      - '3761'
       content-type:
       - application/json
       date:
-      - Tue, 12 May 2020 05:08:53 GMT
+      - Tue, 12 May 2020 19:32:47 GMT
       etag:
-      - '"1D6281B6DDDF8A0"'
+      - '"1D628941D0C6F35"'
       expires:
       - '-1'
       pragma:
@@ -1793,17 +1789,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="EhXn1hhwdLwN0NaKZvHkGl0c5hSoGmhTZFw3oZXEvwqEcSBg4pMdsMstwmWg"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-151.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="EhXn1hhwdLwN0NaKZvHkGl0c5hSoGmhTZFw3oZXEvwqEcSBg4pMdsMstwmWg"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-129dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-151dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="EhXn1hhwdLwN0NaKZvHkGl0c5hSoGmhTZFw3oZXEvwqEcSBg4pMdsMstwmWg"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -1815,7 +1811,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 12 May 2020 05:08:54 GMT
+      - Tue, 12 May 2020 19:32:48 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_resource_id.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_resource_id.yaml
@@ -21,57 +21,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
   response:
     body:
-      string: '{"error":{"code":"ServerTimeout","message":"The request timed out.
-        Diagnostic information: timestamp ''20200510T131417Z'', subscription id ''a6f7834d-3304-4890-82af-ec04cb382539'',
-        tracking id ''26d63c60-38d1-47ea-a8b7-4f6a3a21afbe'', request correlation
-        id ''26d63c60-38d1-47ea-a8b7-4f6a3a21afbe''."}}'
-    headers:
-      cache-control:
-      - no-cache
-      connection:
-      - close
-      content-length:
-      - '294'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sun, 10 May 2020 13:14:17 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-failure-cause:
-      - gateway
-    status:
-      code: 503
-      message: Service Unavailable
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - appservice plan create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --sku
-      User-Agent:
-      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.5.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-10T13:13:47Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:17Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -80,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 10 May 2020 13:14:16 GMT
+      - Tue, 12 May 2020 05:07:19 GMT
       expires:
       - '-1'
       pragma:
@@ -130,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:14:17 GMT
+      - Tue, 12 May 2020 05:07:21 GMT
       expires:
       - '-1'
       pragma:
@@ -176,7 +126,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-10T13:13:47Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:17Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -185,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 10 May 2020 13:14:17 GMT
+      - Tue, 12 May 2020 05:07:21 GMT
       expires:
       - '-1'
       pragma:
@@ -227,8 +177,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":35574,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-227_35574","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":29997,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-129_29997","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -237,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:14:23 GMT
+      - Tue, 12 May 2020 05:07:31 GMT
       expires:
       - '-1'
       pragma:
@@ -284,8 +234,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":35574,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-227_35574","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":29997,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-129_29997","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -294,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:14:24 GMT
+      - Tue, 12 May 2020 05:07:33 GMT
       expires:
       - '-1'
       pragma:
@@ -352,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:14:24 GMT
+      - Tue, 12 May 2020 05:07:34 GMT
       expires:
       - '-1'
       pragma:
@@ -399,8 +349,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        Europe","properties":{"serverFarmId":35574,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-227_35574","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        Europe","properties":{"serverFarmId":29997,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-129_29997","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -409,7 +359,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:14:24 GMT
+      - Tue, 12 May 2020 05:07:35 GMT
       expires:
       - '-1'
       pragma:
@@ -466,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:14:25 GMT
+      - Tue, 12 May 2020 05:07:36 GMT
       expires:
       - '-1'
       pragma:
@@ -519,20 +469,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:14:28.64","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:39.9266667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
         all","description":"Allow all access"}],"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
-        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5669'
+      - '5634'
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:14:48 GMT
+      - Tue, 12 May 2020 05:07:56 GMT
       etag:
-      - '"1D626CCEFBD830B"'
+      - '"1D6281B42FB45C0"'
       expires:
       - '-1'
       pragma:
@@ -584,17 +534,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-227dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-129dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -606,7 +556,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Sun, 10 May 2020 13:14:48 GMT
+      - Tue, 12 May 2020 05:07:57 GMT
       expires:
       - '-1'
       pragma:
@@ -648,7 +598,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-10T13:13:44Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-12T05:07:13Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -657,7 +607,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 10 May 2020 13:14:50 GMT
+      - Tue, 12 May 2020 05:07:59 GMT
       expires:
       - '-1'
       pragma:
@@ -717,19 +667,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Sun, 10 May 2020 13:14:50 GMT
+      - Tue, 12 May 2020 05:08:01 GMT
       duration:
-      - '1330262'
+      - '868363'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - htKZvCnr8HUR1REZieaQY4s8XIj+ROFv1UinuZtIuDo=
+      - dusSHMGp8AHql3T0nao3jfF854LW2KCS83LdNeRhCpA=
       ocp-aad-session-key:
-      - JjxVogHhMxX7Ef4RqWvmJnGglMagHLBIT3OifKekOAyLiVdCWce1OXtZVIkbd203vepvApcK8EVWhYY4Q_gcWZBBdFlDOPQq3F7888nDpXStlfO_-P2VooJ_rtIEoen-.5AbvQ0Z7hViNs6ISL_8fPHyjV7XltTNXQs8xo5F_AGU
+      - 7l6PxrW6ku37Z98X_ya-cHprwlCS8wHMARY7VpcV5qA6cRn7PaVD87AflFeYeaoU-9UFPoT0ZK8IqKAn0085HHz3gOoAGCbE4Zrdtla4VuE6DsxRCUqjCprDa_Fb5GJN.whq2Uq7_Rvy20ky1Mxuifvvb27Iski-uvTP4yRNFBU8
       pragma:
       - no-cache
       request-id:
-      - 69301580-ff05-425f-8272-b8331d4ceed8
+      - a48f4b0b-c47b-4819-bd57-231a0e4d3d94
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -786,7 +736,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 10 May 2020 13:14:52 GMT
+      - Tue, 12 May 2020 05:08:05 GMT
       expires:
       - '-1'
       pragma:
@@ -841,7 +791,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 10 May 2020 13:15:23 GMT
+      - Tue, 12 May 2020 05:08:36 GMT
       expires:
       - '-1'
       pragma:
@@ -901,19 +851,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Sun, 10 May 2020 13:15:23 GMT
+      - Tue, 12 May 2020 05:08:38 GMT
       duration:
-      - '681154'
+      - '597140'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - DTbc+ix7+LLHlTTkVueMm+LsccsKsJNfJqnQvKw39+w=
+      - +mFhW3zfNlL3MqkQdNCdtnQrkmSB0OaKpcrtrJZMtTY=
       ocp-aad-session-key:
-      - OwAgbRiME70C94sv-Zn2sJAVNaiYYzLo54HZfL929tiq9OgvHKfPNCErb8X_Ml9Iu5oYy8zueqN3Qe_bMVtC68YPFpflnuFU069BuNGHLWiiCca8LbcxafT0Wit9kf6o.N1XyPMtyezhPxwL2OuqK0xh21offiBccg19L9fApdto
+      - xFmd30BJeaztQgte0MtqpTpv7_sf9BTPFw9Q2DIx7LesoFUhSyCPWgcoz04y9GwNpOiC-9tGgwlxY2e6bf8hJFkO3V2FHnrSof-IWdrrkZrPKoSxTjhfjRu1_s4OFHjg.HjFTPFr-rdLTEPnAqElPlYbJT7dBrqrcpwP1fEXzPog
       pragma:
       - no-cache
       request-id:
-      - 912e2aee-a563-4278-a1a4-5a50f9e25615
+      - 94a84400-3980-4f12-9106-dfab3febacf7
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -956,7 +906,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 10 May 2020 13:15:23 GMT
+      - Tue, 12 May 2020 05:08:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1027,7 +977,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 10 May 2020 13:15:24 GMT
+      - Tue, 12 May 2020 05:08:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1047,7 +997,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.278
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-powered-by:
       - ASP.NET
     status:
@@ -1085,7 +1035,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 10 May 2020 13:15:25 GMT
+      - Tue, 12 May 2020 05:08:40 GMT
       expires:
       - '-1'
       pragma:
@@ -1102,7 +1052,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=85.191.83.80;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=185.107.14.16;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
@@ -1136,7 +1086,7 @@ interactions:
     uri: https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/import?api-version=7.0
   response:
     body:
-      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/aee50af278ef4b80b383cdc4c1c78e2d","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/aee50af278ef4b80b383cdc4c1c78e2d","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/aee50af278ef4b80b383cdc4c1c78e2d","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589116526,"updated":1589116526,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589116526,"updated":1589116526}}}'
+      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/f91c346dff034e0f89e40366db1fdd80","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/f91c346dff034e0f89e40366db1fdd80","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/f91c346dff034e0f89e40366db1fdd80","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589260122,"updated":1589260122,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589260122,"updated":1589260122}}}'
     headers:
       cache-control:
       - no-cache
@@ -1145,7 +1095,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 10 May 2020 13:15:26 GMT
+      - Tue, 12 May 2020 05:08:42 GMT
       expires:
       - '-1'
       pragma:
@@ -1159,7 +1109,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=85.191.83.80;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=185.107.14.16;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - westeurope
       x-ms-keyvault-service-version:
@@ -1192,18 +1142,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:14:29.1366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:40.7","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5474'
+      - '5428'
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:15:26 GMT
+      - Tue, 12 May 2020 05:08:43 GMT
       etag:
-      - '"1D626CCEFBD830B"'
+      - '"1D6281B42FB45C0"'
       expires:
       - '-1'
       pragma:
@@ -1256,7 +1206,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sun, 10 May 2020 13:15:26 GMT
+      - Tue, 12 May 2020 05:08:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1304,7 +1254,7 @@ interactions:
     body:
       string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
         ''0b9188a0-540d-4262-9311-61bb1a0235ef'' does not exist or one of its queried
-        reference-property objects are not present."},"requestId":"03c6c13a-22d7-45d5-a105-51c750d3a485","date":"2020-05-10T13:15:27"}}'
+        reference-property objects are not present."},"requestId":"f94db2b7-8254-48e9-bdce-4ce9a99988f2","date":"2020-05-12T05:08:45"}}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1317,19 +1267,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Sun, 10 May 2020 13:15:27 GMT
+      - Tue, 12 May 2020 05:08:44 GMT
       duration:
-      - '572415'
+      - '590574'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - gouRwkMGqa9oecE8OcsEopiI8YHb0gp+p/F97njONMQ=
+      - b9ASSZteLM8czm9V1W7BZ5NF7ky+34pVlnCiBkefH2U=
       ocp-aad-session-key:
-      - ZTSujUbpXyi1RdhQcWezbOqZoATPr_LDruGwTx8qhuWqVZWMXus_6ElHo961vvLCyUqjfMOjR-HWO50KScmJ12C7K3EfFDINepNluj5N50BCk_UAQz6uyNZ-7GRxFb83.8TkE--cXKrLu1aVc3r95vWYBBcu26jn8wQ0yuVg-y3Y
+      - Gd2jTvEdU6_NMAZI-dUkiypom6oQIzqpHRmcvaFES-kJbdsPluS46_LTA6HyKfb5ZYrz6p1zHoYPTRu252OB6aEqZgwwWzNgwuBDqXXUAtrufRDDz1Ezf0m3BS8w83-0._S_uX9Ofi1SEZ6qZSk35Tp4BzIJQmCf1eY1uWGejstE
       pragma:
       - no-cache
       request-id:
-      - 03c6c13a-22d7-45d5-a105-51c750d3a485
+      - f94db2b7-8254-48e9-bdce-4ce9a99988f2
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1381,19 +1331,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Sun, 10 May 2020 13:15:27 GMT
+      - Tue, 12 May 2020 05:08:45 GMT
       duration:
-      - '657638'
+      - '632852'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - OVWdKJpEaDVjKez2/zHG7VUEvTFK1ivsTh03KZzgw4c=
+      - iYxoT8fSWWhlxJc2rGBuP3JOC8UJ+1n2qF9+WsQLam4=
       ocp-aad-session-key:
-      - 9d1D6GvAV10LTNBgkrugAipPZEcr3AVThJnQ08CdmY_Ci6GCFMaTlvATUdmDiUrzkQO4eLBR9qqZOD_8FxP0yCOSylwOdlvOQE7IRn7Dikjtwc1wtNGV1UjBaCevAzFo.5qp9lm40wmTnIklah3HA4Zeoi7JhtUyKM8iJWTX8zO8
+      - R5lguPe1VmhOzvwLO1XWuZJpuR-IjfRZX4IW9B28libZpUTIpFo5XGQV6gmffxdqUTW7MEhwpF85-cnYWZgi_Q-U8oV_qVZx2UCssCuBJEwg5JyN8GE7RIORvFKBbXzN.ASWvp9pCgdjaBphQTU7I06QIxA32waRm0hl1JVMgTHw
       pragma:
       - no-cache
       request-id:
-      - ef1ad9f0-f40c-4052-b204-a025cf5121b7
+      - 6d4f5d3b-883a-4b1f-9ca2-4b5d2b7a8ccd
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1443,7 +1393,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:15:29 GMT
+      - Tue, 12 May 2020 05:08:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1493,18 +1443,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:14:29.1366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:40.7","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5474'
+      - '5428'
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:15:29 GMT
+      - Tue, 12 May 2020 05:08:49 GMT
       etag:
-      - '"1D626CCEFBD830B"'
+      - '"1D6281B42FB45C0"'
       expires:
       - '-1'
       pragma:
@@ -1549,18 +1499,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:14:29.1366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:07:40.7","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5474'
+      - '5428'
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:15:29 GMT
+      - Tue, 12 May 2020 05:08:49 GMT
       etag:
-      - '"1D626CCEFBD830B"'
+      - '"1D6281B42FB45C0"'
       expires:
       - '-1'
       pragma:
@@ -1614,7 +1564,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:15:29 GMT
+      - Tue, 12 May 2020 05:08:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1668,9 +1618,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:15:31 GMT
+      - Tue, 12 May 2020 05:08:50 GMT
       etag:
-      - '"1D626CCEFBD830B"'
+      - '"1D6281B42FB45C0"'
       expires:
       - '-1'
       pragma:
@@ -1722,20 +1672,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:15:32.6366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:52.65","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
         all","description":"Allow all access"}],"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
-        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5714'
+      - '5669'
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:15:32 GMT
+      - Tue, 12 May 2020 05:08:53 GMT
       etag:
-      - '"1D626CCEFBD830B"'
+      - '"1D6281B42FB45C0"'
       expires:
       - '-1'
       pragma:
@@ -1782,18 +1732,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
-        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:15:32.6366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-129.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-12T05:08:52.65","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"52.166.78.97","possibleInboundIpAddresses":"52.166.78.97","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59","possibleOutboundIpAddresses":"52.166.78.97,52.166.76.57,52.166.72.50,52.166.72.42,52.166.73.59,51.144.105.240,40.91.195.191","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-129","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5514'
+      - '5469'
       content-type:
       - application/json
       date:
-      - Sun, 10 May 2020 13:15:34 GMT
+      - Tue, 12 May 2020 05:08:53 GMT
       etag:
-      - '"1D626CD1596D7CB"'
+      - '"1D6281B6DDDF8A0"'
       expires:
       - '-1'
       pragma:
@@ -1843,17 +1793,17 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-129.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-227dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-129dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="WmqCggEzjtZ7XQLjmRwMQ5FkCbvnCAB730matlRfcRhACR4XfofM3w3Lueo3"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -1865,7 +1815,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Sun, 10 May 2020 13:15:34 GMT
+      - Tue, 12 May 2020 05:08:54 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_resource_id.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_resource_id.yaml
@@ -1,0 +1,1888 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
+  response:
+    body:
+      string: '{"error":{"code":"ServerTimeout","message":"The request timed out.
+        Diagnostic information: timestamp ''20200510T131417Z'', subscription id ''a6f7834d-3304-4890-82af-ec04cb382539'',
+        tracking id ''26d63c60-38d1-47ea-a8b7-4f6a3a21afbe'', request correlation
+        id ''26d63c60-38d1-47ea-a8b7-4f6a3a21afbe''."}}'
+    headers:
+      cache-control:
+      - no-cache
+      connection:
+      - close
+      content-length:
+      - '294'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 10 May 2020 13:14:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 503
+      message: Service Unavailable
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-10T13:13:47Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '432'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 10 May 2020 13:14:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "ssl-test-plan000003", "type": "Microsoft.Web/serverfarms", "location":
+      "westeurope", "properties": {"skuName": "B1", "capacity": 1}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --sku
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/validate?api-version=2019-08-01
+  response:
+    body:
+      string: '{"status":"Success","error":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '33'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:14:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --sku
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-10T13:13:47Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '432'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 10 May 2020 13:14:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westeurope", "properties": {"perSiteScaling": false, "isXenon":
+      false}, "sku": {"name": "B1", "tier": "BASIC", "capacity": 1}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - appservice plan create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '140'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --sku
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        Europe","properties":{"serverFarmId":35574,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-227_35574","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1536'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:14:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        Europe","properties":{"serverFarmId":35574,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-227_35574","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1536'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:14:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"name": "web-ssl-test000004", "type": "Microsoft.Web/sites", "location":
+      "West Europe", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003"}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '329'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/validate?api-version=2019-08-01
+  response:
+    body:
+      string: '{"status":"Success","error":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '33'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:14:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        Europe","properties":{"serverFarmId":35574,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-WestEuropewebspace","subscription":"a6f7834d-3304-4890-82af-ec04cb382539","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        Europe","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-am2-227_35574","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1536'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:14:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "web-ssl-test000004", "type": "Site"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/checknameavailability?api-version=2019-08-01
+  response:
+    body:
+      string: '{"nameAvailable":true,"reason":"","message":""}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '47'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:14:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"location": "West Europe", "properties": {"serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003",
+      "reserved": false, "isXenon": false, "hyperV": false, "siteConfig": {"netFrameworkVersion":
+      "v4.6", "appSettings": [{"name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "10.14"}],
+      "localMySqlEnabled": false, "http20Enabled": true}, "scmSiteAlsoStopped": false,
+      "httpsOnly": false}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '544'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:14:28.64","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5669'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:14:48 GMT
+      etag:
+      - '"1D626CCEFBD830B"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --plan
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004/publishxml?api-version=2019-08-01
+  response:
+    body:
+      string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
+        publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-227dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile></publishData>
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1678'
+      content-type:
+      - application/xml
+      date:
+      - Sun, 10 May 2020 13:14:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-resource/8.0.1 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2020-05-10T13:13:44Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '432'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 10 May 2020 13:14:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":["65cc641f-cccd-4643-97e0-a17e3045e541","e26c2fcc-ab91-4a61-b35c-03cdc8dddf66","46129a58-a698-46f0-aa5b-17f6586297d9","6db1f1db-2b46-403f-be40-e39395f08dbb","6dc145d6-95dd-4191-b9c3-185575ee6f6b","41fcdd7d-4733-4863-9cf4-c65b83ce2df4","2f442157-a11c-46b9-ae5b-6e39ff4e5849","c4801e8a-cb58-4c35-aca6-f2dcc106f287","0898bdbb-73b0-471a-81e5-20f1fe4dd66e","617b097b-4b93-4ede-83de-5f075bb5fb2f","33c4f319-9bdd-48d6-9c4d-410b750a4a5a","4828c8ec-dc2e-4779-b502-87ac9ce28ab7","3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"],"skuId":"c7df2760-2c81-4ef7-b578-5b5392b571df"},{"disabledPlans":["39b5c996-467e-4e60-bd62-46066f572726"],"skuId":"90d8b3f8-712e-4f7b-aa1e-62e7ae6cbe96"},{"disabledPlans":["e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72"],"skuId":"09015f9f-377f-4538-bbb5-f75ceb09358a"},{"disabledPlans":[],"skuId":"dcb1a3ae-b33f-4487-846a-a640262fadf4"},{"disabledPlans":[],"skuId":"f30db892-07e9-47e9-837c-80727f46fd3d"},{"disabledPlans":[],"skuId":"26a18e8f-4d14-46f8-835a-ed3ba424a961"},{"disabledPlans":[],"skuId":"412ce1a7-a499-41b3-8eb6-b38f2bbc5c3f"},{"disabledPlans":[],"skuId":"488ba24a-39a9-4473-8ee5-19291e71b002"},{"disabledPlans":[],"skuId":"b05e124f-c7cc-45a0-a6aa-8cf78c946968"},{"disabledPlans":["0b03f40b-c404-40c3-8651-2aceb74365fa","b650d915-9886-424b-a08d-633cede56f57","e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72","fe71d6c3-a2ea-4499-9778-da042bf08063","fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"],"skuId":"ea126fc5-a19e-42e2-a731-da9d437bffcf"},{"disabledPlans":[],"skuId":"c5928f49-12ba-48f7-ada3-0d743a3601d5"},{"disabledPlans":[],"skuId":"87bbbc60-4754-4998-8c88-227dca264858"}],"assignedPlans":[{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2020-03-11T23:06:38Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"},{"assignedTimestamp":"2019-11-04T20:02:03Z","capabilityStatus":"Enabled","service":"WhiteboardServices","servicePlanId":"4a51bca5-1eff-43f5-878c-177680f191af"},{"assignedTimestamp":"2019-10-15T04:17:14Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"5136a095-5cf0-4aff-bec3-e84448b38ea5"},{"assignedTimestamp":"2019-10-15T04:17:14Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb0351d-3b08-4503-993d-383af8de41e3"},{"assignedTimestamp":"2019-08-08T23:29:37Z","capabilityStatus":"Enabled","service":"MicrosoftFormsProTest","servicePlanId":"97f29a83-1a20-44ff-bf48-5e4ad11f3e51"},{"assignedTimestamp":"2019-05-23T01:47:36Z","capabilityStatus":"Enabled","service":"DYN365AISERVICEINSIGHTS","servicePlanId":"1412cdc1-d593-4ad1-9050-40c30ad0b023"},{"assignedTimestamp":"2019-05-09T22:32:19Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"199a5c09-e0ca-4e37-8f7c-b05d533e1ea2"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"ProjectProgramsAndPortfolios","servicePlanId":"818523f5-016b-4355-9be8-ed6944946ea7"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"fa200448-008c-4acb-abd4-ea106ed2199d"},{"assignedTimestamp":"2019-04-02T05:38:04Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"50554c47-71d9-49fd-bc54-42a2765c555c"},{"assignedTimestamp":"2018-11-18T17:43:28Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"d20bfa21-e9ae-43fc-93c2-20783f0840c3"},{"assignedTimestamp":"2018-11-18T17:43:28Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"d5368ca3-357e-4acb-9c21-8495fb025d1f"},{"assignedTimestamp":"2018-11-17T17:45:51Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"50e68c76-46c6-4674-81f9-75456511b170"},{"assignedTimestamp":"2018-11-17T17:45:51Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"17ab22cd-a0b3-4536-910a-cb6eb12696c0"},{"assignedTimestamp":"2018-10-11T18:25:27Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"018fb91e-cee3-418c-9063-d7562978bdaf"},{"assignedTimestamp":"2018-10-11T18:25:26Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"ca4be917-fbce-4b52-839e-6647467a1668"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"b1188c4c-1b36-4018-b48b-ee07604f6feb"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"},{"assignedTimestamp":"2018-10-11T18:25:25Z","capabilityStatus":"Deleted","service":"MicrosoftCommunicationsOnline","servicePlanId":"4828c8ec-dc2e-4779-b502-87ac9ce28ab7"},{"assignedTimestamp":"2018-08-29T07:16:06Z","capabilityStatus":"Enabled","service":"Sway","servicePlanId":"a23b959c-7ce8-4e57-9140-b90eb88a9e97"},{"assignedTimestamp":"2018-08-29T07:16:06Z","capabilityStatus":"Deleted","service":"OfficeForms","servicePlanId":"159f4cd6-e380-449f-a816-af1a9ef76344"},{"assignedTimestamp":"2018-04-26T17:45:50Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"bea4c11e-220a-4e6d-8eb8-8ea15d019f90"},{"assignedTimestamp":"2018-04-26T17:45:50Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"6c57d4b6-3b23-47a5-9bc9-69f17b4947b3"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"2125cfd7-2110-4567-83c4-c1cd5275163d"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2018-04-24T03:21:47Z","capabilityStatus":"Deleted","service":"SharePoint","servicePlanId":"c4048e79-4474-4c74-ba9b-c31ff225e511"},{"assignedTimestamp":"2018-03-20T15:10:18Z","capabilityStatus":"Deleted","service":"MicrosoftStream","servicePlanId":"acffdce6-c30f-4dc2-81c0-372e33c515ec"},{"assignedTimestamp":"2018-03-17T08:10:29Z","capabilityStatus":"Enabled","service":"WindowsDefenderATP","servicePlanId":"871d91ec-ec1a-452b-a83f-bd76c7d770ef"},{"assignedTimestamp":"2018-03-17T08:10:29Z","capabilityStatus":"Enabled","service":"Windows","servicePlanId":"e7c91390-7625-45be-94e0-e16907e03118"},{"assignedTimestamp":"2018-03-17T02:35:48Z","capabilityStatus":"Enabled","service":"AzureAdvancedThreatAnalytics","servicePlanId":"14ab5db5-e6c4-4b20-b4bc-13e36fd2227f"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"CRM","servicePlanId":"bf36ca64-95c6-4918-9275-eb9f4ce2c04f"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"PowerAppsService","servicePlanId":"874fc546-6efe-4d22-90b8-5c4e7aa59f4b"},{"assignedTimestamp":"2018-02-24T03:21:01Z","capabilityStatus":"Deleted","service":"ProcessSimple","servicePlanId":"7e6d7d78-73de-46ba-83b1-6d25117334ba"},{"assignedTimestamp":"2018-01-09T00:28:58Z","capabilityStatus":"Enabled","service":"ProjectWorkManagement","servicePlanId":"b737dad2-2f6c-4c65-90e3-ca563267e8b9"},{"assignedTimestamp":"2017-12-31T23:10:50Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"41781fb2-bc02-4b7c-bd55-b576c07bb09d"},{"assignedTimestamp":"2017-12-31T23:10:50Z","capabilityStatus":"Enabled","service":"MultiFactorService","servicePlanId":"8a256a2b-b617-496d-b51b-e76466e88db0"},{"assignedTimestamp":"2017-12-31T06:32:41Z","capabilityStatus":"Deleted","service":"Adallom","servicePlanId":"932ad362-64a8-4783-9106-97849a1a30b9"},{"assignedTimestamp":"2017-12-16T19:57:33Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"5689bec4-755d-4753-8b61-40975025187c"},{"assignedTimestamp":"2017-12-16T19:57:33Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"2e2ddb96-6af9-4b1d-a3f0-d6ecfd22edb2"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"8c098270-9dd4-4350-9b30-ba4703f3b36b"},{"assignedTimestamp":"2017-11-12T20:20:22Z","capabilityStatus":"Enabled","service":"To-Do","servicePlanId":"3fb82609-8c27-4f7b-bd51-30634711ee67"},{"assignedTimestamp":"2017-10-07T01:41:03Z","capabilityStatus":"Enabled","service":"Netbreeze","servicePlanId":"03acaee3-9492-4f40-aed4-bcb6b32981b6"},{"assignedTimestamp":"2017-10-07T01:41:03Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"d56f3deb-50d8-465a-bedb-f079817ccac1"},{"assignedTimestamp":"2017-06-26T10:50:26Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"e212cbc7-0961-4c40-9825-01117710dcb1"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"MicrosoftStream","servicePlanId":"6c6042f5-6f01-4d67-b8c1-eb99d36eed3e"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"eec0eb4f-6444-4f95-aba0-50c24d67f998"},{"assignedTimestamp":"2017-06-11T20:26:15Z","capabilityStatus":"Enabled","service":"SCO","servicePlanId":"c1ec4a95-1f05-45b3-a911-aa3fa01094f5"},{"assignedTimestamp":"2017-05-13T01:11:22Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"8e0c0a52-6a6c-4d40-8370-dd62790dcd70"},{"assignedTimestamp":"2017-02-21T21:53:31Z","capabilityStatus":"Enabled","service":"Deskless","servicePlanId":"8c7d2df8-86f0-4902-b2ed-a0458298f3b3"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"07699545-9485-468e-95b6-2fca3738be01"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"TeamspaceAPI","servicePlanId":"57ff2da0-773e-42df-b2af-ffb7a2317929"},{"assignedTimestamp":"2016-12-02T08:00:06Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"9c0dab89-a30c-4117-86e7-97bda240acd2"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"PowerBI","servicePlanId":"70d33638-9c74-4d01-bfd3-562de28bd4ba"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"34c0d7a0-a70f-4668-9238-47f9fc208882"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"9f431833-0334-42de-a7dc-70aa40db46db"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"4de31727-a228-4ec3-a5bf-8e45b5ca48cc"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"YammerEnterprise","servicePlanId":"7547a3fe-08ee-4ccb-b430-5077c5041653"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Deleted","service":"AzureAnalysis","servicePlanId":"2049e525-b859-401b-b2a0-e0a31c4b1fe4"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Deleted","service":"PowerBI","servicePlanId":"fc0a60aa-feee-4746-a0e3-aecfe81a38dd"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"43de0ff5-c92c-492b-9116-175376d08c38"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"0feaeb32-d00e-4d66-bd5a-43b5b83db82c"},{"assignedTimestamp":"2016-10-27T10:37:21Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb87545-963c-4e0d-99df-69c6916d9eb0"},{"assignedTimestamp":"2012-10-18T11:17:30Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"663a804f-1c30-4ff0-9915-9db84f0d1cea"},{"assignedTimestamp":"2015-12-14T08:31:18Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"e61a2945-1d4e-4523-b6e7-30ba39d20f32"},{"assignedTimestamp":"2016-06-30T05:43:33Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"2c4ec2dc-c62d-4167-a966-52a3e6374015"},{"assignedTimestamp":"2016-06-30T05:43:33Z","capabilityStatus":"Enabled","service":"KratosAppsService","servicePlanId":"0b4346bb-8dc3-4079-9dfc-513696f56039"}],"city":"Kongens
+        Lyngby","companyName":"DENMARK","consentProvidedForMinor":null,"country":null,"createdDateTime":null,"creationType":null,"department":"Global
+        CSA Denmark COGS","dirSyncEnabled":true,"displayName":"Mads Damg\u00e5rd","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Mads","immutableId":"301328","isCompromised":null,"jobTitle":"SR
+        CLOUD SOLUTION ARCHITECT","lastDirSyncTime":"2020-04-29T08:59:58Z","legalAgeGroupClassification":null,"mail":"madsd@microsoft.com","mailNickname":"madsd","mobile":"+4551578136","onPremisesDistinguishedName":"CN=Mads
+        Damg\u00e5rd,OU=UserAccounts,DC=europe,DC=corp,DC=microsoft,DC=com","onPremisesSecurityIdentifier":"S-1-5-21-1721254763-462695806-1538882281-2655010","otherMails":[],"passwordPolicies":"DisablePasswordExpiration","passwordProfile":null,"physicalDeliveryOfficeName":"LYNGBY/Mobile","postalCode":null,"preferredLanguage":null,"provisionedPlans":[{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Deleted","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Adallom"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Netbreeze"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"microsoftcommunicationsonline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftOffice"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"}],"provisioningErrors":[],"proxyAddresses":["smtp:madsd@sales.microsoft.com","x500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=user01a2850e","SMTP:madsd@microsoft.com","x500:/o=microsoft/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=userff21d3b0","x500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=madsd_microsoft.comc37e77e4","x500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=user31cebcc7e1b7241a","X500:/o=MMS/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=user77aa8516","x500:/o=microsoft/ou=First
+        Administrative Group/cn=Recipients/cn=madsd","x500:/o=SDF/ou=Exchange Administrative
+        Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=contact46dc0812","x500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=madsddf0a188e10","x500:/O=microsoft/OU=europe/cn=Recipients/cn=madsd","x500:/O=Nokia/OU=HUB/cn=Recipients/cn=madsd","x500:/o=SDF/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=51490-madsd_9845154d95","x500:/o=MSNBC/ou=Servers/cn=Recipients/cn=madsd","smtp:MADSD@service.microsoft.com"],"refreshTokensValidFromDateTime":"2019-11-16T08:17:12Z","showInAddressList":true,"signInNames":[],"sipProxyAddress":"madsd@microsoft.com","state":null,"streetAddress":null,"surname":"Damg\u00e5rd","telephoneNumber":"+45
+        (45) 678476","thumbnailPhoto@odata.mediaEditLink":"directoryObjects/0b9188a0-540d-4262-9311-61bb1a0235ef/Microsoft.DirectoryServices.User/thumbnailPhoto","thumbnailPhoto@odata.mediaContentType":"image/Jpeg","usageLocation":"DK","userIdentities":[],"userPrincipalName":"madsd@microsoft.com","userState":null,"userStateChangedOn":null,"userType":null,"extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"MOBILE","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"99998","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToPersonnelNbr":"1184534","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToFullName":"Coffin,
+        Callum D","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToEmailName":"CALCOF","extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10212147","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"91890670","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10212147","extension_18e31482d3fb4a8ea958aa96b662f508_SupervisorInd":"N","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1023","extension_18e31482d3fb4a8ea958aa96b662f508_LocationAreaCode":"DK","extension_18e31482d3fb4a8ea958aa96b662f508_PersonnelNumber":"301328"}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '18983'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Sun, 10 May 2020 13:14:50 GMT
+      duration:
+      - '1330262'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - htKZvCnr8HUR1REZieaQY4s8XIj+ROFv1UinuZtIuDo=
+      ocp-aad-session-key:
+      - JjxVogHhMxX7Ef4RqWvmJnGglMagHLBIT3OifKekOAyLiVdCWce1OXtZVIkbd203vepvApcK8EVWhYY4Q_gcWZBBdFlDOPQq3F7888nDpXStlfO_-P2VooJ_rtIEoen-.5AbvQ0Z7hViNs6ISL_8fPHyjV7XltTNXQs8xo5F_AGU
+      pragma:
+      - no-cache
+      request-id:
+      - 69301580-ff05-425f-8272-b8331d4ceed8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westeurope", "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+      "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
+      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "0b9188a0-540d-4262-9311-61bb1a0235ef",
+      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
+      "backup", "restore", "recover"], "secrets": ["get", "list", "set", "delete",
+      "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
+      "import", "update", "managecontacts", "getissuers", "listissuers", "setissuers",
+      "deleteissuers", "manageissuers", "recover"], "storage": ["get", "list", "delete",
+      "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}}],
+      "softDeleteRetentionInDays": 90, "networkAcls": {"bypass": "AzureServices",
+      "defaultAction": "Allow", "ipRules": [], "virtualNetworkRules": []}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '895'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net","provisioningState":"RegisteringDns"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1153'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 10 May 2020 13:14:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1149'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 10 May 2020 13:15:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27Microsoft.Azure.WebSites%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
+        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft.Azure.WebSites","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access all the APIs registered with App Service","adminConsentDisplayName":"Access
+        APIs registered with App Service","id":"e0ea806b-d128-49dc-ac08-2bf18f7874d8","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access all the APIs registered with App Service","userConsentDisplayName":"Access
+        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["Microsoft.Azure.WebSites","abfa0a7c-a6b6-4736-8310-5855508787cd"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1677'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Sun, 10 May 2020 13:15:23 GMT
+      duration:
+      - '681154'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - DTbc+ix7+LLHlTTkVueMm+LsccsKsJNfJqnQvKw39+w=
+      ocp-aad-session-key:
+      - OwAgbRiME70C94sv-Zn2sJAVNaiYYzLo54HZfL929tiq9OgvHKfPNCErb8X_Ml9Iu5oYy8zueqN3Qe_bMVtC68YPFpflnuFU069BuNGHLWiiCca8LbcxafT0Wit9kf6o.N1XyPMtyezhPxwL2OuqK0xh21offiBccg19L9fApdto
+      pragma:
+      - no-cache
+      request-id:
+      - 912e2aee-a563-4278-a1a4-5a50f9e25615
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault set-policy
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --spn --secret-permissions
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1149'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 10 May 2020 13:15:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westeurope", "tags": {}, "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+      "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
+      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "0b9188a0-540d-4262-9311-61bb1a0235ef",
+      "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
+      "backup", "restore", "recover"], "secrets": ["get", "list", "set", "delete",
+      "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
+      "import", "update", "managecontacts", "getissuers", "listissuers", "setissuers",
+      "deleteissuers", "manageissuers", "recover"], "storage": ["get", "list", "delete",
+      "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}},
+      {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "f8daea97-62e7-4026-becf-13c2ea98e8b4",
+      "permissions": {"secrets": ["get"]}}], "vaultUri": "https://kv-ssl-test000005.vault.azure.net/",
+      "enabledForDeployment": false, "enableSoftDelete": true, "softDeleteRetentionInDays":
+      90}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - keyvault set-policy
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1056'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g --name --spn --secret-permissions
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 10 May 2020 13:15:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - 0
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-keyvault/7.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/import?api-version=7.0
+  response:
+    body:
+      string: '{"error":{"code":"Unauthorized","message":"Request is missing a Bearer
+        or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '87'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 10 May 2020 13:15:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=85.191.83.80;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westeurope
+      x-ms-keyvault-service-version:
+      - 1.1.3.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '{"value": "MIIKYgIBAzCCCh4GCSqGSIb3DQEHAaCCCg8EggoLMIIKBzCCBggGCSqGSIb3DQEHAaCCBfkEggX1MIIF8TCCBe0GCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAiXDoyN14zikgICB9AEggTYczAG9RXE6P9dZzKEkuAB3zAoIpepICAcTQO38wV1z2dd3E1p7vBI+RYv1Td3965af6LUHeW7iHwE1h+qUntxAQtW7vVI7cUFa9iP0Heu/ijuZraY1lmKQEzFWffCE1XIgwcH3yHpi88Ow1Au64PfaaYPlrAgklPQ69DPIwM9JuhBd5qXW1XDe6XQ1msu6kvEFR1SNLN4Ul6BfKSPvzhVPKVnq33Lbt/QsVkZ3DtabLz8sW6qVYjEa5R8uW2Z7OaBtBbQWGkM6vnuaUpnE0pXxo815RTsvHXVlZkfgSCeOakmGIAygU/EU8BGvubAWx7WNo6RWFCOiT25tJspW6VY9JEse5ESvc4QnUQm1f0C3YPCcCDUCwEt3ZatGSr4MnJHN2Y1OEf1aWjewz0Se1bP2o/SwihyBNqXXZ3QzjxC8vrR+l6E7fPX3UVPJG5hHZfn2q5aofU/OyrPLUUDCaRlrM5oBADouQBy+t77/pobdvShgdYhiy/QCD6mJGalk6OEdfvp35uoL4jgo2irh4i9C3oOzSXFADUjivG66ZsVIN0k43boaO+JueqVso4GNYB8Zz4FIRlPQOZNCXHcuqvhnU0SGhujeb+H0LSXw53xmiwpWwB7xdv7b/qacaoOV1S3C8ZTM6FkJ8oKmNRMIWiIyfgyXQpmqaMND6nCVkcKkYbmVgNQZdWmbiKg1NGm66Q8rLtSUdIlyyCYzmxngLAa4zEbqPqgMwP4LIyCnxKn7hguBeyLsDvYRk029pgLnVVl5fl+Ijk4w2Noor/Axn3yD2gXCy5h9Xel1iXUqr4JtaJnWOoELx5KFwGhXeHdmRUjRVigbVN+nNd2AdtLih2eBimKpRm2NoBCrfGg9KUDpSi8eSTmbXW/enBWkdGrlu9lVTpgK3tlXW3VUveJh15rtwxTUagsee3G06w6YOu0ZRmT4hNfV2FWmjCuB4VCkY+KeFndsRLdC52odvO2z0u2nwBlvRjFrzErpAJdHWWv+XQ/fuOOjBbP5mvV1+gPEEA8QY4tvi/ac1n5S8L2oVNhaF39+QYlwMdcpLFy2BAw2PN7OnNAQMKViTu4iqVA6861oDa22D9EVufpyvSQj4Y0UoGhs8kS8aT8qsHUvabPlrjqslSuaIDB3H2kVSXXVW9kmMLmRNlhqm7Kowa4jjobr2lNY5dZFjJKy3wD2lsBdRHvsGrC35/vakI6Qy0WHcgA1YM7JwJl808lCQ9fi5Jcd/3tjfyhRv6AvZ6Na2VMZwg2bNOCJfhMKgTyssqRLy5us9zRXRvDFI8IQHmoNcliDnQZIcaVApPx095wQOOm4n8dqfw0AFSSRpgdQT6yQRxlNUyqhQbaUzlUKxxf9F6iVvpDMizmDbCB2/wapF+1/6M4HZfHT0JV4nnOtjr96Yfm1pUYN6jkcsyyeYypOFMKcbaTe9UtU9XU/AxJnkBOl2U7YRuffu3ElkZv0pZggWaNeQ3sCE5scVrFsi8+/AFz1O264knbXyw07leoal/JKIiAquq1Hx6QMzShgz/ympyGVHcC2DJBqjOQ/E8b/34WjUaBMop+JNMStUZnoJqL68rQcxkRdWAEj27f+A2c9nagz0TyCXLB5s/LQu3mbknXQzDbH7qJQxOidFg675fqaTrhekaR7psnJDGB2zATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEEAYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwB0AHIAbwBuAGcAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMGUGCSqGSIb3DQEJFDFYHlYAUAB2AGsAVABtAHAAOgAzAGUAYQAxADIAYQBiADcALQBjAGMAYgA4AC0ANAA3ADcAZAAtAGEAYQBlADQALQA5ADgAZQA1AGYAZgAzAGEANgA4ADcAZjCCA/cGCSqGSIb3DQEHBqCCA+gwggPkAgEAMIID3QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQII49JHcCo5YoCAgfQgIIDsNAp0Fem6ktVE6yy8cO2q9jHI94QEA5Xu4T5v/RWz1VJJ2SdSCBXvrCYdhldYVSoXbSbeLTBsULmi/6ST1VkMETbtrl8RlW8DzzDFeYisyeZtOuxbHcVX8ByqDFo/Ro/vydvx7CRx11IstHIeg64qeVsofMU9NRS3rCGU9CwCjJ4aV9QFgZa0vEnROAZnaI1uRWOuMuHT98Kvv/wJ93xZJq2voAASyysePaZq/pUlzmRuyC/Pz2uXdNIoOu8BykMjvXw4kFzDCWt1DljYaijTLX9hGgzgxdbAOw1/2RSlEaYXpxPrhaYxOTFLGByyO2F1arn3btiMGTxBh61/2Gswg+gpUWX9J3jlT77pXXgyHgZ4YBJ45cWkTCmSSOqjyjdP6buSRInPlfTKDfQGi0riI32qdcO77gCvJdMOcN5HTleglaCDvQyFfYRAzWQ+EQ4N0WfnfDYe8v7+o136wht8cxxKQmo4/FbfOMURe6L1Hlj/hOie6yUD8+lqNMF3oFW42/rMUke5OWZZEIqDeN8tg08f/h7T2i10HW5zuDwAMllqwSdcfNZOESpcbAGbZn76wvvG2sYMXmT3lZvel4iWD8yOZTWIaCKv1+p5GqKTIiIpVOl7iXS4QTwbuNaMJl4a92zuCrnWxTJgw+ZCsmEvpC4u/OUivv7l1R7eJgbo/gdbtuaZWr3Ei4jaOlQj7W6OOGjJDAzzzY1MndsoBA+6HC3KsOCmP9aoXjp8g6hTMNnWZVehPE3Bq4AjHPoP3YXYFHfqqetUhYxnajYd6AB0JPiM9anCMTgbqUHhCTK8B+smPMCijRAGESbrP3EDcmSEJ2mjobV4SllM0qbfKBvU9ZdbUGaOHSytD/fplWpH4oc6SBvHyhK/WPzBz+o7uwgzD70Spl9OiqhsitQTw1asjWKRCs3rrby5tpAfbD0V0lSgLa9ac9bOP/B82LwRe5V7bG/TY+oE5hrN+d50rYl+FBzGsh0lZ//b9lbJIylFhNKz+C2zEobd846u90tYfBvbHgo8RSbIN082uGLo3Vi3d0g/uhkhSMqLNQdYkBku2akqPcPIVrgdaT1ezCgoxX61q5UTjtdRuZv1d9u1ZhOA8iO7Gqi0C/9MQAQhk9uhbHg+88gLE5VFeRgt7H+fI2OjvFqSkq6Xk8Tio4RCQp54wnZ9cyOl7i5mZ7pqEZBUPxbXS6ssQYjuFi67Bl4BqYdIIV11mEYCccDAuyzNmoRy6LnvKFF4JUfEWZvO09PSU7qMDswHzAHBgUrDgMCGgQUSM2AwxMfBXKBH7nTqtFwI2zPF/0EFN4t6/m7IFHS48s+ZjArJodRXSNNAgIH0A==\n",
+      "pwd": "test", "policy": {"secret_props": {"contentType": "application/x-pkcs12"}},
+      "attributes": {"enabled": true, "nbf": 1514790000, "exp": 4701913200}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3722'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-keyvault/7.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/import?api-version=7.0
+  response:
+    body:
+      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/aee50af278ef4b80b383cdc4c1c78e2d","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/aee50af278ef4b80b383cdc4c1c78e2d","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/aee50af278ef4b80b383cdc4c1c78e2d","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1589116526,"updated":1589116526,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1589116526,"updated":1589116526}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2241'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 10 May 2020 13:15:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=85.191.83.80;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - westeurope
+      x-ms-keyvault-service-version:
+      - 1.1.3.0
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:14:29.1366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5474'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:15:26 GMT
+      etag:
+      - '"1D626CCEFBD830B"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-keyvault/2.2.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"westeurope","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"0b9188a0-540d-4262-9311-61bb1a0235ef","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sun, 10 May 2020 13:15:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-service-version:
+      - 1.1.0.278
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/0b9188a0-540d-4262-9311-61bb1a0235ef?api-version=1.6
+  response:
+    body:
+      string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
+        ''0b9188a0-540d-4262-9311-61bb1a0235ef'' does not exist or one of its queried
+        reference-property objects are not present."},"requestId":"03c6c13a-22d7-45d5-a105-51c750d3a485","date":"2020-05-10T13:15:27"}}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '294'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Sun, 10 May 2020 13:15:27 GMT
+      duration:
+      - '572415'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - gouRwkMGqa9oecE8OcsEopiI8YHb0gp+p/F97njONMQ=
+      ocp-aad-session-key:
+      - ZTSujUbpXyi1RdhQcWezbOqZoATPr_LDruGwTx8qhuWqVZWMXus_6ElHo961vvLCyUqjfMOjR-HWO50KScmJ12C7K3EfFDINepNluj5N50BCk_UAQz6uyNZ-7GRxFb83.8TkE--cXKrLu1aVc3r95vWYBBcu26jn8wQ0yuVg-y3Y
+      pragma:
+      - no-cache
+      request-id:
+      - 03c6c13a-22d7-45d5-a105-51c750d3a485
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/f8daea97-62e7-4026-becf-13c2ea98e8b4?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
+        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft.Azure.WebSites","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access all the APIs registered with App Service","adminConsentDisplayName":"Access
+        APIs registered with App Service","id":"e0ea806b-d128-49dc-ac08-2bf18f7874d8","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access all the APIs registered with App Service","userConsentDisplayName":"Access
+        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["Microsoft.Azure.WebSites","abfa0a7c-a6b6-4736-8310-5855508787cd"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1674'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Sun, 10 May 2020 13:15:27 GMT
+      duration:
+      - '657638'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - OVWdKJpEaDVjKez2/zHG7VUEvTFK1ivsTh03KZzgw4c=
+      ocp-aad-session-key:
+      - 9d1D6GvAV10LTNBgkrugAipPZEcr3AVThJnQ08CdmY_Ci6GCFMaTlvATUdmDiUrzkQO4eLBR9qqZOD_8FxP0yCOSylwOdlvOQE7IRn7Dikjtwc1wtNGV1UjBaCevAzFo.5qp9lm40wmTnIklah3HA4Zeoi7JhtUyKM8iJWTX8zO8
+      pragma:
+      - no-cache
+      request-id:
+      - ef1ad9f0-f40c-4052-b204-a025cf5121b7
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''b\''{"location": "West Europe", "properties": {"password": "", "keyVaultId":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005",
+      "keyVaultSecretName": "test-cert", "serverFarmId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003"}}\'''''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '534'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/certificates/clitest.rg000002-kv-ssl-test000005-test-cert?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/certificates/clitest.rg000002-kv-ssl-test000005-test-cert","name":"clitest.rg000002-kv-ssl-test000005-test-cert","type":"Microsoft.Web/certificates","location":"West
+        Europe","properties":{"friendlyName":"","subjectName":"*.azurewebsites.net","hostNames":["*.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"*.azurewebsites.net","issueDate":"2018-01-01T07:00:00+00:00","expirationDate":"2118-12-31T07:00:00+00:00","password":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.keyvault/vaults/kv-ssl-test000005","keyVaultSecretName":"test-cert","keyVaultSecretStatus":"Initialized","webSpace":"clitest.rg000002-WestEuropewebspace","serverFarmId":null,"tags":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1361'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:15:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      warning:
+      - 199 Some of the uploaded certificates are either self-signed or expired.,199
+        Some of the uploaded certificates cannot be validated to a trusted CA
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:14:29.1366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5474'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:15:29 GMT
+      etag:
+      - '"1D626CCEFBD830B"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:14:29.1366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5474'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:15:29 GMT
+      etag:
+      - '"1D626CCEFBD830B"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/certificates?api-version=2019-08-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/certificates/clitest.rg000002-kv-ssl-test000005-test-cert","name":"clitest.rg000002-kv-ssl-test000005-test-cert","type":"Microsoft.Web/certificates","location":"West
+        Europe","properties":{"friendlyName":"","subjectName":"*.azurewebsites.net","hostNames":["*.azurewebsites.net"],"pfxBlob":null,"siteName":null,"selfLink":null,"issuer":"*.azurewebsites.net","issueDate":"2018-01-01T07:00:00+00:00","expirationDate":"2118-12-31T07:00:00+00:00","password":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","valid":null,"toDelete":null,"cerBlob":null,"publicKeyHash":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.keyvault/vaults/kv-ssl-test000005","keyVaultSecretName":"test-cert","keyVaultSecretStatus":"Initialized","webSpace":"clitest.rg000002-WestEuropewebspace","serverFarmId":null,"tags":null}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1399'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:15:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004/hostNameBindings?api-version=2019-08-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004/hostNameBindings/web-ssl-test000004.azurewebsites.net","name":"web-ssl-test000004/web-ssl-test000004.azurewebsites.net","type":"Microsoft.Web/sites/hostNameBindings","location":"West
+        Europe","properties":{"siteName":"web-ssl-test000004","domainId":null,"hostNameType":"Verified"}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '527'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:15:31 GMT
+      etag:
+      - '"1D626CCEFBD830B"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "West Europe", "properties": {"hostNameSslStates": [{"name":
+      "web-ssl-test000004.azurewebsites.net", "sslState": "SniEnabled", "thumbprint":
+      "9E9735C45C792B03B3FFCCA614852B32EE71AD6B", "toUpdate": true}], "reserved":
+      false, "isXenon": false, "hyperV": false, "scmSiteAlsoStopped": false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '303'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:15:32.6366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5714'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:15:32 GMT
+      etag:
+      - '"1D626CCEFBD830B"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"West
+        Europe","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-WestEuropewebspace","selfLink":"https://waws-prod-am2-227.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-WestEuropewebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-05-10T13:15:32.6366667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"EA90FB08540C6A5AD4F3DC0DFE9A80BDBE4909CF0221945DC9AD904F2BDB1C9A","kind":"app","inboundIpAddress":"40.114.194.188","possibleInboundIpAddresses":"40.114.194.188","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152","possibleOutboundIpAddresses":"40.114.194.188,40.114.195.235,40.114.196.155,40.114.197.189,40.114.199.152,104.40.254.139,40.114.193.214,40.114.199.120","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-am2-227","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5514'
+      content-type:
+      - application/json
+      date:
+      - Sun, 10 May 2020 13:15:34 GMT
+      etag:
+      - '"1D626CD1596D7CB"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl bind
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --certificate-thumbprint --ssl-type
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-web/0.44.0 Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004/publishxml?api-version=2019-08-01
+  response:
+    body:
+      string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
+        publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-227.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-am2-227dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="KTf7pfdGhkE6eCnSbSjcPweeESGfgzLzCdBHDfpYSgPQhpofFcqbJL4PduMl"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile></publishData>
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1678'
+      content-type:
+      - application/xml
+      date:
+      - Sun, 10 May 2020 13:15:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -1382,41 +1382,6 @@ class WebappSSLImportCertTest(ScenarioTest):
             'appservice plan create -g {} -n {} --sku B1'.format(resource_group, plan_name))
         self.cmd(
             'webapp create -g {} -n {} --plan {}'.format(resource_group, webapp_name, plan_name))
-        self.cmd('keyvault create -g {} -n {}'.format(kv_resource_group, kv_name))
-        self.cmd('keyvault set-policy -g {} --name {} --spn {} --secret-permissions get'.format(
-            kv_resource_group, kv_name, 'Microsoft.Azure.WebSites'))
-        self.cmd('keyvault certificate import --name {} --vault-name {} --file "{}" --password {}'.format(
-            cert_name, kv_name, pfx_file, cert_password))
-
-        self.cmd('webapp config ssl import --resource-group {} --name {}  --key-vault {} --key-vault-certificate-name {}'.format(resource_group, webapp_name, kv_name, cert_name), checks=[
-            JMESPathCheck('keyVaultSecretStatus', 'Initialized'),
-            JMESPathCheck('thumbprint', cert_thumbprint)
-        ])
-
-        self.cmd('webapp config ssl bind -g {} -n {} --certificate-thumbprint {} --ssl-type {}'.format(resource_group, webapp_name, cert_thumbprint, 'SNI'), checks=[
-            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].sslState".format(
-                webapp_name), 'SniEnabled'),
-            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].thumbprint".format(
-                webapp_name), cert_thumbprint)
-        ])
-
-    @ResourceGroupPreparer(parameter_name='kv_resource_group', location='westeurope')
-    @ResourceGroupPreparer(location='westeurope')
-    def test_webapp_ssl_import_resource_id(self, resource_group, kv_resource_group):
-        plan_name = self.create_random_name(prefix='ssl-test-plan', length=24)
-        webapp_name = self.create_random_name(prefix='web-ssl-test', length=20)
-        kv_name = self.create_random_name(prefix='kv-ssl-test', length=20)
-        # Cert Generated using
-        # https://docs.microsoft.com/azure/app-service-web/web-sites-configure-ssl-certificate#bkmk_ssopenssl
-        pfx_file = os.path.join(TEST_DIR, 'server.pfx')
-        cert_password = 'test'
-        cert_thumbprint = '9E9735C45C792B03B3FFCCA614852B32EE71AD6B'
-        cert_name = 'test-cert'
-        # we configure tags here in a hope to capture a repro for https://github.com/Azure/azure-cli/issues/6929
-        self.cmd(
-            'appservice plan create -g {} -n {} --sku B1'.format(resource_group, plan_name))
-        self.cmd(
-            'webapp create -g {} -n {} --plan {}'.format(resource_group, webapp_name, plan_name))
         kv_id = self.cmd('keyvault create -g {} -n {}'.format(kv_resource_group, kv_name)).get_output_in_json()['id']
         self.cmd('keyvault set-policy -g {} --name {} --spn {} --secret-permissions get'.format(
             kv_resource_group, kv_name, 'Microsoft.Azure.WebSites'))

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -1400,6 +1400,7 @@ class WebappSSLImportCertTest(ScenarioTest):
                 webapp_name), cert_thumbprint)
         ])
 
+    @AllowLargeResponse()
     @ResourceGroupPreparer(parameter_name='kv_resource_group', location='westeurope')
     @ResourceGroupPreparer(location='westeurope')
     def test_webapp_ssl_import_resource_id(self, resource_group, kv_resource_group):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -1365,6 +1365,79 @@ class WebappSSLImportCertTest(ScenarioTest):
                 webapp_name), cert_thumbprint)
         ])
 
+    @ResourceGroupPreparer(parameter_name='kv_resource_group', location='westeurope')
+    @ResourceGroupPreparer(location='westeurope')
+    def test_webapp_ssl_import_crossrg(self, resource_group, kv_resource_group):
+        plan_name = self.create_random_name(prefix='ssl-test-plan', length=24)
+        webapp_name = self.create_random_name(prefix='web-ssl-test', length=20)
+        kv_name = self.create_random_name(prefix='kv-ssl-test', length=20)
+        # Cert Generated using
+        # https://docs.microsoft.com/azure/app-service-web/web-sites-configure-ssl-certificate#bkmk_ssopenssl
+        pfx_file = os.path.join(TEST_DIR, 'server.pfx')
+        cert_password = 'test'
+        cert_thumbprint = '9E9735C45C792B03B3FFCCA614852B32EE71AD6B'
+        cert_name = 'test-cert'
+        # we configure tags here in a hope to capture a repro for https://github.com/Azure/azure-cli/issues/6929
+        self.cmd(
+            'appservice plan create -g {} -n {} --sku B1'.format(resource_group, plan_name))
+        self.cmd(
+            'webapp create -g {} -n {} --plan {}'.format(resource_group, webapp_name, plan_name))
+        self.cmd('keyvault create -g {} -n {}'.format(kv_resource_group, kv_name))
+        self.cmd('keyvault set-policy -g {} --name {} --spn {} --secret-permissions get'.format(
+            kv_resource_group, kv_name, 'Microsoft.Azure.WebSites'))
+        self.cmd('keyvault certificate import --name {} --vault-name {} --file "{}" --password {}'.format(
+            cert_name, kv_name, pfx_file, cert_password))
+
+        self.cmd('webapp config ssl import --resource-group {} --name {}  --key-vault {} --key-vault-certificate-name {}'.format(resource_group, webapp_name, kv_name, cert_name), checks=[
+            JMESPathCheck('keyVaultSecretStatus', 'Initialized'),
+            JMESPathCheck('thumbprint', cert_thumbprint)
+        ])
+
+        self.cmd('webapp config ssl bind -g {} -n {} --certificate-thumbprint {} --ssl-type {}'.format(resource_group, webapp_name, cert_thumbprint, 'SNI'), checks=[
+            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].sslState".format(
+                webapp_name), 'SniEnabled'),
+            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].thumbprint".format(
+                webapp_name), cert_thumbprint)
+        ])
+
+    @ResourceGroupPreparer(parameter_name='kv_resource_group', location='westeurope')
+    @ResourceGroupPreparer(location='westeurope')
+    def test_webapp_ssl_import_resource_id(self, resource_group, kv_resource_group):
+        plan_name = self.create_random_name(prefix='ssl-test-plan', length=24)
+        webapp_name = self.create_random_name(prefix='web-ssl-test', length=20)
+        kv_name = self.create_random_name(prefix='kv-ssl-test', length=20)
+        # Cert Generated using
+        # https://docs.microsoft.com/azure/app-service-web/web-sites-configure-ssl-certificate#bkmk_ssopenssl
+        pfx_file = os.path.join(TEST_DIR, 'server.pfx')
+        cert_password = 'test'
+        cert_thumbprint = '9E9735C45C792B03B3FFCCA614852B32EE71AD6B'
+        cert_name = 'test-cert'
+        # we configure tags here in a hope to capture a repro for https://github.com/Azure/azure-cli/issues/6929
+        self.cmd(
+            'appservice plan create -g {} -n {} --sku B1'.format(resource_group, plan_name))
+        self.cmd(
+            'webapp create -g {} -n {} --plan {}'.format(resource_group, webapp_name, plan_name))
+        self.cmd('keyvault create -g {} -n {}'.format(kv_resource_group, kv_name))
+        self.cmd('keyvault set-policy -g {} --name {} --spn {} --secret-permissions get'.format(
+            kv_resource_group, kv_name, 'Microsoft.Azure.WebSites'))
+        self.cmd('keyvault certificate import --name {} --vault-name {} --file "{}" --password {}'.format(
+            cert_name, kv_name, pfx_file, cert_password))
+
+        kv_id = '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.KeyVault/vaults/{}'.format(
+            self.get_subscription_id(), kv_resource_group, kv_name)
+
+        self.cmd('webapp config ssl import --resource-group {} --name {}  --key-vault {} --key-vault-certificate-name {}'.format(resource_group, webapp_name, kv_id, cert_name), checks=[
+            JMESPathCheck('keyVaultSecretStatus', 'Initialized'),
+            JMESPathCheck('thumbprint', cert_thumbprint)
+        ])
+
+        self.cmd('webapp config ssl bind -g {} -n {} --certificate-thumbprint {} --ssl-type {}'.format(resource_group, webapp_name, cert_thumbprint, 'SNI'), checks=[
+            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].sslState".format(
+                webapp_name), 'SniEnabled'),
+            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].thumbprint".format(
+                webapp_name), cert_thumbprint)
+        ])
+
 
 class WebappUndeleteTest(ScenarioTest):
     @AllowLargeResponse(8192)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -1400,44 +1400,40 @@ class WebappSSLImportCertTest(ScenarioTest):
                 webapp_name), cert_thumbprint)
         ])
 
-    # @AllowLargeResponse()
-    # @ResourceGroupPreparer(parameter_name='kv_resource_group', location='westeurope')
-    # @ResourceGroupPreparer(location='westeurope')
-    # def test_webapp_ssl_import_resource_id(self, resource_group, kv_resource_group):
-    #     plan_name = self.create_random_name(prefix='ssl-test-plan', length=24)
-    #     webapp_name = self.create_random_name(prefix='web-ssl-test', length=20)
-    #     kv_name = self.create_random_name(prefix='kv-ssl-test', length=20)
-    #     # Cert Generated using
-    #     # https://docs.microsoft.com/azure/app-service-web/web-sites-configure-ssl-certificate#bkmk_ssopenssl
-    #     pfx_file = os.path.join(TEST_DIR, 'server.pfx')
-    #     cert_password = 'test'
-    #     cert_thumbprint = '9E9735C45C792B03B3FFCCA614852B32EE71AD6B'
-    #     cert_name = 'test-cert'
-    #     # we configure tags here in a hope to capture a repro for https://github.com/Azure/azure-cli/issues/6929
-    #     self.cmd(
-    #         'appservice plan create -g {} -n {} --sku B1'.format(resource_group, plan_name))
-    #     self.cmd(
-    #         'webapp create -g {} -n {} --plan {}'.format(resource_group, webapp_name, plan_name))
-    #     self.cmd('keyvault create -g {} -n {}'.format(kv_resource_group, kv_name))
-    #     self.cmd('keyvault set-policy -g {} --name {} --spn {} --secret-permissions get'.format(
-    #         kv_resource_group, kv_name, 'Microsoft.Azure.WebSites'))
-    #     self.cmd('keyvault certificate import --name {} --vault-name {} --file "{}" --password {}'.format(
-    #         cert_name, kv_name, pfx_file, cert_password))
+    @ResourceGroupPreparer(parameter_name='kv_resource_group', location='westeurope')
+    @ResourceGroupPreparer(location='westeurope')
+    def test_webapp_ssl_import_resource_id(self, resource_group, kv_resource_group):
+        plan_name = self.create_random_name(prefix='ssl-test-plan', length=24)
+        webapp_name = self.create_random_name(prefix='web-ssl-test', length=20)
+        kv_name = self.create_random_name(prefix='kv-ssl-test', length=20)
+        # Cert Generated using
+        # https://docs.microsoft.com/azure/app-service-web/web-sites-configure-ssl-certificate#bkmk_ssopenssl
+        pfx_file = os.path.join(TEST_DIR, 'server.pfx')
+        cert_password = 'test'
+        cert_thumbprint = '9E9735C45C792B03B3FFCCA614852B32EE71AD6B'
+        cert_name = 'test-cert'
+        # we configure tags here in a hope to capture a repro for https://github.com/Azure/azure-cli/issues/6929
+        self.cmd(
+            'appservice plan create -g {} -n {} --sku B1'.format(resource_group, plan_name))
+        self.cmd(
+            'webapp create -g {} -n {} --plan {}'.format(resource_group, webapp_name, plan_name))
+        kv_id = self.cmd('keyvault create -g {} -n {}'.format(kv_resource_group, kv_name)).get_output_in_json()['id']
+        self.cmd('keyvault set-policy -g {} --name {} --spn {} --secret-permissions get'.format(
+            kv_resource_group, kv_name, 'Microsoft.Azure.WebSites'))
+        self.cmd('keyvault certificate import --name {} --vault-name {} --file "{}" --password {}'.format(
+            cert_name, kv_name, pfx_file, cert_password))
 
-    #     kv_id = '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.KeyVault/vaults/{}'.format(
-    #         self.get_subscription_id(), kv_resource_group, kv_name)
+        self.cmd('webapp config ssl import --resource-group {} --name {}  --key-vault {} --key-vault-certificate-name {}'.format(resource_group, webapp_name, kv_id, cert_name), checks=[
+            JMESPathCheck('keyVaultSecretStatus', 'Initialized'),
+            JMESPathCheck('thumbprint', cert_thumbprint)
+        ])
 
-    #     self.cmd('webapp config ssl import --resource-group {} --name {}  --key-vault {} --key-vault-certificate-name {}'.format(resource_group, webapp_name, kv_id, cert_name), checks=[
-    #         JMESPathCheck('keyVaultSecretStatus', 'Initialized'),
-    #         JMESPathCheck('thumbprint', cert_thumbprint)
-    #     ])
-
-    #     self.cmd('webapp config ssl bind -g {} -n {} --certificate-thumbprint {} --ssl-type {}'.format(resource_group, webapp_name, cert_thumbprint, 'SNI'), checks=[
-    #         JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].sslState".format(
-    #             webapp_name), 'SniEnabled'),
-    #         JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].thumbprint".format(
-    #             webapp_name), cert_thumbprint)
-    #     ])
+        self.cmd('webapp config ssl bind -g {} -n {} --certificate-thumbprint {} --ssl-type {}'.format(resource_group, webapp_name, cert_thumbprint, 'SNI'), checks=[
+            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].sslState".format(
+                webapp_name), 'SniEnabled'),
+            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].thumbprint".format(
+                webapp_name), cert_thumbprint)
+        ])
 
 
 class WebappUndeleteTest(ScenarioTest):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -1400,44 +1400,44 @@ class WebappSSLImportCertTest(ScenarioTest):
                 webapp_name), cert_thumbprint)
         ])
 
-    @AllowLargeResponse()
-    @ResourceGroupPreparer(parameter_name='kv_resource_group', location='westeurope')
-    @ResourceGroupPreparer(location='westeurope')
-    def test_webapp_ssl_import_resource_id(self, resource_group, kv_resource_group):
-        plan_name = self.create_random_name(prefix='ssl-test-plan', length=24)
-        webapp_name = self.create_random_name(prefix='web-ssl-test', length=20)
-        kv_name = self.create_random_name(prefix='kv-ssl-test', length=20)
-        # Cert Generated using
-        # https://docs.microsoft.com/azure/app-service-web/web-sites-configure-ssl-certificate#bkmk_ssopenssl
-        pfx_file = os.path.join(TEST_DIR, 'server.pfx')
-        cert_password = 'test'
-        cert_thumbprint = '9E9735C45C792B03B3FFCCA614852B32EE71AD6B'
-        cert_name = 'test-cert'
-        # we configure tags here in a hope to capture a repro for https://github.com/Azure/azure-cli/issues/6929
-        self.cmd(
-            'appservice plan create -g {} -n {} --sku B1'.format(resource_group, plan_name))
-        self.cmd(
-            'webapp create -g {} -n {} --plan {}'.format(resource_group, webapp_name, plan_name))
-        self.cmd('keyvault create -g {} -n {}'.format(kv_resource_group, kv_name))
-        self.cmd('keyvault set-policy -g {} --name {} --spn {} --secret-permissions get'.format(
-            kv_resource_group, kv_name, 'Microsoft.Azure.WebSites'))
-        self.cmd('keyvault certificate import --name {} --vault-name {} --file "{}" --password {}'.format(
-            cert_name, kv_name, pfx_file, cert_password))
+    # @AllowLargeResponse()
+    # @ResourceGroupPreparer(parameter_name='kv_resource_group', location='westeurope')
+    # @ResourceGroupPreparer(location='westeurope')
+    # def test_webapp_ssl_import_resource_id(self, resource_group, kv_resource_group):
+    #     plan_name = self.create_random_name(prefix='ssl-test-plan', length=24)
+    #     webapp_name = self.create_random_name(prefix='web-ssl-test', length=20)
+    #     kv_name = self.create_random_name(prefix='kv-ssl-test', length=20)
+    #     # Cert Generated using
+    #     # https://docs.microsoft.com/azure/app-service-web/web-sites-configure-ssl-certificate#bkmk_ssopenssl
+    #     pfx_file = os.path.join(TEST_DIR, 'server.pfx')
+    #     cert_password = 'test'
+    #     cert_thumbprint = '9E9735C45C792B03B3FFCCA614852B32EE71AD6B'
+    #     cert_name = 'test-cert'
+    #     # we configure tags here in a hope to capture a repro for https://github.com/Azure/azure-cli/issues/6929
+    #     self.cmd(
+    #         'appservice plan create -g {} -n {} --sku B1'.format(resource_group, plan_name))
+    #     self.cmd(
+    #         'webapp create -g {} -n {} --plan {}'.format(resource_group, webapp_name, plan_name))
+    #     self.cmd('keyvault create -g {} -n {}'.format(kv_resource_group, kv_name))
+    #     self.cmd('keyvault set-policy -g {} --name {} --spn {} --secret-permissions get'.format(
+    #         kv_resource_group, kv_name, 'Microsoft.Azure.WebSites'))
+    #     self.cmd('keyvault certificate import --name {} --vault-name {} --file "{}" --password {}'.format(
+    #         cert_name, kv_name, pfx_file, cert_password))
 
-        kv_id = '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.KeyVault/vaults/{}'.format(
-            self.get_subscription_id(), kv_resource_group, kv_name)
+    #     kv_id = '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.KeyVault/vaults/{}'.format(
+    #         self.get_subscription_id(), kv_resource_group, kv_name)
 
-        self.cmd('webapp config ssl import --resource-group {} --name {}  --key-vault {} --key-vault-certificate-name {}'.format(resource_group, webapp_name, kv_id, cert_name), checks=[
-            JMESPathCheck('keyVaultSecretStatus', 'Initialized'),
-            JMESPathCheck('thumbprint', cert_thumbprint)
-        ])
+    #     self.cmd('webapp config ssl import --resource-group {} --name {}  --key-vault {} --key-vault-certificate-name {}'.format(resource_group, webapp_name, kv_id, cert_name), checks=[
+    #         JMESPathCheck('keyVaultSecretStatus', 'Initialized'),
+    #         JMESPathCheck('thumbprint', cert_thumbprint)
+    #     ])
 
-        self.cmd('webapp config ssl bind -g {} -n {} --certificate-thumbprint {} --ssl-type {}'.format(resource_group, webapp_name, cert_thumbprint, 'SNI'), checks=[
-            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].sslState".format(
-                webapp_name), 'SniEnabled'),
-            JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].thumbprint".format(
-                webapp_name), cert_thumbprint)
-        ])
+    #     self.cmd('webapp config ssl bind -g {} -n {} --certificate-thumbprint {} --ssl-type {}'.format(resource_group, webapp_name, cert_thumbprint, 'SNI'), checks=[
+    #         JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].sslState".format(
+    #             webapp_name), 'SniEnabled'),
+    #         JMESPathCheck("hostNameSslStates|[?name=='{}.azurewebsites.net']|[0].thumbprint".format(
+    #             webapp_name), cert_thumbprint)
+    #     ])
 
 
 class WebappUndeleteTest(ScenarioTest):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Prior to this change, issues were raised #11867 as the command were failing if the key vault was not in the same resource group as the web app. An option existed to provide a resource id, but this was not documented enough to be discoverable. The change allows key vault to be imported across all resource groups in the subscription in context without any change, and if it is not found, a suggestion to provide the full resource id is displayed. Further a help example of using resource id is added.
There are no changes to the parameter list or breaking changes.

**Testing Guide**  
The two examples in az webapp config ssl import --help

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AppService] az webapp|functionapp config ssl import: Lookup key vault across resources groups in subscription and improve help and examples.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
