### PR TITLE
[Core] fix logging file fd leaking

### DIFF
--- a/src/azure-cli-core/azure/cli/core/azlogging.py
+++ b/src/azure-cli-core/azure/cli/core/azlogging.py
@@ -177,7 +177,7 @@ class AzCliLogging(CLILogging):
 
     @staticmethod
     def deinit_cmd_metadata_logging(cli_ctx):
-        cli_ctx.logging.end_cmd_metadata_logging(cli_ctx.result.exit_code if cli_ctx else 128)
+        cli_ctx.logging.end_cmd_metadata_logging(cli_ctx.result.exit_code if cli_ctx.result else 128)
 
     def end_cmd_metadata_logging(self, exit_code):  # leave it non '-' prefix to not to break user
         if self.command_metadata_logger:

--- a/src/azure-cli-core/azure/cli/core/azlogging.py
+++ b/src/azure-cli-core/azure/cli/core/azlogging.py
@@ -177,8 +177,7 @@ class AzCliLogging(CLILogging):
 
     @staticmethod
     def deinit_cmd_metadata_logging(cli_ctx):
-        self = cli_ctx.logging
-        self.end_cmd_metadata_logging(cli_ctx.result.exit_code if cli_ctx.result else 128)
+        cli_ctx.logging.end_cmd_metadata_logging(cli_ctx.result.exit_code if cli_ctx else 128)
 
     def end_cmd_metadata_logging(self, exit_code):  # leave it non '-' prefix to not to break user
         if self.command_metadata_logger:

--- a/src/azure-cli-core/azure/cli/core/azlogging.py
+++ b/src/azure-cli-core/azure/cli/core/azlogging.py
@@ -187,6 +187,7 @@ class AzCliLogging(CLILogging):
             # We have finished metadata logging, remove handler and set command_metadata_handler to None.
             # crucial to remove handler as in python logger objects are shared which can affect testing of this logger
             # we do not want duplicate handlers to be added in subsequent calls of _init_command_logfile_handlers
+            self.command_logger_handler.close()
             self.command_metadata_logger.removeHandler(self.command_logger_handler)
             self.command_metadata_logger = None
 

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -56,7 +56,7 @@ DEPENDENCIES = [
     'colorama>=0.3.9',
     'humanfriendly>=4.7,<9.0',
     'jmespath',
-    'knack==0.7.0rc3',
+    'knack==0.7.0rc4',
     'msrest>=0.4.4',
     'msrestazure>=0.6.3',
     'paramiko>=2.0.8,<3.0.0',

--- a/src/azure-cli/azure/cli/__main__.py
+++ b/src/azure-cli/azure/cli/__main__.py
@@ -47,7 +47,6 @@ try:
 
     elapsed_time = timeit.default_timer() - start_time
 
-    az_cli.logging.end_cmd_metadata_logging(exit_code)
     sys.exit(exit_code)
 
 except KeyboardInterrupt:
@@ -61,7 +60,6 @@ except SystemExit as ex:  # some code directly call sys.exit, this is to make su
     except NameError:
         pass
 
-    az_cli.logging.end_cmd_metadata_logging(exit_code)
     raise ex
 
 finally:

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -100,7 +100,7 @@ isodate==0.6.0
 Jinja2==2.10.1
 jmespath==0.9.4
 jsmin==2.2.2
-knack==0.7.0rc3
+knack==0.7.0rc4
 MarkupSafe==1.1.1
 mock==4.0.2
 msrestazure==0.6.3

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -100,7 +100,7 @@ isodate==0.6.0
 Jinja2==2.10.1
 jmespath==0.9.4
 jsmin==2.2.2
-knack==0.7.0rc3
+knack==0.7.0rc4
 MarkupSafe==1.1.1
 mock==4.0.2
 msrest==0.6.9

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -98,7 +98,7 @@ isodate==0.6.0
 Jinja2==2.10.1
 jmespath==0.9.4
 jsmin==2.2.2
-knack==0.7.0rc3
+knack==0.7.0rc4
 MarkupSafe==1.1.1
 mock==4.0.2
 msrest==0.6.9

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -131,7 +131,7 @@ DEPENDENCIES = [
     'cryptography>=2.3.1,<3.0.0',
     'fabric~=2.4',
     'jsmin~=2.2.2',
-    'knack==0.7.0rc3',
+    'knack==0.7.0rc4',
     'mock~=4.0',
     'paramiko>=2.0.8,<3.0.0',
     'pyOpenSSL>=17.1.0',


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR mainly did is to To make CLI instance close logger file after it's invoked, specifically:
1. Fix the bug that would leak file handler and its corresponding fd (Fix https://github.com/Azure/azure-cli/issues/12882, Fix https://github.com/Azure/azure-cli/issues/10435)
2. Fix the edge bug that file logger would write to previous file handler like `test_feedback.py` because of cli never clean up only when it exists.
3. Bump knack to 0.7.0rc4 because need its new feature support

The original discussion list [here](https://github.com/Azure/azure-cli/pull/12971).


With the [PR of knack](https://github.com/microsoft/knack/pull/199/files) which make knack be aware of SystemExit and the timing to raise EVENT_CLI_POST_EXECUTE  is merged, the test should be fine.

**Testing Guide**  
Follow the guide in the previous [PR](https://github.com/Azure/azure-cli/pull/12971), it will show `(deleted)` files when you `lsof` to inspect the opened files of CLI.
With this fix, it won't show again.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
