### PR TITLE
[Storage] az storage blob sync: Fix the incorrect error message when azcopy cannot find the installation location (#9576) 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -185,7 +185,7 @@ def _get_default_install_location():
         install_location = os.path.expanduser(os.path.join('~', 'bin/azcopy'))
     else:
         raise CLIError('The {} platform is not currently supported. '
-                       'If you want to know which platforms are supported, please refer to the document '
+                       'If you want to know which platforms are supported, please refer to the document for supported platforms: '
                        'https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10#download-azcopy'
                        .format(system))
     return install_location

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -184,8 +184,8 @@ def _get_default_install_location():
     elif system in ('Linux', 'Darwin'):
         install_location = os.path.expanduser(os.path.join('~', 'bin/azcopy'))
     else:
-        raise CLIError('The {} platform is not currently supported. '
-                       'If you want to know which platforms are supported, please refer to the document for supported platforms: '
+        raise CLIError('The {} platform is not currently supported. If you want to know which platforms are supported, '
+                       'please refer to the document for supported platforms: '
                        'https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10#download-azcopy'
                        .format(system))
     return install_location

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -178,12 +178,16 @@ def _get_default_install_location():
     if system == 'Windows':
         home_dir = os.environ.get('USERPROFILE')
         if not home_dir:
-            return None
+            raise CLIError('In the Windows platform, please specify the environment variable "USERPROFILE" '
+                           'as the installation location.')
         install_location = os.path.join(home_dir, r'.azcopy\azcopy.exe')
     elif system in ('Linux', 'Darwin'):
         install_location = os.path.expanduser(os.path.join('~', 'bin/azcopy'))
     else:
-        install_location = None
+        raise CLIError('The {} platform is not currently supported. '
+                       'If you want to know which platforms are supported, please refer to the document '
+                       'https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10#download-azcopy'
+                       .format(system))
     return install_location
 
 


### PR DESCRIPTION
Issue: #9576

**Description<!--Mandatory-->**  
If the install location in `_get_default_install_location()` is not found, `None` will be returned, resulting in an unreasonable error prompt in the judgment of `os.path.isfile(install_location)` in the subsequent process:
> stat: path should be string, bytes, os.PathLike or integer, not NoneType

So I added the correct exception throw when it couldn't find the install location to help the customers understand the reason for the error.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
