### PR TITLE
[RBAC] az ad sp create-for-rbac: refine error message when user specify an invalid scope

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -495,7 +495,7 @@ def _build_role_scope(resource_group_name, scope, subscription_id):
         if resource_group_name:
             err = 'Resource group "{}" is redundant because scope is supplied'
             raise CLIError(err.format(resource_group_name))
-        from msrestazure.tools import is_valid_resource_id
+        from azure.mgmt.core.tools import is_valid_resource_id
         if scope.startswith('/subscriptions/') and not is_valid_resource_id(scope):
             raise CLIError('Invalid scope. Please use --help to view the valid format.')
     elif scope == '':

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -496,7 +496,7 @@ def _build_role_scope(resource_group_name, scope, subscription_id):
             err = 'Resource group "{}" is redundant because scope is supplied'
             raise CLIError(err.format(resource_group_name))
         from msrestazure.tools import is_valid_resource_id
-        if not is_valid_resource_id(scope):
+        if scope.startswith('/subscriptions/') and not is_valid_resource_id(scope):
             raise CLIError('Invalid scope. Please use --help to view the valid format.')
     elif scope == '':
         raise CLIError('Invalid scope. Please use --help to view the valid format.')

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -495,6 +495,9 @@ def _build_role_scope(resource_group_name, scope, subscription_id):
         if resource_group_name:
             err = 'Resource group "{}" is redundant because scope is supplied'
             raise CLIError(err.format(resource_group_name))
+        from msrestazure.tools import is_valid_resource_id
+        if not is_valid_resource_id(scope):
+            raise CLIError('Invalid scope. Please use --help to view the valid format.')
     elif scope == '':
         raise CLIError('Invalid scope. Please use --help to view the valid format.')
     elif resource_group_name:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR is to fix #7441 

Previously if user specify scope with an invalid resource id, CLI will prompt a strange error message just as described in the issue.

We add a check whether it is a valid resource id here.

The reason why I didn't combine it with `scope == ''` is that I don't want to change previous check sequence.

**Testing Guide**  
`az ad sp create-for-rbac --name myTestSP --role contributor --scopes /subscriptions/<subscription>/<resource_group>`

Prompt below error:
_Invalid scope. Please use --help to view the valid format._

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
