### PR TITLE
[Core] fix core tests failed under certain profiles

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -365,13 +365,15 @@ class TestHelpLoads(unittest.TestCase):
         self.assertEqual(obj_param_dict["--arg1 -a"].value_sources[0]['link']['command'], "az foo bar")
         self.assertEqual(obj_param_dict["--arg1 -a"].value_sources[1]['link']['command'], "az bar baz")
 
-        self.assertEqual(command_help_obj.examples[0].short_summary, "Alpha Example")
-        self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 a --arg2 b --arg3 c")
-        self.assertEqual(command_help_obj.examples[0].supported_profiles, "2018-03-01-hybrid, latest")
-        self.assertEqual(command_help_obj.examples[0].unsupported_profiles, None)
+        if self.test_cli.cloud.profile in ['2018-03-01-hybrid', 'latest']:
+            # if won't show under other profiles
+            self.assertEqual(command_help_obj.examples[0].short_summary, "Alpha Example")
+            self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 a --arg2 b --arg3 c")
+            self.assertEqual(command_help_obj.examples[0].supported_profiles, "2018-03-01-hybrid, latest")
+            self.assertEqual(command_help_obj.examples[0].unsupported_profiles, None)
 
-        self.assertEqual(command_help_obj.examples[1].supported_profiles, None)
-        self.assertEqual(command_help_obj.examples[1].unsupported_profiles, "2017-03-09-profile")
+            self.assertEqual(command_help_obj.examples[1].supported_profiles, None)
+            self.assertEqual(command_help_obj.examples[1].unsupported_profiles, "2017-03-09-profile")
 
     @mock.patch('pkgutil.iter_modules', side_effect=lambda x: [(None, MOCKED_COMMAND_LOADER_MOD, None)])
     @mock.patch('azure.cli.core.commands._load_command_loader', side_effect=mock_load_command_loader)
@@ -425,14 +427,16 @@ class TestHelpLoads(unittest.TestCase):
         self.assertEqual(obj_param_dict["--arg2 -b"].value_sources[2]['link'], {"command": "az test show",
                                                                                 "title": "Show test details"})
 
-        self.assertEqual(command_help_obj.examples[0].short_summary, "A simple example")
-        self.assertEqual(command_help_obj.examples[0].long_summary, "More detail on the simple example.")
-        self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 apple --arg2 ball --arg3 cat")
-        self.assertEqual(command_help_obj.examples[0].supported_profiles, "2018-03-01-hybrid, latest")
-        self.assertEqual(command_help_obj.examples[0].unsupported_profiles, None)
+        if self.test_cli.cloud.profile in ['2018-03-01-hybrid', 'latest']:
+            # if won't show under other profiles
+            self.assertEqual(command_help_obj.examples[0].short_summary, "A simple example")
+            self.assertEqual(command_help_obj.examples[0].long_summary, "More detail on the simple example.")
+            self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 apple --arg2 ball --arg3 cat")
+            self.assertEqual(command_help_obj.examples[0].supported_profiles, "2018-03-01-hybrid, latest")
+            self.assertEqual(command_help_obj.examples[0].unsupported_profiles, None)
 
-        self.assertEqual(command_help_obj.examples[1].supported_profiles, None)
-        self.assertEqual(command_help_obj.examples[1].unsupported_profiles, "2017-03-09-profile")
+            self.assertEqual(command_help_obj.examples[1].supported_profiles, None)
+            self.assertEqual(command_help_obj.examples[1].unsupported_profiles, "2017-03-09-profile")
 
     @mock.patch('inspect.getmembers', side_effect=mock_inspect_getmembers)
     @mock.patch('pkgutil.iter_modules', side_effect=lambda x: [(None, MOCKED_COMMAND_LOADER_MOD, None)])
@@ -486,10 +490,12 @@ class TestHelpLoads(unittest.TestCase):
         self.assertEqual(obj_param_dict["--arg3"].value_sources[2]['link'],
                          {"command": "az test show", "title": "Show test details. Json file"})
 
-        self.assertEqual(command_help_obj.examples[0].short_summary, "A simple example from json")
-        self.assertEqual(command_help_obj.examples[0].long_summary, "More detail on the simple example.")
-        self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 alpha --arg2 beta --arg3 chi")
-        self.assertEqual(command_help_obj.examples[0].supported_profiles, "2018-03-01-hybrid, latest")
+        if self.test_cli.cloud.profile in ['2018-03-01-hybrid', 'latest']:
+            # if won't show under other profiles
+            self.assertEqual(command_help_obj.examples[0].short_summary, "A simple example from json")
+            self.assertEqual(command_help_obj.examples[0].long_summary, "More detail on the simple example.")
+            self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 alpha --arg2 beta --arg3 chi")
+            self.assertEqual(command_help_obj.examples[0].supported_profiles, "2018-03-01-hybrid, latest")
 
         # validate other parameters, which have help from help.py and help.yamls
         self.assertEqual(obj_param_dict["--arg1 -a"].short_summary, "A short summary.")

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -366,7 +366,6 @@ class TestHelpLoads(unittest.TestCase):
         self.assertEqual(obj_param_dict["--arg1 -a"].value_sources[1]['link']['command'], "az bar baz")
 
         if self.test_cli.cloud.profile in ['2018-03-01-hybrid', 'latest']:
-            # if won't show under other profiles
             self.assertEqual(command_help_obj.examples[0].short_summary, "Alpha Example")
             self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 a --arg2 b --arg3 c")
             self.assertEqual(command_help_obj.examples[0].supported_profiles, "2018-03-01-hybrid, latest")
@@ -374,6 +373,10 @@ class TestHelpLoads(unittest.TestCase):
 
             self.assertEqual(command_help_obj.examples[1].supported_profiles, None)
             self.assertEqual(command_help_obj.examples[1].unsupported_profiles, "2017-03-09-profile")
+        else:
+            # only supported example here
+            self.assertEqual(len(command_help_obj.examples), 1)
+            self.assertEqual(command_help_obj.examples[0].unsupported_profiles, '2017-03-09-profile')
 
     @mock.patch('pkgutil.iter_modules', side_effect=lambda x: [(None, MOCKED_COMMAND_LOADER_MOD, None)])
     @mock.patch('azure.cli.core.commands._load_command_loader', side_effect=mock_load_command_loader)
@@ -428,7 +431,6 @@ class TestHelpLoads(unittest.TestCase):
                                                                                 "title": "Show test details"})
 
         if self.test_cli.cloud.profile in ['2018-03-01-hybrid', 'latest']:
-            # if won't show under other profiles
             self.assertEqual(command_help_obj.examples[0].short_summary, "A simple example")
             self.assertEqual(command_help_obj.examples[0].long_summary, "More detail on the simple example.")
             self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 apple --arg2 ball --arg3 cat")
@@ -437,6 +439,10 @@ class TestHelpLoads(unittest.TestCase):
 
             self.assertEqual(command_help_obj.examples[1].supported_profiles, None)
             self.assertEqual(command_help_obj.examples[1].unsupported_profiles, "2017-03-09-profile")
+        else:
+            # only supported example here
+            self.assertEqual(len(command_help_obj.examples), 1)
+            self.assertEqual(command_help_obj.examples[0].unsupported_profiles, '2017-03-09-profile')
 
     @mock.patch('inspect.getmembers', side_effect=mock_inspect_getmembers)
     @mock.patch('pkgutil.iter_modules', side_effect=lambda x: [(None, MOCKED_COMMAND_LOADER_MOD, None)])
@@ -491,11 +497,13 @@ class TestHelpLoads(unittest.TestCase):
                          {"command": "az test show", "title": "Show test details. Json file"})
 
         if self.test_cli.cloud.profile in ['2018-03-01-hybrid', 'latest']:
-            # if won't show under other profiles
             self.assertEqual(command_help_obj.examples[0].short_summary, "A simple example from json")
             self.assertEqual(command_help_obj.examples[0].long_summary, "More detail on the simple example.")
             self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 alpha --arg2 beta --arg3 chi")
             self.assertEqual(command_help_obj.examples[0].supported_profiles, "2018-03-01-hybrid, latest")
+        else:
+            # only supported example here
+            self.assertEqual(len(command_help_obj.examples), 0)
 
         # validate other parameters, which have help from help.py and help.yamls
         self.assertEqual(obj_param_dict["--arg1 -a"].short_summary, "A short summary.")

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -383,7 +383,6 @@ class TestHelpLoads(unittest.TestCase):
         if self.test_cli.cloud.profile == '2017-03-09-profile':
             self.assertEqual(len(command_help_obj.examples), 0)
 
-
     @mock.patch('pkgutil.iter_modules', side_effect=lambda x: [(None, MOCKED_COMMAND_LOADER_MOD, None)])
     @mock.patch('azure.cli.core.commands._load_command_loader', side_effect=mock_load_command_loader)
     def test_load_from_help_yaml(self, mocked_load, mocked_pkg_util):

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -512,8 +512,12 @@ class TestHelpLoads(unittest.TestCase):
             self.assertEqual(command_help_obj.examples[0].long_summary, "More detail on the simple example.")
             self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 alpha --arg2 beta --arg3 chi")
             self.assertEqual(command_help_obj.examples[0].supported_profiles, "2018-03-01-hybrid, latest")
-        else:
+
+        if self.test_cli.cloud.profile == '2019-03-01-hybrid':
             # only supported example here
+            self.assertEqual(len(command_help_obj.examples), 0)
+
+        if self.test_cli.cloud.profile == '2017-03-09-profile':
             self.assertEqual(len(command_help_obj.examples), 0)
 
         # validate other parameters, which have help from help.py and help.yamls

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -373,10 +373,16 @@ class TestHelpLoads(unittest.TestCase):
 
             self.assertEqual(command_help_obj.examples[1].supported_profiles, None)
             self.assertEqual(command_help_obj.examples[1].unsupported_profiles, "2017-03-09-profile")
-        else:
-            # only supported example here
+
+        if self.test_cli.cloud.profile == '2019-03-01-hybrid':
             self.assertEqual(len(command_help_obj.examples), 1)
+            self.assertEqual(command_help_obj.examples[0].short_summary, "A simple example unsupported on latest")
+            self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 a --arg2 b")
             self.assertEqual(command_help_obj.examples[0].unsupported_profiles, '2017-03-09-profile')
+
+        if self.test_cli.cloud.profile == '2017-03-09-profile':
+            self.assertEqual(len(command_help_obj.examples), 0)
+
 
     @mock.patch('pkgutil.iter_modules', side_effect=lambda x: [(None, MOCKED_COMMAND_LOADER_MOD, None)])
     @mock.patch('azure.cli.core.commands._load_command_loader', side_effect=mock_load_command_loader)

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -445,10 +445,15 @@ class TestHelpLoads(unittest.TestCase):
 
             self.assertEqual(command_help_obj.examples[1].supported_profiles, None)
             self.assertEqual(command_help_obj.examples[1].unsupported_profiles, "2017-03-09-profile")
-        else:
-            # only supported example here
+
+        if self.test_cli.cloud.profile == '2019-03-01-hybrid':
             self.assertEqual(len(command_help_obj.examples), 1)
+            self.assertEqual(command_help_obj.examples[0].short_summary, "Another example unsupported on latest")
+            self.assertEqual(command_help_obj.examples[0].command, "az test alpha --arg1 apple --arg2 ball")
             self.assertEqual(command_help_obj.examples[0].unsupported_profiles, '2017-03-09-profile')
+
+        if self.test_cli.cloud.profile == '2017-03-09-profile':
+            self.assertEqual(len(command_help_obj.examples), 0)
 
     @mock.patch('inspect.getmembers', side_effect=mock_inspect_getmembers)
     @mock.patch('pkgutil.iter_modules', side_effect=lambda x: [(None, MOCKED_COMMAND_LOADER_MOD, None)])


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Make tests of `src/azure-cli-core/azure/cli/core/tests/test_help.py` complete pass core under different profiles.

Currently, jobs like **Automation Test** running under different profiles didn't run with azure-cli-core module, which is incomplete for our tests and it would fail if running under 2019 and 2017 profiles.

I discovered it with the latest change on azdev https://github.com/Azure/azure-cli-dev-tools/pull/188, and the tests `src/azure-cli-core/azure/cli/core/tests/test_help.py::TestHelpLoads` would fail if running under profile 2019-03-01-hybrid beause of the help entries would behave differently under 2019 and 2017 profiles but the tests are expected to assert everything under every profile. 
That's why they failed.

**Testing Guide**  
On original branch, switch to other 2019-03-01-hybrid profile:
`az cloud update --profile 2019-03-01-hybrid`,
then run tests with:
`pytest -x -v --log-level=WARN src/azure-cli-core/azure/cli/core/tests/test_help.py::TestHelpLoads`
the 4 tests under this test Class should fail.

After checking out my changes,
run it again, the 4 tests should pass.


**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
