### PR TITLE
{Identity} Support managed identity login

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -111,7 +111,7 @@ class Profile(object):
 
         self._management_resource_uri = self.cli_ctx.cloud.endpoints.management
         self._ad_resource_uri = self.cli_ctx.cloud.endpoints.active_directory_resource_id
-        self._msal_scope = self.cli_ctx.cloud.endpoints.active_directory_resource_id + '/.default'
+        self._msal_scope = self.cli_ctx.cloud.endpoints.active_directory_resource_id.rstrip('/') + '/.default'
         self._ad = self.cli_ctx.cloud.endpoints.active_directory
         self._msi_creds = None
 
@@ -200,8 +200,57 @@ class Profile(object):
         # use deepcopy as we don't want to persist these changes to file.
         return deepcopy(consolidated)
 
+    def login_with_managed_identity(self, identity_id=None, allow_no_subscriptions=None, find_subscriptions=True):
+        # pylint: disable=too-many-statements
+
+        # https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
+        # Managed identities for Azure resources is the new name for the service formerly known as
+        # Managed Service Identity (MSI).
+
+        resource = self.cli_ctx.cloud.endpoints.active_directory_resource_id
+        identity = Identity()
+        credential, mi_info = identity.login_with_managed_identity(identity_id, resource)
+
+        tenant = mi_info[Identity.MANAGED_IDENTITY_TENANT_ID]
+        if find_subscriptions:
+            logger.info('Finding subscriptions...')
+            subscription_finder = SubscriptionFinder(self.cli_ctx)
+            subscriptions = subscription_finder.find_using_specific_tenant(tenant, credential)
+            if not subscriptions:
+                if allow_no_subscriptions:
+                    subscriptions = self._build_tenant_level_accounts([tenant])
+                else:
+                    raise CLIError('No access was configured for the VM, hence no subscriptions were found. '
+                                   "If this is expected, use '--allow-no-subscriptions' to have tenant level access.")
+        else:
+            subscriptions = self._build_tenant_level_accounts([tenant])
+
+        # Get info for persistence
+        user_name = mi_info[Identity.MANAGED_IDENTITY_TYPE]
+        id_type_to_identity_type = {
+            Identity.MANAGED_IDENTITY_CLIENT_ID: MsiAccountTypes.user_assigned_client_id,
+            Identity.MANAGED_IDENTITY_OBJECT_ID: MsiAccountTypes.user_assigned_object_id,
+            Identity.MANAGED_IDENTITY_RESOURCE_ID: MsiAccountTypes.user_assigned_resource_id,
+            None: MsiAccountTypes.system_assigned
+        }
+
+        # Previously we persist user's input in assignedIdentityInfo:
+        #     "assignedIdentityInfo": "MSIClient-eecb2419-a29d-4580-a92a-f6a7b7b71300",
+        # Now we persist the output - info extracted from the access token.
+        # client_id, object_id, and resource_id are unified to client_id, which is the only persisted field.
+        # Also, the name "MSI" is deprecated. So will be assignedIdentityInfo.
+        legacy_identity_type = id_type_to_identity_type[mi_info[Identity.MANAGED_IDENTITY_ID_TYPE]]
+        legacy_base_name = ('{}-{}'.format(legacy_identity_type, identity_id) if identity_id else legacy_identity_type)
+        client_id = mi_info[Identity.MANAGED_IDENTITY_CLIENT_ID]
+
+        consolidated = self._normalize_properties(user_name, subscriptions, is_service_principal=True,
+                                                  user_assigned_identity_id=legacy_base_name,
+                                                  managed_identity_client_id=client_id)
+        self._set_subscriptions(consolidated)
+        return deepcopy(consolidated)
+
     def _normalize_properties(self, user, subscriptions, is_service_principal, cert_sn_issuer_auth=None,
-                              user_assigned_identity_id=None, home_account_id=None):
+                              user_assigned_identity_id=None, home_account_id=None, managed_identity_client_id=None):
         import sys
         consolidated = []
         for s in subscriptions:
@@ -219,13 +268,15 @@ class Profile(object):
                 _STATE: s.state.value,
                 _USER_ENTITY: {
                     _USER_NAME: user,
-                    _USER_TYPE: _SERVICE_PRINCIPAL if is_service_principal else _USER,
-                    _USER_HOME_ACCOUNT_ID: home_account_id
+                    _USER_TYPE: _SERVICE_PRINCIPAL if is_service_principal else _USER
                 },
                 _IS_DEFAULT_SUBSCRIPTION: False,
                 _TENANT_ID: s.tenant_id,
                 _ENVIRONMENT_NAME: self.cli_ctx.cloud.name
             }
+
+            if home_account_id:
+                subscription_dict[_USER_ENTITY][_USER_HOME_ACCOUNT_ID] = home_account_id
             # for Subscriptions - List REST API 2019-06-01's subscription account
             if subscription_dict[_SUBSCRIPTION_NAME] != _TENANT_LEVEL_ACCOUNT_NAME:
                 if hasattr(s, 'home_tenant_id'):
@@ -233,12 +284,17 @@ class Profile(object):
                 if hasattr(s, 'managed_by_tenants'):
                     subscription_dict[_MANAGED_BY_TENANTS] = [{_TENANT_ID: t.tenant_id} for t in s.managed_by_tenants]
 
-            consolidated.append(subscription_dict)
-
             if cert_sn_issuer_auth:
-                consolidated[-1][_USER_ENTITY][_SERVICE_PRINCIPAL_CERT_SN_ISSUER_AUTH] = True
+                subscription_dict[_USER_ENTITY][_SERVICE_PRINCIPAL_CERT_SN_ISSUER_AUTH] = True
+            if managed_identity_client_id:
+                subscription_dict[_USER_ENTITY]['clientId'] = managed_identity_client_id
+
+            # This will be deprecated and client_id will be the only persisted ID
+            logger.warning("assignedIdentityInfo will be deprecated in the future. Only client ID should be used.")
             if user_assigned_identity_id:
-                consolidated[-1][_USER_ENTITY][_ASSIGNED_IDENTITY_INFO] = user_assigned_identity_id
+                subscription_dict[_USER_ENTITY][_ASSIGNED_IDENTITY_INFO] = user_assigned_identity_id
+
+            consolidated.append(subscription_dict)
         return consolidated
 
     def _build_tenant_level_accounts(self, tenants):
@@ -259,74 +315,6 @@ class Profile(object):
         s = SubscriptionType()
         s.state = StateType.enabled
         return s
-
-    def find_subscriptions_in_vm_with_msi(self, identity_id=None, allow_no_subscriptions=None):
-        # pylint: disable=too-many-statements
-
-        import jwt
-        from requests import HTTPError
-        from msrestazure.azure_active_directory import MSIAuthentication
-        from msrestazure.tools import is_valid_resource_id
-        resource = self.cli_ctx.cloud.endpoints.active_directory_resource_id
-
-        if identity_id:
-            if is_valid_resource_id(identity_id):
-                msi_creds = MSIAuthentication(resource=resource, msi_res_id=identity_id)
-                identity_type = MsiAccountTypes.user_assigned_resource_id
-            else:
-                authenticated = False
-                try:
-                    msi_creds = MSIAuthentication(resource=resource, client_id=identity_id)
-                    identity_type = MsiAccountTypes.user_assigned_client_id
-                    authenticated = True
-                except HTTPError as ex:
-                    if ex.response.reason == 'Bad Request' and ex.response.status == 400:
-                        logger.info('Sniff: not an MSI client id')
-                    else:
-                        raise
-
-                if not authenticated:
-                    try:
-                        identity_type = MsiAccountTypes.user_assigned_object_id
-                        msi_creds = MSIAuthentication(resource=resource, object_id=identity_id)
-                        authenticated = True
-                    except HTTPError as ex:
-                        if ex.response.reason == 'Bad Request' and ex.response.status == 400:
-                            logger.info('Sniff: not an MSI object id')
-                        else:
-                            raise
-
-                if not authenticated:
-                    raise CLIError('Failed to connect to MSI, check your managed service identity id.')
-
-        else:
-            # msal : msi
-            identity_type = MsiAccountTypes.system_assigned
-            from azure.identity import AuthenticationRequiredError, ManagedIdentity
-            # msi_cred = MSIAuthentication(resource=resource)
-            msi_cred = ManagedIdentity()
-
-        token_entry = msi_cred.get_token('https://management.azure.com/.default')
-        token = token_entry.token
-        logger.info('MSI: token was retrieved. Now trying to initialize local accounts...')
-        decode = jwt.decode(token, verify=False, algorithms=['RS256'])
-        tenant = decode['tid']
-
-        subscription_finder = SubscriptionFinder(self.cli_ctx, self.auth_ctx_factory, None)
-        subscriptions = subscription_finder.find_from_raw_token(tenant, token)
-        base_name = ('{}-{}'.format(identity_type, identity_id) if identity_id else identity_type)
-        user = _USER_ASSIGNED_IDENTITY if identity_id else _SYSTEM_ASSIGNED_IDENTITY
-        if not subscriptions:
-            if allow_no_subscriptions:
-                subscriptions = self._build_tenant_level_accounts([tenant])
-            else:
-                raise CLIError('No access was configured for the VM, hence no subscriptions were found. '
-                               "If this is expected, use '--allow-no-subscriptions' to have tenant level access.")
-
-        consolidated = self._normalize_properties(user, subscriptions, is_service_principal=True,
-                                                  user_assigned_identity_id=base_name)
-        self._set_subscriptions(consolidated)
-        return deepcopy(consolidated)
 
     def find_subscriptions_in_cloud_console(self):
         import jwt

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -51,8 +51,8 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('tenant', options_list=['--tenant', '-t'], help='The AAD tenant, must provide when using service principals.', validator=validate_tenant)
             c.argument('allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
             c.ignore('_subscription')  # hide the global subscription parameter
-            c.argument('identity', options_list=('-i', '--identity'), action='store_true', help="Log in using the Virtual Machine's identity", arg_group='Managed Service Identity')
-            c.argument('identity_port', type=int, help="the port to retrieve tokens for login. Default: 50342", arg_group='Managed Service Identity')
+            c.argument('identity', options_list=('-i', '--identity'), action='store_true', help="Log in using the Virtual Machine's managed identity", arg_group='Managed Identity')
+            c.argument('identity_port', type=int, help="the port to retrieve tokens for login. Default: 50342", arg_group='Managed Identity')
             c.argument('use_device_code', action='store_true',
                        help="Use CLI's old authentication flow based on device code. CLI will also use this if it can't launch a browser in your behalf, e.g. in remote SSH or Cloud Shell")
             c.argument('use_cert_sn_issuer', action='store_true', help='used with a service principal configured with Subject Name and Issuer Authentication in order to support automatic certificate rolls')

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -23,10 +23,10 @@ helps['login'] = """
         - name: Log in with a service principal using client certificate.
           text: >
             az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
-        - name: Log in using a VM's system assigned identity
+        - name: Log in using a VM's system-assigned managed identity
           text: >
             az login --identity
-        - name: Log in using a VM's user assigned identity. Client or object ids of the service identity also work
+        - name: Log in using a VM's user-assigned managed identity. Client or object ids of the service identity also work
           text: >
             az login --identity -u /subscriptions/<subscriptionId>/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
     """

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -125,7 +125,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
     if identity:
         if in_cloud_console():
             return profile.find_subscriptions_in_cloud_console()
-        return profile.find_subscriptions_in_vm_with_msi(username, allow_no_subscriptions)
+        return profile.login_with_managed_identity(username, allow_no_subscriptions)
     if in_cloud_console():  # tell users they might not need login
         logger.warning(_CLOUD_CONSOLE_LOGIN_WARNING)
 


### PR DESCRIPTION
## Description
Support managed identity.

## Testing

It currently shows a warning about the used managed identity. We can remove it in the official version. 

> Using Managed Identity: {"type": "systemAssignedIdentity", "id_type": "client_id", "tenant_id": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "client_id": "263438d4-b108-497e-8400-f9d5172495ae", "object_id": "63bdf800-9003-4644-b23c-0caeabf62a42", "resource_id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/xxx/providers/Microsoft.Compute/virtualMachines/xxx"}

Also it shows a warning for deprecating `assignedIdentityInfo`:

> assignedIdentityInfo will be deprecated in the future. Only client ID should be used.

### Login with default managed identity

When running `az login --identity` without `--username`, the behavior of **Azure Instance Metadata Service (IMDS)** is 

- Check whether there is a system-assigned identity:
    - ✔ If so, use it to retrieve the access token
    - ❌ If not, check whether there is **only one** user-assigned identity:
        - ✔ If so, use it to retrieve the access token
        - ❌ If not, raise an error

The actual identity is deduced from the output:

- Check whether `Microsoft.ManagedIdentity` appears in `resource_id` from the decoded access token:
    - ✔ If so, assume user-assigned identity
    - ❌ If not, assume system-assigned identity

The original behavior is incorrect as **the default identity is not always a system-assigned one**:

- Check whether `--username` is provide in the command:
    - ✔ If so, assume user-assigned identity
    - ❌ If not, assume system-assigned identity

So this change fixes issue https://github.com/Azure/azure-cli/issues/13188.

```json
> az login --identity
Using Managed Identity: {"type": "systemAssignedIdentity", "id_type": null, "tenant_id": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "client_id": "263438d4-b108-497e-8400-f9d5172495ae", "object_id": "63bdf800-9003-4644-b23c-0caeabf62a42", "resource_id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/jlwinrg/providers/Microsoft.Compute/virtualMachines/jlwin"}
assignedIdentityInfo will be deprecated in the future. Only client ID should be used.
[
  {
    "environmentName": "AzureCloud",
    "homeTenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "id": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "isDefault": true,
    "managedByTenants": [
      {
        "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
      }
    ],
    "name": "AzureSDKTest",
    "state": "Enabled",
    "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "user": {
      "assignedIdentityInfo": "MSI",
      "clientId": "263438d4-b108-497e-8400-f9d5172495ae",
      "name": "systemAssignedIdentity",
      "type": "servicePrincipal"
    }
  }
]
```
### Login with **user-assigned managed identity** explicitly

`clientId` is now the unified property to replace `assignedIdentityInfo`.

```json
> az login --identity --username 263438d4-b108-497e-8400-f9d5172495ae
Using Managed Identity: {"type": "systemAssignedIdentity", "id_type": "client_id", "tenant_id": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "client_id": "263438d4-b108-497e-8400-f9d5172495ae", "object_id": "63bdf800-9003-4644-b23c-0caeabf62a42", "resource_id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/xxx/providers/Microsoft.Compute/virtualMachines/xxx"}
assignedIdentityInfo will be deprecated in the future. Only client ID should be used.
[
  {
    "environmentName": "AzureCloud",
    "homeTenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "id": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "isDefault": true,
    "managedByTenants": [
      {
        "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
      }
    ],
    "name": "AzureSDKTest",
    "state": "Enabled",
    "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "user": {
      "assignedIdentityInfo": "MSIClient-263438d4-b108-497e-8400-f9d5172495ae",
      "clientId": "263438d4-b108-497e-8400-f9d5172495ae",
      "name": "systemAssignedIdentity",
      "type": "servicePrincipal"
    }
  }
]
```

## Known Issues

Login with **resource ID** and **object ID** for user-assigned managed identity is currently unsupported due to https://github.com/Azure/azure-sdk-for-python/issues/10989.
