### PR TITLE
[AKS] remove range check for updating min count for autoscaler

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2117,8 +2117,7 @@ def aks_update(cmd, client, resource_group_name, name,
         raise CLIError('There are more than one node pool in the cluster. Please use "az aks nodepool" command '
                        'to update per node pool auto scaler settings')
 
-    node_count = instance.agent_pool_profiles[0].count
-    _validate_autoscaler_update_counts(min_count, max_count, node_count, enable_cluster_autoscaler or
+    _validate_autoscaler_update_counts(min_count, max_count, enable_cluster_autoscaler or
                                        update_cluster_autoscaler)
 
     if enable_cluster_autoscaler:
@@ -2886,9 +2885,8 @@ def aks_agentpool_update(cmd, client, resource_group_name, cluster_name, nodepoo
                        '"--tags" or "--mode"')
 
     instance = client.get(resource_group_name, cluster_name, nodepool_name)
-    node_count = instance.count
 
-    _validate_autoscaler_update_counts(min_count, max_count, node_count, enable_cluster_autoscaler or
+    _validate_autoscaler_update_counts(min_count, max_count, enable_cluster_autoscaler or
                                        update_cluster_autoscaler)
 
     if enable_cluster_autoscaler:
@@ -3129,7 +3127,7 @@ def _check_cluster_autoscaler_flag(enable_cluster_autoscaler,
             raise CLIError('min-count and max-count are required for --enable-cluster-autoscaler, please use the flag')
 
 
-def _validate_autoscaler_update_counts(min_count, max_count, node_count, is_enable_or_update):
+def _validate_autoscaler_update_counts(min_count, max_count, is_enable_or_update):
     """
     Validates the min, max, and node count when performing an update
     """
@@ -3140,8 +3138,6 @@ def _validate_autoscaler_update_counts(min_count, max_count, node_count, is_enab
     if min_count is not None and max_count is not None:
         if int(min_count) > int(max_count):
             raise CLIError('Value of min-count should be less than or equal to value of max-count.')
-        if int(node_count) < int(min_count) or int(node_count) > int(max_count):
-            raise CLIError("Current node count '{}' is not in the range of min-count and max-count.".format(node_count))
 
 
 def _print_or_merge_credentials(path, kubeconfig, overwrite_existing, context_name):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Unblock updating minCount in both aks update and aks nodepool update when minCount < actual node count < max Count.

With this, minCount can be greater than the actual node count. Later scale operations equal to or greater than minCount, will respect that minCount in operations.

[CLI-extensions PR
](https://github.com/Azure/azure-cli-extensions/pull/1606)
**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
