### PR TITLE
{CI} Fix running full test timeout on profile when in batch mode

### DIFF
--- a/.azure-pipelines/templates/automation_test.yml
+++ b/.azure-pipelines/templates/automation_test.yml
@@ -27,7 +27,7 @@ steps:
       if [[ "$(System.PullRequest.TargetBranch)" != "" ]]; then
         azdev test --series --repo=./ --src=HEAD --tgt=origin/$(System.PullRequest.TargetBranch) --cli-ci --profile ${{ parameters.profile }}
       else
-        azdev test --series
+        azdev test --series --profile ${{ parameters.profile }}
       fi
     displayName: "Test on Profile ${{ parameters.profile }}"
     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -426,7 +426,7 @@ jobs:
 
 - job: AutomationTest20190301
   displayName: Automation Test (Profile 2019-03-01)
-  timeoutInMinutes: 30
+  timeoutInMinutes: 120
   pool:
     vmImage: 'ubuntu-16.04'
   strategy:
@@ -443,7 +443,7 @@ jobs:
 
 - job: AutomationTest20180301
   displayName: Automation Test (Profile 2018-03-01)
-  timeoutInMinutes: 30
+  timeoutInMinutes: 120
   pool:
     vmImage: 'ubuntu-16.04'
   strategy:
@@ -460,7 +460,7 @@ jobs:
 
 - job: AutomationTest20170309
   displayName: Automation Test (Profile 2017-03-09)
-  timeoutInMinutes: 30
+  timeoutInMinutes: 120
   pool:
     vmImage: 'ubuntu-16.04'
   strategy:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
CI now wrongly run all test on Batched CI mode because of not passing profile value.

**Testing Guide**  
Test PR https://github.com/Azure/azure-cli/pull/13221
other profiles (not latest) should run all tests under corresponding profiles instead of the buggy way to run 1936 tests.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
