### PR TITLE
[Extension] fix loading wrong metadata for wheel type extension

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -147,7 +147,8 @@ class WheelExtension(Extension):
         for dist_info_dirname in info_dirs:
             try:
                 ext_whl_metadata = pkginfo.Wheel(dist_info_dirname)
-                metadata.update(vars(ext_whl_metadata))
+                if self.name == ext_whl_metadata.name:
+                    metadata.update(vars(ext_whl_metadata))
             except ValueError:
                 logger.warning('extension % contains invalid metadata for Python Package', self.name)
 

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -213,7 +213,8 @@ class DevExtension(Extension):
             egg_metadata_path = os.path.join(ext_dir, egg_info_dirname, )
             try:
                 ext_whl_metadata = pkginfo.Develop(egg_metadata_path)
-                metadata.update(vars(ext_whl_metadata))
+                if self.name == ext_whl_metadata.name:
+                    metadata.update(vars(ext_whl_metadata))
             except ValueError:
                 logger.warning('extension % contains invalid metadata for Python Package', self.name)
 

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -138,7 +138,8 @@ class WheelExtension(Extension):
             return None
         metadata = {}
         ext_dir = self.path or get_extension_path(self.name)
-        info_dirs = glob(os.path.join(ext_dir, '*.*-info'))
+        info_dirs = glob(os.path.join(ext_dir, self.name.replace('-', '_') + '*.*-info'))
+
         azext_metadata = WheelExtension.get_azext_metadata(ext_dir)
         if azext_metadata:
             metadata.update(azext_metadata)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
With this https://github.com/Azure/azure-cli/pull/12782 merged, the ability to load metadata from a Python Package is enhanced, but the algorithm is to travel all folders under a specific extension home folder.
https://github.com/Azure/azure-cli/blob/69c99339b7b56263eb8167df2eed0c5593963195/src/azure-cli-core/azure/cli/core/extension/__init__.py#L146-L151

The problem is that if there are other folder named with `.dist-info`, it will load their metadata too, which will show a wrong extension version. Such as `azure-iot` and `alias`, as it has dependecies and CLI will place those dependecies inside the same folder for `azure-iot`.
```
$ ll ~/.azure/cliextensions/azure-iot           
total 568K
drwxrwxr-x 3 harold harold 4.0K Apr 28 11:25 attr
drwxrwxr-x 2 harold harold 4.0K Apr 28 11:25 attrs-19.3.0.dist-info
drwxrwxr-x 9 harold harold 4.0K Apr 28 11:25 azext_iot
drwxrwxr-x 2 harold harold 4.0K Apr 28 11:25 azure_iot-0.9.1.dist-info
-rw-rw-r-- 1 harold harold 289K Apr 28 11:25 azure_iot-0.9.1-py2.py3-none-any.whl
drwxrwxr-x 2 harold harold 4.0K Apr 28 11:25 bin
-rw-rw-r-- 1 harold harold  126 Apr 28 11:25 easy_install.py
drwxrwxr-x 6 harold harold 4.0K Apr 28 11:25 jsonschema
drwxrwxr-x 2 harold harold 4.0K Apr 28 11:25 jsonschema-3.0.2.dist-info
drwxrwxr-x 4 harold harold 4.0K Apr 28 11:25 paho
drwxrwxr-x 2 harold harold 4.0K Apr 28 11:25 paho_mqtt-1.5.0.dist-info
drwxrwxr-x 5 harold harold 4.0K Apr 28 11:25 pkg_resources
-rwxrwxr-x 1 harold harold 166K Apr 28 11:25 pvectorc.cpython-36m-x86_64-linux-gnu.so
drwxrwxr-x 2 harold harold 4.0K Apr 28 11:25 __pycache__
drwxrwxr-x 3 harold harold 4.0K Apr 28 11:25 pyrsistent
drwxrwxr-x 2 harold harold 4.0K Apr 28 11:25 pyrsistent-0.16.0.dist-info
-rw-rw-r-- 1 harold harold   23 Apr 28 11:25 _pyrsistent_version.py
drwxrwxr-x 6 harold harold 4.0K Apr 28 11:25 setuptools
drwxrwxr-x 2 harold harold 4.0K Apr 28 11:25 setuptools-46.1.3.dist-info
drwxrwxr-x 2 harold harold 4.0K Apr 28 11:25 six-1.14.0.dist-info
-rw-rw-r-- 1 harold harold  34K Apr 28 11:25 six.py
```
That's why causing this bug.

**Testing Guide**  
Before fix, try install `azure-iot` extension, then `az extension list -o table` it will show a wrong version instead of its current version `0.9.1`
After fix, it will show `0.9.1`

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
