### PR TITLE
{Packaging} Remove wheel as a runtime dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # basic
 setuptools==40.0.0
-wheel==0.31.1
 pip>=9.0.1

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -62,7 +62,6 @@ DEPENDENCIES = [
     'msrest>=0.4.4',
     'msrestazure>=0.6.3',
     'paramiko>=2.0.8,<3.0.0',
-    'pkginfo',
     'PyJWT',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
     'requests~=2.20',

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -67,7 +67,6 @@ DEPENDENCIES = [
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
     'requests~=2.20',
     'six~=1.12',
-    'wheel==0.30.0',
     'pkginfo>=1.5.0.1',
     'azure-mgmt-resource==9.0.0',
     'azure-mgmt-core==1.0.0'


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
wheel should not be needed to run Azure CLI. It is only used in packaging.

To remove wheel from azure-cli-core dependencies, we need to install wheel in packaging scripts. ~~It seems they're already doing this, will check them one by one.~~ Verified that MSI, homebrew and pypi use setup.py to build wheels during packaging, and their script all include a step to install wheel. Other packages use requirements file to install dependency, wheel is not used.

For the packaging of extensions, as azdev has the dependency of wheel, it should be fine.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
