### PR TITLE
{Docs} Increase visibility of doc/use_cli_effectively.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,23 @@ For scripting purposes, we output certain exit codes for differing scenarios.
 |2   |Parser error; check input to command line.   |
 |3   |Missing ARM resource; used for existence check from `show` commands.   |
 
-#### More Samples and Snippets
-For more usage examples, take a look at our [GitHub samples repo](http://github.com/Azure/azure-cli-samples) or [https://docs.microsoft.com/cli/azure/overview](https://docs.microsoft.com/cli/azure/overview).
+#### Common Scenarios and Using CLI Effectively
 
-For how to use CLI effectively, check out [tips](./doc/use_cli_effectively.md).
+Please check [Tips for using Azure CLI effectively](doc/use_cli_effectively.md). It describes some common scenarios:
+
+- [Output formatting (json, table, or tsv)](doc/use_cli_effectively.md#output-formatting-json-table-or-tsv)
+- [Pass values from one command to another](doc/use_cli_effectively.md#pass-values-from-one-command-to-another)
+- [Async operations](doc/use_cli_effectively.md#async-operations)
+- [Generic update arguments](doc/use_cli_effectively.md#generic-update-arguments)
+- [Generic resource commands - az resource](doc/use_cli_effectively.md#generic-resource-commands---az-resource)
+- [REST API command - az rest](doc/use_cli_effectively.md#rest-api-command---az-rest)
+- [Quoting issues](doc/use_cli_effectively.md#quoting-issues)
+- [Work behind a proxy](doc/use_cli_effectively.md#work-behind-a-proxy)
+- [Concurrent builds](doc/use_cli_effectively.md#concurrent-builds)
+
+#### More Samples and Snippets
+
+For more usage examples, take a look at our [GitHub samples repo](http://github.com/Azure/azure-cli-samples) or [https://docs.microsoft.com/cli/azure/overview](https://docs.microsoft.com/cli/azure/overview).
 
 ## Reporting issues and feedback
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please refer to the [install guide](https://docs.microsoft.com/cli/azure/install
 
 A list of common install issues and their resolutions are available at [install troubleshooting](https://github.com/Azure/azure-cli/blob/dev/doc/install_troubleshooting.md).
 
-### Developer Installation (see below)
+### Developer installation (see below)
 
 - [Docker](#docker)
 - [Edge Builds](#edge-builds)
@@ -47,7 +47,7 @@ Here are a few features and concepts that can help you get the most out of the A
 
 The following examples are showing using the `--output table` format, you can change your default using the `az configure` command.
 
-#### Tab Completion
+#### Tab completion
 
 We support tab-completion for groups, commands, and some parameters
 
@@ -76,7 +76,8 @@ demo32111vm             Windows
 dcos-master-39DB807E-0  Linux
 ```
 
-#### Exit Codes
+#### Exit codes
+
 For scripting purposes, we output certain exit codes for differing scenarios.
 
 |Exit Code   |Scenario   |
@@ -86,7 +87,7 @@ For scripting purposes, we output certain exit codes for differing scenarios.
 |2   |Parser error; check input to command line.   |
 |3   |Missing ARM resource; used for existence check from `show` commands.   |
 
-#### Common Scenarios and Using CLI Effectively
+### Common scenarios and use Azure CLI effectively
 
 Please check [Tips for using Azure CLI effectively](doc/use_cli_effectively.md). It describes some common scenarios:
 
@@ -94,13 +95,13 @@ Please check [Tips for using Azure CLI effectively](doc/use_cli_effectively.md).
 - [Pass values from one command to another](doc/use_cli_effectively.md#pass-values-from-one-command-to-another)
 - [Async operations](doc/use_cli_effectively.md#async-operations)
 - [Generic update arguments](doc/use_cli_effectively.md#generic-update-arguments)
-- [Generic resource commands - az resource](doc/use_cli_effectively.md#generic-resource-commands---az-resource)
-- [REST API command - az rest](doc/use_cli_effectively.md#rest-api-command---az-rest)
+- [Generic resource commands - `az resource`](doc/use_cli_effectively.md#generic-resource-commands---az-resource)
+- [REST API command - `az rest`](doc/use_cli_effectively.md#rest-api-command---az-rest)
 - [Quoting issues](doc/use_cli_effectively.md#quoting-issues)
 - [Work behind a proxy](doc/use_cli_effectively.md#work-behind-a-proxy)
 - [Concurrent builds](doc/use_cli_effectively.md#concurrent-builds)
 
-#### More Samples and Snippets
+### More samples and snippets
 
 For more usage examples, take a look at our [GitHub samples repo](http://github.com/Azure/azure-cli-samples) or [https://docs.microsoft.com/cli/azure/overview](https://docs.microsoft.com/cli/azure/overview).
 
@@ -110,7 +111,7 @@ If you encounter any bugs with the tool please file an issue in the [Issues](htt
 
 To provide feedback from the command line, try the `az feedback` command.
 
-## Developer Installation
+## Developer installation
 
 ### Docker
 
@@ -127,7 +128,7 @@ For example:
 $ docker run -u $(id -u):$(id -g) -v ${HOME}:/home/az -e HOME=/home/az --rm -it azuresdk/azure-cli-python:dev
 ```
 
-### Edge Builds
+### Edge builds
 
 If you want to get the latest build from the `dev` branch, you can use our "edge" builds.
 
@@ -167,7 +168,7 @@ If you would like to get builds of arbitrary commit or PR, see:
 
 [Try new features before release](doc/try_new_features_before_release.md)
 
-## Developer Setup
+## Developer setup
 
 If you would like to setup a development environment and contribute to the CLI, see:
 
@@ -175,7 +176,7 @@ If you would like to setup a development environment and contribute to the CLI, 
 
 [Authoring Command Modules](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules)
 
-## Contribute Code
+## Contribute code
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 

--- a/doc/use_cli_effectively.md
+++ b/doc/use_cli_effectively.md
@@ -97,15 +97,15 @@ Most update commands in the CLI feature the three generic arguments: `--add`, `-
 
 ## Generic resource commands - `az resource`
 
-There may be cases where a service you are interested in does not have CLI command coverage. You can use the `az resource create/show/list/delete/update/invoke-action` commands to work with these resources. A few suggestions here:
+There may be cases where a service you are interested in does not have CLI command coverage. You can use the `az resource create/show/list/delete/update/invoke-action` commands to work with these resources. Here are a few suggestions:
 1. If only `create/update` are involved, consider using `az group deployment create`. Leverage [Azure Quickstart Templates](https://github.com/Azure/azure-quickstart-templates) for working examples.
 2. Check out the Rest API reference for the request payload, URL and API version. As an example, check out the community's comments on [how to create AppInsights](https://github.com/Azure/azure-cli/issues/5543).
 
 ## REST API command - `az rest`
 
-If neither generic update arguments nor `az resource` meets your needs, you can use `az rest` command to call the REST API. It automatically authenticates using the credential logged in and sets header `Content-Type: application/json`.
+If neither generic update arguments nor `az resource` meets your needs, you can use `az rest` command to call the REST API. It automatically authenticates using the logged-in credential and sets header `Content-Type: application/json`.
 
-This is extremely useful for calling [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/api/overview?toc=./ref/toc.json&view=graph-rest-1.0) which is not supported by CLI commands yet ([#12946](https://github.com/Azure/azure-cli/issues/12946)).
+This is extremely useful for calling [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/api/overview?toc=./ref/toc.json&view=graph-rest-1.0) which is not currently supported by CLI commands ([#12946](https://github.com/Azure/azure-cli/issues/12946)).
 
 For example, to update `redirectUris` for an [Application](https://docs.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0), we call the [Update application](https://docs.microsoft.com/en-us/graph/api/application-update?view=graph-rest-1.0&tabs=http) REST API with:
 
@@ -130,7 +130,7 @@ This becomes an issue because when the command shell (Bash, Zsh, Windows Command
 - PowerShell: [About Quoting Rules](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules)
 - Windows Command Prompt: [How-to: Escape Characters, Delimiters and Quotes at the Windows command line](https://ss64.com/nt/syntax-esc.html)
 
-To avoid surprises, here are a few suggestions:
+To avoid unanticipated results, here are a few suggestions:
 
 1. If the value contains whitespace, you must wrap it in quotes.
 2. In bash or Windows PowerShell, both single and double quotes will be interpreted, while in Windows Command Prompt, only double quotes are handled which means single quotes will be interpreted as a part of the value.

--- a/doc/use_cli_effectively.md
+++ b/doc/use_cli_effectively.md
@@ -98,8 +98,8 @@ Most update commands in the CLI feature the three generic arguments: `--add`, `-
 ## Generic resource commands - `az resource`
 
 There may be cases where a service you are interested in does not have CLI command coverage. You can use the `az resource create/show/list/delete/update/invoke-action` commands to work with these resources. A few suggestions here:
-  1. If only `create/update` are involved, consider using `az group deployment create`. Leverage [Azure Quickstart Templates](https://github.com/Azure/azure-quickstart-templates) for working examples.
-  2. Check out the Rest API reference for the request payload, URL and API version. As an example, check out the community's comments on [how to create AppInsights](https://github.com/Azure/azure-cli/issues/5543).
+1. If only `create/update` are involved, consider using `az group deployment create`. Leverage [Azure Quickstart Templates](https://github.com/Azure/azure-quickstart-templates) for working examples.
+2. Check out the Rest API reference for the request payload, URL and API version. As an example, check out the community's comments on [how to create AppInsights](https://github.com/Azure/azure-cli/issues/5543).
 
 ## REST API command - `az rest`
 
@@ -107,8 +107,7 @@ If neither generic update arguments nor `az resource` meets your needs, you can 
 
 This is extremely useful for calling [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/api/overview?toc=./ref/toc.json&view=graph-rest-1.0) which is not supported by CLI commands yet ([#12946](https://github.com/Azure/azure-cli/issues/12946)). 
 
-For example, to update `redirectUris` for an [Application](https://docs.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0),
-we call the [Update application](https://docs.microsoft.com/en-us/graph/api/application-update?view=graph-rest-1.0&tabs=http) REST API with:
+For example, to update `redirectUris` for an [Application](https://docs.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0), we call the [Update application](https://docs.microsoft.com/en-us/graph/api/application-update?view=graph-rest-1.0&tabs=http) REST API with:
 
 ```sh
 # Line breaks for legibility only
@@ -119,7 +118,7 @@ az rest --method GET
 
 # Update `redirectUris` for `web` property
 az rest --method PATCH
-        --uri 'https://graph.microsoft.com/v1.0/applications/b4e4d2ab-e2cb-45d5-a31a-98eb3f364001'
+        --url 'https://graph.microsoft.com/v1.0/applications/b4e4d2ab-e2cb-45d5-a31a-98eb3f364001'
         --body '{"web":{"redirectUris":["https://myapp.com"]}}'
 ```
  

--- a/doc/use_cli_effectively.md
+++ b/doc/use_cli_effectively.md
@@ -162,8 +162,39 @@ To avoid surprises, here are a few suggestions:
 
     # Correct
     $ az version --query '"azure-cli"'
-    "2.4.0"
+    "2.5.1"
+
+    $ az version --query \"azure-cli\"
+    "2.5.1"
+
+    $ az version --query "\"azure-cli\""
+    "2.5.1"
     ```
+
+    In Command Prompt:
+    ```cmd
+    > az version --query "\"azure-cli\""
+    "2.5.1"
+
+    > az version --query \"azure-cli\"
+    "2.5.1"
+    ```
+
+    In PowerShell (see item 12 for why extra escaping is needed):
+    ```powershell
+    > az version --query '\"azure-cli\"'
+    "2.5.1"
+
+    > az version --query "\`"azure-cli\`""
+    "2.5.1"
+
+    > az --% version --query "\"azure-cli\""
+    "2.5.1"
+
+    > az --% version --query \"azure-cli\"
+    "2.5.1"
+    ```
+
 11. The best way to troubleshoot a quoting issue is to run the command with `--debug` flag. It reveals the actual arguments received by CLI in [Python's syntax](https://docs.python.org/3/tutorial/introduction.html#strings). For example, in Bash:
 
     ```sh

--- a/doc/use_cli_effectively.md
+++ b/doc/use_cli_effectively.md
@@ -150,7 +150,7 @@ To avoid surprises, here are a few suggestions:
     - `--arg "foo" "bar"`: OK: Quoted, space-separated list
     - `--arg "foo bar"`: BAD. This is a string with a space in it, not a space-separated list.
 9. When running Azure CLI commands in PowerShell, parsing errors will occur when the arguments contain special characters of PowerShell, such as at `@`. You can solve this problem by adding `` ` `` before the special character to escape it, or by enclosing the argument with single or double quotes `'`/`"`. For example, `az group deployment create --parameters @parameters.json` doesn't work in PowerShell because `@` is parsed as a [splatting symbol](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_splatting). To fix this, you may change the argument to `` `@parameters.json`` or `'@parameters.json'`.
-10. When using `--query` with a command, some characters of [JMESPath](https://jmespath.org/specification.html) need to be escaped in the shell:
+10. When using `--query` with a command, some characters of [JMESPath](https://jmespath.org/specification.html) need to be escaped in the shell. For example, in Bash:
     ```sh
     # Wrong, as the dash needs to be quoted in a JMESPath query
     $ az version --query azure-cli

--- a/doc/use_cli_effectively.md
+++ b/doc/use_cli_effectively.md
@@ -188,6 +188,9 @@ To avoid surprises, here are a few suggestions:
     > az version --query "\`"azure-cli\`""
     "2.5.1"
 
+    > az version --query "\""azure-cli\"""
+    "2.5.1"
+
     > az --% version --query "\"azure-cli\""
     "2.5.1"
 

--- a/doc/use_cli_effectively.md
+++ b/doc/use_cli_effectively.md
@@ -105,7 +105,7 @@ There may be cases where a service you are interested in does not have CLI comma
 
 If neither generic update arguments nor `az resource` meets your needs, you can use `az rest` command to call the REST API. It automatically authenticates using the credential logged in and sets header `Content-Type: application/json`.
 
-This is extremely useful for calling [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/api/overview?toc=./ref/toc.json&view=graph-rest-1.0) which is not supported by CLI commands yet ([#12946](https://github.com/Azure/azure-cli/issues/12946)). 
+This is extremely useful for calling [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/api/overview?toc=./ref/toc.json&view=graph-rest-1.0) which is not supported by CLI commands yet ([#12946](https://github.com/Azure/azure-cli/issues/12946)).
 
 For example, to update `redirectUris` for an [Application](https://docs.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0), we call the [Update application](https://docs.microsoft.com/en-us/graph/api/application-update?view=graph-rest-1.0&tabs=http) REST API with:
 
@@ -113,7 +113,7 @@ For example, to update `redirectUris` for an [Application](https://docs.microsof
 # Line breaks for legibility only
 
 # Get the application
-az rest --method GET 
+az rest --method GET
         --url 'https://graph.microsoft.com/v1.0/applications/b4e4d2ab-e2cb-45d5-a31a-98eb3f364001'
 
 # Update `redirectUris` for `web` property
@@ -121,7 +121,7 @@ az rest --method PATCH
         --url 'https://graph.microsoft.com/v1.0/applications/b4e4d2ab-e2cb-45d5-a31a-98eb3f364001'
         --body '{"web":{"redirectUris":["https://myapp.com"]}}'
 ```
- 
+
 ## Quoting issues
 
 This becomes an issue because when the command shell (Bash, Zsh, Windows Command Prompt, PowerShell, etc) parses the CLI command, it will interpret the quotes and spaces. Always refer to the documents when you are uncertain about the usage of a shell:
@@ -149,17 +149,8 @@ To avoid surprises, here are a few suggestions:
     - `--arg foo bar`: OK. Unquoted, space-separated list
     - `--arg "foo" "bar"`: OK: Quoted, space-separated list
     - `--arg "foo bar"`: BAD. This is a string with a space in it, not a space-separated list.
-9. When running Azure CLI commands in PowerShell, parsing errors will occur when the arguments contain special characters of PowerShell, such as at `@`. You can solve this problem by adding `` ` `` before the special character to escape it, or by enclosing the argument with single or double quotes `'`/`"`. For example, `az group deployment create --parameters @parameters.json` doesn't work in PowerShell because `@` is parsed as a [splatting symbol](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_splatting). To fix this, you may change the argument to `` `@parameters.json`` or `'@parameters.json'`. 
-10. On Windows, `az` is a batch script (at `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin\az.cmd`). When there is no space in an argument, PowerShell will strip the quotes and pass the argument to Command Prompt. This causes the argument to be parsed again by Command Prompt. For example, when running `az "a&b"` in PowerShell, `b` is treated as a separate command instead of part of the argument like Command Prompt does, because quotes are removed by PowerShell and the ampersand `&` is parsed again by Command Prompt as a [command separator](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490954(v=technet.10)#using-multiple-commands-and-conditional-processing-symbols). 
-     
-    To prevent this, you may use [stop-parsing symbol](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing) `--%` between `az` and arguments like `az --% vm create ...`. This can also solve the above-mentioned special character issue and is recommended whenever any issue happens when invoking a batch script from PowerShell.
-     
-    > The stop-parsing symbol (--%), introduced in PowerShell 3.0, directs PowerShell to refrain from interpreting input as PowerShell commands or expressions.
-    >
-    > When it encounters a stop-parsing symbol, PowerShell treats the remaining characters in the line as a literal.
-     
-    This issue is tracked at https://github.com/PowerShell/PowerShell/issues/1995
-11. When using `--query` with a command, some characters of [JMESPath](https://jmespath.org/specification.html) need to be escaped in the shell:
+9. When running Azure CLI commands in PowerShell, parsing errors will occur when the arguments contain special characters of PowerShell, such as at `@`. You can solve this problem by adding `` ` `` before the special character to escape it, or by enclosing the argument with single or double quotes `'`/`"`. For example, `az group deployment create --parameters @parameters.json` doesn't work in PowerShell because `@` is parsed as a [splatting symbol](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_splatting). To fix this, you may change the argument to `` `@parameters.json`` or `'@parameters.json'`.
+10. When using `--query` with a command, some characters of [JMESPath](https://jmespath.org/specification.html) need to be escaped in the shell:
     ```sh
     # Wrong, as the dash needs to be quoted in a JMESPath query
     $ az version --query azure-cli
@@ -173,25 +164,26 @@ To avoid surprises, here are a few suggestions:
     $ az version --query '"azure-cli"'
     "2.4.0"
     ```
-12. The best way to troubleshoot a quoting issue is to run the command with `--debug` flag. It reveals the actual arguments received by CLI in [Python's syntax](https://docs.python.org/3/tutorial/introduction.html#strings). For example, in Bash: 
+11. The best way to troubleshoot a quoting issue is to run the command with `--debug` flag. It reveals the actual arguments received by CLI in [Python's syntax](https://docs.python.org/3/tutorial/introduction.html#strings). For example, in Bash:
 
     ```sh
     # Wrong, as quotes and spaces are interpreted by Bash
     $ az {"key": "value"} --debug
     Command arguments: ['{key:', 'value}', '--debug']
-    
+
     # Wrong, as quotes are interpreted by Bash
     $ az {"key":"value"} --debug
     Command arguments: ['{key:value}', '--debug']
-    
+
     # Correct
     $ az '{"key":"value"}' --debug
     Command arguments: ['{"key":"value"}', '--debug']
-    
+
     # Correct
     $ az "{\"key\":\"value\"}" --debug
     Command arguments: ['{"key":"value"}', '--debug']
     ```
+12. Due to a known issue of PowerShell, some extra escaping rules apply, see [Quoting issues with PowerShell](quoting-issues-with-powershell.md) for more information
 
 ## Work behind a proxy
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -31,7 +31,7 @@ COMPONENT_PREFIX = 'azure-cli-'
 SSLERROR_TEMPLATE = ('Certificate verification failed. This typically happens when using Azure CLI behind a proxy '
                      'that intercepts traffic with a self-signed certificate. '
                      # pylint: disable=line-too-long
-                     'Please add this certificate to the trusted CA bundle: https://github.com/Azure/azure-cli/blob/dev/doc/use_cli_effectively.md#working-behind-a-proxy. '
+                     'Please add this certificate to the trusted CA bundle: https://github.com/Azure/azure-cli/blob/dev/doc/use_cli_effectively.md#work-behind-a-proxy. '
                      'Error detail: {}')
 
 _PROXYID_RE = re.compile(


### PR DESCRIPTION
## Description

- Increase visibility of `doc/use_cli_effectively.md`, thus avoiding issues like 
    - Output formatting: #8579
    - Command chaining: #6821
    - Quoting issues: #13208, #13152, #11008, #12970, #11641, #11668, #11003, #10997, #8827, #8070, #7054, #10370, #9228, #8630, #9742
    - Proxy/SSL issues: #13032, #12911, #12310, #12122, #11436, #11356, #11166, #11113, #11069, #11068, #10921, #10860, #10463, #10272, #10236, #10079, #11654, #12566, #11806, #9232, #9030 , #8734, #5841
    - Generic update arguments: #10287, #10297, #10568, #10073, #1582
    - Storage Commands: #12242, #9852
- Add docs for `az rest`
- Add quoting issues for `--query`
- Add quoting issue troubleshooting guide

In order to be consistent with public docs like [Create an Azure service principal with the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest),

- Non-leading upper case letters in headings are converted to lower case letters
    ```diff
    - Generic Resource Commands
    + Generic resource commands
    ```
- Gerunds (verb + -ing) are converted to their base forms
    ```diff
    - Working behind a proxy
    + Work behind a proxy
    ```

## Testing Guide

View the rendered file by clicking **View file**.

![image](https://user-images.githubusercontent.com/4003950/80577821-20212200-8a3a-11ea-9deb-15c335ef607e.png)

# Remark

⚠ Renaming the titles may break anchors in previous issues, without any workarounds or redirection, but this is inevitable in order to be more friendly to future readers. 
