### PR TITLE
{Extension} Enhance the ability to filter extension's dist-info in order to get correct METADATA 

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -138,7 +138,7 @@ class WheelExtension(Extension):
             return None
         metadata = {}
         ext_dir = self.path or get_extension_path(self.name)
-        info_dirs = glob(os.path.join(ext_dir, self.name.replace('-', '_') + '*.*-info'))
+        info_dirs = glob(os.path.join(ext_dir, self.name.replace('-', '_') + '-' + '*.dist-info'))
 
         azext_metadata = WheelExtension.get_azext_metadata(ext_dir)
         if azext_metadata:

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -177,13 +177,13 @@ class WheelExtension(Extension):
         if os.path.isdir(EXTENSIONS_DIR):
             for ext_name in os.listdir(EXTENSIONS_DIR):
                 ext_path = os.path.join(EXTENSIONS_DIR, ext_name)
-                pattern = os.path.join(ext_path, '*.*-info')
+                pattern = os.path.join(ext_path, '*.dist-info')
                 if os.path.isdir(ext_path) and glob(pattern):
                     exts.append(WheelExtension(ext_name, ext_path))
         if os.path.isdir(EXTENSIONS_SYS_DIR):
             for ext_name in os.listdir(EXTENSIONS_SYS_DIR):
                 ext_path = os.path.join(EXTENSIONS_SYS_DIR, ext_name)
-                pattern = os.path.join(ext_path, '*.*-info')
+                pattern = os.path.join(ext_path, '*.dist-info')
                 if os.path.isdir(ext_path) and glob(pattern):
                     ext = WheelExtension(ext_name, ext_path)
                     if ext not in exts:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
The fix https://github.com/Azure/azure-cli/pull/13222 here to filter extension's metadata has potention bugs.

https://github.com/Azure/azure-cli/blob/154ecaa0b179b57aed4e9df162d664da2a5e3c46/src/azure-cli-core/azure/cli/core/extension/__init__.py#L141

If some dependecies have longer name and prefix with the extension name, it make still crash. Currently just lucky.

Besides, the current way to filter will still filter out those folders ends with `.egg-info` which contains PKG-INFO instead of METADATA. So, it would crash due to incorrect metadata format for `pkginfo.Wheel`

Fix https://github.com/Azure/azure-cli/issues/13241
Fix https://github.com/Azure/azure-iot-cli-extension/issues/173
Fix https://github.com/Azure/azure-cli/issues/13240

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
