### PR TITLE
[Backup] Allow FriendlyName in enable protection for AzureFileShare command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
@@ -132,7 +132,7 @@ def _try_get_protectable_item_for_afs(cli_ctx, vault_name, resource_group_name, 
                   if protectable_item.name.lower() == afs_name.lower()]
     else:
         result = [protectable_item for protectable_item in result
-                  if protectable_item.name.split(';')[-1].lower() == afs_name.lower()]
+                  if protectable_item.properties.friendly_name.lower() == afs_name.lower()]
     if len(result) > 1:
         raise CLIError("Could not find a unique resource, Please pass native names instead")
     if len(result) == 1:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
az backup protection enable-for-azurefileshare cmd was taking uniqueName as input. Added support for friendlyName .

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
