### PR TITLE
{Identity} az logout

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_identity.py
+++ b/src/azure-cli-core/azure/cli/core/_identity.py
@@ -216,6 +216,45 @@ class Identity:
 
         return credential, managed_identity_info
 
+    def logout_user(self, home_account_id):
+        from msal import PublicClientApplication
+        # sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py:122
+        from azure.identity._internal.msal_credentials import _load_cache
+        cache = _load_cache()
+        app = PublicClientApplication(authority=self.authority, client_id=_CLIENT_ID, token_cache=cache)
+
+        accounts = app.get_accounts()
+        logger.warning('Before account removal:')
+        logger.warning(json.dumps(accounts))
+
+        account = {
+            "environment": self.authority,
+            "home_account_id": home_account_id
+        }
+        app.remove_account(account)
+
+        accounts = app.get_accounts()
+        logger.warning('After account removal:')
+        logger.warning(json.dumps(accounts))
+
+    def logout_all(self):
+        from msal import PublicClientApplication
+        from azure.identity._internal.msal_credentials import _load_cache
+        cache = _load_cache()
+        # TODO: Support multi-authority logout
+        app = PublicClientApplication(authority=self.authority, client_id=_CLIENT_ID, token_cache=cache)
+
+        accounts = app.get_accounts()
+        logger.warning('Before account removal:')
+        logger.warning(json.dumps(accounts))
+
+        for account in accounts:
+            app.remove_account(account)
+
+        accounts = app.get_accounts()
+        logger.warning('After account removal:')
+        logger.warning(json.dumps(accounts))
+
     def get_user_credential(self, home_account_id, username):
         auth_profile = AuthProfile(self.authority, home_account_id, self.tenant_id, username)
         return InteractiveBrowserCredential(profile=auth_profile, silent_auth_only=True)

--- a/src/azure-cli-core/azure/cli/core/_identity.py
+++ b/src/azure-cli-core/azure/cli/core/_identity.py
@@ -216,44 +216,52 @@ class Identity:
 
         return credential, managed_identity_info
 
-    def logout_user(self, home_account_id):
+    def get_user(self, user_or_sp=None):
         from msal import PublicClientApplication
         # sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py:122
         from azure.identity._internal.msal_credentials import _load_cache
         cache = _load_cache()
-        app = PublicClientApplication(authority=self.authority, client_id=_CLIENT_ID, token_cache=cache)
+        authority = "https://{}/organizations".format(self.authority)
+        app = PublicClientApplication(authority=authority, client_id=_CLIENT_ID, token_cache=cache)
+        return app.get_accounts(user_or_sp)
 
-        accounts = app.get_accounts()
-        logger.warning('Before account removal:')
-        logger.warning(json.dumps(accounts))
+    def logout_user(self, user_or_sp):
+        from msal import PublicClientApplication
+        # sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py:122
+        from azure.identity._internal.msal_credentials import _load_cache
+        cache = _load_cache()
+        authority = "https://{}/organizations".format(self.authority)
+        app = PublicClientApplication(authority=authority, client_id=_CLIENT_ID, token_cache=cache)
 
-        account = {
-            "environment": self.authority,
-            "home_account_id": home_account_id
-        }
-        app.remove_account(account)
+        accounts = app.get_accounts(user_or_sp)
+        logger.info('Before account removal:')
+        logger.info(json.dumps(accounts))
 
-        accounts = app.get_accounts()
-        logger.warning('After account removal:')
-        logger.warning(json.dumps(accounts))
+        for account in accounts:
+            app.remove_account(account)
+
+        accounts = app.get_accounts(user_or_sp)
+        logger.info('After account removal:')
+        logger.info(json.dumps(accounts))
 
     def logout_all(self):
         from msal import PublicClientApplication
         from azure.identity._internal.msal_credentials import _load_cache
         cache = _load_cache()
         # TODO: Support multi-authority logout
-        app = PublicClientApplication(authority=self.authority, client_id=_CLIENT_ID, token_cache=cache)
+        authority = "https://{}/organizations".format(self.authority)
+        app = PublicClientApplication(authority=authority, client_id=_CLIENT_ID, token_cache=cache)
 
         accounts = app.get_accounts()
-        logger.warning('Before account removal:')
-        logger.warning(json.dumps(accounts))
+        logger.info('Before account removal:')
+        logger.info(json.dumps(accounts))
 
         for account in accounts:
             app.remove_account(account)
 
         accounts = app.get_accounts()
-        logger.warning('After account removal:')
-        logger.warning(json.dumps(accounts))
+        logger.info('After account removal:')
+        logger.info(json.dumps(accounts))
 
     def get_user_credential(self, home_account_id, username):
         auth_profile = AuthProfile(self.authority, home_account_id, self.tenant_id, username)

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -127,7 +127,6 @@ class Profile(object):
 
         credential=None
         auth_profile=None
-        adal_cache = ADALCredentialCache(cli_ctx=self.cli_ctx)
         identity = Identity(self._authority, tenant, cred_cache=self._adal_cache)
 
         if not subscription_finder:

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -43,6 +43,14 @@ class ProfileCommandsLoader(AzCommandsLoader):
     # pylint: disable=line-too-long
     def load_arguments(self, command):
         from azure.cli.core.api import get_subscription_id_list
+        from azure.cli.core.commands.parameters import get_three_state_flag
+        from knack.arguments import CLIArgumentType
+
+        clear_credential_type = CLIArgumentType(options_list=['--clear-credential', '-c'],
+                                                arg_type=get_three_state_flag(),
+                                                help="Clear the credential stored in MSAL encrypted cache. "
+                                                     "The user will also be logged out from other SDK tools "
+                                                     "which uses Azure CLI's credential via Single Sign-On.")
 
         with self.argument_context('login') as c:
             c.argument('password', options_list=['--password', '-p'], help="Credentials like user password, or for a service principal, provide client secret or a pem file with key and public certificate. Will prompt if not given.")
@@ -58,7 +66,8 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('use_cert_sn_issuer', action='store_true', help='used with a service principal configured with Subject Name and Issuer Authentication in order to support automatic certificate rolls')
 
         with self.argument_context('logout') as c:
-            c.argument('username', help='account user, if missing, logout the current active account')
+            c.argument('username', options_list=['--username', '-u'], help='account user, if missing, logout the current active account')
+            c.argument('clear_credential', clear_credential_type)
             c.ignore('_subscription')  # hide the global subscription parameter
 
         with self.argument_context('account') as c:
@@ -77,5 +86,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('resource_type', get_enum_type(cloud_resource_types), options_list=['--resource-type'], arg_group='', help='Type of well-known resource.')
             c.argument('tenant', options_list=['--tenant', '-t'], is_preview=True, help='Tenant ID for which the token is acquired. Only available for user and service principal account, not for MSI or Cloud Shell account')
 
+        with self.argument_context('account logout') as c:
+            c.argument('clear_credential', clear_credential_type)
 
 COMMAND_LOADER_CLS = ProfileCommandsLoader

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -93,12 +93,12 @@ def set_active_subscription(cmd, subscription):
     profile.set_active_subscription(subscription)
 
 
-def account_clear(cmd):
+def account_clear(cmd, clear_credential=False):
     """Clear all stored subscriptions. To clear individual, use 'logout'"""
     if in_cloud_console():
         logger.warning(_CLOUD_CONSOLE_LOGOUT_WARNING)
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    profile.logout_all()
+    profile.logout_all(clear_credential)
 
 
 # pylint: disable=inconsistent-return-statements
@@ -175,7 +175,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
     return all_subscriptions
 
 
-def logout(cmd, username=None):
+def logout(cmd, username=None, clear_credential=False):
     """Log out to remove access to Azure subscriptions"""
     if in_cloud_console():
         logger.warning(_CLOUD_CONSOLE_LOGOUT_WARNING)
@@ -183,7 +183,7 @@ def logout(cmd, username=None):
     profile = Profile(cli_ctx=cmd.cli_ctx)
     if not username:
         username = profile.get_current_account_user()
-    profile.logout(username)
+    profile.logout(username, clear_credential)
 
 
 def list_locations(cmd):


### PR DESCRIPTION
## Description

Support `az login`. 

This PR changes the behavior of `az logout` and `az account clear` so that they only clear the profiles and legacy cache. 

To clear shared token from MSAL encrypted cache, user will need to specify `--clear-credential`. 

## MSAL cache handling

Regardless of whether the user is logged in, CLI will always check the MSAL cache for the specified username or all users, and show warnings accordingly. 

It first checks whether the cache exists (for the username):

- ✔ Yes, check if the command wants to clear the cache
  - ✔ Yes, clear the cache and show a warning that the user is also logged out from other SDKs
  - ❌ No, show a warning that the credential is still stored in MSAL encrypted cache (ℹ The word **encrypted** is very important and can't be omitted.)
- ❌ No, show a warning that the cache doesn't exist

In the future we need to create some extra commands to manage MSAL cache directly and bootstrap CLI from MSAL cache. 

