### PR TITLE
[AzureStack][AKS]Add AKS into AzureStack profile

### DIFF
--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -228,8 +228,7 @@ AZURE_API_PROFILES = {
         ResourceType.MGMT_CONTAINERSERVICE: SDKProfile('2020-03-01', {
             'container_services': '2017-07-01',
             'open_shift_managed_clusters': '2019-10-27-preview'
-        }),
-        ResourceType.MGMT_CONTAINERREGISTRY: '2019-05-01'
+        })
     },
     '2018-03-01-hybrid': {
         ResourceType.MGMT_STORAGE: '2016-01-01',

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -190,7 +190,11 @@ AZURE_API_PROFILES = {
         }),
         ResourceType.MGMT_APPSERVICE: '2019-08-01',
         ResourceType.MGMT_IOTHUB: '2019-07-01-preview',
-        ResourceType.MGMT_ARO: '2020-04-30'
+        ResourceType.MGMT_ARO: '2020-04-30',
+        ResourceType.MGMT_CONTAINERSERVICE: SDKProfile('2020-03-01', {
+            'container_services': '2017-07-01',
+            'open_shift_managed_clusters': '2019-10-27-preview'
+        })
     },
     '2019-03-01-hybrid': {
         ResourceType.MGMT_STORAGE: '2017-10-01',

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -54,13 +54,13 @@ class ResourceType(Enum):  # pylint: disable=too-few-public-methods
     MGMT_APPSERVICE = ('azure.mgmt.web', 'WebSiteManagementClient')
     MGMT_IOTHUB = ('azure.mgmt.iothub', 'IotHubClient')
     MGMT_ARO = ('azure.mgmt.redhatopenshift', 'AzureRedHatOpenShiftClient')
+    MGMT_CONTAINERSERVICE = ('azure.mgmt.containerservice', 'ContainerServiceClient')
     # the "None" below will stay till a command module fills in the type so "get_mgmt_service_client"
     # can be provided with "ResourceType.XXX" to initialize the client object. This usually happens
     # when related commands start to support Multi-API
     DATA_STORAGE = ('azure.multiapi.storage', None)
     DATA_STORAGE_BLOB = ('azure.multiapi.storagev2.blob', None)
     DATA_COSMOS_TABLE = ('azure.multiapi.cosmosdb', None)
-    MGMT_CONTAINERSERVICE = ('azure.mgmt.containerservice', None)
     MGMT_ADVISOR = ('azure.mgmt.advisor', None)
     MGMT_MEDIA = ('azure.mgmt.media', None)
     MGMT_BACKUP = ('azure.mgmt.recoveryservicesbackup', None)
@@ -220,7 +220,8 @@ AZURE_API_PROFILES = {
         # API versions
         ResourceType.MGMT_APPSERVICE: '2018-02-01',
         ResourceType.MGMT_EVENTHUB: '2017-04-01',
-        ResourceType.MGMT_IOTHUB: '2019-03-22'
+        ResourceType.MGMT_IOTHUB: '2019-03-22',
+        ResourceType.MGMT_CONTAINERSERVICE: '2020-03-01'
     },
     '2018-03-01-hybrid': {
         ResourceType.MGMT_STORAGE: '2016-01-01',

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -221,7 +221,10 @@ AZURE_API_PROFILES = {
         ResourceType.MGMT_APPSERVICE: '2018-02-01',
         ResourceType.MGMT_EVENTHUB: '2017-04-01',
         ResourceType.MGMT_IOTHUB: '2019-03-22',
-        ResourceType.MGMT_CONTAINERSERVICE: '2020-03-01'
+        ResourceType.MGMT_CONTAINERSERVICE: SDKProfile('2020-03-01', {
+            'container_services': '2017-07-01',
+            'open_shift_managed_clusters': '2019-10-27-preview'
+        }),
     },
     '2018-03-01-hybrid': {
         ResourceType.MGMT_STORAGE: '2016-01-01',

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -229,6 +229,7 @@ AZURE_API_PROFILES = {
             'container_services': '2017-07-01',
             'open_shift_managed_clusters': '2019-10-27-preview'
         }),
+        ResourceType.MGMT_CONTAINERREGISTRY: '2019-05-01'
     },
     '2018-03-01-hybrid': {
         ResourceType.MGMT_STORAGE: '2016-01-01',

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -61,7 +61,9 @@ def get_container_service_client(cli_ctx, **_):
     from azure.mgmt.containerservice import ContainerServiceClient
     from azure.cli.core.profiles import ResourceType, get_api_version
 
-    return get_mgmt_service_client(cli_ctx, ContainerServiceClient, api_version=get_api_version(cli_ctx, ResourceType.MGMT_CONTAINERSERVICE))
+    return get_mgmt_service_client(cli_ctx,
+                                   ContainerServiceClient,
+                                   api_version=get_api_version(cli_ctx, ResourceType.MGMT_CONTAINERSERVICE))
 
 
 def get_osa_container_service_client(cli_ctx, **_):

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -5,7 +5,7 @@
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.parameters import get_resources_in_subscription
-from azure.cli.core.profiles import ResourceType, get_api_version
+from azure.cli.core.profiles import ResourceType
 from knack.util import CLIError
 
 

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -5,7 +5,7 @@
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.parameters import get_resources_in_subscription
-from azure.cli.core.profiles import ResourceType
+from azure.cli.core.profiles import ResourceType, get_api_version
 from knack.util import CLIError
 
 
@@ -59,7 +59,6 @@ def get_auth_management_client(cli_ctx, scope=None, **_):
 
 def get_container_service_client(cli_ctx, **_):
     from azure.mgmt.containerservice import ContainerServiceClient
-    from azure.cli.core.profiles import ResourceType, get_api_version
 
     return get_mgmt_service_client(cli_ctx,
                                    ContainerServiceClient,

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -60,7 +60,7 @@ def get_auth_management_client(cli_ctx, scope=None, **_):
 def get_container_service_client(cli_ctx, **_):
     from azure.mgmt.containerservice import ContainerServiceClient
 
-    return get_mgmt_service_client(cli_ctx, ContainerServiceClient, ResourceType.MGMT_CONTAINERSERVICE)
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_CONTAINERSERVICE)
 
 
 def get_osa_container_service_client(cli_ctx, **_):

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -58,8 +58,6 @@ def get_auth_management_client(cli_ctx, scope=None, **_):
 
 
 def get_container_service_client(cli_ctx, **_):
-    from azure.mgmt.containerservice import ContainerServiceClient
-
     return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_CONTAINERSERVICE)
 
 

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -60,8 +60,7 @@ def get_auth_management_client(cli_ctx, scope=None, **_):
 def get_container_service_client(cli_ctx, **_):
     from azure.mgmt.containerservice import ContainerServiceClient
 
-    return get_mgmt_service_client(cli_ctx,
-                                   ContainerServiceClient,
+    return get_mgmt_service_client(cli_ctx, ContainerServiceClient,
                                    api_version=get_api_version(cli_ctx, ResourceType.MGMT_CONTAINERSERVICE))
 
 

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -60,8 +60,7 @@ def get_auth_management_client(cli_ctx, scope=None, **_):
 def get_container_service_client(cli_ctx, **_):
     from azure.mgmt.containerservice import ContainerServiceClient
 
-    return get_mgmt_service_client(cli_ctx, ContainerServiceClient,
-                                   api_version=get_api_version(cli_ctx, ResourceType.MGMT_CONTAINERSERVICE))
+    return get_mgmt_service_client(cli_ctx, ContainerServiceClient, ResourceType.MGMT_CONTAINERSERVICE)
 
 
 def get_osa_container_service_client(cli_ctx, **_):

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -59,8 +59,9 @@ def get_auth_management_client(cli_ctx, scope=None, **_):
 
 def get_container_service_client(cli_ctx, **_):
     from azure.mgmt.containerservice import ContainerServiceClient
+    from azure.cli.core.profiles import ResourceType, get_api_version
 
-    return get_mgmt_service_client(cli_ctx, ContainerServiceClient)
+    return get_mgmt_service_client(cli_ctx, ContainerServiceClient, api_version=get_api_version(cli_ctx, ResourceType.MGMT_CONTAINERSERVICE))
 
 
 def get_osa_container_service_client(cli_ctx, **_):

--- a/src/azure-cli/azure/cli/command_modules/acs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/commands.py
@@ -24,14 +24,16 @@ from ._format import aks_versions_table_format
 def load_command_table(self, _):
 
     container_services_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.containerservice.v2017_07_01.operations.'
+        operations_tmpl='azure.mgmt.containerservice.operations.'
                         '_container_services_operations#ContainerServicesOperations.{}',
+        operation_group='container_services',
         client_factory=cf_container_services
     )
 
     managed_clusters_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.containerservice.v2020_03_01.operations.'
+        operations_tmpl='azure.mgmt.containerservice.operations.'
                         '_managed_clusters_operations#ManagedClustersOperations.{}',
+        operation_group='managed_clusters',
         client_factory=cf_managed_clusters
     )
 
@@ -42,8 +44,9 @@ def load_command_table(self, _):
     )
 
     openshift_managed_clusters_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.containerservice.v2019_10_27_preview.operations.'
+        operations_tmpl='azure.mgmt.containerservice.operations.'
                         '_open_shift_managed_clusters_operations#OpenShiftManagedClustersOperations.{}',
+        operation_group='open_shift_managed_clusters',
         client_factory=cf_openshift_managed_clusters
     )
 

--- a/src/azure-cli/azure/cli/command_modules/acs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/commands.py
@@ -6,6 +6,7 @@
 # pylint: disable=no-name-in-module,import-error
 from azure.cli.core.commands import CliCommandType
 from azure.cli.core.commands.arm import deployment_validate_table_format
+from azure.cli.core.profiles import ResourceType
 
 from ._client_factory import cf_container_services
 from ._client_factory import cf_managed_clusters
@@ -27,6 +28,7 @@ def load_command_table(self, _):
         operations_tmpl='azure.mgmt.containerservice.operations.'
                         '_container_services_operations#ContainerServicesOperations.{}',
         operation_group='container_services',
+        resource_type=ResourceType.MGMT_CONTAINERSERVICE,
         client_factory=cf_container_services
     )
 
@@ -34,12 +36,14 @@ def load_command_table(self, _):
         operations_tmpl='azure.mgmt.containerservice.operations.'
                         '_managed_clusters_operations#ManagedClustersOperations.{}',
         operation_group='managed_clusters',
+        resource_type=ResourceType.MGMT_CONTAINERSERVICE,
         client_factory=cf_managed_clusters
     )
 
     agent_pools_sdk = CliCommandType(
         operations_tmpl='azext_aks_preview.vendored_sdks.azure_mgmt_preview_aks.'
                         'operations._agent_pools_operations#AgentPoolsOperations.{}',
+        resource_type=ResourceType.MGMT_CONTAINERSERVICE,
         client_factory=cf_managed_clusters
     )
 
@@ -47,6 +51,7 @@ def load_command_table(self, _):
         operations_tmpl='azure.mgmt.containerservice.operations.'
                         '_open_shift_managed_clusters_operations#OpenShiftManagedClustersOperations.{}',
         operation_group='open_shift_managed_clusters',
+        resource_type=ResourceType.MGMT_CONTAINERSERVICE,
         client_factory=cf_openshift_managed_clusters
     )
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR adds Azure Kubernetes Service (AKS) and Azure Container Registry (ACR) CLI into Azure Stack profile given the AKS and ACR will be private preview around July 2020.
1. Add MGMT_CONTAINERSERVICE and MGMT_CONTAINERREGISTRY in 2019-03-01-hybrid profile
2. Update acs commands to have multi-api support

**Testing Guide**  
<!--Example commands with explanations.-->
1. Switch to Azure Stack profile
2. Use AKS and ACR CLI to test

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
