### PR TITLE
[ARM] az deployment sub/group what-if: Fix array alignment and error handling

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -385,7 +385,7 @@ def _should_consider_property_change_path(property_change):
     if property_change_type in (PropertyChangeType.delete, PropertyChangeType.modify):
         return _is_leaf(property_change.before)
 
-    return bool(property_change.children)
+    return not property_change.children
 
 
 def format_json(value, enable_color=True):

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -62,7 +62,7 @@ def load_arguments(self, _):
     deployment_what_if_no_pretty_print_type = CLIArgumentType(options_list=['--no-pretty-print'], action='store_true',
                                                               help='Disable pretty-print for What-If results. When set, the output format type will be used.')
     deployment_what_if_confirmation_type = CLIArgumentType(options_list=['--confirm-with-what-if', '-c'], action='store_true',
-                                                           help='Instruct the command to run deployment What-If before excuting the deployment. It then prompts you to acknowledge resource changes before it continues.',
+                                                           help='Instruct the command to run deployment What-If before executing the deployment. It then prompts you to acknowledge resource changes before it continues.',
                                                            is_preview=True, min_api='2019-07-01')
 
     _PROVIDER_HELP_TEXT = 'the resource namespace, aka \'provider\''

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -635,6 +635,13 @@ def what_if_deploy_arm_template_at_subscription_scope(cmd,
 def _what_if_deploy_arm_template_core(cli_ctx, what_if_poller, no_pretty_print):
     what_if_result = LongRunningOperation(cli_ctx)(what_if_poller)
 
+    if what_if_result.error:
+        # The status code is 200 even when there's an error, because
+        # it is technically a successful What-If operation. The error
+        # is on the ARM template but not the operation.
+        err_message = _build_what_if_error_message(what_if_result.error)
+        raise CLIError(err_message)
+
     if no_pretty_print:
         return what_if_result
 
@@ -657,6 +664,13 @@ def _what_if_deploy_arm_template_core(cli_ctx, what_if_poller, no_pretty_print):
             init()
 
     return None
+
+
+def _build_what_if_error_message(what_if_error):
+    err_messages = [f'{what_if_error.code} - {what_if_error.message}']
+    for detail in what_if_error.details or []:
+        err_messages.append(_build_what_if_error_message(detail))
+    return '\n'.join(err_messages)
 
 
 def _prepare_deployment_properties_unmodified(cli_ctx, template_file=None, template_uri=None, parameters=None,

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
@@ -413,7 +413,7 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
                     "stringValue": "The quick brown fox jumps over the lazy dog.",
                     "emptyArray": [],
                     "emptyObject": {},
-                    "arrayContaingValues": ["foo", "bar"]
+                    "arrayContaingValues": ["foo", "bar"],
                 },
             ),
         ]
@@ -445,16 +445,8 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
                 resource_id="subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1/providers/p1/foo",
                 change_type=ChangeType.modify,
                 delta=[
-                    WhatIfPropertyChange(
-                        path="path",
-                        property_change_type=PropertyChangeType.delete,
-                        before={},
-                    ),
-                    WhatIfPropertyChange(
-                        path="long.path",
-                        property_change_type=PropertyChangeType.create,
-                        after=[],
-                    ),
+                    WhatIfPropertyChange(path="path", property_change_type=PropertyChangeType.delete, before={},),
+                    WhatIfPropertyChange(path="long.path", property_change_type=PropertyChangeType.create, after=[],),
                     WhatIfPropertyChange(
                         path="long.nested.path",
                         property_change_type=PropertyChangeType.array,

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
@@ -344,7 +344,7 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
                 change_type=ChangeType.modify,
                 delta=[
                     WhatIfPropertyChange(
-                        path="path.a.to.simple.change",
+                        path="path.a.to.change",
                         property_change_type=PropertyChangeType.modify,
                         before="foo",
                         after="bar",
@@ -383,7 +383,7 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
 Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
 {Color.PURPLE}
   ~ p1/foo{Color.RESET}
-    {Color.PURPLE}~{Color.RESET} path.a.to.simple.change{Color.RESET}:{Color.RESET} {Color.ORANGE}"foo"{Color.RESET} => {Color.GREEN}"bar"{Color.RESET}
+    {Color.PURPLE}~{Color.RESET} path.a.to.change{Color.RESET}:{Color.RESET} {Color.ORANGE}"foo"{Color.RESET} => {Color.GREEN}"bar"{Color.RESET}
     {Color.PURPLE}~{Color.RESET} path.b.to.nested.change{Color.RESET}:{Color.RESET} [
       {Color.PURPLE}~{Color.RESET} 4{Color.RESET}:{Color.RESET}
 
@@ -401,7 +401,7 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
 
         self.assertIn(expected, result)
 
-    def test_no_color_mode(self):
+    def test_json_alignment(self):
         changes = [
             WhatIfChange(
                 resource_id="subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1/providers/p1/foo",
@@ -411,6 +411,9 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
                     "numberValue": 1.2,
                     "booleanValue": True,
                     "stringValue": "The quick brown fox jumps over the lazy dog.",
+                    "emptyArray": [],
+                    "emptyObject": {},
+                    "arrayContaingValues": ["foo", "bar"]
                 },
             ),
         ]
@@ -424,6 +427,56 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
       numberValue:  1.2
       booleanValue: true
       stringValue:  "The quick brown fox jumps over the lazy dog."
+      emptyArray:   []
+      emptyObject:  {{}}
+      arrayContaingValues: [
+        0: "foo"
+        1: "bar"
+      ]
+"""
+
+        result = format_what_if_operation_result(WhatIfOperationResult(changes=changes), False)
+
+        self.assertIn(expected, result)
+
+    def test_property_changes_alignment(self):
+        changes = [
+            WhatIfChange(
+                resource_id="subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1/providers/p1/foo",
+                change_type=ChangeType.modify,
+                delta=[
+                    WhatIfPropertyChange(
+                        path="path",
+                        property_change_type=PropertyChangeType.delete,
+                        before={},
+                    ),
+                    WhatIfPropertyChange(
+                        path="long.path",
+                        property_change_type=PropertyChangeType.create,
+                        after=[],
+                    ),
+                    WhatIfPropertyChange(
+                        path="long.nested.path",
+                        property_change_type=PropertyChangeType.array,
+                        children=[
+                            WhatIfPropertyChange(
+                                path="5", property_change_type=PropertyChangeType.delete, before=12345
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ]
+
+        expected = f"""
+Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
+
+  ~ p1/foo
+    - path:      {{}}
+    + long.path: []
+    ~ long.nested.path: [
+      - 5: 12345
+      ]
 """
 
         result = format_what_if_operation_result(WhatIfOperationResult(changes=changes), False)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
We found a couple of small issues in the newly added `az deployment sub/group what-if` commands. The PR contains fixes for them:

- Fix a typo in a parameter help message
- Fix alignment for non-empty array in What-If results
- Added error handling for what-if error with 200 status code

**Testing Guide**  
To execute a resource group level what-if, run:
```bash
az deployment group what-if --template-file <path-to-template-file>
```

To execute a subscription level what-if, run:
```bash
az deployment sub what-if --template-file <path-to-template-file>
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
