### PR TITLE
[ACS] bug fix: remove fields cleanup for fields that no longer exist

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3232,14 +3232,10 @@ def _remove_osa_nulls(managed_clusters):
     by the server, but get recreated by the CLI's own "to_dict" serialization.
     """
     attrs = ['tags', 'plan', 'type', 'id']
-    ap_master_attrs = ['name', 'os_type']
     for managed_cluster in managed_clusters:
         for attr in attrs:
             if getattr(managed_cluster, attr, None) is None:
                 delattr(managed_cluster, attr)
-        for attr in ap_master_attrs:
-            if getattr(managed_cluster.master_pool_profile, attr, None) is None:
-                delattr(managed_cluster.master_pool_profile, attr)
     return managed_clusters
 
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
There was an error introduced in https://github.com/Azure/azure-cli/pull/12240 where AROv3   has been upgraded to latest API version. Fields `name` and `os_type` has been dropped from master pool profile in azure-sdk-for-python: https://github.com/Azure/azure-sdk-for-python/pull/10464/files

**Testing Guide**  
create an OpenShift cluster 
`az openshift create -g <group_name> -n <resource_name> --location eastus2`
try show or list command:
`az openshift list`
`az openshift show -g <group_name> -n <resource_name>`
They should execute without error and display the cluster info.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
