### PR TITLE
[AppConfig] Bug fix for list key values with fields

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_help.py
@@ -143,12 +143,12 @@ short-summary: List key-values.
 examples:
   - name: List all key-values with null label.
     text: az appconfig kv list -n MyAppConfiguration --label \\0
-  - name: List a specfic key for any label start with v1. using connection string.
+  - name: List a specific key for any label start with v1. using connection string.
     text: az appconfig kv list --key color --connection-string Endpoint=https://contoso.azconfig.io;Id=xxx;Secret=xxx --label v1.*
   - name: List all keys with any labels and query only key, value and tags.
     text: az appconfig kv list --connection-string Endpoint=https://contoso.azconfig.io;Id=xxx;Secret=xxx --fields key value tags --datetime "2019-05-01T11:24:12Z"
-  - name: List content of key vault reference with key prefix 'KVRef_'.
-    text: az appconfig kv list --connection-string Endpoint=https://contoso.azconfig.io;Id=xxx;Secret=xxx  --key "KVRef_*" --resolve-keyvault
+  - name: List content of key vault reference with key prefix 'KVRef_' and only select key and value.
+    text: az appconfig kv list -n MyAppConfiguration --key "KVRef_*" --resolve-keyvault --query "[*].{key:key, value:value}"
   - name: List key-values with multiple labels.
     text: az appconfig kv list --label test,prod,\\0 -n MyAppConfiguration
 """

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -252,8 +252,7 @@ def __read_kv_from_config_store(cmd,
 
     query_option = QueryKeyValueCollectionOptions(key_filter=key,
                                                   label_filter=label if label else QueryKeyValueCollectionOptions.empty_label,
-                                                  query_datetime=datetime,
-                                                  fields=fields)
+                                                  query_datetime=datetime)
     try:
         keyvalue_iterable = azconfig_client.get_keyvalues(query_option)
         retrieved_kvs = []

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -252,7 +252,8 @@ def __read_kv_from_config_store(cmd,
 
     query_option = QueryKeyValueCollectionOptions(key_filter=key,
                                                   label_filter=label if label else QueryKeyValueCollectionOptions.empty_label,
-                                                  query_datetime=datetime)
+                                                  query_datetime=datetime,
+                                                  fields=fields)
     try:
         keyvalue_iterable = azconfig_client.get_keyvalues(query_option)
         retrieved_kvs = []
@@ -277,15 +278,7 @@ def __read_kv_from_config_store(cmd,
             if keyvault_client and kv.content_type == KeyVaultConstants.KEYVAULT_CONTENT_TYPE:
                 __resolve_secret(keyvault_client, kv)
 
-            # select fields
-            if fields:
-                partial_kv = {}
-                for field in fields:
-                    partial_kv[field.name.lower()] = kv.__dict__[
-                        field.name.lower()]
-                retrieved_kvs.append(partial_kv)
-            else:
-                retrieved_kvs.append(kv)
+            retrieved_kvs.append(kv)
             count += 1
             if count >= top:
                 return retrieved_kvs

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
@@ -171,7 +171,7 @@ def load_arguments(self, _):
     with self.argument_context('appconfig kv list') as c:
         c.argument('key', help='If no key specified, return all keys by default. Support star sign as filters, for instance abc* means keys with abc as prefix.')
         c.argument('label', help="If no label specified, list all labels. Support star sign as filters, for instance abc* means labels with abc as prefix. Use '\\0' for null label.")
-        c.argument('resolve_keyvault', arg_type=get_three_state_flag(), help="Resolve the content of key vault reference. This argument should NOT be specified along with --fields instead use --query for customized query.")
+        c.argument('resolve_keyvault', arg_type=get_three_state_flag(), help="Resolve the content of key vault reference. This argument should NOT be specified along with --fields. Instead use --query for customized query.")
 
     with self.argument_context('appconfig kv restore') as c:
         c.argument('key', help='If no key specified, restore all keys by default. Support star sign as filters, for instance abc* means keys with abc as prefix.')

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
@@ -171,7 +171,7 @@ def load_arguments(self, _):
     with self.argument_context('appconfig kv list') as c:
         c.argument('key', help='If no key specified, return all keys by default. Support star sign as filters, for instance abc* means keys with abc as prefix.')
         c.argument('label', help="If no label specified, list all labels. Support star sign as filters, for instance abc* means labels with abc as prefix. Use '\\0' for null label.")
-        c.argument('resolve_keyvault', arg_type=get_three_state_flag(), help="Resolve the content of key vault reference.")
+        c.argument('resolve_keyvault', arg_type=get_three_state_flag(), help="Resolve the content of key vault reference. This argument should NOT be specified along with --fields instead use --query for customized query.")
 
     with self.argument_context('appconfig kv restore') as c:
         c.argument('key', help='If no key specified, restore all keys by default. Support star sign as filters, for instance abc* means keys with abc as prefix.')

--- a/src/azure-cli/azure/cli/command_modules/appconfig/keyvalue.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/keyvalue.py
@@ -516,6 +516,9 @@ def list_key(cmd,
              top=None,
              all_=False,
              resolve_keyvault=False):
+    if fields and resolve_keyvault:
+        raise CLIError("Please provide only one of these arguments: '--fields' or '--resolve-keyvault'. See 'az appconfig kv list -h' for examples.")
+
     keyvalues = __read_kv_from_config_store(cmd,
                                             name=name,
                                             connection_string=connection_string,

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export.json
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export.json
@@ -1,6 +1,6 @@
 {
-  "Language": "spanish",
   "FeatureManagement": {
     "Beta": false
-  }
+  },
+  "Language": "spanish"
 }

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export_features.json
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export_features.json
@@ -1,6 +1,6 @@
 {
-  "Color": "Red",
   "Region": "West US",
+  "Color": "Red",
   "FeatureManagement": {
     "Beta": false,
     "Percentage": true,

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export_features_prop.json
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export_features_prop.json
@@ -1,12 +1,12 @@
-#Tue Apr 28 10:18:34 China Standard Time 2020
-Color=Red
-Region=West US
+#Wed May 06 10:57:50 Pacific Daylight Time 2020
 feature-management.FalseFeature=false
 feature-management.FeatureSample.enabled-for[0].Name=Filter1
-feature-management.FeatureSample.enabled-for[0].Parameters.paramforfilter1=value1
 feature-management.FeatureSample.enabled-for[1].Name=Filter2
-feature-management.FeatureSample.enabled-for[2].Name=Filter@3
-feature-management.FeatureSample.enabled-for[3].Name=filter.4
-feature-management.FeatureSample.enabled-for[3].Parameters.EmptyValue=
 feature-management.FeatureSample.enabled-for[3].Parameters.dotInFilter.Param=?
+feature-management.FeatureSample.enabled-for[2].Name=Filter@3
 feature-management.TrueFeature=true
+feature-management.FeatureSample.enabled-for[3].Name=filter.4
+Region=West US
+feature-management.FeatureSample.enabled-for[0].Parameters.paramforfilter1=value1
+feature-management.FeatureSample.enabled-for[3].Parameters.EmptyValue=
+Color=Red

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export_features_yaml.json
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export_features_yaml.json
@@ -1,7 +1,6 @@
-Color: Red
 Region: West US
+Color: Red
 feature-management:
-  Beta: false
   Timestamp:
     enabled-for:
     - Name: Local Tests
@@ -12,3 +11,4 @@ feature-management:
       Parameters:
         EndTime: '2019-11-01T00:00:00Z'
         StartTime: '2019-09-02T00:00:00Z'
+  Beta: false


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Fix a bug for using ```appconfig kv list``` with both ```--fields``` and ```--resolve-keyvault```. Previously if content type is not included in ```--fields```, it won't resolve any key vault references.  

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
