### PR TITLE
[AppService] az webapp auth update: Add optional parameter to update runtime-version

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -740,7 +740,17 @@ def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=No
         auth_settings.unauthenticated_client_action = UnauthenticatedClientAction.allow_anonymous
     elif action:
         auth_settings.unauthenticated_client_action = UnauthenticatedClientAction.redirect_to_login_page
-        auth_settings.default_provider = AUTH_TYPES[action]
+        auth_settings.default_provider = AUTH_TYPES[action]    
+    # validate runtime version
+    from version_parser.version import Version
+    try:
+        if runtime_version is not None:
+            if runtime_version.startswith("~") and len(runtime_version) > 1:
+                Version(runtime_version[1:])
+            else:
+                Version(runtime_version)
+    except(Exception, SystemExit) as ex:
+        raise CLIError('Usage Error: --runtime-version set to invalid value')
 
     import inspect
     frame = inspect.currentframe()

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -723,6 +723,7 @@ def get_auth_settings(cmd, resource_group_name, name, slot=None):
     return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get_auth_settings', slot)
 
 def is_auth_runtime_version_valid(runtime_version=None):
+    
     if runtime_version is None:
         return True
     if runtime_version.startswith("~") and len(runtime_version) > 1:
@@ -739,6 +740,7 @@ def is_auth_runtime_version_valid(runtime_version=None):
             int(version)
         except ValueError:
             return False
+            
     return True
 
 def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=None,  # pylint: disable=unused-argument
@@ -758,7 +760,7 @@ def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=No
         auth_settings.unauthenticated_client_action = UnauthenticatedClientAction.allow_anonymous
     elif action:
         auth_settings.unauthenticated_client_action = UnauthenticatedClientAction.redirect_to_login_page
-        auth_settings.default_provider = AUTH_TYPES[action]    
+        auth_settings.default_provider = AUTH_TYPES[action]
     # validate runtime version
     if not is_auth_runtime_version_valid(runtime_version):
         raise CLIError('Usage Error: --runtime-version set to invalid value')

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -724,7 +724,7 @@ def get_auth_settings(cmd, resource_group_name, name, slot=None):
 
 
 def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=None,  # pylint: disable=unused-argument
-                         client_id=None, token_store_enabled=None,  # pylint: disable=unused-argument
+                         client_id=None, token_store_enabled=None, runtime_version=None,  # pylint: disable=unused-argument
                          token_refresh_extension_hours=None,  # pylint: disable=unused-argument
                          allowed_external_redirect_urls=None, client_secret=None,  # pylint: disable=unused-argument
                          allowed_audiences=None, issuer=None, facebook_app_id=None,  # pylint: disable=unused-argument

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -722,8 +722,8 @@ def remove_identity(cmd, resource_group_name, name, slot=None):
 def get_auth_settings(cmd, resource_group_name, name, slot=None):
     return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get_auth_settings', slot)
 
+
 def is_auth_runtime_version_valid(runtime_version=None):
-    
     if runtime_version is None:
         return True
     if runtime_version.startswith("~") and len(runtime_version) > 1:
@@ -740,8 +740,8 @@ def is_auth_runtime_version_valid(runtime_version=None):
             int(version)
         except ValueError:
             return False
-            
     return True
+
 
 def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=None,  # pylint: disable=unused-argument
                          client_id=None, token_store_enabled=None, runtime_version=None,  # pylint: disable=unused-argument

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_authentication.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_authentication.yaml
@@ -649,7 +649,7 @@ interactions:
       Content-Length:
       - '0'
       ParameterSetName:
-      - -g -n --enabled --action --token-store --token-refresh-extension-hours --aad-client-id
+      - -g -n --enabled --action --token-store --token-refresh-extension-hours --runtime-version --aad-client-id
         --aad-client-secret --aad-allowed-token-audiences --aad-token-issuer-url --facebook-app-id
         --facebook-app-secret --facebook-oauth-scopes
       User-Agent:
@@ -698,7 +698,7 @@ interactions:
 - request:
     body: '{"properties": {"enabled": true, "unauthenticatedClientAction": "RedirectToLoginPage",
       "tokenStoreEnabled": false, "defaultProvider": "Facebook", "tokenRefreshExtensionHours":
-      7.2, "clientId": "aad_client_id", "clientSecret": "aad_secret", "issuer": "https://issuer_url",
+      7.2, "runtimeVersion": "1.2.8", "clientId": "aad_client_id", "clientSecret": "aad_secret", "issuer": "https://issuer_url",
       "allowedAudiences": ["https://audience1"], "facebookAppId": "facebook_id", "facebookAppSecret":
       "facebook_secret", "facebookOAuthScopes": ["public_profile", "email"]}}'
     headers:
@@ -715,7 +715,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - -g -n --enabled --action --token-store --token-refresh-extension-hours --aad-client-id
+      - -g -n --enabled --action --token-store --token-refresh-extension-hours --runtime-version --aad-client-id
         --aad-client-secret --aad-allowed-token-audiences --aad-token-issuer-url --facebook-app-id
         --facebook-app-secret --facebook-oauth-scopes
       User-Agent:
@@ -728,7 +728,7 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_webapp_authentication000001/providers/Microsoft.Web/sites/webapp-authentication-test000002/config/authsettings","name":"authsettings","type":"Microsoft.Web/sites/config","location":"West
-        US","properties":{"enabled":true,"runtimeVersion":"~1","unauthenticatedClientAction":"RedirectToLoginPage","tokenStoreEnabled":false,"allowedExternalRedirectUrls":null,"defaultProvider":"Facebook","tokenRefreshExtensionHours":7.2,"clientId":"aad_client_id","clientSecret":"aad_secret","clientSecretCertificateThumbprint":null,"issuer":"https://issuer_url","allowedAudiences":["https://audience1"],"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":"facebook_id","facebookAppSecret":"facebook_secret","facebookOAuthScopes":["public_profile","email"],"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null}}'
+        US","properties":{"enabled":true,"runtimeVersion":"1.2.8","unauthenticatedClientAction":"RedirectToLoginPage","tokenStoreEnabled":false,"allowedExternalRedirectUrls":null,"defaultProvider":"Facebook","tokenRefreshExtensionHours":7.2,"clientId":"aad_client_id","clientSecret":"aad_secret","clientSecretCertificateThumbprint":null,"issuer":"https://issuer_url","allowedAudiences":["https://audience1"],"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":"facebook_id","facebookAppSecret":"facebook_secret","facebookOAuthScopes":["public_profile","email"],"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null}}'
     headers:
       cache-control:
       - no-cache

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -2052,7 +2052,7 @@ class WebappAuthenticationTest(ScenarioTest):
 
         self.assertIn('https://audience1', result['allowedAudiences'])
         self.assertIn('email', result['facebookOauthScopes'])
-        self.assertIn('public_profile', result['facebookgitOauthScopes'])
+        self.assertIn('public_profile', result['facebookOauthScopes'])
 
 
 class WebappUpdateTest(ScenarioTest):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -2030,7 +2030,7 @@ class WebappAuthenticationTest(ScenarioTest):
 
         # update and verify
         result = self.cmd('webapp auth update -g {} -n {} --enabled true --action LoginWithFacebook '
-                          '--token-store false --token-refresh-extension-hours 7.2 '
+                          '--token-store false --token-refresh-extension-hours 7.2 --runtime-version 1.2.8'
                           '--aad-client-id aad_client_id --aad-client-secret aad_secret '
                           '--aad-allowed-token-audiences https://audience1 --aad-token-issuer-url https://issuer_url '
                           '--facebook-app-id facebook_id --facebook-app-secret facebook_secret '
@@ -2042,6 +2042,7 @@ class WebappAuthenticationTest(ScenarioTest):
                               JMESPathCheck('enabled', True),
                               JMESPathCheck('tokenStoreEnabled', False),
                               JMESPathCheck('tokenRefreshExtensionHours', 7.2),
+                              JMESPathCheck('runtimeVersion', '1.2.8'),
                               JMESPathCheck('clientId', 'aad_client_id'),
                               JMESPathCheck('clientSecret', 'aad_secret'),
                               JMESPathCheck('issuer', 'https://issuer_url'),

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -2031,7 +2031,7 @@ class WebappAuthenticationTest(ScenarioTest):
 
         # update and verify
         result = self.cmd('webapp auth update -g {} -n {} --enabled true --action LoginWithFacebook '
-                          '--token-store false --token-refresh-extension-hours 7.2 --runtime-version 1.2.8'
+                          '--token-store false --token-refresh-extension-hours 7.2 --runtime-version 1.2.8 '
                           '--aad-client-id aad_client_id --aad-client-secret aad_secret '
                           '--aad-allowed-token-audiences https://audience1 --aad-token-issuer-url https://issuer_url '
                           '--facebook-app-id facebook_id --facebook-app-secret facebook_secret '

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -2019,6 +2019,7 @@ class WebappAuthenticationTest(ScenarioTest):
             JMESPathCheck('tokenStoreEnabled', None),
             JMESPathCheck('allowedExternalRedirectUrls', None),
             JMESPathCheck('tokenRefreshExtensionHours', None),
+            JMESPathCheck('runtimeVersion', None),
             JMESPathCheck('clientId', None),
             JMESPathCheck('clientSecret', None),
             JMESPathCheck('allowedAudiences', None),
@@ -2051,7 +2052,7 @@ class WebappAuthenticationTest(ScenarioTest):
 
         self.assertIn('https://audience1', result['allowedAudiences'])
         self.assertIn('email', result['facebookOauthScopes'])
-        self.assertIn('public_profile', result['facebookOauthScopes'])
+        self.assertIn('public_profile', result['facebookgitOauthScopes'])
 
 
 class WebappUpdateTest(ScenarioTest):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
We want to offer support via the Azure CLI tool to update the runtime version of the App Service Authentication/Authorization module. This is done by exposing a runtime version parameter in the "webapp auth update" command, already offered through the Azure CLI tool.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
