### PR TITLE
{Profile} Bump ADAL version to 1.2.3

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -50,7 +50,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'adal~=1.2',
+    'adal~=1.2.3',
     'argcomplete~=1.8',
     'azure-cli-telemetry',
     'colorama>=0.3.9',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -1,4 +1,4 @@
-adal==1.2.1
+adal==1.2.3
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.9
 argcomplete==1.11.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -1,4 +1,4 @@
-adal==1.2.1
+adal==1.2.3
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.9
 argcomplete==1.11.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -1,4 +1,4 @@
-adal==1.2.1
+adal==1.2.3
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.7
 argcomplete==1.11.1


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Fix https://github.com/Azure/azure-cli/issues/12938: `az login` fails because instance discovery failes with `login.windows.net` in private cloud

This PR bumps ADAL version to 1.2.3 so that private cloud can use `login.microsoftonline.com` to make instance discovery. The old ADAL uses `login.windows.net` to make instance discovery, which fails in a private cloud.

Corresponding ADAL issue: https://github.com/AzureAD/azure-activedirectory-library-for-python/issues/224
Corresponding ADAL PR: https://github.com/AzureAD/azure-activedirectory-library-for-python/pull/227


**Testing Guide**  
`az login`
