### PR TITLE
[Network] az network dns zone: support - character

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/zone_file/parse_zone_file.py
+++ b/src/azure-cli/azure/cli/command_modules/network/zone_file/parse_zone_file.py
@@ -59,7 +59,7 @@ date_regex_dict = {
 
 _REGEX = {
     'ttl': r'(?P<delim>\$ttl)\s+(?P<val>\d+\w*)',
-    'origin': r'(?P<delim>\$origin)\s+(?P<val>[\w\.]+)',
+    'origin': r'(?P<delim>\$origin)\s+(?P<val>[\w\.-]+)',
     'soa': r'(?P<name>[@\*\w\.-]*)\s+(?:(?P<ttl>\d+\w*)\s+)?(?:(?P<class>in)\s+)?(?P<delim>soa)\s+(?P<host>[\w\.-]+)\s+(?P<email>[\w\.-]+)\s+(?P<serial>\d*)\s+(?P<refresh>\w*)\s+(?P<retry>\w*)\s+(?P<expire>\w*)\s+(?P<minimum>\w*)?',
     'a': r'(?P<name>[@\*\w\.-]*)\s+(?:(?P<ttl>\d+\w*)\s+)?(?:(?P<class>in)\s+)?(?P<delim>a)\s+(?P<ip>[\d\.]+)',
     'ns': r'(?P<name>[@\*\w\.-]*)\s+(?:(?P<ttl>\d+\w*)\s+)?(?:(?P<class>in)\s+)?(?P<delim>ns)\s+(?P<host>[\w\.-]+)',


### PR DESCRIPTION
**Description<!--Mandatory-->**  
See internal ICM 187136418
We are failing to import zones when domain name in $origin contains hypens.
This is because we don't parse it correctly in the regex (only alphanumeric char are evaluated with "\w" and that doesn't include hypen, like it is for outher resurces like CNAME.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
