### PR TITLE
{CI} Temporary disable CredScan since ADO bug

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,25 +42,25 @@ jobs:
         echo "Reject pull request directly to master branch"
         exit 1
 
-- job: CredScan
-  displayName: "Credential Scan"
-  pool:
-    vmImage: "windows-2019"
-  steps:
-    - task: ms-codeanalysis.vss-microsoft-security-code-analysis.build-task-credscan.CredScan@2
-      displayName: 'CredScan'
-      inputs:
-        toolVersion: 'Latest'
-        suppressionsFile: './scripts/ci/credscan/CredScanSuppressions.json'
-    - task: ms-codeanalysis.vss-microsoft-security-code-analysis.build-task-postanalysis.PostAnalysis@1
-      displayName: 'Post Analysis'
-      inputs:
-        AllTools: false
-        BinSkim: false
-        CredScan: true
-        RoslynAnalyzers: false
-        TSLint: false
-        ToolLogsNotFoundAction: 'Standard'
+# - job: CredScan
+#   displayName: "Credential Scan"
+#   pool:
+#     vmImage: "windows-2019"
+#   steps:
+#     - task: ms-codeanalysis.vss-microsoft-security-code-analysis.build-task-credscan.CredScan@2
+#       displayName: 'CredScan'
+#       inputs:
+#         toolVersion: 'Latest'
+#         suppressionsFile: './scripts/ci/credscan/CredScanSuppressions.json'
+#     - task: ms-codeanalysis.vss-microsoft-security-code-analysis.build-task-postanalysis.PostAnalysis@1
+#       displayName: 'Post Analysis'
+#       inputs:
+#         AllTools: false
+#         BinSkim: false
+#         CredScan: true
+#         RoslynAnalyzers: false
+#         TSLint: false
+#         ToolLogsNotFoundAction: 'Standard'
 
 - job: ExtractMetadata
   displayName: Extract Metadata


### PR DESCRIPTION
**Description<!--Mandatory-->**  
All build fails because of the same reason, the job CredScan is missing
![image](https://user-images.githubusercontent.com/14357159/81366477-5dae3b00-911d-11ea-8a71-cbb22046b789.png)

Like this:
![image](https://user-images.githubusercontent.com/14357159/81366500-6a329380-911d-11ea-8d7e-c97bf5db13b1.png)

The tool set contianing CredScan in Azure SDK account is missing unknowingly.

Temporary disable it for unblocking our development until it's sovled.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
