### PR TITLE
[Storage] az storage share-rm restore: Add support for soft delete

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -757,7 +757,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
     with self.argument_context('storage share') as c:
         c.argument('share_name', share_name_type, options_list=('--name', '-n'))
 
-    for item in ['create', 'delete', 'exists', 'list', 'show', 'update']:
+    for item in ['create', 'delete', 'exists', 'list', 'show', 'update', 'restore']:
         with self.argument_context('storage share-rm {}'.format(item), resource_type=ResourceType.MGMT_STORAGE) as c:
             c.argument('resource_group_name', required=False)
             c.argument('account_name', storage_account_type)

--- a/src/azure-cli/azure/cli/command_modules/storage/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands.py
@@ -412,6 +412,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.command('list', 'list')
         g.show_command('show', 'get')
         g.command('update', 'update')
+        g.command('restore', 'restore', min_api='2019-06-01')
 
     with self.command_group('storage share', command_type=file_sdk,
                             custom_command_type=get_custom_sdk('file', file_data_service_factory)) as g:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

`Soft-delete should apply to both FileStorage (premium) and GPv2 (standard) file shares. `

`The "deleted-version" parameter (version in the returned result set from SRP) is used to disambiguate different shares with the same name that have been deleted. This is the main open item on the SRP spec as of the time of writing. `

`This spec calls for a new command, restore, that will undelete a file share. `

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] : az storage share-rm restore: Restore a file share within a valid retention days if share soft delete is enabled.
[Storage] : az storage share-rm list: Add --include-deleted to list all shares including deleted items.
[Storage] : az storage share-rm show: Add --include-deleted to show deleted item properties.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
