### PR TITLE
{CI} Allow CI to pass on fork repos

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
   steps:
     - bash: |
         echo "Check Title of Pull Request: #$(System.PullRequest.PullRequestNumber)"
-        title=$(curl https://api.github.com/repos/Azure/azure-cli/pulls/$(System.PullRequest.PullRequestNumber) | jq -r '.title')
+        title=$(curl https://api.github.com/repos/$(Build.Repository.Name)/pulls/$(System.PullRequest.PullRequestNumber) | jq -r '.title')
         if [ "$(System.PullRequest.TargetBranch)" != "release" ] && echo $title | grep -iqF hotfix; then
           echo "Hotfix PR should target release branch."
           exit 1


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Replace the hard-coded repo name `Azure/azure-cli` to [`$(Build.Repository.Name)`](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables) so that CI can pass on fork repos.


Variable | Description
-- | --
Build.Repository.Name | The name of the triggering repository.This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.

