### PR TITLE
[App Service] Implement webapp list-instances and per-instance SSH and remote connections

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_appservice_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_appservice_utils.py
@@ -10,8 +10,10 @@ MSI_LOCAL_ID = '[system]'
 
 
 def _generic_site_operation(cli_ctx, resource_group_name, name, operation_name, slot=None,
-                            extra_parameter=None, client=None):
-    client = client or web_client_factory(cli_ctx)
+                            api_version=None, extra_parameter=None, client=None):
+    # api_version was added to support targeting a specific API
+    # Based on get_appconfig_service_client example
+    client = client or web_client_factory(cli_ctx, api_version=api_version)
     operation = getattr(client.web_apps,
                         operation_name if slot is None else operation_name + '_slot')
     if slot is None:

--- a/src/azure-cli/azure/cli/command_modules/appservice/_appservice_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_appservice_utils.py
@@ -10,7 +10,7 @@ MSI_LOCAL_ID = '[system]'
 
 
 def _generic_site_operation(cli_ctx, resource_group_name, name, operation_name, slot=None,
-                            api_version=None, extra_parameter=None, client=None):
+                             extra_parameter=None, client=None, api_version=None):
     # api_version was added to support targeting a specific API
     # Based on get_appconfig_service_client example
     client = client or web_client_factory(cli_ctx, api_version=api_version)

--- a/src/azure-cli/azure/cli/command_modules/appservice/_appservice_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_appservice_utils.py
@@ -10,7 +10,7 @@ MSI_LOCAL_ID = '[system]'
 
 
 def _generic_site_operation(cli_ctx, resource_group_name, name, operation_name, slot=None,
-                             extra_parameter=None, client=None, api_version=None):
+                            extra_parameter=None, client=None, api_version=None):
     # api_version was added to support targeting a specific API
     # Based on get_appconfig_service_client example
     client = client or web_client_factory(cli_ctx, api_version=api_version)

--- a/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
@@ -29,10 +29,10 @@ def ex_handler_factory(creating_plan=False, no_throw=False):
     return _polish_bad_errors
 
 
-def web_client_factory(cli_ctx, **_):
+def web_client_factory(cli_ctx, api_version=None, **_):
     from azure.cli.core.profiles import ResourceType
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_APPSERVICE)
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_APPSERVICE, api_version=api_version)
 
 
 def providers_client_factory(cli_ctx):

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -1637,6 +1637,11 @@ examples:
         az webapp list --query "[?state=='Running']"
 """
 
+helps['webapp list-instances'] = """
+type: command
+short-summary: List all scaled out instances of a web app or web app slot.
+"""
+
 helps['webapp list-runtimes'] = """
 type: command
 short-summary: List available built-in stacks which can be used for web apps.

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -612,6 +612,7 @@ def load_arguments(self, _):
         c.argument('port', options_list=['--port', '-p'],
                    help='Port for the remote connection. Default: Random available port', type=int)
         c.argument('timeout', options_list=['--timeout', '-t'], help='timeout in seconds. Defaults to none', type=int)
+        c.argument('instance', options_list=['--instance', '-i'], help='Webapp instance to connect to. Defaults to none.')
 
     with self.argument_context('webapp create-remote-connection') as c:
         c.argument('port', options_list=['--port', '-p'],

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -143,6 +143,10 @@ def load_arguments(self, _):
     with self.argument_context('webapp show') as c:
         c.argument('name', arg_type=webapp_name_arg_type)
 
+    with self.argument_context('webapp list-instances') as c:
+        c.argument('name', arg_type=webapp_name_arg_type, id_part=None)
+        c.argument('slot', options_list=['--slot', '-s'], help='Name of the web app slot. Default to the productions slot if not specified.')
+
     with self.argument_context('webapp list-runtimes') as c:
         c.argument('linux', action='store_true', help='list runtime stacks for linux based web apps')
 
@@ -618,6 +622,7 @@ def load_arguments(self, _):
         c.argument('port', options_list=['--port', '-p'],
                    help='Port for the remote connection. Default: Random available port', type=int)
         c.argument('timeout', options_list=['--timeout', '-t'], help='timeout in seconds. Defaults to none', type=int)
+        c.argument('instance', options_list=['--instance', '-i'], help='Webapp instance to connect to. Defaults to none.')
 
     with self.argument_context('webapp vnet-integration') as c:
         c.argument('name', arg_type=webapp_name_arg_type, id_part=None)

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -91,6 +91,7 @@ def load_command_table(self, _):
         g.custom_command('start', 'start_webapp', validator=validate_app_or_slot_exists_in_rg)
         g.custom_command('restart', 'restart_webapp', validator=validate_app_or_slot_exists_in_rg)
         g.custom_command('browse', 'view_in_browser')
+        g.custom_command('list-instances', 'list_instances')
         # Move back to using list_runtimes function once Available Stacks API is updated (it's updated with Antares deployments)
         g.custom_command('list-runtimes', 'list_runtimes_hardcoded')
         g.custom_command('identity assign', 'assign_identity', validator=validate_app_or_slot_exists_in_rg)

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -91,7 +91,7 @@ def load_command_table(self, _):
         g.custom_command('start', 'start_webapp', validator=validate_app_or_slot_exists_in_rg)
         g.custom_command('restart', 'restart_webapp', validator=validate_app_or_slot_exists_in_rg)
         g.custom_command('browse', 'view_in_browser')
-        g.custom_command('list-instances', 'list_instances')
+        g.custom_command('list-instances', 'list_instances', validator=validate_app_or_slot_exists_in_rg)
         # Move back to using list_runtimes function once Available Stacks API is updated (it's updated with Antares deployments)
         g.custom_command('list-runtimes', 'list_runtimes_hardcoded')
         g.custom_command('identity assign', 'assign_identity', validator=validate_app_or_slot_exists_in_rg)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3687,7 +3687,10 @@ def get_tunnel(cmd, resource_group_name, name, port=None, slot=None, instance=No
         instances = list_instances(cmd, resource_group_name, name, slot=slot)
         instance_names = set(i.name for i in instances)
         if instance not in instance_names:
-            raise CLIError("The provided instance '{}' is not valid for this webapp.".format(instance))
+            if not slot is None:
+                raise CLIError("The provided instance '{}' is not valid for this webapp and slot.".format(instance))
+            else
+                raise CLIError("The provided instance '{}' is not valid for this webapp.".format(instance))
 
     scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3684,13 +3684,9 @@ def get_tunnel(cmd, resource_group_name, name, port=None, slot=None, instance=No
     
     # Validate that we have a known instance (case-sensitive)
     if not instance is None:
-        instance_found = False
         instances = list_instances(cmd, resource_group_name, name, slot=slot)
-        for t_instance in instances:
-            if t_instance.name == instance:
-                instance_found = True
-                break
-        if instance_found == False:
+        instance_names = set(i.name for i in instances)
+        if instance not in instance_names:
             raise CLIError("The provided instance '{}' is not valid for this webapp.".format(instance))
 
     scm_url = _get_scm_url(cmd, resource_group_name, name, slot)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -881,7 +881,7 @@ def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=No
 
 
 def list_instances(cmd, resource_group_name, name, slot=None):
-    # TODO: API Version 2019-08-01 does not return slot instances, however 2018-02-01 does
+    # API Version 2019-08-01 does not return slot instances, however 2018-02-01 does
     return  _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_instance_identifiers', slot)
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -880,8 +880,9 @@ def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=No
 
 
 def list_instances(cmd, resource_group_name, name, slot=None):
-    # API Version 2019-08-01 does not return slot instances, however 2018-02-01 does
-    return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_instance_identifiers', slot, api_version="2018-02-01")
+    # API Version 2019-08-01 (latest as of writing this code) does not return slot instances, however 2018-02-01 does
+    return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_instance_identifiers', slot,
+                                   api_version="2018-02-01")
 
 
 # Currently using hardcoded values instead of this function. This function calls the stacks API;

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3681,6 +3681,17 @@ def get_tunnel(cmd, resource_group_name, name, port=None, slot=None, instance=No
     if port is None:
         port = 0  # Will auto-select a free port from 1024-65535
         logger.info('No port defined, creating on random free port')
+    
+    # Validate that we have a known instance (case-sensitive)
+    if not instance is None:
+        instance_found = False
+        instances = list_instances(cmd, resource_group_name, name, slot=slot)
+        for t_instance in instances:
+            if t_instance.name == instance:
+                instance_found = True
+                break
+        if instance_found == False:
+            raise CLIError("The provided instance '{}' is not valid for this webapp.".format(instance))
 
     scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -881,7 +881,7 @@ def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=No
 
 def list_instances(cmd, resource_group_name, name, slot=None):
     # API Version 2019-08-01 does not return slot instances, however 2018-02-01 does
-    return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_instance_identifiers', slot)
+    return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_instance_identifiers', slot, api_version="2018-02-01")
 
 
 # Currently using hardcoded values instead of this function. This function calls the stacks API;

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3689,7 +3689,7 @@ def get_tunnel(cmd, resource_group_name, name, port=None, slot=None, instance=No
         if instance not in instance_names:
             if not slot is None:
                 raise CLIError("The provided instance '{}' is not valid for this webapp and slot.".format(instance))
-            else
+            else:
                 raise CLIError("The provided instance '{}' is not valid for this webapp.".format(instance))
 
     scm_url = _get_scm_url(cmd, resource_group_name, name, slot)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -881,7 +881,7 @@ def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=No
 
 def list_instances(cmd, resource_group_name, name, slot=None):
     # API Version 2019-08-01 does not return slot instances, however 2018-02-01 does
-    return  _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_instance_identifiers', slot)
+    return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_instance_identifiers', slot)
 
 
 # Currently using hardcoded values instead of this function. This function calls the stacks API;
@@ -3659,9 +3659,10 @@ def _ping_scm_site(cmd, resource_group, name, instance=None):
     import urllib3
     authorization = urllib3.util.make_headers(basic_auth='{}:{}'.format(user_name, password))
     cookies = {}
-    if not instance is None:
+    if instance is not None:
         cookies['ARRAffinity'] = instance
-    requests.get(scm_url + '/api/settings', headers=authorization, verify=not should_disable_connection_verify(), cookies=cookies)
+    requests.get(scm_url + '/api/settings', headers=authorization, verify=not should_disable_connection_verify(),
+                 cookies=cookies)
 
 
 def is_webapp_up(tunnel_server):
@@ -3681,16 +3682,15 @@ def get_tunnel(cmd, resource_group_name, name, port=None, slot=None, instance=No
     if port is None:
         port = 0  # Will auto-select a free port from 1024-65535
         logger.info('No port defined, creating on random free port')
-    
+
     # Validate that we have a known instance (case-sensitive)
-    if not instance is None:
+    if instance is not None:
         instances = list_instances(cmd, resource_group_name, name, slot=slot)
         instance_names = set(i.name for i in instances)
         if instance not in instance_names:
-            if not slot is None:
+            if slot is not None:
                 raise CLIError("The provided instance '{}' is not valid for this webapp and slot.".format(instance))
-            else:
-                raise CLIError("The provided instance '{}' is not valid for this webapp.".format(instance))
+            raise CLIError("The provided instance '{}' is not valid for this webapp.".format(instance))
 
     scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -590,6 +590,7 @@ def show_webapp(cmd, resource_group_name, name, slot=None, app_instance=None):
         raise CLIError("'{}' app doesn't exist".format(name))
     _rename_server_farm_props(webapp)
     _fill_ftp_publishing_url(cmd, webapp, resource_group_name, name, slot)
+    _fill_instances(cmd, webapp, resource_group_name, name, slot)
     return webapp
 
 
@@ -877,6 +878,10 @@ def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=No
             setattr(auth_settings, arg, values[arg] if arg not in bool_flags else values[arg] == 'true')
 
     return _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'update_auth_settings', slot, auth_settings)
+
+
+def list_instances(cmd, resource_group_name, name, slot=None):
+    return  _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_instance_identifiers', slot)
 
 
 # Currently using hardcoded values instead of this function. This function calls the stacks API;

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -590,7 +590,6 @@ def show_webapp(cmd, resource_group_name, name, slot=None, app_instance=None):
         raise CLIError("'{}' app doesn't exist".format(name))
     _rename_server_farm_props(webapp)
     _fill_ftp_publishing_url(cmd, webapp, resource_group_name, name, slot)
-    _fill_instances(cmd, webapp, resource_group_name, name, slot)
     return webapp
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -881,6 +881,7 @@ def update_auth_settings(cmd, resource_group_name, name, enabled=None, action=No
 
 
 def list_instances(cmd, resource_group_name, name, slot=None):
+    # TODO: API Version 2019-08-01 does not return slot instances, however 2018-02-01 does
     return  _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_instance_identifiers', slot)
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
@@ -94,7 +94,7 @@ class TunnelServer:
             http = urllib3.PoolManager(cert_reqs='CERT_NONE')
         headers = urllib3.util.make_headers(basic_auth='{0}:{1}'.format(self.remote_user_name, self.remote_password))
         url = 'https://{}{}'.format(self.remote_addr, '/AppServiceTunnel/Tunnel.ashx?GetStatus&GetStatusAPIVer=2')
-        if not self.instance is None:
+        if self.instance is not None:
             headers['Cookie'] = 'ARRAffinity=' + self.instance
         r = http.request(
             'GET',

--- a/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
@@ -95,7 +95,7 @@ class TunnelServer:
         headers = urllib3.util.make_headers(basic_auth='{0}:{1}'.format(self.remote_user_name, self.remote_password))
         url = 'https://{}{}'.format(self.remote_addr, '/AppServiceTunnel/Tunnel.ashx?GetStatus&GetStatusAPIVer=2')
         if not self.instance is None:
-            headers['Cookie'] = 'ARRAffinity='+self.instance
+            headers['Cookie'] = 'ARRAffinity=' + self.instance
         r = http.request(
             'GET',
             url,
@@ -141,8 +141,8 @@ class TunnelServer:
             self.client.settimeout(60 * 60)
             host = 'wss://{}{}'.format(self.remote_addr, '/AppServiceTunnel/Tunnel.ashx')
             basic_auth_header = ['Authorization: Basic {}'.format(basic_auth_string)]
-            if not self.instance is None:
-                basic_auth_header.append('Cookie: ARRAffinity='+self.instance)
+            if self.instance is not None:
+                basic_auth_header.append('Cookie: ARRAffinity=' + self.instance)
             cli_logger = get_logger()  # get CLI logger which has the level set through command lines
             is_verbose = any(handler.level <= logs.INFO for handler in cli_logger.handlers)
             if is_verbose:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
@@ -154,7 +154,7 @@ class TunnelServer:
             self.ws = create_connection(host,
                                         sockopt=((socket.IPPROTO_TCP, socket.TCP_NODELAY, 1),),
                                         class_=TunnelWebSocket,
-                                        header=[basic_auth_header],
+                                        header=basic_auth_header,
                                         sslopt={'cert_reqs': ssl.CERT_NONE},
                                         timeout=60 * 60,
                                         enable_multithread=True)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
The create-remote-connection and ssh webapp commands are very useful when debugging a poorly running app. However sometimes it is important to be connected to a specific instances. For example, if one instance is responding slower than another, debugging that specific instance is critical even though they should be identical in every way.

This pull request implements a new webapp command `webapp list-instances` and add the `--instance` parameter to ssh and create-remote-connection.

~~One aspect not resolved is when listing instances of a slot, the API version 2019-08-01 does not return a value. This is something specific to that API call and not a fault of the azure-cli codebase.~~

Edit: I forcefully target API version 2018-02-01 when querying the instance information because the latest version (2019-08-01) does not support slot instances. This included modifying the `_generic_site_operation` and `web_client_factory` functions.

The method used to perform this work is to emulate a browser request with an ARRAffinity cookie specifying a certain instance to the Azure load balancer in front of the web app. This is used since there is no API provided way to request a specific instance in HTTP request or WSS socket establishment.

This is the documented way to connect to a specific instance of Kudu as provided here: https://docs.microsoft.com/en-us/archive/blogs/kaushal/azure-app-service-how-to-connect-to-the-kudu-site-of-a-specific-instance

***Concerns***

This pull request does not have tests. I am not familiar with how the tests are structured for azure-cli to mock them myself. If you have guidance on how to do that, I will add it in. Otherwise, I welcome any of the maintainers to add in the requisite tests.

I did not make this into a subgroup for `webapp list` because the `list-runtimes` is not a function of a webapp itself and it doesn't feel right to change the `webapp list` functionality. That would be a breaking change.

**Testing Guide**  

* `az webapp list-instances -g 'resource-group' -n 'webapp-name'`
  * Lists the instances of a webapp (Microsoft.Web/sites/{webapp}/instances
* `az webapp list-instances -g 'resource-group' -n 'webapp-name' --slot 'slot-name'`
  * Lists the instances of a webapp (Microsoft.Web/sites/{webapp}/slots/{slot}/instances
* `az webapp create-remote-connection -g 'resource-group' -n 'webapp-name' -i 'instance-id'`
  * Establishes a remote connection tunnel to the requested instance
* `az webapp ssh -g 'resource-group' -n 'webapp-name' -i 'instance-id'`
  * Establishes a ssh session to the requested instance
* `az webapp create-remote-connection -g 'resource-group' -n 'webapp-name' -i 'instance-id' --slot 'slot'`
  * Establishes a remote connection tunnel to the requested instance on the requested slot
* `az webapp ssh -g 'resource-group' -n 'webapp-name' -i 'instance-id' --slot 'slot'`
  * Establishes a ssh session to the requested instance on the requested slot

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[App Service] az webapp: Add list-instances command 
[App Service] az webapp ssh: Add --instance parameter to connect to a specific instance
[App Service] az webapp create-remote-connection: Add --instance parameter to connect to a specific instance

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
