### PR TITLE
{Compute} az vm auto-shutdown: remove a validation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -900,14 +900,12 @@ def auto_shutdown_vm(cmd, resource_group_name, vm_name, off=None, email=None, we
                         namespace='Microsoft.Compute', type='virtualMachines', name=vm_name)
     if off:
         if email is not None or webhook is not None or time is not None:
-            # I don't want to disturb users. So I warn instead of raising an error.
+            # I don't want to disrupt users. So I warn instead of raising an error.
             logger.warning('If --off, other parameters will be ignored.')
         return client.global_schedules.delete(resource_group_name, name)
 
     if time is None:
         raise CLIError('usage error: --time is a required parameter')
-    if email is not None and webhook is None:
-        raise CLIError('usage error: --webhook is missing')
     daily_recurrence = {'time': time}
     notification_settings = None
     if webhook:

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_auto_shutdown.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vm_auto_shutdown.yaml
@@ -14,23 +14,23 @@ interactions:
       - -g -n --image --nsg-rule
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001","name":"cli_test_vm_auto_shutdown000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-30T07:38:37Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001","name":"cli_test_vm_auto_shutdown000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-09T02:03:54Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '471'
+      - '428'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:38:43 GMT
+      - Sat, 09 May 2020 02:04:04 GMT
       expires:
       - '-1'
       pragma:
@@ -109,11 +109,11 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:38:44 GMT
+      - Sat, 09 May 2020 02:04:06 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Thu, 30 Apr 2020 07:43:44 GMT
+      - Sat, 09 May 2020 02:09:06 GMT
       source-age:
       - '0'
       strict-transport-security:
@@ -124,21 +124,21 @@ interactions:
       - 1.1 varnish (Varnish/6.0)
       - 1.1 varnish
       x-cache:
-      - HIT, MISS
+      - MISS, HIT
       x-cache-hits:
-      - 3, 0
+      - 0, 1
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - a96cae283b145451107365036dd39616e64fa197
+      - cce706fbd4a445f69f52d05015cff7b5e8e7fc96
       x-frame-options:
       - deny
       x-github-request-id:
-      - 553C:502D:49866:4FAA9:5EAA6892
+      - 0E9A:6B51:37A430:3B7A01:5EB5E485
       x-served-by:
-      - cache-tyo19931-TYO
+      - cache-sin18028-SIN
       x-timer:
-      - S1588232324.385396,VS0,VE244
+      - S1588989846.680453,VS0,VE336
       x-xss-protection:
       - 1; mode=block
     status:
@@ -159,7 +159,7 @@ interactions:
       - -g -n --image --nsg-rule
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-network/10.1.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-network/10.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -175,7 +175,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:38:44 GMT
+      - Sat, 09 May 2020 02:04:06 GMT
       expires:
       - '-1'
       pragma:
@@ -235,25 +235,25 @@ interactions:
       - -g -n --image --nsg-rule
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/vm_deploy_YPgRggY64jYX484Mwh9U1wK1G9PpMvrD","name":"vm_deploy_YPgRggY64jYX484Mwh9U1wK1G9PpMvrD","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7871171923615174554","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-04-30T07:38:48.9924526Z","duration":"PT2.0471941S","correlationId":"ab199a00-2e11-4d53-8135-64a9e6abb5ce","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/vm_deploy_lYt69cESJmVxweXGAmmTinKg6D7eAgKr","name":"vm_deploy_lYt69cESJmVxweXGAmmTinKg6D7eAgKr","type":"Microsoft.Resources/deployments","properties":{"templateHash":"11221119138800917668","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-05-09T02:04:11.8598672Z","duration":"PT2.9872147S","correlationId":"a5c67606-a8a7-4377-94ae-79aafe39a7c3","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/vm_deploy_YPgRggY64jYX484Mwh9U1wK1G9PpMvrD/operationStatuses/08586133745585323956?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/vm_deploy_lYt69cESJmVxweXGAmmTinKg6D7eAgKr/operationStatuses/08586126170366049748?api-version=2019-07-01
       cache-control:
       - no-cache
       content-length:
-      - '2742'
+      - '2743'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:38:49 GMT
+      - Sat, 09 May 2020 02:04:13 GMT
       expires:
       - '-1'
       pragma:
@@ -282,9 +282,9 @@ interactions:
       - -g -n --image --nsg-rule
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586133745585323956?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586126170366049748?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -296,7 +296,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:39:20 GMT
+      - Sat, 09 May 2020 02:04:43 GMT
       expires:
       - '-1'
       pragma:
@@ -325,9 +325,9 @@ interactions:
       - -g -n --image --nsg-rule
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586133745585323956?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586126170366049748?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -339,7 +339,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:39:50 GMT
+      - Sat, 09 May 2020 02:05:14 GMT
       expires:
       - '-1'
       pragma:
@@ -368,9 +368,9 @@ interactions:
       - -g -n --image --nsg-rule
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586133745585323956?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586126170366049748?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -382,7 +382,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:40:20 GMT
+      - Sat, 09 May 2020 02:05:44 GMT
       expires:
       - '-1'
       pragma:
@@ -411,9 +411,9 @@ interactions:
       - -g -n --image --nsg-rule
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586133745585323956?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586126170366049748?api-version=2019-07-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -425,7 +425,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:40:51 GMT
+      - Sat, 09 May 2020 02:06:14 GMT
       expires:
       - '-1'
       pragma:
@@ -454,21 +454,21 @@ interactions:
       - -g -n --image --nsg-rule
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/vm_deploy_YPgRggY64jYX484Mwh9U1wK1G9PpMvrD","name":"vm_deploy_YPgRggY64jYX484Mwh9U1wK1G9PpMvrD","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7871171923615174554","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-04-30T07:40:33.9277673Z","duration":"PT1M46.9825088S","correlationId":"ab199a00-2e11-4d53-8135-64a9e6abb5ce","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Resources/deployments/vm_deploy_lYt69cESJmVxweXGAmmTinKg6D7eAgKr","name":"vm_deploy_lYt69cESJmVxweXGAmmTinKg6D7eAgKr","type":"Microsoft.Resources/deployments","properties":{"templateHash":"11221119138800917668","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-05-09T02:06:10.8084615Z","duration":"PT2M1.935809S","correlationId":"a5c67606-a8a7-4377-94ae-79aafe39a7c3","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3809'
+      - '3808'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:40:51 GMT
+      - Sat, 09 May 2020 02:06:15 GMT
       expires:
       - '-1'
       pragma:
@@ -497,7 +497,7 @@ interactions:
       - -g -n --image --nsg-rule
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-compute/12.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-compute/12.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -506,16 +506,16 @@ interactions:
     body:
       string: "{\r\n  \"name\": \"vm1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Compute/virtualMachines/vm1\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"8f1ba08e-e4ef-41eb-9134-1ed274cf4e7b\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"a897f2d5-9df8-40bd-8be5-804052e706ca\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n        \"sku\": \"7.5\",\r\n
         \       \"version\": \"latest\",\r\n        \"exactVersion\": \"7.5.201808150\"\r\n
         \     },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\":
-        \"vm1_OsDisk_1_62d0f6794b6a451baa9854b3269d417b\",\r\n        \"createOption\":
+        \"vm1_OsDisk_1_f69d33a79b7f48c39464bd26a0fc57b9\",\r\n        \"createOption\":
         \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\":
         {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VM_AUTO_SHUTDOWNFL7AGXWV2E4ABHUBTOEEZGWQVKE2DS4IEXJISUEWHP7XX6EAO7/providers/Microsoft.Compute/disks/vm1_OsDisk_1_62d0f6794b6a451baa9854b3269d417b\"\r\n
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VM_AUTO_SHUTDOWNK2364UD7T52BDTJ4YLC24IAEPOLTARLAF3YUGAR3FADEYZOSQI/providers/Microsoft.Compute/disks/vm1_OsDisk_1_f69d33a79b7f48c39464bd26a0fc57b9\"\r\n
         \       },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm1\",\r\n
         \     \"adminUsername\": \"fey\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
@@ -532,15 +532,15 @@ interactions:
         [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\",\r\n
         \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
         \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2020-04-30T07:40:50+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_OsDisk_1_62d0f6794b6a451baa9854b3269d417b\",\r\n
+        \"2020-05-09T02:06:15+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_OsDisk_1_f69d33a79b7f48c39464bd26a0fc57b9\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-04-30T07:39:27.0629191+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-05-09T02:04:55.0446787+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2020-04-30T07:40:32.9068611+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2020-05-09T02:06:07.9350178+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -552,7 +552,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:40:52 GMT
+      - Sat, 09 May 2020 02:06:16 GMT
       expires:
       - '-1'
       pragma:
@@ -569,7 +569,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3996,Microsoft.Compute/LowCostGet30Min;31992
+      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31997
     status:
       code: 200
       message: OK
@@ -588,7 +588,7 @@ interactions:
       - -g -n --image --nsg-rule
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-network/10.1.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-network/10.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -596,12 +596,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\",\r\n
-        \ \"etag\": \"W/\\\"140c626d-d45e-4bc3-9c45-1cc235e4f51d\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"0851ff4d-c4cb-41e2-9cd9-67dc23e0bc25\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"bfc315ac-7288-495f-b778-f058f1a86d92\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"904bbbd9-80ea-4d3f-8fb9-f786d55ec896\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\",\r\n
-        \       \"etag\": \"W/\\\"140c626d-d45e-4bc3-9c45-1cc235e4f51d\\\"\",\r\n
+        \       \"etag\": \"W/\\\"0851ff4d-c4cb-41e2-9cd9-67dc23e0bc25\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
@@ -610,8 +610,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"d511y3j1dvze5ljfr0sxvyum5b.dx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-3B-93-F2\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"zyitpdglmesefmarxn0sv5ul2a.dx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-5A-FD-5D\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -625,9 +625,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:40:52 GMT
+      - Sat, 09 May 2020 02:06:16 GMT
       etag:
-      - W/"140c626d-d45e-4bc3-9c45-1cc235e4f51d"
+      - W/"0851ff4d-c4cb-41e2-9cd9-67dc23e0bc25"
       expires:
       - '-1'
       pragma:
@@ -644,7 +644,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - ddcabc2c-d8b0-4dce-8385-bb3c51e0d885
+      - 815429d7-bedf-487b-8de3-51479e7e4ced
     status:
       code: 200
       message: OK
@@ -663,7 +663,7 @@ interactions:
       - -g -n --image --nsg-rule
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-network/10.1.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-network/10.1.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
@@ -671,10 +671,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"c5800097-3467-4827-8548-19d8d5e6b672\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"c8cbece2-d605-4b2f-9822-cfc2cec01f12\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"4748c1d8-415a-43ce-bb68-f2bb8423d3e7\",\r\n
-        \   \"ipAddress\": \"13.91.226.63\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"4f5c9999-eff2-48c6-ab9b-7f6eb7777dd2\",\r\n
+        \   \"ipAddress\": \"13.64.237.252\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
         \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
@@ -683,13 +683,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '996'
+      - '997'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:40:53 GMT
+      - Sat, 09 May 2020 02:06:17 GMT
       etag:
-      - W/"c5800097-3467-4827-8548-19d8d5e6b672"
+      - W/"c8cbece2-d605-4b2f-9822-cfc2cec01f12"
       expires:
       - '-1'
       pragma:
@@ -706,7 +706,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - a9c81037-d951-4e7b-bc3f-eb978e63e0a3
+      - ab006822-9d0c-4ea6-946f-7a6ace0d45de
     status:
       code: 200
       message: OK
@@ -725,23 +725,23 @@ interactions:
       - -g -n --time --email --webhook
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001","name":"cli_test_vm_auto_shutdown000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-30T07:38:37Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001","name":"cli_test_vm_auto_shutdown000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-09T02:03:54Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '471'
+      - '428'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:40:54 GMT
+      - Sat, 09 May 2020 02:06:17 GMT
       expires:
       - '-1'
       pragma:
@@ -778,14 +778,14 @@ interactions:
       - -g -n --time --email --webhook
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-devtestlabs/4.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-devtestlabs/4.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.DevTestLab/schedules/shutdown-computevm-vm1?api-version=2018-09-15
   response:
     body:
-      string: '{"properties":{"status":"Enabled","taskType":"ComputeVmShutdownTask","dailyRecurrence":{"time":"1730"},"timeZoneId":"UTC","notificationSettings":{"status":"Enabled","timeInMinutes":30,"webhookUrl":"https://example.com/","emailRecipient":"foo@bar.com"},"createdDate":"2020-04-30T07:40:59.7765241+00:00","targetResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Compute/virtualMachines/vm1","provisioningState":"Succeeded","uniqueIdentifier":"e9429d0e-5607-4d97-a3f4-4cd4e641d70f"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/microsoft.devtestlab/schedules/shutdown-computevm-vm1","name":"shutdown-computevm-vm1","type":"microsoft.devtestlab/schedules","location":"westus"}'
+      string: '{"properties":{"status":"Enabled","taskType":"ComputeVmShutdownTask","dailyRecurrence":{"time":"1730"},"timeZoneId":"UTC","notificationSettings":{"status":"Enabled","timeInMinutes":30,"webhookUrl":"https://example.com/","emailRecipient":"foo@bar.com"},"createdDate":"2020-05-09T02:06:26.8030096+00:00","targetResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001/providers/Microsoft.Compute/virtualMachines/vm1","provisioningState":"Succeeded","uniqueIdentifier":"66603874-8499-414e-8550-9de74126b37d"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001/providers/microsoft.devtestlab/schedules/shutdown-computevm-vm1","name":"shutdown-computevm-vm1","type":"microsoft.devtestlab/schedules","location":"westus"}'
     headers:
       cache-control:
       - no-cache
@@ -794,7 +794,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:41:00 GMT
+      - Sat, 09 May 2020 02:06:28 GMT
       expires:
       - '-1'
       pragma:
@@ -829,23 +829,23 @@ interactions:
       - -g -n --off
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vm_auto_shutdown000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001","name":"cli_test_vm_auto_shutdown000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-04-30T07:38:37Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vm_auto_shutdown000001","name":"cli_test_vm_auto_shutdown000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-09T02:03:54Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '471'
+      - '428'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 30 Apr 2020 07:41:02 GMT
+      - Sat, 09 May 2020 02:06:30 GMT
       expires:
       - '-1'
       pragma:
@@ -876,7 +876,7 @@ interactions:
       - -g -n --off
       User-Agent:
       - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.3
-        azure-mgmt-devtestlabs/4.0.0 Azure-SDK-For-Python AZURECLI/2.5.0
+        azure-mgmt-devtestlabs/4.0.0 Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: DELETE
@@ -890,7 +890,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 30 Apr 2020 07:41:05 GMT
+      - Sat, 09 May 2020 02:06:34 GMT
       expires:
       - '-1'
       pragma:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Issue: #12701 #7234
PR: https://github.com/Azure/azure-cli/pull/13199

Remove a validation in client side. @jiasli @triple-it
Let service make the decision. The current behavior of service is that webhook is mandatory. I don't think it is reasonable, either. Maybe the service will update in the future. Anyway, remove this validation in CLI.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
