### PR TITLE
{ACR} Use azure.multiapi.storage for storage blob service

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
@@ -12,14 +12,14 @@ import requests
 from knack.log import get_logger
 from knack.util import CLIError
 from msrestazure.azure_exceptions import CloudError
-from azure.storage.blob import BlockBlobService
+from azure.cli.core.profiles import ResourceType, get_sdk
 from ._azure_utils import get_blob_info
 from ._constants import TASK_VALID_VSTS_URLS
 
 logger = get_logger(__name__)
 
 
-def upload_source_code(client,
+def upload_source_code(cmd, client,
                        registry_name,
                        resource_group_name,
                        source_location,
@@ -54,6 +54,7 @@ def upload_source_code(client,
         raise CLIError("Failed to get a SAS URL to upload context.")
 
     account_name, endpoint_suffix, container_name, blob_name, sas_token = get_blob_info(upload_url)
+    BlockBlobService = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE, 'blob#BlockBlobService')
     BlockBlobService(account_name=account_name,
                      sas_token=sas_token,
                      endpoint_suffix=endpoint_suffix).create_blob_from_path(

--- a/src/azure-cli/azure/cli/command_modules/acr/_stream_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_stream_utils.py
@@ -9,8 +9,8 @@ import colorama
 from knack.util import CLIError
 from knack.log import get_logger
 from msrestazure.azure_exceptions import CloudError
-from azure.storage.blob import AppendBlobService
 from azure.common import AzureHttpError
+from azure.cli.core.profiles import ResourceType, get_sdk
 from ._azure_utils import get_blob_info
 
 logger = get_logger(__name__)
@@ -19,7 +19,7 @@ DEFAULT_CHUNK_SIZE = 1024 * 4
 DEFAULT_LOG_TIMEOUT_IN_SEC = 60 * 30  # 30 minutes
 
 
-def stream_logs(client,
+def stream_logs(cmd, client,
                 run_id,
                 registry_name,
                 resource_group_name,
@@ -43,7 +43,7 @@ def stream_logs(client,
 
     account_name, endpoint_suffix, container_name, blob_name, sas_token = get_blob_info(
         log_file_sas)
-
+    AppendBlobService = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE, 'blob#AppendBlobService')
     _stream_logs(no_format,
                  DEFAULT_CHUNK_SIZE,
                  DEFAULT_LOG_TIMEOUT_IN_SEC,

--- a/src/azure-cli/azure/cli/command_modules/acr/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_utils.py
@@ -435,7 +435,7 @@ def parse_actions_from_repositories(allow_or_remove_repository):
     return actions
 
 
-def prepare_source_location(source_location, client_registries, registry_name, resource_group_name):
+def prepare_source_location(cmd, source_location, client_registries, registry_name, resource_group_name):
     if not source_location or source_location.lower() == ACR_NULL_CONTEXT:
         source_location = None
     elif os.path.exists(source_location):
@@ -448,7 +448,7 @@ def prepare_source_location(source_location, client_registries, registry_name, r
 
         try:
             source_location = upload_source_code(
-                client_registries, registry_name, resource_group_name,
+                cmd, client_registries, registry_name, resource_group_name,
                 source_location, tar_file_path, "", "")
         except Exception as err:
             raise CLIError(err)

--- a/src/azure-cli/azure/cli/command_modules/acr/build.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/build.py
@@ -69,7 +69,7 @@ def acr_build(cmd,  # pylint: disable=too-many-locals
                 uuid.uuid4().hex, original_docker_file_name)
 
             source_location = upload_source_code(
-                client_registries, registry_name, resource_group_name,
+                cmd, client_registries, registry_name, resource_group_name,
                 source_location, tar_file_path,
                 docker_file_path, docker_file_in_tar)
             # For local source, the docker file is added separately into tar as the new file name (docker_file_in_tar)

--- a/src/azure-cli/azure/cli/command_modules/acr/build.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/build.py
@@ -134,7 +134,7 @@ def acr_build(cmd,  # pylint: disable=too-many-locals
         from ._run_polling import get_run_with_polling
         return get_run_with_polling(cmd, client, run_id, registry_name, resource_group_name)
 
-    return stream_logs(client, run_id, registry_name, resource_group_name, no_format, True)
+    return stream_logs(cmd, client, run_id, registry_name, resource_group_name, no_format, True)
 
 
 def _warn_unsupported_image_name(image_names):

--- a/src/azure-cli/azure/cli/command_modules/acr/pack.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/pack.py
@@ -49,7 +49,7 @@ def acr_pack_build(cmd,  # pylint: disable=too-many-locals
 
     client_registries = cf_acr_registries_tasks(cmd.cli_ctx)
     source_location = prepare_source_location(
-        source_location, client_registries, registry_name, resource_group_name)
+        cmd, source_location, client_registries, registry_name, resource_group_name)
     if not source_location:
         raise CLIError('Building with Buildpacks requires a valid source location.')
 
@@ -109,4 +109,4 @@ def acr_pack_build(cmd,  # pylint: disable=too-many-locals
         from ._run_polling import get_run_with_polling
         return get_run_with_polling(cmd, client, run_id, registry_name, resource_group_name)
 
-    return stream_logs(client, run_id, registry_name, resource_group_name, no_format, True)
+    return stream_logs(cmd, client, run_id, registry_name, resource_group_name, no_format, True)

--- a/src/azure-cli/azure/cli/command_modules/acr/run.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/run.py
@@ -52,7 +52,7 @@ def acr_run(cmd,  # pylint: disable=too-many-locals
 
     client_registries = cf_acr_registries_tasks(cmd.cli_ctx)
     source_location = prepare_source_location(
-        source_location, client_registries, registry_name, resource_group_name)
+        cmd, source_location, client_registries, registry_name, resource_group_name)
 
     platform_os, platform_arch, platform_variant = get_validate_platform(cmd, platform)
 
@@ -114,4 +114,4 @@ def acr_run(cmd,  # pylint: disable=too-many-locals
         from ._run_polling import get_run_with_polling
         return get_run_with_polling(cmd, client, run_id, registry_name, resource_group_name)
 
-    return stream_logs(client, run_id, registry_name, resource_group_name, no_format, True)
+    return stream_logs(cmd, client, run_id, registry_name, resource_group_name, no_format, True)

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -795,7 +795,7 @@ def acr_task_run(cmd,  # pylint: disable=too-many-locals
         update_trigger_token = base64.b64encode(update_trigger_token.encode()).decode()
 
     task_id = get_task_id_from_task_name(cmd.cli_ctx, resource_group_name, registry_name, task_name)
-    context_path = prepare_source_location(context_path, client_registries, registry_name, resource_group_name)
+    context_path = prepare_source_location(cmd, context_path, client_registries, registry_name, resource_group_name)
 
     override_task_step_properties = OverrideTaskStepProperties(
         context_path=context_path,

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -828,7 +828,7 @@ def acr_task_run(cmd,  # pylint: disable=too-many-locals
         from ._run_polling import get_run_with_polling
         return get_run_with_polling(cmd, client, run_id, registry_name, resource_group_name)
 
-    return stream_logs(client, run_id, registry_name, resource_group_name, True)
+    return stream_logs(cmd, client, run_id, registry_name, resource_group_name, True)
 
 
 def acr_task_show_run(cmd,
@@ -920,7 +920,7 @@ def acr_task_logs(cmd,
                                                   task_name=task_name,
                                                   image=image))
 
-    return stream_logs(client, run_id, registry_name, resource_group_name)
+    return stream_logs(cmd, client, run_id, registry_name, resource_group_name)
 
 
 def _get_list_runs_message(base_message, task_name=None, image=None):

--- a/src/azure-cli/azure/cli/command_modules/acr/taskrun.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/taskrun.py
@@ -59,4 +59,4 @@ def acr_taskrun_logs(cmd,
     response = client_taskruns.get(resource_group_name, registry_name, taskrun_name)
     run_id = response.run_result.run_id
 
-    return stream_logs(client, run_id, registry_name, resource_group_name)
+    return stream_logs(cmd, client, run_id, registry_name, resource_group_name)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -36,7 +36,6 @@ from azure.mgmt.storage import StorageManagementClient
 from azure.mgmt.applicationinsights import ApplicationInsightsManagementClient
 from azure.mgmt.relay.models import AccessRights
 from azure.cli.command_modules.relay._client_factory import hycos_mgmt_client_factory, namespaces_mgmt_client_factory
-from azure.storage.blob import BlockBlobService, BlobPermissions
 from azure.cli.command_modules.network._client_factory import network_client_factory
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
@@ -44,7 +43,7 @@ from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.util import in_cloud_console, shell_safe_json_parse, open_page_in_browser, get_json_object, \
     ConfiguredDefaultSetter, sdk_no_wait
 from azure.cli.core.util import get_az_user_agent
-from azure.cli.core.profiles import ResourceType
+from azure.cli.core.profiles import ResourceType, get_sdk
 
 from .tunnel import TunnelServer
 
@@ -502,7 +501,7 @@ def upload_zip_to_storage(cmd, resource_group_name, name, src, slot=None):
 
     container_name = "function-releases"
     blob_name = "{}-{}.zip".format(datetime.datetime.today().strftime('%Y%m%d%H%M%S'), str(uuid.uuid4()))
-
+    BlockBlobService = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE, 'blob#BlockBlobService')
     block_blob_service = BlockBlobService(connection_string=storage_connection)
     if not block_blob_service.exists(container_name):
         block_blob_service.create_container(container_name)
@@ -522,6 +521,7 @@ def upload_zip_to_storage(cmd, resource_group_name, name, src, slot=None):
     now = datetime.datetime.now()
     blob_start = now - datetime.timedelta(minutes=10)
     blob_end = now + datetime.timedelta(weeks=520)
+    BlobPermissions = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE, 'blob#BlobPermissions')
     blob_token = block_blob_service.generate_blob_shared_access_signature(container_name,
                                                                           blob_name,
                                                                           permission=BlobPermissions(read=True),

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -36,6 +36,7 @@ from azure.mgmt.storage import StorageManagementClient
 from azure.mgmt.applicationinsights import ApplicationInsightsManagementClient
 from azure.mgmt.relay.models import AccessRights
 from azure.cli.command_modules.relay._client_factory import hycos_mgmt_client_factory, namespaces_mgmt_client_factory
+from azure.storage.blob import BlockBlobService, BlobPermissions
 from azure.cli.command_modules.network._client_factory import network_client_factory
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
@@ -43,7 +44,7 @@ from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.util import in_cloud_console, shell_safe_json_parse, open_page_in_browser, get_json_object, \
     ConfiguredDefaultSetter, sdk_no_wait
 from azure.cli.core.util import get_az_user_agent
-from azure.cli.core.profiles import ResourceType, get_sdk
+from azure.cli.core.profiles import ResourceType
 
 from .tunnel import TunnelServer
 
@@ -501,7 +502,7 @@ def upload_zip_to_storage(cmd, resource_group_name, name, src, slot=None):
 
     container_name = "function-releases"
     blob_name = "{}-{}.zip".format(datetime.datetime.today().strftime('%Y%m%d%H%M%S'), str(uuid.uuid4()))
-    BlockBlobService = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE, 'blob#BlockBlobService')
+
     block_blob_service = BlockBlobService(connection_string=storage_connection)
     if not block_blob_service.exists(container_name):
         block_blob_service.create_container(container_name)
@@ -521,7 +522,6 @@ def upload_zip_to_storage(cmd, resource_group_name, name, src, slot=None):
     now = datetime.datetime.now()
     blob_start = now - datetime.timedelta(minutes=10)
     blob_end = now + datetime.timedelta(weeks=520)
-    BlobPermissions = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE, 'blob#BlobPermissions')
     blob_token = block_blob_service.generate_blob_shared_access_signature(container_name,
                                                                           blob_name,
                                                                           permission=BlobPermissions(read=True),


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Because the latest `azure.storage.blob` is for track2 without supporting for `BlockBlobService`, `AppendBlobService` ..., which are in track1, using `azure.multiapi.storage` can prevent the breaking change in `azure.stroage.blob`.

**Testing Guide**  
<!--Example commands with explanations.-->

From my investigation, these changes will influence `az acr build` and `az acr pack build`, but there is no test for these commands.
@yugangw-msft  Can you help test them? And I will recommend you to add test for such commands. 

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
