### PR TITLE
{batchai} Change storage dependency

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/batchai/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/batchai/custom.py
@@ -766,6 +766,9 @@ def _get_files_from_bfs(cli_ctx, bfs, path, expiry):
     """
     from azure.storage.blob import BlockBlobService
     from azure.storage.blob.models import Blob, BlobPermissions
+    BlockBlobService = get_sdk(cli_ctx, ResourceType.DATA_STORAGE, 'blob#BlockBlobService')
+    Blob = get_sdk(cli_ctx, ResourceType.DATA_STORAGE, 'blob#Blob')
+    BlobPermissions = get_sdk(cli_ctx, ResourceType.DATA_STORAGE, 'blob#BlobPermissions')
     result = []
     service = BlockBlobService(bfs.account_name, _get_storage_account_key(cli_ctx, bfs.account_name, None))
     effective_path = _get_path_for_storage(path)

--- a/src/azure-cli/azure/cli/command_modules/batchai/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/batchai/custom.py
@@ -764,8 +764,6 @@ def _get_files_from_bfs(cli_ctx, bfs, path, expiry):
     :param str path: path to list files from.
     :param int expiry: SAS expiration time in minutes.
     """
-    from azure.storage.blob import BlockBlobService
-    from azure.storage.blob.models import Blob, BlobPermissions
     BlockBlobService = get_sdk(cli_ctx, ResourceType.DATA_STORAGE, 'blob#BlockBlobService')
     Blob = get_sdk(cli_ctx, ResourceType.DATA_STORAGE, 'blob#Blob')
     BlobPermissions = get_sdk(cli_ctx, ResourceType.DATA_STORAGE, 'blob#BlobPermissions')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Because the latest `azure.storage.blob` is for track2 without supporting for `BlockBlobService`, `AppendBlobService` ..., which are in track1, using `azure.multiapi.storage` can prevent the breaking change in `azure.stroage.blob`.

**Testing Guide**  
<!--Example commands with explanations.-->

`az batchai cluster file list`

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
