### PR TITLE
[AKS] Fix that cli doe not fail when user only specifies Windows password

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1738,7 +1738,17 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
         linux_profile = ContainerServiceLinuxProfile(admin_username=admin_username, ssh=ssh_config)
 
     windows_profile = None
-    if windows_admin_username:
+    if windows_admin_username or windows_admin_password:
+        # To avoid that windows_admin_password is set but windows_admin_username is not
+        if windows_admin_username is None:
+            try:
+                from knack.prompting import prompt
+                windows_admin_username = prompt('windows_admin_username: ')
+                # The validation for admin_username in ManagedClusterWindowsProfile will fail even if
+                # users still set windows_admin_username to empty here
+            except NoTTYException:
+                raise CLIError('Please specify username for Windows in non-interactive mode.')
+
         if windows_admin_password is None:
             try:
                 windows_admin_password = prompt_pass(


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This change will help users to validate whether windows-admin-username is set when they want to create a cluster with Windows agent pools.
For example, a user only sets windows-admin-passowrd so a cluster without specifying Windows admin username and password will be created.
```
az aks create --resource-group testcanada --name canada2 --node-count 1 --kubernetes-version 1.14.1 --generate-ssh-keys --windows-admin-password "P@SSW)RD!@#!@" --enable-vmss --network-plugin azure
```


**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
