### PR TITLE
{Core} Bump to jmespath==0.9.5

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -98,7 +98,7 @@ idna==2.8
 invoke==1.2.0
 isodate==0.6.0
 Jinja2==2.10.1
-jmespath==0.9.4
+jmespath==0.9.5
 jsmin==2.2.2
 knack==0.7.0rc4
 MarkupSafe==1.1.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -98,7 +98,7 @@ idna==2.8
 invoke==1.2.0
 isodate==0.6.0
 Jinja2==2.10.1
-jmespath==0.9.4
+jmespath==0.9.5
 jsmin==2.2.2
 knack==0.7.0rc4
 MarkupSafe==1.1.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -96,7 +96,7 @@ idna==2.8
 invoke==1.2.0
 isodate==0.6.0
 Jinja2==2.10.1
-jmespath==0.9.4
+jmespath==0.9.5
 jsmin==2.2.2
 knack==0.7.0rc4
 MarkupSafe==1.1.1


### PR DESCRIPTION
Doc update to jmespath version 0.9.5

Customer has raised a Github issue https://github.com/MicrosoftDocs/azure-docs-cli/issues/1966 to get the doc updated with latest version of jmespath to reflect the issue that was resolved. 

after upgrade Fedora32, run az command wil raises SynataxWarning
```
/usr/lib64/az/lib/python3.6/site-packages/jmespath/visitor.py:32: SyntaxWarning: "is" with a literal. Did you mean "=="?
if x is 0 or x is 1:
/usr/lib64/az/lib/python3.6/site-packages/jmespath/visitor.py:32: SyntaxWarning: "is" with a literal. Did you mean "=="?
if x is 0 or x is 1:
/usr/lib64/az/lib/python3.6/site-packages/jmespath/visitor.py:34: SyntaxWarning: "is" with a literal. Did you mean "=="?
elif y is 0 or y is 1:
/usr/lib64/az/lib/python3.6/site-packages/jmespath/visitor.py:34: SyntaxWarning: "is" with a literal. Did you mean "=="?
elif y is 0 or y is 1:
/usr/lib64/az/lib/python3.6/site-packages/jmespath/visitor.py:260: SyntaxWarning: "is" with a literal. Did you mean "=="?
if original_result is 0:
```

this issues is fixed by jmespath 0.9.5
jmespath/jmespath.py#187

Maybe this requirement document should be upgrade
https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/requirements.py3.Linux.txt
