### PR TITLE
[ARO]Change CLIError to correct flag for --worker-vm-disk-size-gb

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_validators.py
@@ -220,4 +220,4 @@ def validate_worker_vm_disk_size_gb(namespace):
 
         if namespace.worker_vm_disk_size_gb < 128:
             raise CLIError(
-                '--worker_vm_disk_size_gb must be greater than or equal to 128.')
+                '--worker-vm-disk-size-gb must be greater than or equal to 128.')

--- a/src/azure-cli/azure/cli/command_modules/aro/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_validators.py
@@ -177,6 +177,7 @@ def validate_visibility(key):
     def _validate_visibility(namespace):
         visibility = getattr(namespace, key)
         if visibility is not None:
+            visibility = visibility.capitalize()
             if visibility not in ['Private', 'Public']:
                 raise CLIError("Invalid --%s '%s'." %
                                (key.replace('_', '-'), visibility))


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
CLIError pointed to flag `--worker_vm_disk_size_gb` instead of `--worker-vm-disk-size-gb`

**Testing Guide**  
<!--Example commands with explanations.-->
`None`

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
