### PR TITLE
[ARM] `az deployment operation`: Redirect to `az deployment operation`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/commands.py
@@ -256,9 +256,9 @@ def load_command_table(self, _):
         g.custom_wait_command('wait', 'get_deployment_at_subscription_scope', deprecate_info=g.deprecate(redirect='deployment sub wait', hide=True))
         g.custom_command('cancel', 'cancel_deployment_at_subscription_scope', deprecate_info=g.deprecate(redirect='deployment sub cancel', hide=True))
 
-    with self.command_group('deployment operation', resource_deployment_operation_sdk, min_api='2018-05-01', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES, deprecate_info=self.deprecate(redirect='deployment operation sub', hide=True)) as g:
-        g.custom_command('list', 'list_deployment_operations_at_subscription_scope')
-        g.custom_show_command('show', 'get_deployment_operations_at_subscription_scope', client_factory=cf_deployment_operations)
+    with self.command_group('deployment operation', resource_deployment_operation_sdk, min_api='2018-05-01', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES) as g:
+        g.custom_command('list', 'list_deployment_operations_at_subscription_scope', deprecate_info=g.deprecate(redirect='deployment operation sub list', hide=True))
+        g.custom_show_command('show', 'get_deployment_operations_at_subscription_scope', client_factory=cf_deployment_operations, deprecate_info=g.deprecate(redirect='deployment operation sub show', hide=True))
 
     # az deployment sub
     with self.command_group('deployment sub', resource_deployment_sdk, min_api='2018-05-01', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES) as g:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
We have a deprecation info for 'az deployment operation' to redicrect to 'az deployment operation sub'. Today the issue is that notice is returned for the other sub groups in 'az deployment operation'. e.g. you see the notice even for 'az deployment operation group'. 

The PR is a fix for that issue. 

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
