### PR TITLE
[Compute] az vm list-skus: Update --zone behavior, return all type skus now

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -442,7 +442,7 @@ def load_arguments(self, _):
 
     with self.argument_context('vm list-skus') as c:
         c.argument('size', options_list=['--size', '-s'], help="size name, partial name is accepted")
-        c.argument('zone', options_list=['--zone', '-z'], arg_type=get_three_state_flag(), help="show all vm size supporting availability zones")
+        c.argument('zone', options_list=['--zone', '-z'], arg_type=get_three_state_flag(), help="show skus supporting availability zones")
         c.argument('show_all', options_list=['--all'], arg_type=get_three_state_flag(),
                    help="show all information including vm sizes not available under the current subscription")
         c.argument('resource_type', options_list=['--resource-type', '-r'], help='resource types e.g. "availabilitySets", "snapshots", "disks", etc')

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -983,8 +983,7 @@ def list_skus(cmd, location=None, size=None, zone=None, show_all=None, resource_
     if size:
         result = [x for x in result if x.resource_type == 'virtualMachines' and size.lower() in x.name.lower()]
     if zone:
-        result = [x for x in result if x.resource_type == 'virtualMachines' and
-                  x.location_info and x.location_info[0].zones]
+        result = [x for x in result if x.location_info and x.location_info[0].zones]
     return result
 
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

https://github.com/Azure/azure-cli/issues/13407

`az vm list-skus` lists details for compute-related resource SKUs.
`--zone` parameter has a wrong behavior.
```
--zone -z
Show all vm size supporting availability zones.
```

**Before:**
```
> az vm list-skus -l uksouth -r hostGroups/hosts -z true -o table

```
**After:**
```
> az vm list-skus -l uksouth -r hostGroups/hosts -z true -o table
ResourceType      Locations    Name        Zones    Restrictions
----------------  -----------  ----------  -------  --------------
hostGroups/hosts  uksouth      DSv3-Type1  1,2,3    None
hostGroups/hosts  uksouth      ESv3-Type1  1,2,3    None
hostGroups/hosts  uksouth      DSv3-Type2  1,2,3    None
hostGroups/hosts  uksouth      ESv3-Type2  1,2,3    None
hostGroups/hosts  uksouth      FSv2-Type2  1,2,3    None
```

**Testing Guide**  
<!--Example commands with explanations.-->
```
az vm list-skus -l uksouth -r hostGroups/hosts -z true -o table
```

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
