### PR TITLE
{Identity} Adopt latest changes from Azure Identity #10612

### DIFF
--- a/src/azure-cli-core/azure/cli/core/authentication.py
+++ b/src/azure-cli-core/azure/cli/core/authentication.py
@@ -48,14 +48,14 @@ class AuthenticationWrapper(Authentication):
             if in_cloud_console():
                 AuthenticationWrapper._log_hostname()
             raise err
-        except ClientAuthenticationError:
+        except ClientAuthenticationError as err:
             # pylint: disable=no-member
             if in_cloud_console():
                 AuthenticationWrapper._log_hostname()
 
             raise CLIError("Credentials have expired due to inactivity or "
-                           "configuration of your account was changed.{}".format(
-                               "Please run 'az login'" if not in_cloud_console() else ''))
+                           "configuration of your account was changed. {}Error details: {}".format(
+                           "Please run 'az login'. " if not in_cloud_console() else '', err))
             # todo: error type
             # err = (getattr(err, 'error_response', None) or {}).get('error_description') or ''
             # if 'AADSTS70008' in err:  # all errors starting with 70008 should be creds expiration related


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Adopt latest changes from Azure Identity https://github.com/Azure/azure-sdk-for-python/pull/10612

As stated in https://github.com/chlowell/azure-sdk-for-python/pull/4#issuecomment-619240415, `UsernamePasswordCredential` doesn't support `authenticate` anymore. When **username+password** is used as authentication method, `AuthenticationRecord` can't be created. Azure CLI can't persist `AuthenticationRecord` and retrieve the refresh token anymore. 
  
Actually, I think maybe we shouldn't use the name Interactive, but instead, we can flatten `InteractiveCredential` and directly put `InteractiveBrowserCredential`, `DeviceCodeCredential` and `UsernamePasswordCredential` under `PublicClientCredential`.

Created [Teams thread :UsernamePasswordCredential.authenticate is removed](https://teams.microsoft.com/l/message/19:85462ed2792e424bb248555e238caa8c@thread.skype/1589354647097?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1589354647097&teamName=Azure%20SDK&channelName=Service%20-%20Azure.Identity&createdTime=1589354647097)
