### PR TITLE
[Lab] Fix for issue #7904 date validation bug in lab vm creation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/lab/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/validators.py
@@ -143,7 +143,7 @@ def _validate_expiration_date(namespace):
     if namespace.expiration_date:
         import datetime
         import dateutil.parser
-        if datetime.datetime.utcnow().date() >= dateutil.parser.parse(namespace.expiration_date).date():
+        if datetime.datetime.utcnow() >= dateutil.parser.parse(namespace.expiration_date):
             raise CLIError("Expiration date '{}' must be in future.".format(namespace.expiration_date))
 
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Current documentation marks this as a naive UTC date. 

**Testing Guide**  
<!--Example commands with explanations.-->
`az lab vm create --lab-name {LabName} -g {ResourceGroup} --name {VMName} --image "Ubuntu Server 16.04 LTS" --image-type gallery --expiration-date {YYYY-MM-DDThh:mm:ss}`
* current datetime +2 hours
* vm should be created without error

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] Fix #7904: az lab vm create: Fix date validation

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
