### PR TITLE
{Core} Load vnet/subnet global definition for local context by default

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -351,7 +351,8 @@ class MainCommandsLoader(CLICommandsLoader):
         return self.command_table
 
     def load_arguments(self, command=None):
-        from azure.cli.core.commands.parameters import resource_group_name_type, get_location_type, deployment_name_type
+        from azure.cli.core.commands.parameters import (
+            resource_group_name_type, get_location_type, deployment_name_type, vnet_name_type, subnet_name_type)
         from knack.arguments import ignore_type
 
         # omit specific command to load everything
@@ -370,6 +371,8 @@ class MainCommandsLoader(CLICommandsLoader):
                 with loader.argument_context('') as c:
                     c.argument('resource_group_name', resource_group_name_type)
                     c.argument('location', get_location_type(self.cli_ctx))
+                    c.argument('vnet_name', vnet_name_type)
+                    c.argument('subnet', subnet_name_type)
                     c.argument('deployment_name', deployment_name_type)
                     c.argument('cmd', ignore_type)
 

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -304,17 +304,10 @@ zone_type = CLIArgumentType(
 )
 
 vnet_name_type = CLIArgumentType(
-    options_list='--vnet-name',
-    metavar='NAME',
-    help='The virtual network (VNet) name.',
-    completer=get_resource_name_completion_list('Microsoft.Network/virtualNetworks'),
     local_context_attribute=LocalContextAttribute(name='vnet_name', actions=[LocalContextAction.GET])
 )
 
 subnet_name_type = CLIArgumentType(
-    options_list='--subnet',
-    metavar='NAME',
-    help='The subnet name.',
     local_context_attribute=LocalContextAttribute(name='subnet_name', actions=[LocalContextAction.GET]))
 
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -198,6 +198,7 @@ class LocalContextScenarioTest(ScenarioTest):
     def tearDown(self):
         super(LocalContextScenarioTest, self).tearDown()
         self.cmd('local-context off')
+        self.cmd('local-context delete --all --purge -y')
         os.chdir(self.original_working_dir)
         if os.path.exists(self.working_dir):
             import shutil

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -198,7 +198,6 @@ class LocalContextScenarioTest(ScenarioTest):
     def tearDown(self):
         super(LocalContextScenarioTest, self).tearDown()
         self.cmd('local-context off')
-        self.cmd('local-context delete --all --purge -y')
         os.chdir(self.original_working_dir)
         if os.path.exists(self.working_dir):
             import shutil


### PR DESCRIPTION
**Description<!--Mandatory-->**  
We will support `vnet`/`subnet` for local context by default just as `resource_group` do. If the argument name is defined as `vnet_name` and `subnet`, it will support local context `GET` action automatically.

**Testing Guide**  

- `az local-context on`

> Command group 'local-context' is experimental and not covered by customer support. Please use with discretion.
> Local context is turned on, you can run `az local-context off` to turn it off.

- `az network vnet create -g myRG -n my-vnet-1 --subnet-name my-subnet-1`

> Local context is turned on. Its information is saved in working directory D:\code\cli\azure-cli. You can run `az local-context off` to turn it off.
> Command argument values saved to local context: --resource-group: xiaojianxu, --name: xxj-vnet-1, --subnet-name: xxj-subnet-1
> {
>   "newVNet": {
>     "addressSpace": {
>       "addressPrefixes": [
>         "10.0.0.0/16"
>       ]
>     },
>    ...
> }

- `az acr network-rule add -h`

> Command
>     az acr network-rule add : Add a network rule.
> 
> Arguments
>     --name -n [Required] : The name of the container registry. You can configure the default
>                            registry name using `az configure --defaults acr=<registry name>`.
>     --ip-address         : IPv4 address or CIDR range.
>     --resource-group -g  : Name of resource group. You can configure the default group using `az
>                            configure --defaults group=<name>`.  **Local Context: myRG**.
>     --subnet             : Name or ID of subnet. If name is supplied, `--vnet-name` must be
>                            supplied.  **Local Context: my-subnet-1**.
>     --vnet-name          : Name of a virtual network.  **Local Context: my-vnet-1**.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
