### PR TITLE
[ARM] az resource tag: Fix the problem of tagging resources with resource type `Microsoft.ContainerRegistry/registries/webhooks` (#13255)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -2581,7 +2581,8 @@ class _ResourceUtils(object):  # pylint: disable=too-many-instance-attributes
         # please add the service type that needs to be requested with PATCH type here
         # for example: the properties of RecoveryServices/vaults must be filled, and a PUT request that passes back
         # to properties will fail due to the lack of properties, so the PATCH type should be used
-        need_patch_service = ['Microsoft.RecoveryServices/vaults', 'Microsoft.Resources/resourceGroups']
+        need_patch_service = ['Microsoft.RecoveryServices/vaults', 'Microsoft.Resources/resourceGroups',
+                              'Microsoft.ContainerRegistry/registries/webhooks']
 
         if resource is not None and resource.type in need_patch_service:
             parameters = GenericResource(tags=tags)

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_tag_update_by_patch.yaml
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_tag_update_by_patch.yaml
@@ -13,131 +13,131 @@ interactions:
       ParameterSetName:
       - -g -n --resource-type --is-full-object -p
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorizations":[{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},{"applicationId":"3b2fa68d-a091-48c9-95be-88d572e08fb7","roleDefinitionId":"47d68fae-99c7-4c10-b9db-2316116a061e"}],"resourceTypes":[{"resourceType":"vaults","locations":["West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorizations":[{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},{"applicationId":"3b2fa68d-a091-48c9-95be-88d572e08fb7","roleDefinitionId":"47d68fae-99c7-4c10-b9db-2316116a061e"},{"applicationId":"9bdab391-7bbe-42e8-8132-e4491dc29cc0","roleDefinitionId":"0383f7f5-023d-4379-b2c7-9ef786459969"}],"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
+        SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-07-10-preview","2018-07-10","2018-01-10","2017-09-01","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '12029'
+      - '12934'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 15 Jan 2020 04:23:33 GMT
+      - Wed, 20 May 2020 07:22:51 GMT
       expires:
       - '-1'
       pragma:
@@ -169,24 +169,24 @@ interactions:
       ParameterSetName:
       - -g -n --resource-type --is-full-object -p
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2019-05-13
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
   response:
     body:
-      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-01-15T04%3A23%3A37.5206441Z''\"","properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-05-20T07%3A22%3A59.4370269Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '460'
+      - '544'
       content-type:
       - application/json
       date:
-      - Wed, 15 Jan 2020 04:23:37 GMT
+      - Wed, 20 May 2020 07:23:00 GMT
       expires:
       - '-1'
       pragma:
@@ -216,131 +216,131 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorizations":[{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},{"applicationId":"3b2fa68d-a091-48c9-95be-88d572e08fb7","roleDefinitionId":"47d68fae-99c7-4c10-b9db-2316116a061e"}],"resourceTypes":[{"resourceType":"vaults","locations":["West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorizations":[{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},{"applicationId":"3b2fa68d-a091-48c9-95be-88d572e08fb7","roleDefinitionId":"47d68fae-99c7-4c10-b9db-2316116a061e"},{"applicationId":"9bdab391-7bbe-42e8-8132-e4491dc29cc0","roleDefinitionId":"0383f7f5-023d-4379-b2c7-9ef786459969"}],"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
+        SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-07-10-preview","2018-07-10","2018-01-10","2017-09-01","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '12029'
+      - '12934'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 15 Jan 2020 04:23:38 GMT
+      - Wed, 20 May 2020 07:23:01 GMT
       expires:
       - '-1'
       pragma:
@@ -368,24 +368,24 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2019-05-13
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
   response:
     body:
-      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-01-15T04%3A23%3A37.5206441Z''\"","properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-05-20T07%3A22%3A59.4370269Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '460'
+      - '544'
       content-type:
       - application/json
       date:
-      - Wed, 15 Jan 2020 04:23:38 GMT
+      - Wed, 20 May 2020 07:23:01 GMT
       expires:
       - '-1'
       pragma:
@@ -421,24 +421,24 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2019-05-13
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
   response:
     body:
-      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-01-15T04%3A23%3A41.9549097Z''\"","tags":{"cli-test":"test"},"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-05-20T07%3A23%3A04.1584791Z''\"","tags":{"cli-test":"test"},"properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '487'
+      - '571'
       content-type:
       - application/json
       date:
-      - Wed, 15 Jan 2020 04:23:43 GMT
+      - Wed, 20 May 2020 07:23:06 GMT
       expires:
       - '-1'
       pragma:
@@ -472,131 +472,131 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorizations":[{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},{"applicationId":"3b2fa68d-a091-48c9-95be-88d572e08fb7","roleDefinitionId":"47d68fae-99c7-4c10-b9db-2316116a061e"}],"resourceTypes":[{"resourceType":"vaults","locations":["West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorizations":[{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},{"applicationId":"3b2fa68d-a091-48c9-95be-88d572e08fb7","roleDefinitionId":"47d68fae-99c7-4c10-b9db-2316116a061e"},{"applicationId":"9bdab391-7bbe-42e8-8132-e4491dc29cc0","roleDefinitionId":"0383f7f5-023d-4379-b2c7-9ef786459969"}],"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
+        SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-07-10-preview","2018-07-10","2018-01-10","2017-09-01","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '12029'
+      - '12934'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 15 Jan 2020 04:23:44 GMT
+      - Wed, 20 May 2020 07:23:07 GMT
       expires:
       - '-1'
       pragma:
@@ -624,24 +624,24 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2019-05-13
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
   response:
     body:
-      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-01-15T04%3A23%3A41.9549097Z''\"","tags":{"cli-test":"test"},"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-05-20T07%3A23%3A04.1584791Z''\"","tags":{"cli-test":"test"},"properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '487'
+      - '571'
       content-type:
       - application/json
       date:
-      - Wed, 15 Jan 2020 04:23:44 GMT
+      - Wed, 20 May 2020 07:23:08 GMT
       expires:
       - '-1'
       pragma:
@@ -677,24 +677,24 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2019-05-13
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
   response:
     body:
-      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-01-15T04%3A23%3A47.1378961Z''\"","tags":{},"properties":{"provisioningState":"Succeeded"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-05-20T07%3A23%3A10.7697117Z''\"","tags":{},"properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '470'
+      - '554'
       content-type:
       - application/json
       date:
-      - Wed, 15 Jan 2020 04:23:49 GMT
+      - Wed, 20 May 2020 07:23:13 GMT
       expires:
       - '-1'
       pragma:
@@ -722,30 +722,227 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
+      - resource delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorizations":[{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},{"applicationId":"3b2fa68d-a091-48c9-95be-88d572e08fb7","roleDefinitionId":"47d68fae-99c7-4c10-b9db-2316116a061e"},{"applicationId":"9bdab391-7bbe-42e8-8132-e4491dc29cc0","roleDefinitionId":"0383f7f5-023d-4379-b2c7-9ef786459969"}],"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-07-10-preview","2018-07-10","2018-01-10","2017-09-01","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12934'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 20 May 2020 07:23:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 20 May 2020 07:23:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '204'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
       - resource tag
       Connection:
       - keep-alive
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001","name":"cli_test_tag_update_by_patch000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-01-15T04:23:27Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001","name":"cli_test_tag_update_by_patch000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-05-20T07:21:37Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '428'
+      - '471'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 15 Jan 2020 04:23:49 GMT
+      - Wed, 20 May 2020 07:23:21 GMT
       expires:
       - '-1'
       pragma:
@@ -777,28 +974,234 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001","name":"cli_test_tag_update_by_patch000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"cli-test":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001","name":"cli_test_tag_update_by_patch000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"cli-test":"test","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '374'
+      - '417'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 15 Jan 2020 04:23:52 GMT
+      - Wed, 20 May 2020 07:23:24 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus", "sku": {"name": "Standard"}, "properties": {"adminUserEnabled":
+      false, "publicNetworkAccess": "Enabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - acr create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '128'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g -l --sku
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-containerregistry/3.0.0rc12
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003?api-version=2019-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"type":"Microsoft.ContainerRegistry/registries","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003","name":"clireg000003","location":"westus","tags":{},"properties":{"loginServer":"clireg000003.azurecr.io","creationDate":"2020-05-20T07:23:30.8133972Z","provisioningState":"Succeeded","adminUserEnabled":false,"policies":{"quarantinePolicy":{"status":"disabled"},"trustPolicy":{"type":"Notary","status":"disabled"},"retentionPolicy":{"days":7,"lastUpdatedTime":"2020-05-20T07:23:31.5644646+00:00","status":"disabled"}},"encryption":{"status":"disabled"},"dataEndpointEnabled":false,"dataEndpointHostNames":[],"privateEndpointConnections":[],"publicNetworkAccess":"Enabled"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '902'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 20 May 2020 07:23:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - acr webhook create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -r --uri --actions
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.ContainerRegistry%2Fregistries%27&api-version=2019-07-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003","name":"clireg000003","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Standard","tier":"Standard"},"location":"westus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/feng-cli-rg/providers/Microsoft.ContainerRegistry/registries/fengCR007","name":"fengCR007","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Basic","tier":"Basic"},"location":"centralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zhoxing-test/providers/Microsoft.ContainerRegistry/registries/zhoxingtest","name":"zhoxingtest","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Standard","tier":"Standard"},"location":"westus","tags":{}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '963'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 20 May 2020 07:23:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - acr webhook create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -r --uri --actions
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-containerregistry/3.0.0rc12
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003?api-version=2019-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"type":"Microsoft.ContainerRegistry/registries","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003","name":"clireg000003","location":"westus","tags":{},"properties":{"loginServer":"clireg000003.azurecr.io","creationDate":"2020-05-20T07:23:30.8133972Z","provisioningState":"Succeeded","adminUserEnabled":false,"policies":{"quarantinePolicy":{"status":"disabled"},"trustPolicy":{"type":"Notary","status":"disabled"},"retentionPolicy":{"days":7,"lastUpdatedTime":"2020-05-20T07:23:31.5644646+00:00","status":"disabled"}},"encryption":{"status":"disabled"},"dataEndpointEnabled":false,"dataEndpointHostNames":[],"privateEndpointConnections":[],"publicNetworkAccess":"Enabled"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '902'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 20 May 2020 07:23:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus", "properties": {"serviceUri": "http://www.microsoft.com",
+      "status": "enabled", "actions": ["push"]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - acr webhook create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -r --uri --actions
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-containerregistry/3.0.0rc12
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook?api-version=2019-12-01-preview
+  response:
+    body:
+      string: '{"type":"Microsoft.ContainerRegistry/registries/webhooks","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook","name":"cliregwebhook","location":"westus","tags":{},"properties":{"status":"enabled","scope":"","actions":["push"],"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 20 May 2020 07:23:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -820,137 +1223,1234 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorizations":[{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},{"applicationId":"737d58c1-397a-46e7-9d12-7d8c830883c2","roleDefinitionId":"716bb53a-0390-4428-bf41-b1bedde7d751"},{"applicationId":"918d0db8-4a38-4938-93c1-9313bdfe0272","roleDefinitionId":"dcd2d2c9-3f80-4d72-95a8-2593111b4b12"},{"applicationId":"d2fa1650-4805-4a83-bcb9-cf41fe63539c","roleDefinitionId":"c15f8dab-b103-4f8d-9afb-fbe4b8e98de2"},{"applicationId":"a4c95b9e-3994-40cc-8953-5dc66d48348d","roleDefinitionId":"dc88c655-90fa-48d9-8d51-003cc8738508"},{"applicationId":"62c559cd-db0c-4da0-bab2-972528c65d42","roleDefinitionId":"437b639a-6d74-491d-959f-d172e8c5c1fc"}],"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","France
+        Central","South Africa North","UAE North","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","East US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"registries/scopeMaps","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/tokens","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/generateCredentials","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnections","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies/validate","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateLinkResources","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/importImage","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","France Central","South
+        Africa North","UAE North","Central US","Canada East","Canada Central","UK
+        South","UK West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/exportPipelines","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/importPipelines","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/pipelineRuns","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/listBuildSourceUploadUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/scheduleRun","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/taskRuns","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"None"},{"resourceType":"registries/taskRuns/listDetails","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/agentPools","locations":["East
+        US","West US 2","South Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/agentPools/listQueueStatus","locations":["East
+        US","West US 2","South Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/runs/listLogSasUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs/cancel","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/tasks","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"defaultApiVersion":"2019-04-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"registries/tasks/listDetails","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/getBuildSourceUploadUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/queueBuild","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/getLogLink","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/cancel","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/buildTasks/listSourceRepositoryProperties","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps/listBuildArguments","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/setupAuth","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/authorize","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","France Central","Central
+        US","South Africa North","UAE North","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/listPolicies","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/updatePolicies","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/eventGridFilters","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01"],"capabilities":"None"},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01","2017-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '30392'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 20 May 2020 07:23:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook?api-version=2019-05-01
+  response:
+    body:
+      string: '{"type":"Microsoft.ContainerRegistry/registries/webhooks","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook","name":"cliregwebhook","location":"westus","tags":{},"properties":{"status":"enabled","scope":"","actions":["push"],"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 20 May 2020 07:23:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"tags": {"cli-test": "test"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook?api-version=2019-05-01
+  response:
+    body:
+      string: '{"type":"Microsoft.ContainerRegistry/registries/webhooks","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook","name":"cliregwebhook","location":"westus","tags":{"cli-test":"test"},"properties":{"status":"enabled","scope":"","actions":["push"],"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '467'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 20 May 2020 07:23:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorizations":[{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},{"applicationId":"737d58c1-397a-46e7-9d12-7d8c830883c2","roleDefinitionId":"716bb53a-0390-4428-bf41-b1bedde7d751"},{"applicationId":"918d0db8-4a38-4938-93c1-9313bdfe0272","roleDefinitionId":"dcd2d2c9-3f80-4d72-95a8-2593111b4b12"},{"applicationId":"d2fa1650-4805-4a83-bcb9-cf41fe63539c","roleDefinitionId":"c15f8dab-b103-4f8d-9afb-fbe4b8e98de2"},{"applicationId":"a4c95b9e-3994-40cc-8953-5dc66d48348d","roleDefinitionId":"dc88c655-90fa-48d9-8d51-003cc8738508"},{"applicationId":"62c559cd-db0c-4da0-bab2-972528c65d42","roleDefinitionId":"437b639a-6d74-491d-959f-d172e8c5c1fc"}],"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","France
+        Central","South Africa North","UAE North","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","East US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"registries/scopeMaps","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/tokens","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/generateCredentials","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnections","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies/validate","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateLinkResources","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/importImage","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","France Central","South
+        Africa North","UAE North","Central US","Canada East","Canada Central","UK
+        South","UK West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/exportPipelines","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/importPipelines","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/pipelineRuns","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/listBuildSourceUploadUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/scheduleRun","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/taskRuns","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"None"},{"resourceType":"registries/taskRuns/listDetails","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/agentPools","locations":["East
+        US","West US 2","South Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/agentPools/listQueueStatus","locations":["East
+        US","West US 2","South Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/runs/listLogSasUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs/cancel","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/tasks","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"defaultApiVersion":"2019-04-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"registries/tasks/listDetails","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/getBuildSourceUploadUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/queueBuild","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/getLogLink","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/cancel","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/buildTasks/listSourceRepositoryProperties","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps/listBuildArguments","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/setupAuth","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/authorize","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","France Central","Central
+        US","South Africa North","UAE North","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/listPolicies","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/updatePolicies","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/eventGridFilters","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01"],"capabilities":"None"},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01","2017-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '30392'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 20 May 2020 07:23:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook?api-version=2019-05-01
+  response:
+    body:
+      string: '{"type":"Microsoft.ContainerRegistry/registries/webhooks","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook","name":"cliregwebhook","location":"westus","tags":{"cli-test":"test"},"properties":{"status":"enabled","scope":"","actions":["push"],"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '467'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 20 May 2020 07:23:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"tags": {}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '12'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
+      accept-language:
+      - en-US
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook?api-version=2019-05-01
+  response:
+    body:
+      string: '{"type":"Microsoft.ContainerRegistry/registries/webhooks","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook","name":"cliregwebhook","location":"westus","tags":{},"properties":{"status":"enabled","scope":"","actions":["push"],"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 20 May 2020 07:23:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
       - resource delete
       Connection:
       - keep-alive
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorizations":[{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},{"applicationId":"3b2fa68d-a091-48c9-95be-88d572e08fb7","roleDefinitionId":"47d68fae-99c7-4c10-b9db-2316116a061e"}],"resourceTypes":[{"resourceType":"vaults","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorizations":[{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},{"applicationId":"737d58c1-397a-46e7-9d12-7d8c830883c2","roleDefinitionId":"716bb53a-0390-4428-bf41-b1bedde7d751"},{"applicationId":"918d0db8-4a38-4938-93c1-9313bdfe0272","roleDefinitionId":"dcd2d2c9-3f80-4d72-95a8-2593111b4b12"},{"applicationId":"d2fa1650-4805-4a83-bcb9-cf41fe63539c","roleDefinitionId":"c15f8dab-b103-4f8d-9afb-fbe4b8e98de2"},{"applicationId":"a4c95b9e-3994-40cc-8953-5dc66d48348d","roleDefinitionId":"dc88c655-90fa-48d9-8d51-003cc8738508"},{"applicationId":"62c559cd-db0c-4da0-bab2-972528c65d42","roleDefinitionId":"437b639a-6d74-491d-959f-d172e8c5c1fc"}],"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","France
+        Central","South Africa North","UAE North","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","East US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Central US
-        EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        SupportsLocation"},{"resourceType":"registries/scopeMaps","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/tokens","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/generateCredentials","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnections","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies/validate","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateLinkResources","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/importImage","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","France Central","South
+        Africa North","UAE North","Central US","Canada East","Canada Central","UK
+        South","UK West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/exportPipelines","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/importPipelines","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/pipelineRuns","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/listBuildSourceUploadUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/scheduleRun","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/taskRuns","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"None"},{"resourceType":"registries/taskRuns/listDetails","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/agentPools","locations":["East
+        US","West US 2","South Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/agentPools/listQueueStatus","locations":["East
+        US","West US 2","South Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/runs/listLogSasUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs/cancel","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/tasks","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"defaultApiVersion":"2019-04-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"registries/tasks/listDetails","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/getBuildSourceUploadUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/queueBuild","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/getLogLink","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/cancel","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/buildTasks/listSourceRepositoryProperties","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps/listBuildArguments","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/setupAuth","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/authorize","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","East US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","France Central","Central
+        US","South Africa North","UAE North","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/listPolicies","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/updatePolicies","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/eventGridFilters","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01"],"capabilities":"None"},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01","2017-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '12029'
+      - '30392'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 15 Jan 2020 04:23:53 GMT
+      - Wed, 20 May 2020 07:23:55 GMT
       expires:
       - '-1'
       pragma:
@@ -980,12 +2480,12 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-resource/6.0.0 Azure-SDK-For-Python AZURECLI/2.0.80
+      - python/3.8.0 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/9.0.0
+        Azure-SDK-For-Python AZURECLI/2.5.1
       accept-language:
       - en-US
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2019-05-13
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook?api-version=2019-05-01
   response:
     body:
       string: ''
@@ -995,17 +2495,19 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 15 Jan 2020 04:23:57 GMT
+      - Wed, 20 May 2020 07:23:59 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '199'
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
     status:
       code: 200
       message: OK


### PR DESCRIPTION
Issue: #13255

**Description<!--Mandatory-->**  
The properties of `ServiceUri` for `Microsoft.ContainerRegistry/registries/webhooks` must be filled, and a `PUT` request that passes back to properties will fail due to the lack of properties, so the `PATCH` type should be used.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
