### PR TITLE
[Network] az network private-endpoint: deprecate --group-ids and redirect to --group-id

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -771,7 +771,7 @@ def load_arguments(self, _):
         c.argument('subnet', validator=get_subnet_validator(), help=subnet_help, id_part=None)
         c.argument('virtual_network_name', help='The virtual network (VNet) associated with the subnet (Omit if supplying a subnet id).', metavar='', id_part=None)
         c.argument('private_connection_resource_id', help='The resource id of which private enpoint connect to')
-        c.argument('group_ids', nargs='+', help='The ID(s) of the group(s) obtained from the remote resource that this private endpoint should connect to. You can use "az keyvault(storage/etc) private-link-resource list" to obtain the list of group ids.')
+        c.argument('group_ids', nargs='+', options_list=[c.deprecate(target='--group-ids', redirect='--group-id'), '--group-id'], help='The ID of the group obtained from the remote resource that this private endpoint should connect to. You can use "az network private-link-resource list" to obtain the list of group ids.')
         c.argument('request_message', help='A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars.')
         c.argument('manual_request', help='Use manual request to establish the connection', arg_type=get_three_state_flag())
         c.argument('connection_name', help='Name of the private link service connection.')

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
@@ -67,7 +67,7 @@ class NetworkPrivateLinkKeyVaultScenarioTest(ScenarioTest):
                       '-l {loc} '
                       '--connection-name {pe_connection} '
                       '--private-connection-resource-id {kv_id} '
-                      '--group-ids vault').get_output_in_json()
+                      '--group-id vault').get_output_in_json()
         self.kwargs['pe_id'] = pe['id']
 
         # Show the connection at vault side
@@ -178,7 +178,7 @@ class NetworkPrivateLinkStorageAccountScenarioTest(ScenarioTest):
         private_endpoint = self.cmd(
             'network private-endpoint create -g {rg} -n {pe} --vnet-name {vnet} --subnet {subnet} -l {loc} '
             '--connection-name {pe_connection} --private-connection-resource-id {sa_id} '
-            '--group-ids blob').get_output_in_json()
+            '--group-id blob').get_output_in_json()
         self.assertEqual(private_endpoint['name'], self.kwargs['pe'])
         self.assertEqual(private_endpoint['privateLinkServiceConnections'][0]['name'], self.kwargs['pe_connection'])
         self.assertEqual(private_endpoint['privateLinkServiceConnections'][0]['privateLinkServiceConnectionState']['status'], 'Approved')
@@ -245,7 +245,7 @@ class NetworkPrivateLinkACRScenarioTest(ScenarioTest):
         # add an endpoint and approve it
         result = self.cmd(
             'network private-endpoint create -n {endpoint_name} -g {rg} --subnet {subnet_name} --vnet-name {vnet_name}  '
-            '--private-connection-resource-id {registry_id} --group-ids registry --connection-name {endpoint_conn_name} --manual-request').get_output_in_json()
+            '--private-connection-resource-id {registry_id} --group-id registry --connection-name {endpoint_conn_name} --manual-request').get_output_in_json()
         self.assertTrue(self.kwargs['endpoint_name'].lower() in result['name'].lower())
 
         result = self.cmd(
@@ -261,7 +261,7 @@ class NetworkPrivateLinkACRScenarioTest(ScenarioTest):
 
         # add an endpoint and then reject it
         self.cmd(
-            'network private-endpoint create -n {second_endpoint_name} -g {rg} --subnet {subnet_name} --vnet-name {vnet_name} --private-connection-resource-id {registry_id} --group-ids registry --connection-name {second_endpoint_conn_name} --manual-request')
+            'network private-endpoint create -n {second_endpoint_name} -g {rg} --subnet {subnet_name} --vnet-name {vnet_name} --private-connection-resource-id {registry_id} --group-id registry --connection-name {second_endpoint_conn_name} --manual-request')
         result = self.cmd('network private-endpoint-connection list -g {rg} --name {registry_name} --type Microsoft.ContainerRegistry/registries').get_output_in_json()
 
         # the connection request name starts with the registry / resource name
@@ -363,7 +363,7 @@ class NetworkPrivateLinkPrivateLinkScopeScenarioTest(ScenarioTest):
         private_endpoint = self.cmd(
             'network private-endpoint create -g {rg} -n {pe} --vnet-name {vnet} --subnet {subnet} -l {loc} '
             '--connection-name {pe_connection} --private-connection-resource-id {scope_id} '
-            '--group-ids {group_id}').get_output_in_json()
+            '--group-id {group_id}').get_output_in_json()
         self.assertEqual(private_endpoint['name'], self.kwargs['pe'])
         self.assertEqual(private_endpoint['privateLinkServiceConnections'][0]['name'], self.kwargs['pe_connection'])
         self.assertEqual(
@@ -465,7 +465,7 @@ class NetworkPrivateLinkRDBMSScenarioTest(ScenarioTest):
         # Create a private endpoint connection
         private_endpoint = self.cmd('network private-endpoint create -g {} -n {} --vnet-name {} --subnet {} -l {} '
                                     '--connection-name {} --private-connection-resource-id {} '
-                                    '--group-ids {}'
+                                    '--group-id {}'
                                     .format(resource_group, pe_name_auto, vnet, subnet, loc, pe_connection_name_auto, server_id, group_id)).get_output_in_json()
         self.assertEqual(private_endpoint['name'], pe_name_auto)
         self.assertEqual(private_endpoint['privateLinkServiceConnections'][0]['name'], pe_connection_name_auto)
@@ -506,7 +506,7 @@ class NetworkPrivateLinkRDBMSScenarioTest(ScenarioTest):
         # Create a private endpoint connection
         private_endpoint = self.cmd('network private-endpoint create -g {} -n {} --vnet-name {} --subnet {} -l {} '
                                     '--connection-name {} --private-connection-resource-id {} '
-                                    '--group-ids {} --manual-request'
+                                    '--group-id {} --manual-request'
                                     .format(resource_group, pe_name_manual_approve, vnet, subnet, loc, pe_connection_name_manual_approve, server_id, group_id)).get_output_in_json()
         self.assertEqual(private_endpoint['name'], pe_name_manual_approve)
         self.assertEqual(private_endpoint['manualPrivateLinkServiceConnections'][0]['name'], pe_connection_name_manual_approve)
@@ -551,7 +551,7 @@ class NetworkPrivateLinkRDBMSScenarioTest(ScenarioTest):
         # Create a private endpoint connection
         private_endpoint = self.cmd('network private-endpoint create -g {} -n {} --vnet-name {} --subnet {} -l {} '
                                     '--connection-name {} --private-connection-resource-id {} '
-                                    '--group-ids {} --manual-request true'
+                                    '--group-id {} --manual-request true'
                                     .format(resource_group, pe_name_manual_reject, vnet, subnet, loc, pe_connection_name_manual_reject, server_id, group_id)).get_output_in_json()
         self.assertEqual(private_endpoint['name'], pe_name_manual_reject)
         self.assertEqual(private_endpoint['manualPrivateLinkServiceConnections'][0]['name'], pe_connection_name_manual_reject)
@@ -632,7 +632,7 @@ class NetworkPrivateLinkCosmosDBScenarioTest(ScenarioTest):
         # Create a private endpoint connection
         pe = self.cmd('network private-endpoint create -g {rg} -n {pe} --vnet-name {vnet} --subnet {subnet} -l {loc} '
                       '--connection-name {pe_connection} --private-connection-resource-id {acc_id} '
-                      '--group-ids Sql').get_output_in_json()
+                      '--group-id Sql').get_output_in_json()
         self.kwargs['pe_id'] = pe['id']
         self.kwargs['pe_name'] = self.kwargs['pe_id'].split('/')[-1]
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fix #13018 

![image](https://user-images.githubusercontent.com/49134743/82006809-3e725900-969b-11ea-9b43-0844dd1a5168.png)


**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
