### PR TITLE
[ARO] Add Public, Private to params for help with ingress/apiserver visibility

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_help.py
@@ -19,6 +19,8 @@ helps['aro create'] = """
         text: az aro create --resource-group MyResourceGroup --name MyCluster  --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet
       - name: Create an OpenShift cluster with 5 compute nodes and Red Hat Pull Secret
         text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --worker-count 5 --pull-secret @pullsecret.txt
+      - name: Create a Private OpenShift cluster
+        text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --apiserver-visibility Private --ingress-visibility Private
 """
 
 helps['aro list'] = """

--- a/src/azure-cli/azure/cli/command_modules/aro/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_params.py
@@ -16,6 +16,7 @@ from azure.cli.command_modules.aro._validators import validate_vnet_resource_gro
 from azure.cli.command_modules.aro._validators import validate_worker_count
 from azure.cli.command_modules.aro._validators import validate_worker_vm_disk_size_gb
 from azure.cli.core.commands.parameters import name_type
+from azure.cli.core.commands.parameters import get_enum_type
 from azure.cli.core.commands.parameters import resource_group_name_type
 from azure.cli.core.commands.parameters import get_location_type
 from azure.cli.core.commands.parameters import tags_type
@@ -69,12 +70,12 @@ def load_arguments(self, _):
                    help='Count of worker VMs.',
                    validator=validate_worker_count)
 
-        c.argument('apiserver_visibility',
-                   help='API server visibility. Allowed Values: Private, Public',
+        c.argument('apiserver_visibility', arg_type=get_enum_type(['Private', 'Public']),
+                   help='API server visibility.',
                    validator=validate_visibility('apiserver_visibility'))
 
-        c.argument('ingress_visibility',
-                   help='Ingress visibility. Allowed Values: Private, Public',
+        c.argument('ingress_visibility', arg_type=get_enum_type(['Private', 'Public']),
+                   help='Ingress visibility.',
                    validator=validate_visibility('ingress_visibility'))
 
         c.argument('vnet_resource_group_name',

--- a/src/azure-cli/azure/cli/command_modules/aro/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_params.py
@@ -70,11 +70,11 @@ def load_arguments(self, _):
                    validator=validate_worker_count)
 
         c.argument('apiserver_visibility',
-                   help='API server visibility.',
+                   help='API server visibility. Allowed Values: Private, Public',
                    validator=validate_visibility('apiserver_visibility'))
 
         c.argument('ingress_visibility',
-                   help='Ingress visibility.',
+                   help='Ingress visibility. Allowed Values: Private, Public',
                    validator=validate_visibility('ingress_visibility'))
 
         c.argument('vnet_resource_group_name',


### PR DESCRIPTION
Add Public, Private to params for help with ingress/apiserver visibility

**Description<!--Mandatory-->**  

<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Add to Public, Private to describe parameters accepted to --apiserver-visibility and ingress-visibility 
`src/azure-cli/azure/cli/command_modules/aro/_params.py`.
Add an example to `src/azure-cli/azure/cli/command_modules/aro/_help.py` to demonstrate how to create a private cluster when executing `az aro create --help`
Resolves https://github.com/Azure/azure-cli/issues/13530

**Testing Guide**  
<!--Example commands with explanations.-->
None

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
