### PR TITLE
[AKS] fix typo in 'az aks update' exception with no arguments

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2137,7 +2137,7 @@ def aks_update(cmd, client, resource_group_name, name,
                        '"--load-balancer-outbound-ip-prefixes" or'
                        '"--load-balancer-outbound-ports" or'
                        '"--load-balancer-idle-timeout" or'
-                       '"--attach-acr" or "--dettach-acr" or'
+                       '"--attach-acr" or "--detach-acr" or'
                        '"--"api-server-authorized-ip-ranges')
 
     instance = client.get(resource_group_name, name)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Running command `az aks update -g <resource-group> -n <resource-name>` with no further arguments will yield the following exception:

```
Please specify one or more of "--enable-cluster-autoscaler" or "--disable-cluster-autoscaler" or "--update-cluster-autoscaler" or "--load-balancer-managed-outbound-ip-count" or"--load-balancer-outbound-ips" or "--load-balancer-outbound-ip-prefixes" or"--load-balancer-outbound-ports" or"--load-balancer-idle-timeout" or"--attach-acr" or "--dettach-acr" or"--"api-server-authorized-ip-ranges
```

Note the suggestion for `--dettach-acr`. This is a typo as the actual flag is `--detach-acr` with a single t.

**Testing Guide**  
<!--Example commands with explanations.-->

Run the following command with valid resource names:
`az aks update -g <resource-group> -n <resource-name>`
**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AKS] az aks update -g <resource-group> -n <resource-name>: fixed a minor typo in the exception

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
