### PR TITLE
[Identity] Support Cloud Shell login

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -124,7 +124,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
 
     if identity:
         if in_cloud_console():
-            return profile.find_subscriptions_in_cloud_console()
+            return profile.login_in_cloud_shell()
         return profile.login_with_managed_identity(username, allow_no_subscriptions)
     if in_cloud_console():  # tell users they might not need login
         logger.warning(_CLOUD_CONSOLE_LOGIN_WARNING)


### PR DESCRIPTION
## Description

~~Currently can't test in Cloud Shell due to the lack of Python 3.6+. See internal email: Python 3.6+ support in Cloud Shell~~

Use [`pyenv`](https://github.com/pyenv/pyenv) to install Python 3.6+ in Cloud Shell. See https://stackoverflow.com/a/61890236/2199657. Special thanks to @NullMDR for this fascinating solution. 

Log in to Cloud Shell.

```
$ az login --identity
Using Cloud Shell Managed Identity: {"tenant_id": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "unique_name": "xxx@microsoft.com"}
[
  {
    "environmentName": "AzureCloud",
    "homeTenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "id": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "isDefault": true,
    "managedByTenants": [
      {
        "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
      }
    ],
    "name": "AzureSDKTest",
    "state": "Enabled",
    "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "user": {
      "cloudShellID": true,
      "name": "xxx@microsoft.com",
      "type": "user"
    }
  }
]
```

We can also test on a VM with managed identity and set env var `ACC_CLOUD=1` to mock Cloud Shell.

```
C:\Users\admin\env38\Scripts\python.exe C:/Users/admin/azure-cli/src/azure-cli/azure/cli/__main__.py login --identity
Using Cloud Shell Managed Identity: {"tenant_id": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "unique_name": "N/A"}
[
  {
    "environmentName": "AzureCloud",
    "homeTenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "id": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "isDefault": true,
    "managedByTenants": [
      {
        "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
      }
    ],
    "name": "AzureSDKTest",
    "state": "Enabled",
    "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "user": {
      "cloudShellID": true,
      "name": "N/A",
      "type": "user"
    }
  }
]

```

**Testing Guide** 
``` sh
# Install and configure pyenv since we don't have sudo permission in Cloud Shell
curl https://pyenv.run | bash

echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> ~/.bashrc
echo 'eval "$(pyenv init -)"' >> ~/.bashrc
echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc

pyenv install 3.8.3
exec $SHELL

# Follow normal workflow to set up dev environment
python -m venv env383
. ~/env383/bin/activate
pip install azdev
git clone https://github.com/Azure/azure-cli
git fetch origin refs/pull/13567/head
git checkout -b identity-cloud-shell FETCH_HEAD
git clone https://github.com/Azure/azure-sdk-for-python

azdev setup -c
pip install -e azure-sdk-for-python/sdk/identity/azure-identity

# Login with Cloud Shell's identity
az login --identity
```
