### PR TITLE
{Extensions} tests: do not import from absolute path

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_dev_type_extension.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_dev_type_extension.py
@@ -11,7 +11,10 @@ import shutil
 import unittest
 
 from azure.cli.core.extension import DevExtension
-from azure.cli.core.extension.tests.latest import ExtensionTypeTestMixin, get_test_data_file
+try:
+    from azure.cli.core.extension.tests.latest import ExtensionTypeTestMixin, get_test_data_file
+except ImportError:
+    from . import ExtensionTypeTestMixin, get_test_data_file
 
 
 class TestWheelTypeExtensionMetadata(ExtensionTypeTestMixin):

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_wheel_type_extension.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_wheel_type_extension.py
@@ -11,7 +11,10 @@ import shutil
 import unittest
 
 from azure.cli.core.extension import WheelExtension
-from azure.cli.core.extension.tests.latest import ExtensionTypeTestMixin, get_test_data_file
+try:
+    from azure.cli.core.extension.tests.latest import ExtensionTypeTestMixin, get_test_data_file
+except ImportError:
+    from . import ExtensionTypeTestMixin, get_test_data_file
 
 
 class TestWheelTypeExtensionMetadata(ExtensionTypeTestMixin):


### PR DESCRIPTION
Test files/modules are not installed. Import from the current directory, or they will
fail when running in detached mode (eg: autopkgtest in Debian/Ubuntu).
