### PR TITLE
Proof of concept for PowerShell argument completion.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -5,6 +5,7 @@
 
 from __future__ import print_function
 
+import os
 import sys
 import difflib
 
@@ -175,9 +176,12 @@ class AzCliCommandParser(CLICommandParser):
         super(AzCliCommandParser, self).format_help()
 
     def enable_autocomplete(self):
+        output_stream = None
+        if "_ARGCOMPLETE_POWERSHELL" in os.environ:
+            output_stream = sys.stdout.buffer
         argcomplete.autocomplete = AzCompletionFinder()
         argcomplete.autocomplete(self, validator=lambda c, p: c.lower().startswith(p.lower()),
-                                 default_completer=lambda _: ())
+                                 default_completer=lambda _: (), output_stream=output_stream)
 
     def _get_failure_recovery_arguments(self, action=None):
         # Strip the leading "az " and any extraneous whitespace.

--- a/src/azure-cli/az.completion.ps1
+++ b/src/azure-cli/az.completion.ps1
@@ -1,0 +1,59 @@
+$AzCommand = "az"
+
+$AzArgCompleteScriptBlock = {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    # In case of scripts, this object hold the current line after string conversion
+    $line = "$commandAst"
+
+    # The behaviour of completion should depend on the trailing spaces in the current line:
+    # * "command subcommand " --> TAB --> Completion items parameters/sub-subcommands of "subcommand"
+    # * "command subcom" --> TAB --> Completion items to extend "subcom" into matching subcommands.
+    # $line never contains the trailing spaces. However, $cursorPosition is the length of the original
+    # line (with trailing spaces) in this case. This comparision allows the expected user experience.
+    if ($cursorPosition -gt $line.Length) {
+        $line = "$line "
+    }
+
+    # Mock bash with environment variable settings
+    New-Item -Path Env: -Name _ARGCOMPLETE -Value 1 | Out-Null # Enables tab complition in argcomplete
+    New-Item -Path Env: -Name COMP_TYPE -Value 9 | Out-Null # Constant
+    New-Item -Path Env: -Name _ARGCOMPLETE_IFS -Value " " | Out-Null # Separator of the items
+    New-Item -Path Env: -Name _ARGCOMPLETE_SUPPRESS_SPACE -Value 1 | Out-Null # Constant
+    New-Item -Path Env: -Name _ARGCOMPLETE_COMP_WORDBREAKS -Value "" | Out-Null # Constant
+    New-Item -Path Env: -Name COMP_POINT -Value $cursorPosition | Out-Null # Refers to the last character of the current line
+    New-Item -Path Env: -Name COMP_LINE -Value $line | Out-Null # Current line
+
+    # Set a special environment variable to mark that the completion is executed by PowerShell
+    New-Item -Path Env: -Name _ARGCOMPLETE_POWERSHELL -Value 1 | Out-Null
+
+    # Just call the script without any parameter
+    # Since the environment variables are set, the argcomplete.autocomplete(...) function will be executed.
+    # The result will be printed on the standard output (see the details in the Python file).
+    Invoke-Expression $AzCommand -OutVariable completionResult -ErrorVariable errorOut -ErrorAction SilentlyContinue | Out-Null
+
+    # Delete environment variables
+    Remove-Item Env:\_ARGCOMPLETE | Out-Null
+    Remove-Item Env:\COMP_TYPE | Out-Null
+    Remove-Item Env:\_ARGCOMPLETE_IFS | Out-Null
+    Remove-Item Env:\_ARGCOMPLETE_SUPPRESS_SPACE | Out-Null
+    Remove-Item Env:\_ARGCOMPLETE_COMP_WORDBREAKS | Out-Null
+    Remove-Item Env:\COMP_POINT | Out-Null
+    Remove-Item Env:\COMP_LINE | Out-Null
+    
+    Remove-Item Env:\_ARGCOMPLETE_POWERSHELL | Out-Null
+    
+    # If there is only one completion item, it will be immediately used. In this case
+    # a trailing space is important to show the user that the complition for the current
+    # item is ready.
+    $items = $completionResult.Split()
+    if ($items -eq $completionResult) {
+        "$items "
+    }
+    else {
+        $items
+    }
+}
+
+# Register tab completion for the mat command
+Register-ArgumentCompleter -Native -CommandName $AzCommand -ScriptBlock $AzArgCompleteScriptBlock

--- a/src/azure-cli/az.completion.psm1
+++ b/src/azure-cli/az.completion.psm1
@@ -1,0 +1,59 @@
+$AzCommand = "az"
+
+$AzArgCompleteScriptBlock = {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    # In case of scripts, this object hold the current line after string conversion
+    $line = "$commandAst"
+
+    # The behaviour of completion should depend on the trailing spaces in the current line:
+    # * "command subcommand " --> TAB --> Completion items parameters/sub-subcommands of "subcommand"
+    # * "command subcom" --> TAB --> Completion items to extend "subcom" into matching subcommands.
+    # $line never contains the trailing spaces. However, $cursorPosition is the length of the original
+    # line (with trailing spaces) in this case. This comparision allows the expected user experience.
+    if ($cursorPosition -gt $line.Length) {
+        $line = "$line "
+    }
+
+    # Mock bash with environment variable settings
+    New-Item -Path Env: -Name _ARGCOMPLETE -Value 1 | Out-Null # Enables tab complition in argcomplete
+    New-Item -Path Env: -Name COMP_TYPE -Value 9 | Out-Null # Constant
+    New-Item -Path Env: -Name _ARGCOMPLETE_IFS -Value " " | Out-Null # Separator of the items
+    New-Item -Path Env: -Name _ARGCOMPLETE_SUPPRESS_SPACE -Value 1 | Out-Null # Constant
+    New-Item -Path Env: -Name _ARGCOMPLETE_COMP_WORDBREAKS -Value "" | Out-Null # Constant
+    New-Item -Path Env: -Name COMP_POINT -Value $cursorPosition | Out-Null # Refers to the last character of the current line
+    New-Item -Path Env: -Name COMP_LINE -Value $line | Out-Null # Current line
+
+    # Set a special environment variable to mark that the completion is executed by PowerShell
+    New-Item -Path Env: -Name _ARGCOMPLETE_POWERSHELL -Value 1 | Out-Null
+
+    # Just call the script without any parameter
+    # Since the environment variables are set, the argcomplete.autocomplete(...) function will be executed.
+    # The result will be printed on the standard output (see the details in the Python file).
+    Invoke-Expression $AzCommand -OutVariable completionResult -ErrorVariable errorOut -ErrorAction SilentlyContinue | Out-Null
+
+    # Delete environment variables
+    Remove-Item Env:\_ARGCOMPLETE | Out-Null
+    Remove-Item Env:\COMP_TYPE | Out-Null
+    Remove-Item Env:\_ARGCOMPLETE_IFS | Out-Null
+    Remove-Item Env:\_ARGCOMPLETE_SUPPRESS_SPACE | Out-Null
+    Remove-Item Env:\_ARGCOMPLETE_COMP_WORDBREAKS | Out-Null
+    Remove-Item Env:\COMP_POINT | Out-Null
+    Remove-Item Env:\COMP_LINE | Out-Null
+    
+    Remove-Item Env:\_ARGCOMPLETE_POWERSHELL | Out-Null
+    
+    # If there is only one completion item, it will be immediately used. In this case
+    # a trailing space is important to show the user that the complition for the current
+    # item is ready.
+    $items = $completionResult.Split()
+    if ($items -eq $completionResult) {
+        "$items "
+    }
+    else {
+        $items
+    }
+}
+
+# Register tab completion for the mat command
+Register-ArgumentCompleter -Native -CommandName $AzCommand -ScriptBlock $AzArgCompleteScriptBlock

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -163,6 +163,8 @@ setup(
         'az',
         'az.completion.sh',
         'az.bat',
+        'az.completion.ps1',
+        'az.completion.psm1'
     ],
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=DEPENDENCIES,


### PR DESCRIPTION
This is a proof of concept implementation of Azure CLI argument completion in PowerShell.

**Not ready to be merged.**

It is based on this approach, please find the details there:
https://github.com/tibortakacs/powershell-argcomplete

How to use:
- Install Azure CLI on the normal way.
- `. az.completion.ps1` (Dot source the completion script).
- Use `tab` or `ctrl+space` to invoke argument completion on PowerShell.
