### PR TITLE
[Redis] Fix #13529: Change documentation of parameter enable_non_ssl_port 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/redis/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/_params.py
@@ -40,7 +40,7 @@ def load_arguments(self, _):
         c.argument('sku', help='Type of Redis cache.', arg_type=get_enum_type(SkuName))
         c.argument('minimum_tls_version', help='Specifies the TLS version required by clients to connect to cache', arg_type=get_enum_type(TlsVersion))
         c.argument('vm_size', arg_type=get_enum_type(allowed_c_family_sizes + allowed_p_family_sizes), help='Size of Redis cache to deploy. Basic and Standard Cache sizes start with C. Premium Cache sizes start with P')
-        c.argument('enable_non_ssl_port', action='store_true', help='If the value is true, then the non-ssl redis server port (6379) will be enabled.')
+        c.argument('enable_non_ssl_port', action='store_true', help='If specified, then the non-ssl redis server port (6379) will be enabled.')
         c.argument('replicas_per_master', help='The number of replicas to be created per master.', is_preview=True)
 
     with self.argument_context('redis firewall-rules list') as c:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Updated documentation for Redis create parameter - enable_non_ssl_port to fix #13529 

**Testing Guide**  
Only documentation changes

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
