### PR TITLE
{Identity} Support UsernamePasswordCredential.authenticate

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_identity.py
+++ b/src/azure-cli-core/azure/cli/core/_identity.py
@@ -128,8 +128,9 @@ class Identity:
                                                 tenant_id=self.tenant_id,
                                                 client_id=self.client_id,
                                                 username=username,
-                                                password=password)
-        auth_record = credential.au
+                                                password=password,
+                                                enable_persistent_cache=True)
+        auth_record = credential.authenticate()
 
         # todo: remove after ADAL token deprecation
         self._cred_cache.add_credential(credential)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Due to the removal of `UsernamePasswordCredential.authenticate`, when **username+password** is used as the authentication method, Azure CLI **can't persist user's `AuthenticationRecord` and utilize refresh tokens stored in MSAL cache**. In such case, Azure CLI will have to **save user's password** by itself, which is absolutely not a good idea from a security perspective. See https://github.com/Azure/azure-sdk-for-python/issues/11449, https://github.com/Azure/azure-sdk-for-python/issues/11546

This PR solves the above issue by incorporating the changes from https://github.com/Azure/azure-sdk-for-python/pull/11528

⚠ However, using this `AuthenticationRecord` correctly remains unsolved: https://github.com/Azure/azure-sdk-for-python/issues/11448. We use `InteractiveBrowserCredential` as a temporary workaround: https://github.com/Azure/azure-cli/blob/595646e77d799bab68cf028739ab216d8e7a5103/src/azure-cli-core/azure/cli/core/_identity.py#L292-L293

**Testing Guide**  

```
az login -u admin4@AzureSDKTeam.onmicrosoft.com -p xxxx
```
