### PR TITLE
{AppConfig} Fix ContentType display in table format when filtering fields

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_format.py
@@ -81,6 +81,9 @@ def _configstore_credential_format_group(item):
 
 
 def _keyvalue_entry_format_group(item):
+    # CLI core converts KeyValue object field names to camelCase (eg: content_type becomes contentType)
+    # But when customers specify field filters, we return a dict of requested fields instead of KeyValue object
+    # In that case, field names are not converted to camelCase. We need to check for both content_type and contentType
     content_type = _get_value(item, 'contentType')
     content_type = content_type if content_type != ' ' else _get_value(item, 'content_type')
 

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_format.py
@@ -81,11 +81,17 @@ def _configstore_credential_format_group(item):
 
 
 def _keyvalue_entry_format_group(item):
+    content_type = _get_value(item, 'contentType')
+    content_type = content_type if content_type is not ' ' else _get_value(item, 'content_type')
+
+    last_modified = _get_value(item, 'lastModified')
+    last_modified = last_modified if last_modified is not ' ' else _get_value(item, 'last_modified')
+
     return OrderedDict([
-        ('CONTENT TYPE', _get_value(item, 'contentType')),
+        ('CONTENT TYPE', content_type),
         ('KEY', _get_value(item, 'key')),
         ('VALUE', _get_value(item, 'value')),
-        ('LAST MODIFIED', _format_datetime(_get_value(item, 'lastModified'))),
+        ('LAST MODIFIED', _format_datetime(last_modified)),
         ('TAGS', _get_value(item, 'tags')),
         ('LABEL', _get_value(item, 'label')),
         ('LOCKED', _get_value(item, 'locked'))
@@ -93,13 +99,16 @@ def _keyvalue_entry_format_group(item):
 
 
 def _featureflag_entry_format_group(item):
+    last_modified = _get_value(item, 'lastModified')
+    last_modified = last_modified if last_modified is not ' ' else _get_value(item, 'last_modified')
+
     return OrderedDict([
         ('KEY', _get_value(item, 'key')),
         ('LABEL', _get_value(item, 'label')),
         ('STATE', _get_value(item, 'state')),
         ('LOCKED', _get_value(item, 'locked')),
         ('DESCRIPTION', _get_value(item, 'description')),
-        ('LAST MODIFIED', _format_datetime(_get_value(item, 'lastModified'))),
+        ('LAST MODIFIED', _format_datetime(last_modified)),
         ('CONDITIONS', _get_value(item, 'conditions'))
     ])
 

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_format.py
@@ -82,10 +82,10 @@ def _configstore_credential_format_group(item):
 
 def _keyvalue_entry_format_group(item):
     content_type = _get_value(item, 'contentType')
-    content_type = content_type if content_type is not ' ' else _get_value(item, 'content_type')
+    content_type = content_type if content_type != ' ' else _get_value(item, 'content_type')
 
     last_modified = _get_value(item, 'lastModified')
-    last_modified = last_modified if last_modified is not ' ' else _get_value(item, 'last_modified')
+    last_modified = last_modified if last_modified != ' ' else _get_value(item, 'last_modified')
 
     return OrderedDict([
         ('CONTENT TYPE', content_type),
@@ -100,7 +100,7 @@ def _keyvalue_entry_format_group(item):
 
 def _featureflag_entry_format_group(item):
     last_modified = _get_value(item, 'lastModified')
-    last_modified = last_modified if last_modified is not ' ' else _get_value(item, 'last_modified')
+    last_modified = last_modified if last_modified != ' ' else _get_value(item, 'last_modified')
 
     return OrderedDict([
         ('KEY', _get_value(item, 'key')),

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
@@ -134,7 +134,7 @@ def load_arguments(self, _):
         c.argument('format_', options_list=['--format'], arg_type=get_enum_type(['json', 'yaml', 'properties']), help='File format exporting to. Required for file arguments. Currently, feature flags are not supported in properties format.')
         c.argument('depth', validator=validate_import_depth, help="Depth for flattening the json or yaml file to key-value pairs. Flatten to the deepest level by default. Not appicable for property files or feature flags.")
         # bypass cli allowed values limition
-        c.argument('separator', validator=validate_separator, help="Delimiter for flattening the json or yaml file to key-value pairs. Required for importing hierarchical structure. Separator will be ignored for property files and feature flags. Supported values: '.', ',', ';', '-', '_', '__', '/', ':' ")
+        c.argument('separator', validator=validate_separator, help="Delimiter for flattening the json or yaml file to key-value pairs. Required for exporting hierarchical structure. Separator will be ignored for property files and feature flags. Supported values: '.', ',', ';', '-', '_', '__', '/', ':' ")
         c.argument('naming_convention', arg_type=get_enum_type(['pascal', 'camel', 'underscore', 'hyphen']), help='Naming convention to be used for "Feature Management" section of file. Example: pascal = FeatureManagement, camel = featureManagement, underscore = feature_management, hyphen = feature-management.')
         c.argument('resolve_keyvault', arg_type=get_three_state_flag(), validator=validate_resolve_keyvault, help="Resolve the content of key vault reference.")
 

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
@@ -78,7 +78,7 @@ Please specify exactly ONE (suggest connection string) in one of the following o
     if connection_string_env:
         if not is_valid_connection_string(connection_string_env):
             raise CLIError(
-                "The environment variavle connection string is invalid. Correct format should be Endpoint=https://example.appconfig.io;Id=xxxxx;Secret=xxxx")
+                "The environment variable connection string is invalid. Correct format should be Endpoint=https://example.appconfig.io;Id=xxxxx;Secret=xxxx")
 
         if string and connection_string_env != string:
             raise CLIError(error_message)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
When users specify --fields to filter some output fields, the "content_type" and "last_modified" fields are not displayed in tabular output format.


**Testing Guide**  
<!--Example commands with explanations.-->
az appconfig kv list --key * --label *
az appconfig kv list --key * --label * -o table
az appconfig kv list --key * --label * --fields key content_type last_modified
az appconfig kv list --key * --label * --fields key content_type last_modified -o table


**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
