### PR TITLE
[ACS] Remove private cluster and 2019-10-27-preview API

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -66,7 +66,7 @@ def get_container_service_client(cli_ctx, **_):
 def get_osa_container_service_client(cli_ctx, **_):
     from azure.mgmt.containerservice import ContainerServiceClient
 
-    return get_mgmt_service_client(cli_ctx, ContainerServiceClient, api_version='2019-10-27-preview')
+    return get_mgmt_service_client(cli_ctx, ContainerServiceClient, api_version='2019-09-30-preview')
 
 
 def get_graph_rbac_management_client(cli_ctx, **_):

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -939,6 +939,39 @@ short-summary: Manage Azure Red Hat OpenShift Services.
 helps['openshift create'] = """
 type: command
 short-summary: Create a new managed OpenShift cluster.
+parameters:
+  - name: --compute-vm-size -s
+    type: string
+    short-summary: Size of Virtual Machines to create as OpenShift nodes.
+  - name: --compute-count -c
+    type: int
+    short-summary: Number of nodes in the OpenShift node pool.
+  - name: --aad-client-app-id
+    type: string
+    short-summary: The ID of an Azure Active Directory client application. If not specified, a new Azure Active Directory client is created.
+  - name: --aad-client-app-secret
+    type: string
+    short-summary: The secret of an Azure Active Directory client application.
+  - name: --aad-tenant-id
+    type: string
+    short-summary: The ID of an Azure Active Directory tenant.
+  - name: --vnet-peer
+    type: string
+    short-summary: The ID or the name of a subnet in an existing VNet into which to peer the cluster.
+  - name: --vnet-prefix
+    type: string
+    short-summary: The CIDR used on the VNet into which to deploy the cluster.
+  - name: --subnet-prefix
+    type: string
+    short-summary: The CIDR used on the Subnet into which to deploy the cluster.
+  - name: --customer-admin-group-id
+    type: string
+    short-summary: The Object ID of an Azure Active Directory Group that memberships will get synced into the OpenShift group "osa-customer-admins". If not specified, no cluster admin access will be granted.
+  - name: --workspace-id
+    type: string
+    short-summary: The resource id of an existing Log Analytics Workspace to use for storing monitoring data.
+
+
 examples:
   - name: Create an OpenShift cluster and auto create an AAD Client
     text: az openshift create -g MyResourceGroup -n MyManagedCluster
@@ -946,10 +979,10 @@ examples:
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --customer-admin-group-id {GROUP_ID}
   - name: Create an OpenShift cluster with 5 compute nodes and a custom AAD Client.
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --aad-client-app-id {APP_ID} --aad-client-app-secret {APP_SECRET} --aad-tenant-id {TENANT_ID} --compute-count 5
+  - name: Create an Openshift cluster using a custom vnet
+    text: az openshift create -g MyResourceGroup -n MyManagedCluster --vnet-peer "/subscriptions/0000000-0000-0000-0000-000000000000/resourceGroups/openshift-vnet/providers/Microsoft.Network/virtualNetworks/test"
   - name: Create an Openshift cluster with Log Analytics monitoring enabled
     text: az openshift create -g MyResourceGroup -n MyManagedCluster --workspace-id "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MyResourceGroup/providers/Microsoft.OperationalInsights/workspaces/{workspace-id}"
-  - name: Create a private OpenShift cluster
-    text: az openshift create -g MyResourceGroup -n MyManagedCluster --private-cluster --management-subnet-cidr 10.0.1.0/24
 """
 
 helps['openshift delete'] = """
@@ -1019,16 +1052,4 @@ examples:
   - name: Disable Log Analytics monitoring.
     text: |-
         az openshift monitor disable -g MyResourceGroup -n MyManagedCluster
-"""
-
-helps['openshift update'] = """
-type: command
-short-summary: Commands to manage existing Openshift cluster.
-parameters:
-  - name: --refresh-cluster
-    type: boolean
-examples:
-  - name: Trigger nodes rotation.
-    text: az openshift update -g MyResourceGroup -n MyManagedCluster --refresh-cluster
-    crafted: true
 """

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -10,7 +10,7 @@ import platform
 
 from argcomplete.completers import FilesCompleter
 from azure.cli.core.commands.parameters import (
-    file_type, get_enum_type, get_resource_name_completion_list, name_type, tags_type, zones_type, get_three_state_flag)
+    file_type, get_enum_type, get_resource_name_completion_list, name_type, tags_type, zones_type)
 from azure.cli.core.commands.validators import validate_file_or_dict
 from knack.arguments import CLIArgumentType
 
@@ -343,25 +343,9 @@ def load_arguments(self, _):
 
     with self.argument_context('openshift create') as c:
         c.argument('name', validator=validate_linux_host_name)
-        c.argument('aad_client_app_id', help='The ID of an Azure Active Directory client application. If not specified, a new Azure Active Directory client is created.')
-        c.argument('aad_client_app_secret', help='The secret of an Azure Active Directory client application.')
-        c.argument('aad_tenant_id', help='The ID of an Azure Active Directory tenant.')
-        c.argument('compute_count', options_list=['--compute-count', '-c'], help='Number of nodes in the OpenShift node pool.')
-        c.argument('compute_vm_size', options_list=['--compute-vm-size', '-s'], help='Size of Virtual Machines to create as OpenShift nodes.')
-        c.argument('customer_admin_group_id',
-                   help='The Object ID of an Azure Active Directory Group that memberships will get synced into the OpenShift group "osa-customer-admins".'
-                        'If not specified, no cluster admin access will be granted.')
-        c.argument('management_subnet_cidr', help='CIDR of subnet used to create PLS needed for management of the cluster. If provided, also set --private-cluster flag.')
-        c.argument('private_cluster', arg_type=get_three_state_flag(), help='Create private Openshift cluster. If this flag is set, also supply --management-subnet-cidr.')
-        c.argument('subnet_prefix', help='The CIDR used on the Subnet into which to deploy the cluster.')
-        c.argument('vnet_peer',
-                   help='Vnet peering is no longer supported during cluster creation, instead it is possible to edit vnet properties after cluster creation')
-        c.argument('vnet_prefix', help='The CIDR used on the VNet into which to deploy the cluster.')
-        c.argument('workspace_id', help='The resource id of an existing Log Analytics Workspace to use for storing monitoring data.')
-
-    with self.argument_context('openshift update') as c:
-        c.argument('refresh_cluster', arg_type=get_three_state_flag(),
-                   help='Allow nodes to be rotated. Use this flag to trigger nodes rotation after DNS settings change.')
+        c.argument('compute_vm_size', options_list=['--compute-vm-size', '-s'])
+        c.argument('customer_admin_group_id', options_list=['--customer-admin-group-id'])
+        c.argument('workspace_id')
 
     with self.argument_context('openshift monitor enable') as c:
         c.argument('workspace_id', help='The resource ID of an existing Log Analytics Workspace to use for storing monitoring data.')

--- a/src/azure-cli/azure/cli/command_modules/acs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/commands.py
@@ -42,7 +42,7 @@ def load_command_table(self, _):
     )
 
     openshift_managed_clusters_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.containerservice.v2019_10_27_preview.operations.'
+        operations_tmpl='azure.mgmt.containerservice.v2018_09_30_preview.operations.'
                         '_open_shift_managed_clusters_operations#OpenShiftManagedClustersOperations.{}',
         client_factory=cf_openshift_managed_clusters
     )
@@ -119,7 +119,6 @@ def load_command_table(self, _):
     with self.command_group('openshift', openshift_managed_clusters_sdk,
                             client_factory=cf_openshift_managed_clusters) as g:
         g.custom_command('create', 'openshift_create', supports_no_wait=True)
-        g.custom_command('update', 'openshift_update', supports_no_wait=True)
         g.command('delete', 'delete', supports_no_wait=True, confirmation=True)
         g.custom_command('scale', 'openshift_scale', supports_no_wait=True)
         g.custom_show_command('show', 'openshift_show')

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -70,17 +70,15 @@ from azure.mgmt.containerservice.v2020_03_01.models import AgentPool
 from azure.mgmt.containerservice.v2020_03_01.models import ManagedClusterSKU
 from azure.mgmt.containerservice.v2020_03_01.models import ManagedClusterWindowsProfile
 
-from azure.mgmt.containerservice.v2019_10_27_preview.models import OpenShiftManagedClusterAgentPoolProfile
-from azure.mgmt.containerservice.v2019_10_27_preview.models import OpenShiftManagedClusterMasterPoolProfile
-from azure.mgmt.containerservice.v2019_10_27_preview.models import OpenShiftAgentPoolProfileRole
-from azure.mgmt.containerservice.v2019_10_27_preview.models import OpenShiftManagedClusterIdentityProvider
-from azure.mgmt.containerservice.v2019_10_27_preview.models import OpenShiftManagedClusterAADIdentityProvider
-from azure.mgmt.containerservice.v2019_10_27_preview.models import OpenShiftManagedCluster
-from azure.mgmt.containerservice.v2019_10_27_preview.models import OpenShiftRouterProfile
-from azure.mgmt.containerservice.v2019_10_27_preview.models import OpenShiftManagedClusterAuthProfile
-from azure.mgmt.containerservice.v2019_10_27_preview.models import NetworkProfile
-from azure.mgmt.containerservice.v2019_10_27_preview.models import OpenShiftManagedClusterMonitorProfile
-from azure.mgmt.containerservice.v2019_10_27_preview.models import OpenShiftAPIProperties
+from azure.mgmt.containerservice.v2019_09_30_preview.models import OpenShiftManagedClusterAgentPoolProfile
+from azure.mgmt.containerservice.v2019_09_30_preview.models import OpenShiftAgentPoolProfileRole
+from azure.mgmt.containerservice.v2019_09_30_preview.models import OpenShiftManagedClusterIdentityProvider
+from azure.mgmt.containerservice.v2019_09_30_preview.models import OpenShiftManagedClusterAADIdentityProvider
+from azure.mgmt.containerservice.v2019_09_30_preview.models import OpenShiftManagedCluster
+from azure.mgmt.containerservice.v2019_09_30_preview.models import OpenShiftRouterProfile
+from azure.mgmt.containerservice.v2019_09_30_preview.models import OpenShiftManagedClusterAuthProfile
+from azure.mgmt.containerservice.v2019_09_30_preview.models import NetworkProfile
+from azure.mgmt.containerservice.v2019_09_30_preview.models import OpenShiftManagedClusterMonitorProfile
 
 from ._client_factory import cf_container_services
 from ._client_factory import cf_resource_groups
@@ -3236,6 +3234,7 @@ def _remove_osa_nulls(managed_clusters):
     """
     attrs = ['tags', 'plan', 'type', 'id']
     ap_master_attrs = ['name', 'os_type']
+    net_attrs = ['peer_vnet_id']
     for managed_cluster in managed_clusters:
         for attr in attrs:
             if hasattr(managed_cluster, attr) and getattr(managed_cluster, attr) is None:
@@ -3243,6 +3242,9 @@ def _remove_osa_nulls(managed_clusters):
         for attr in ap_master_attrs:
             if getattr(managed_cluster.master_pool_profile, attr, None) is None:
                 delattr(managed_cluster.master_pool_profile, attr)
+        for attr in net_attrs:
+            if getattr(managed_cluster.network_profile, attr, None) is None:
+                delattr(managed_cluster.network_profile, attr)
     return managed_clusters
 
 
@@ -3307,13 +3309,7 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
                      tags=None,
                      no_wait=False,
                      workspace_id=None,
-                     customer_admin_group_id=None,
-                     management_subnet_cidr=None,
-                     private_cluster=None):
-
-    if vnet_peer is not None:
-        raise CLIError('Vnet peering is no longer supported during cluster creation.'
-                       'Instead it is possible to edit vnet properties after cluster creation')
+                     customer_admin_group_id=None):
 
     if location is None:
         location = _get_rg_location(cmd.cli_ctx, resource_group_name)
@@ -3325,13 +3321,6 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
         os_type="Linux",
         role=OpenShiftAgentPoolProfileRole.compute,
         subnet_cidr=subnet_prefix
-    )
-
-    if bool(private_cluster) != bool(management_subnet_cidr is not None):
-        raise CLIError('Both --private-cluster and --management-subnet-cidr need to be supplied or neither.')
-
-    api_properties = OpenShiftAPIProperties(
-        private_api_server=bool(private_cluster)
     )
 
     agent_infra_pool_profile = OpenShiftManagedClusterAgentPoolProfile(
@@ -3346,15 +3335,13 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
     agent_pool_profiles.append(agent_node_pool_profile)
     agent_pool_profiles.append(agent_infra_pool_profile)
 
-    agent_master_pool_profile = OpenShiftManagedClusterMasterPoolProfile(
+    agent_master_pool_profile = OpenShiftManagedClusterAgentPoolProfile(
         name='master',  # Must be 12 chars or less before ACS RP adds to it
         count=int(3),
         vm_size="Standard_D4s_v3",
         os_type="Linux",
-        subnet_cidr=subnet_prefix,
-        api_properties=api_properties
+        subnet_cidr=subnet_prefix
     )
-
     identity_providers = []
 
     create_aad = False
@@ -3383,13 +3370,22 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
 
     default_router_profile = OpenShiftRouterProfile(name='default')
 
+    if vnet_peer is not None:
+        from msrestazure.tools import is_valid_resource_id, resource_id
+        if not is_valid_resource_id(vnet_peer):
+            vnet_peer = resource_id(
+                subscription=get_subscription_id(cmd.cli_ctx),
+                resource_group=resource_group_name,
+                namespace='Microsoft.Network', type='virtualNetwork',
+                name=vnet_peer
+            )
     if workspace_id is not None:
         workspace_id = _format_workspace_id(workspace_id)
         monitor_profile = OpenShiftManagedClusterMonitorProfile(enabled=True, workspace_resource_id=workspace_id)  # pylint: disable=line-too-long
     else:
         monitor_profile = None
 
-    network_profile = NetworkProfile(vnet_cidr=vnet_prefix, management_subnet_cidr=management_subnet_cidr)
+    network_profile = NetworkProfile(vnet_cidr=vnet_prefix, peer_vnet_id=vnet_peer)
     osamc = OpenShiftManagedCluster(
         location=location, tags=tags,
         open_shift_version="v3.11",
@@ -3417,14 +3413,6 @@ def openshift_create(cmd, client, resource_group_name, name,  # pylint: disable=
         if "No registered resource provider found for location" in ex.message:
             raise CLIError('Please make sure your subscription is whitelisted to use this service. https://aka.ms/openshift/managed')  # pylint: disable=line-too-long
         raise ex
-
-
-def openshift_update(cmd, client, resource_group_name, name, refresh_cluster=None, no_wait=False):
-    instance = client.get(resource_group_name, name)
-    if refresh_cluster:
-        instance.refresh_cluster = True
-
-    return sdk_no_wait(no_wait, client.create_or_update, resource_group_name, name, instance)
 
 
 def openshift_show(cmd, client, resource_group_name, name):

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3235,10 +3235,14 @@ def _remove_osa_nulls(managed_clusters):
     by the server, but get recreated by the CLI's own "to_dict" serialization.
     """
     attrs = ['tags', 'plan', 'type', 'id']
+    ap_master_attrs = ['name', 'os_type']
     for managed_cluster in managed_clusters:
         for attr in attrs:
             if hasattr(managed_cluster, attr) and getattr(managed_cluster, attr) is None:
                 delattr(managed_cluster, attr)
+        for attr in ap_master_attrs:
+            if getattr(managed_cluster.master_pool_profile, attr, None) is None:
+                delattr(managed_cluster.master_pool_profile, attr)
     return managed_clusters
 
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR reverts OSA support for `2019-10-17-preview` API version and private clusters. The reason is that in order to use these features the customer's subscription either has to be whitelisted, or feature gate to be removed. Since we have GA'ed ARO v4, we are encouraging customers to use private clusters in v4 rather than v3, hence reverting this change which was broke the client for some customers.  

https://github.com/Azure/OpenShift/issues/183

**Testing Guide**  
create an OpenShift cluster
`az openshift create -g <group_name> -n <resource_name> --location eastus2`
try show or list command:
`az openshift list`
`az openshift show -g <group_name> -n <resource_name>`
They should execute without error and display the cluster info.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
