### PR TITLE
{KeyVault} `az keyvault key download`: refine help message 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_help.py
@@ -158,7 +158,7 @@ short-summary: Manage keys.
 
 helps['keyvault key download'] = """
 type: command
-short-summary: Download a key from a KeyVault.
+short-summary: Downloads the public part of a stored key.
 examples:
   - name: Save the key with PEM encoding
     text: |


### PR DESCRIPTION
Fix: #13548 

The previous help message for `az keyvault key download` has insufficient information. Users may think it can be used to download private keys.

Make it consistent with `az keyvault key show`:
1. `show`: Gets the public part of a stored key.
2. `download`: Downloads the public part of a stored key.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
