### PR TITLE
{KeyVault} Add hyperlinks for `JsonWebKeyType` and `JsonWebKeyCurveName`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -197,8 +197,10 @@ def load_arguments(self, _):
             c.argument('not_before', default=None, help='Key not usable before the provided UTC datetime  (Y-m-d\'T\'H:M:S\'Z\').', type=datetime_type)
 
     with self.argument_context('keyvault key create') as c:
-        c.argument('kty', arg_type=get_enum_type(JsonWebKeyType), validator=validate_key_type)
-        c.argument('curve', arg_type=get_enum_type(JsonWebKeyCurveName))
+        c.argument('kty', arg_type=get_enum_type(JsonWebKeyType), validator=validate_key_type,
+                   help='The type of key to create. For valid values, see: https://docs.microsoft.com/en-us/rest/api/keyvault/createkey/createkey#jsonwebkeytype')
+        c.argument('curve', arg_type=get_enum_type(JsonWebKeyCurveName),
+                   help='Elliptic curve name. For valid values, see: https://docs.microsoft.com/en-us/rest/api/keyvault/createkey/createkey#jsonwebkeycurvename')
 
     with self.argument_context('keyvault key import', arg_group='Key Source') as c:
         c.argument('pem_file', type=file_type, help='PEM file containing the key to be imported.', completer=FilesCompleter(), validator=validate_key_import_source)


### PR DESCRIPTION
Fix: #13013 

The previous doc was inherited from [Swagger](https://github.com/Azure/azure-rest-api-specs/blob/fc44ee327ea1ef5ea3cb999e9c54c4198dd10b27/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.0/keyvault.json#L4457), it's a plaintext: `Elliptic curve name. For valid values, see JsonWebKeyCurveName.` And it doesn't act as a hyperlink in the [docs page](https://docs.microsoft.com/en-us/cli/azure/keyvault/key?view=azure-cli-latest#az-keyvault-key-create-optional-parameters).

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
