### PR TITLE
[AppService] Defaulting AppServiceEnviromentOperations to 2018-02-01 version since…

### DIFF
--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -195,7 +195,9 @@ AZURE_API_PROFILES = {
             'private_link_scopes': '2019-10-17-preview',
             'private_endpoint_connections': '2019-10-17-preview'
         }),
-        ResourceType.MGMT_APPSERVICE: '2019-08-01',
+        ResourceType.MGMT_APPSERVICE: SDKProfile('2019-08-01', {
+            'app_service_environments': '2018-02-01'
+        }),
         ResourceType.MGMT_IOTHUB: '2020-03-01',
         ResourceType.MGMT_ARO: '2020-04-30'
     },

--- a/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
@@ -54,4 +54,4 @@ def cf_providers(cli_ctx, _):
 
 
 def cf_web_client(cli_ctx, _):
-    return web_client_factory(cli_ctx)
+    return web_client_factory(cli_ctx).web_site_management_client

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -109,8 +109,8 @@ def list_appserviceenvironment_plans(cmd, name, resource_group_name=None):
 
 
 def _get_ase_client_factory(cli_ctx, api_version=None):
-    from azure.mgmt.web import WebSiteManagementClient
-    client = get_mgmt_service_client(cli_ctx, WebSiteManagementClient).app_service_environments
+    from azure.cli.core.profiles import ResourceType
+    client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_APPSERVICE).app_service_environments
     if api_version:
         client.api_version = api_version
     return client

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -60,22 +60,26 @@ def ex_handler_factory(creating_plan=False):
 def load_command_table(self, _):
     webclient_sdk = CliCommandType(
         operations_tmpl='azure.mgmt.web.operations#WebSiteManagementClientOperationsMixin.{}',
-        client_factory=cf_web_client
+        client_factory=cf_web_client,
+        operation_group='web_apps'
     )
     appservice_plan_sdk = CliCommandType(
         operations_tmpl='azure.mgmt.web.operations#AppServicePlansOperations.{}',
-        client_factory=cf_plans
+        client_factory=cf_plans,
+        operation_group='app_service_plans'
     )
     webapp_sdk = CliCommandType(
         operations_tmpl='azure.mgmt.web.operations#WebAppsOperations.{}',
-        client_factory=cf_webapps
+        client_factory=cf_webapps,
+        operation_group='web_apps'
     )
 
     appservice_custom = CliCommandType(operations_tmpl='azure.cli.command_modules.appservice.custom#{}')
 
-    webapp_access_restrictions = CliCommandType(operations_tmpl='azure.cli.command_modules.appservice.access_restrictions#{}')
+    webapp_access_restrictions = CliCommandType(operations_tmpl='azure.cli.command_modules.appservice.access_restrictions#{}', operation_group='web_apps')
 
-    appservice_environment = CliCommandType(operations_tmpl='azure.cli.command_modules.appservice.appservice_environment#{}')
+    appservice_environment = CliCommandType(operations_tmpl='azure.cli.command_modules.appservice.appservice_environment#{}',
+                                            operation_group='app_service_environments')
 
     with self.command_group('webapp', webapp_sdk) as g:
         g.custom_command('create', 'create_webapp', exception_handler=ex_handler_factory())
@@ -262,8 +266,9 @@ def load_command_table(self, _):
         g.custom_command('identity assign', 'assign_identity')
         g.custom_show_command('identity show', 'show_identity')
         g.custom_command('identity remove', 'remove_identity')
-        g.generic_update_command('update', setter_name='set_functionapp', exception_handler=ex_handler_factory(),
-                                 custom_func_name='update_functionapp', setter_type=appservice_custom, command_type=webapp_sdk)
+        g.generic_update_command('update', setter_name='set_functionapp', getter_name='get_webapp',
+                                 exception_handler=ex_handler_factory(), custom_func_name='update_functionapp',
+                                 command_type=appservice_custom)
 
     with self.command_group('functionapp config') as g:
         g.custom_command('set', 'update_site_configs')


### PR DESCRIPTION
… swagger is currently broken for a fee operations on the latest version

**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
