### PR TITLE
{Core} Add a hint message for --query error by an invalid JMESPATH

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -153,8 +153,7 @@ class AzCliCommandParser(CLICommandParser):
             logger.error('%(prog)s: error: %(message)s', args)
         self.print_usage(sys.stderr)
         # Manual recommendations
-        manual_recommendations = self._get_manual_recommendations(**args)
-        self._suggestion_msg.extend(manual_recommendations)
+        self._set_manual_recommendations(**args)
         # AI recommendations
         failure_recovery_recommendations = self._get_failure_recovery_recommendations()
         self._suggestion_msg.extend(failure_recovery_recommendations)
@@ -183,12 +182,13 @@ class AzCliCommandParser(CLICommandParser):
         argcomplete.autocomplete(self, validator=lambda c, p: c.lower().startswith(p.lower()),
                                  default_completer=lambda _: ())
 
-    def _get_manual_recommendations(self, **kwargs):
+    def _set_manual_recommendations(self, **kwargs):
         recommendations = []
         # recommendation for --query value error
         if 'message' in kwargs and '--query' in kwargs['message']:
-            recommendations.append('To learn more about [--query JMESPATH] usage in AzureCLI, visit https://aka.ms/CLIQuery')
-        return recommendations
+            recommendations.append('To learn more about [--query JMESPATH] usage in AzureCLI, '
+                                   'visit https://aka.ms/CLIQuery')
+        self._suggestion_msg.extend(recommendations)
 
     def _get_failure_recovery_arguments(self, action=None):
         # Strip the leading "az " and any extraneous whitespace.

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -152,6 +152,10 @@ class AzCliCommandParser(CLICommandParser):
         with CommandLoggerContext(logger):
             logger.error('%(prog)s: error: %(message)s', args)
         self.print_usage(sys.stderr)
+        # Manual recommendations
+        manual_recommendations = self._get_manual_recommendations(**args)
+        self._suggestion_msg.extend(manual_recommendations)
+        # AI recommendations
         failure_recovery_recommendations = self._get_failure_recovery_recommendations()
         self._suggestion_msg.extend(failure_recovery_recommendations)
         self._print_suggestion_msg(sys.stderr)
@@ -178,6 +182,13 @@ class AzCliCommandParser(CLICommandParser):
         argcomplete.autocomplete = AzCompletionFinder()
         argcomplete.autocomplete(self, validator=lambda c, p: c.lower().startswith(p.lower()),
                                  default_completer=lambda _: ())
+
+    def _get_manual_recommendations(self, **kwargs):
+        recommendations = []
+        # recommendation for --query value error
+        if 'message' in kwargs and '--query' in kwargs['message']:
+            recommendations.append('To learn more about [--query JMESPATH] usage in AzureCLI, visit https://aka.ms/CLIQuery')
+        return recommendations
 
     def _get_failure_recovery_arguments(self, action=None):
         # Strip the leading "az " and any extraneous whitespace.

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -153,7 +153,7 @@ class AzCliCommandParser(CLICommandParser):
             logger.error('%(prog)s: error: %(message)s', args)
         self.print_usage(sys.stderr)
         # Manual recommendations
-        self._set_manual_recommendations(**args)
+        self._set_manual_recommendations(args['message'])
         # AI recommendations
         failure_recovery_recommendations = self._get_failure_recovery_recommendations()
         self._suggestion_msg.extend(failure_recovery_recommendations)
@@ -182,10 +182,10 @@ class AzCliCommandParser(CLICommandParser):
         argcomplete.autocomplete(self, validator=lambda c, p: c.lower().startswith(p.lower()),
                                  default_completer=lambda _: ())
 
-    def _set_manual_recommendations(self, **kwargs):
+    def _set_manual_recommendations(self, error_msg):
         recommendations = []
         # recommendation for --query value error
-        if 'message' in kwargs and '--query' in kwargs['message']:
+        if '--query' in error_msg:
             recommendations.append('To learn more about [--query JMESPATH] usage in AzureCLI, '
                                    'visit https://aka.ms/CLIQuery')
         self._suggestion_msg.extend(recommendations)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
1. This PR provides support for printing a hint message below when a [--query JMESPATH] value error occurs.
`To learn more about [--query JMESPATH] usage in AzureCLI, visit https://aka.ms/CLIQuery`

2. As a manual hint, the message will be printed behind the command usage and before the ai-did-you-mean-this recommendations (if there).

**Testing Guide**  
<!--Example commands with explanations.-->
Any commands with the [--query] argument that can raise an error by an invalid JMESPATH.

E.g. Run the command below, you will get the hint message with this PR.
`az group list --query '.xx'`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
