### PR TITLE
[Core] Print error type information

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -69,7 +69,8 @@ def handle_exception(ex):  # pylint: disable=too-many-return-statements
                          "https://docs.microsoft.com/cli/azure/query-azure-cli?view=azure-cli-latest")
             return 1
         if isinstance(ex, (CLIError, CloudError, AzureException, AzureError)):
-            logger.error(ex.args[0])
+            # Another option is showing a description of the error type.
+            logger.error(type(ex).__name__ + ': ' + ex.args[0])
             try:
                 for detail in ex.args[0].error.details:
                     logger.error(detail)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR aims to print error type information when an error occurs.
```
> vm create -g fy -n vm1 --image centos --nsg-rule NONE --admin-user asdf --admin-password as
The password length must be between 12 and 72
```
Users don't know where the error happens. Is it in client or service? Is it a client's requirement or service requirement? Azure CLI has an error type system. We could leverage it to tell users more useful information. Some error handlers have given good examples like `JMESPathTypeError`, `ValidationError`.

A reference of all error types in Azure CLI chould be created in Azure CLI official web pages. Just like https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes.

**[Option 1]** Print type name.
```
> vm create -g fy -n vm1 --image centos --nsg-rule NONE --admin-user asdf --admin-password as
CLIError: The password length must be between 12 and 72
```
**[Option 2]** Print type description.
```
> vm create -g fy -n vm1 --image centos --nsg-rule NONE --admin-user asdf --admin-password as
An error occurs during normal operation of the CLI. Typically due to user error and can be resolved by the user.
The password length must be between 12 and 72
```
**[Option 3]** A combination of option 1 and 2. Print both.

Which one do you think is better?


**Testing Guide**  
<!--Example commands with explanations.-->
Try any command that can trigger an error.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
