### PR TITLE
[Network]: Refine help message and add examples for az network application-gateway address-pool update

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -61,8 +61,12 @@ helps['network application-gateway address-pool update'] = """
 type: command
 short-summary: Update an address pool.
 examples:
-  - name: Update an address pool, add server.
+  - name: Update backend address pool.
     text: az network application-gateway address-pool update -g MyResourceGroup --gateway-name MyAppGateway \\ -n MyAddressPool --servers 10.0.0.4 10.0.0.5 10.0.0.6
+  - name: Add to the backend address pool by using backend server IP address
+    text: |
+        az network application-gateway address-pool update -g MyResourceGroup --gateway-name MyAppGateway -n MyAddressPool \\
+            --add backendAddresses "{ \"ip_address\": \"{10.0.0.13}\" }"
 """
 
 helps['network application-gateway auth-cert'] = """


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This is a fix to refine the help message and adding an example for #12934 

The --servers parameter should contain the entire list of IP Addresses/DNS Names to be added to the backend pool. The explanation for this is not clear in the help and causes confusion. That has been fixed.

There is no example provided for the --add optional parameter. This commit adds an example for this. Adding this example would help understand this parameter and its syntax better. 

The  documentation for this also needs to reflect this change: https://docs.microsoft.com/en-us/cli/azure/network/application-gateway/address-pool?view=azure-cli-latest#az-network-application-gateway-address-pool-update . Not sure how that is updated.

This change has been discussed with @MyronFanQiu in https://github.com/Azure/azure-cli/issues/12934

Tagging @MyronFanQiu as reviewer

Also, there is a bug in the cli for the --add parameter which has been flagged in https://github.com/Azure/azure-cli/issues/13599

**Testing Guide**  
az network application-gateway address-pool update -g scus-stgei-network-rg --gateway-name azurestg-aag01-scus --name appGatewayBackendPool --add backendAddresses "{"ip_address":"10.3.8.100"}"

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
