### PR TITLE
[Identity] Rename auth_only to tenant_access

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -59,7 +59,7 @@ DEPENDENCIES = [
     'knack==0.7.1',
     'msal~=1.3.0',
     'msal-extensions~=0.2.2',
-    'azure-identity==1.4.0b3',
+    'azure-identity==1.4.0b4',
     'msrest>=0.4.4',
     'msrestazure>=0.6.3',
     'paramiko>=2.0.8,<3.0.0',

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -57,7 +57,12 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('service_principal', action='store_true', help='The credential representing a service principal.')
             c.argument('username', options_list=['--username', '-u'], help='user name, service principal, or managed service identity ID')
             c.argument('tenant', options_list=['--tenant', '-t'], help='The AAD tenant, must provide when using service principals.', validator=validate_tenant)
-            c.argument('allow_no_subscriptions', action='store_true', help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as 'az ad'")
+            c.argument('tenant_access', action='store_true',
+                       help='Only log in to the home tenant or the tenant specified by --tenant. CLI will not perform '
+                            'ARM operations to list tenants and subscriptions. Then you may run tenant-level commands, '
+                            'such as `az ad`, `az account get-access-token`.')
+            c.argument('allow_no_subscriptions', action='store_true', deprecate_info=c.deprecate(target='--allow-no-subscriptions', expiration='3.0.0', redirect="--tenant-access", hide=False),
+                       help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as `az ad`")
             c.ignore('_subscription')  # hide the global subscription parameter
             c.argument('identity', options_list=('-i', '--identity'), action='store_true', help="Log in using the Virtual Machine's managed identity", arg_group='Managed Identity')
             c.argument('identity_port', type=int, help="the port to retrieve tokens for login. Default: 50342", arg_group='Managed Identity')

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -103,7 +103,7 @@ def account_clear(cmd, clear_credential=False):
 
 # pylint: disable=inconsistent-return-statements
 def login(cmd, username=None, password=None, service_principal=None, tenant=None, allow_no_subscriptions=False,
-          identity=False, use_device_code=False, use_cert_sn_issuer=None, auth_only=False):
+          identity=False, use_device_code=False, use_cert_sn_issuer=None, tenant_access=False):
     """Log in to access Azure subscriptions"""
     from adal.adal_error import AdalError
     import requests
@@ -147,7 +147,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
             tenant,
             use_device_code=use_device_code,
             allow_no_subscriptions=allow_no_subscriptions,
-            use_cert_sn_issuer=use_cert_sn_issuer, find_subscriptions=not auth_only)
+            use_cert_sn_issuer=use_cert_sn_issuer, find_subscriptions=not tenant_access)
     except AdalError as err:
         # try polish unfriendly server errors
         if username:

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -108,7 +108,7 @@ multidict==4.5.2
 oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
-portalocker==1.4.0
+portalocker==1.7
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -109,7 +109,7 @@ multidict==4.5.2
 oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
-portalocker==1.4.0
+portalocker==1.7
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -106,7 +106,7 @@ msrestazure==0.6.3
 oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
-portalocker==1.2.1
+portalocker==1.7
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -115,7 +115,7 @@ pypiwin32==223
 pyreadline==2.1
 python-dateutil==2.8.0
 pytz==2019.1
-pywin32==225
+pywin32==227
 requests==2.22.0
 requests-oauthlib==1.2.0
 scp==0.13.2


### PR DESCRIPTION
**Description<!--Mandatory-->**  

1. Rename `auth_only` to a better name `tenant_access`, indicating bare tenant-level access.
2. Deprecate `--allow-no-subscriptions`, because:
   1. Even with `--allow-no-subscriptions`, `az login` fails when ARM request is blocked.
   2. Depending on whether the tenant has subscriptions, the `id` property in `az account list/show` is ambiguous: it can mean either tenant ID or subscription ID. 

**Testing Guide**  
```
> az login -h

    --allow-no-subscriptions [Deprecated] : Support access tenants without subscriptions.
                                            It's uncommon but useful to run tenant level commands,
                                            such as `az ad`.
        Option '--allow-no-subscriptions' has been deprecated and will be removed in version
        '3.0.0'. Use '--tenant-access' instead.

    --tenant-access                       : Only log in to the home tenant or the tenant specified
                                            by --tenant. CLI will not perform ARM operations to list
                                            tenants and subscriptions. Then you may run tenant-level
                                            commands, such as `az ad`, `az account get-access-
                                            token`.
```