### PR TITLE
[Monitor] Support no wait for cluster creation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/monitor/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_help.py
@@ -1096,6 +1096,8 @@ short-summary: Update a workspace instance
 helps['monitor log-analytics workspace linked-service'] = """
 type: group
 short-summary: Manage linked service for log analytics workspace.
+long-summary: |
+    Linked services is used to defined a relation from the workspace to another Azure resource. Log Analytics and Azure resources then leverage this connection in their operations. Example uses of Linked Services in Log Analytics workspace are Automation account and workspace association to CMK.
 """
 
 helps['monitor log-analytics workspace linked-service create'] = """

--- a/src/azure-cli/azure/cli/command_modules/monitor/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/commands.py
@@ -20,8 +20,7 @@ def load_command_table(self, _):
         cf_private_link_scopes, cf_private_endpoint_connections, cf_log_analytics_linked_storage)
     from ._exception_handler import monitor_exception_handler, missing_resource_handler
     from .transformers import (action_group_list_table)
-    from .validators import process_autoscale_create_namespace, validate_private_endpoint_connection_id,\
-        make_cluster_creation_as_no_wait_by_default
+    from .validators import process_autoscale_create_namespace, validate_private_endpoint_connection_id
 
     monitor_custom = CliCommandType(
         operations_tmpl='azure.cli.command_modules.monitor.custom#{}',
@@ -384,8 +383,8 @@ def load_command_table(self, _):
         g.command('delete', 'delete', confirmation=True, supports_no_wait=True)
         g.wait_command('wait')
 
-    with self.command_group('monitor log-analytics cluster', log_analytics_cluster_sdk, custom_command_type=log_analytics_cluster_custom, is_preview=True) as g:
-        g.custom_command('create', 'create_log_analytics_cluster', validator=make_cluster_creation_as_no_wait_by_default)
+    with self.command_group('monitor log-analytics cluster', log_analytics_cluster_sdk, custom_command_type=log_analytics_cluster_custom) as g:
+        g.custom_command('create', 'create_log_analytics_cluster', supports_no_wait=True)
         g.custom_command('update', 'update_log_analytics_cluster')
         g.show_command('show', 'get')
         g.command('delete', 'delete', confirmation=True, supports_no_wait=True)

--- a/src/azure-cli/azure/cli/command_modules/monitor/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/commands.py
@@ -375,7 +375,7 @@ def load_command_table(self, _):
         g.command('enable', 'enable')
         g.command('disable', 'disable')
 
-    with self.command_group('monitor log-analytics workspace linked-service', log_analytics_workspace_linked_service_sdk, custom_command_type=log_analytics_workspace_linked_service_custom, is_preview=True) as g:
+    with self.command_group('monitor log-analytics workspace linked-service', log_analytics_workspace_linked_service_sdk, custom_command_type=log_analytics_workspace_linked_service_custom) as g:
         g.custom_command('create', 'create_log_analytics_workspace_linked_service', supports_no_wait=True)
         g.generic_update_command('update', custom_func_name='update_log_analytics_workspace_linked_service', supports_no_wait=True)
         g.show_command('show', 'get')
@@ -391,7 +391,7 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_log_analytics_clusters')
         g.wait_command('wait')
 
-    with self.command_group('monitor log-analytics workspace linked-storage', log_analytics_linked_storage_sdk, custom_command_type=log_analytics_linked_storage_custom, is_preview=True) as g:
+    with self.command_group('monitor log-analytics workspace linked-storage', log_analytics_linked_storage_sdk, custom_command_type=log_analytics_linked_storage_custom) as g:
         g.command('create', 'create_or_update')
         g.custom_command('add', 'add_log_analytics_workspace_linked_storage_accounts')
         g.custom_command('remove', 'remove_log_analytics_workspace_linked_storage_accounts')

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_log_analytics_cluster.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_log_analytics_cluster.py
@@ -20,7 +20,7 @@ class TestClusterScenarios(ScenarioTest):
             'existing_cluster_name': 'yutestcluster4'
         })
 
-        self.cmd("monitor log-analytics cluster create -g {rg1} -n {new_cluster_name} --sku-capacity {sku_capacity}",
+        self.cmd("monitor log-analytics cluster create -g {rg1} -n {new_cluster_name} --sku-capacity {sku_capacity} --no-wait",
                  checks=[])
 
         self.cmd("monitor log-analytics cluster show -g {rg1} -n {new_cluster_name}", checks=[

--- a/src/azure-cli/azure/cli/command_modules/monitor/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/validators.py
@@ -7,16 +7,6 @@ from knack.util import CLIError
 from azure.cli.core.commands.validators import validate_tags, get_default_location_from_resource_group
 
 
-def make_cluster_creation_as_no_wait_by_default(cmd, namespace):
-    get_default_location_from_resource_group(cmd, namespace)
-
-    # Make cluster creation no wait by default before ADX cluster can be provisioned automatically.
-    # TODO: remove this method and make cluster creation support both wait and no wait
-    #  after ADX cluster can be provisioned automatically.
-    cmd.supports_no_wait = True
-    namespace.no_wait = True
-
-
 def process_autoscale_create_namespace(cmd, namespace):
     from msrestazure.tools import parse_resource_id
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR covers the following issues:
- #13593: Expose `--no-wait` for command `az monitor log-analytics cluster create`
- #13754: Remove preview comment for cluster commands
- #13570: Add explanation for linked services

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
