### PR TITLE
[Extension] add --version to support to install from a specific version

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -38,7 +38,7 @@ def _is_compatible_with_cli_version(item):
     return False
 
 
-def _is_greater_than_or_equal_to_cur_version(cur_version):
+def _is_greater_than_cur_version(cur_version):
     if not cur_version:
         return None
     cur_version_parsed = parse_version(cur_version)
@@ -65,7 +65,7 @@ def resolve_from_index(extension_name, cur_version=None, index_url=None, target_
         raise NoExtensionCandidatesError("No extension found with name '{}'".format(extension_name))
 
     filters = [_is_not_platform_specific, _is_compatible_with_cli_version,
-               _is_greater_than_or_equal_to_cur_version(cur_version)]
+               _is_greater_than_cur_version(cur_version)]
 
     for f in filters:
         logger.debug("Candidates %s", [c['filename'] for c in candidates])
@@ -81,7 +81,7 @@ def resolve_from_index(extension_name, cur_version=None, index_url=None, target_
         try:
             chosen = [c for c in candidates_sorted if c['metadata']['version'] == target_version][0]
         except IndexError:
-            raise NoExtensionCandidatesError('Extension with version {} not found'.format(cur_version))
+            raise NoExtensionCandidatesError('Extension with version {} not found'.format(target_version))
     else:
         chosen = candidates_sorted[0]
 

--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -78,7 +78,7 @@ def resolve_from_index(extension_name, cur_version=None, index_url=None):
     if cur_version:
         try:
             chosen = [c for c in candidates_sorted if c['metadata']['version'] == cur_version][0]
-        except Exception:
+        except IndexError:
             raise NoExtensionCandidatesError('Extension with version {} not found'.format(cur_version))
     else:
         chosen = candidates_sorted[0]

--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -38,7 +38,7 @@ def _is_compatible_with_cli_version(item):
     return False
 
 
-def _is_greater_or_equal_than_cur_version(cur_version):
+def _is_greater_than_or_equal_to_cur_version(cur_version):
     if not cur_version:
         return None
     cur_version_parsed = parse_version(cur_version)
@@ -63,7 +63,7 @@ def resolve_from_index(extension_name, cur_version=None, index_url=None):
         raise NoExtensionCandidatesError("No extension found with name '{}'".format(extension_name))
 
     filters = [_is_not_platform_specific, _is_compatible_with_cli_version,
-               _is_greater_or_equal_than_cur_version(cur_version)]
+               _is_greater_than_or_equal_to_cur_version(cur_version)]
 
     for f in filters:
         logger.debug("Candidates %s", [c['filename'] for c in candidates])

--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -64,8 +64,7 @@ def resolve_from_index(extension_name, cur_version=None, index_url=None, target_
     if not candidates:
         raise NoExtensionCandidatesError("No extension found with name '{}'".format(extension_name))
 
-    filters = [_is_not_platform_specific, _is_compatible_with_cli_version,
-               _is_greater_than_cur_version(cur_version)]
+    filters = [_is_not_platform_specific, _is_compatible_with_cli_version, _is_greater_than_cur_version(cur_version)]
 
     for f in filters:
         logger.debug("Candidates %s", [c['filename'] for c in candidates])

--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -53,9 +53,11 @@ def _is_greater_than_or_equal_to_cur_version(cur_version):
     return filter_func
 
 
-def resolve_from_index(extension_name, cur_version=None, index_url=None):
+def resolve_from_index(extension_name, cur_version=None, index_url=None, target_version=None):
     """
     Gets the download Url and digest for the matching extension
+
+    :param cur_version: threshold verssion to filter out extensions.
     """
     candidates = get_index_extensions(index_url=index_url).get(extension_name, [])
 
@@ -75,9 +77,9 @@ def resolve_from_index(extension_name, cur_version=None, index_url=None):
     logger.debug("Candidates %s", [c['filename'] for c in candidates_sorted])
     logger.debug("Choosing the latest of the remaining candidates.")
 
-    if cur_version:
+    if target_version:
         try:
-            chosen = [c for c in candidates_sorted if c['metadata']['version'] == cur_version][0]
+            chosen = [c for c in candidates_sorted if c['metadata']['version'] == target_version][0]
         except IndexError:
             raise NoExtensionCandidatesError('Extension with version {} not found'.format(cur_version))
     else:

--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -45,7 +45,7 @@ def _is_greater_than_cur_version(cur_version):
 
     def filter_func(item):
         item_version = parse_version(item['metadata']['version'])
-        if item_version >= cur_version_parsed:
+        if item_version > cur_version_parsed:
             return True
         logger.debug("Skipping '%s' as %s not greater than current version %s", item['filename'],
                      item_version, cur_version_parsed)

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -224,7 +224,7 @@ def add_extension(cmd, source=None, extension_name=None, index_url=None, yes=Non
                 return
             logger.warning("Overriding development version of '%s' with production version.", extension_name)
         try:
-            source, ext_sha256 = resolve_from_index(extension_name, cur_version=version, index_url=index_url)
+            source, ext_sha256 = resolve_from_index(extension_name, index_url=index_url, target_version=version)
         except NoExtensionCandidatesError as err:
             logger.debug(err)
 

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/__init__.py
@@ -7,6 +7,7 @@ import os
 import unittest
 import tempfile
 import shutil
+import mock
 
 
 def get_test_data_file(filename):
@@ -20,3 +21,34 @@ class ExtensionTypeTestMixin(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.ext_dir, ignore_errors=True)
+
+
+class IndexPatch:
+    def __init__(self, data=None):
+        self.patcher = mock.patch('azure.cli.core.extension._resolve.get_index_extensions', return_value=data)
+
+    def __enter__(self):
+        self.patcher.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.patcher.stop()
+
+
+def mock_ext(filename, version=None, download_url=None, digest=None, project_url=None):
+    d = {
+        'filename': filename,
+        'metadata': {
+            'version': version,
+            'extensions': {
+                'python.details': {
+                    'project_urls': {
+                        'Home': project_url or 'https://github.com/azure/some-extension'
+                    }
+                }
+            }
+        },
+        'downloadUrl': download_url or 'http://contoso.com/{}'.format(filename),
+        'sha256Digest': digest
+    }
+    return d

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
@@ -205,7 +205,7 @@ class TestExtensionCommands(unittest.TestCase):
 
         non_existing_version = '0.0.5'
         with IndexPatch(mocked_index_data):
-            with self.assertRaisesRegex(CLIError, non_existing_version) as err:
+            with self.assertRaisesRegex(CLIError, non_existing_version):
                 add_extension(self.cmd, extension_name=extension_name, version=non_existing_version)
 
     def test_add_extension_with_name_valid_checksum(self):

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
@@ -18,6 +18,8 @@ from azure.cli.core.extension.operations import (list_extensions, add_extension,
 from azure.cli.core.extension._resolve import NoExtensionCandidatesError
 from azure.cli.core.mock import DummyCli
 
+from . import IndexPatch, mock_ext
+
 
 def _get_test_data_file(filename):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', filename)
@@ -170,6 +172,26 @@ class TestExtensionCommands(unittest.TestCase):
             pip_cmd = args[0][0]
             if '--proxy' in pip_cmd:
                 raise AssertionError("proxy parameter in check_output args although no proxy specified")
+
+    def test_add_extension_with_specific_version(self):
+        from azure.cli.core.extension.operations import resolve_from_index
+
+        extension_name = MY_EXT_NAME
+        extension1 = 'myfirstcliextension-0.0.3+dev-py2.py3-none-any.whl'
+        extension2 = 'myfirstcliextension-0.0.4+dev-py2.py3-none-any.whl'
+
+        mocked_index_data = {
+            extension_name: [
+                mock_ext(extension1, version='0.0.3+dev', download_url=_get_test_data_file(extension1)),
+                mock_ext(extension2, version='0.0.4+dev', download_url=_get_test_data_file(extension2))
+            ]
+        }
+
+        with IndexPatch(mocked_index_data):
+            add_extension(self.cmd, extension_name=extension_name, version='0.0.3+dev')
+            ext = show_extension(extension_name)
+            self.assertEqual(ext['name'], extension_name)
+            self.assertEqual(ext['version'], '0.0.3+dev')
 
     def test_add_extension_with_name_valid_checksum(self):
         extension_name = MY_EXT_NAME

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
@@ -174,8 +174,6 @@ class TestExtensionCommands(unittest.TestCase):
                 raise AssertionError("proxy parameter in check_output args although no proxy specified")
 
     def test_add_extension_with_specific_version(self):
-        from azure.cli.core.extension.operations import resolve_from_index
-
         extension_name = MY_EXT_NAME
         extension1 = 'myfirstcliextension-0.0.3+dev-py2.py3-none-any.whl'
         extension2 = 'myfirstcliextension-0.0.4+dev-py2.py3-none-any.whl'
@@ -192,6 +190,23 @@ class TestExtensionCommands(unittest.TestCase):
             ext = show_extension(extension_name)
             self.assertEqual(ext['name'], extension_name)
             self.assertEqual(ext['version'], '0.0.3+dev')
+
+    def test_add_extension_with_non_existing_version(self):
+        extension_name = MY_EXT_NAME
+        extension1 = 'myfirstcliextension-0.0.3+dev-py2.py3-none-any.whl'
+        extension2 = 'myfirstcliextension-0.0.4+dev-py2.py3-none-any.whl'
+
+        mocked_index_data = {
+            extension_name: [
+                mock_ext(extension1, version='0.0.3+dev', download_url=_get_test_data_file(extension1)),
+                mock_ext(extension2, version='0.0.4+dev', download_url=_get_test_data_file(extension2))
+            ]
+        }
+
+        non_existing_version = '0.0.5'
+        with IndexPatch(mocked_index_data):
+            with self.assertRaisesRegex(CLIError, non_existing_version) as err:
+                add_extension(self.cmd, extension_name=extension_name, version=non_existing_version)
 
     def test_add_extension_with_name_valid_checksum(self):
         extension_name = MY_EXT_NAME

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
@@ -92,9 +92,9 @@ class TestResolveFilters(unittest.TestCase):
         self.assertTrue(filter_func(mock_ext('myext-0.0.2-py2.py3-none-any.whl', '0.0.2')))
         self.assertTrue(filter_func(mock_ext('myext-0.0.1+dev-py2.py3-none-any.whl', '0.0.1+dev')))
         self.assertTrue(filter_func(mock_ext('myext-0.0.1.post1-py2.py3-none-any.whl', '0.0.1.post1')))
-        self.assertTrue(filter_func(mock_ext('myext-0.0.1-py2.py3-none-any.whl', '0.0.1')))
 
         self.assertFalse(filter_func(mock_ext('myext-0.0.1.pre1-py2.py3-none-any.whl', '0.0.1.pre1')))
+        self.assertFalse(filter_func(mock_ext('myext-0.0.1-py2.py3-none-any.whl', '0.0.1')))
 
 
 class TestResolveProjectUrlFromIndex(unittest.TestCase):

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
@@ -7,7 +7,7 @@ import mock
 
 from azure.cli.core.extension._resolve import (resolve_from_index, resolve_project_url_from_index,
                                                NoExtensionCandidatesError, _is_not_platform_specific,
-                                               _is_greater_or_equal_than_cur_version)
+                                               _is_greater_than_or_equal_to_cur_version)
 
 
 class IndexPatch(object):
@@ -96,9 +96,9 @@ class TestResolveFilters(unittest.TestCase):
         self.assertFalse(_is_not_platform_specific(mock_ext('myext-1.1.26.0-py2-none-linux_armv7l.whl')))
 
     def test_greater_than_current(self):
-        self.assertIsNone(_is_greater_or_equal_than_cur_version(None))
-        self.assertIsNotNone(_is_greater_or_equal_than_cur_version('0.0.1'))
-        filter_func = _is_greater_or_equal_than_cur_version('0.0.1')
+        self.assertIsNone(_is_greater_than_or_equal_to_cur_version(None))
+        self.assertIsNotNone(_is_greater_than_or_equal_to_cur_version('0.0.1'))
+        filter_func = _is_greater_than_or_equal_to_cur_version('0.0.1')
         filter_func
         self.assertTrue(filter_func(mock_ext('myext-0.0.2-py2.py3-none-any.whl', '0.0.2')))
         self.assertTrue(filter_func(mock_ext('myext-0.0.1+dev-py2.py3-none-any.whl', '0.0.1+dev')))

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
@@ -72,7 +72,7 @@ class TestResolveFromIndex(unittest.TestCase):
             self.assertEqual(resolve_from_index(name)[0], index_data[name][1]['downloadUrl'])
 
     def test_filter_version(self):
-        ext_name = 'hellp'
+        ext_name = 'hello'
         index_data = {
             ext_name: [
                 mock_ext('hello-0.1.0-py3-none-any.whl', '0.1.0'),

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
@@ -55,7 +55,7 @@ class TestResolveFromIndex(unittest.TestCase):
             # Should choose the second one as py version is not considered platform specific.
             self.assertEqual(resolve_from_index(name)[0], index_data[name][1]['downloadUrl'])
 
-    def test_filter_version(self):
+    def test_filter_target_version(self):
         ext_name = 'hello'
         index_data = {
             ext_name: [
@@ -65,8 +65,8 @@ class TestResolveFromIndex(unittest.TestCase):
         }
 
         with IndexPatch(index_data):
-            self.assertEqual(resolve_from_index(ext_name, cur_version='0.1.0')[0], index_data[ext_name][0]['downloadUrl'])
-            self.assertEqual(resolve_from_index(ext_name, cur_version='0.2.0')[0], index_data[ext_name][1]['downloadUrl'])
+            self.assertEqual(resolve_from_index(ext_name, target_version='0.1.0')[0], index_data[ext_name][0]['downloadUrl'])
+            self.assertEqual(resolve_from_index(ext_name, target_version='0.2.0')[0], index_data[ext_name][1]['downloadUrl'])
 
 
 class TestResolveFilters(unittest.TestCase):

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
@@ -6,7 +6,7 @@ import unittest
 
 from azure.cli.core.extension._resolve import (resolve_from_index, resolve_project_url_from_index,
                                                NoExtensionCandidatesError, _is_not_platform_specific,
-                                               _is_greater_than_or_equal_to_cur_version)
+                                               _is_greater_than_cur_version)
 from . import IndexPatch, mock_ext
 
 
@@ -64,9 +64,14 @@ class TestResolveFromIndex(unittest.TestCase):
             ]
         }
 
+        # resolve okay
         with IndexPatch(index_data):
             self.assertEqual(resolve_from_index(ext_name, target_version='0.1.0')[0], index_data[ext_name][0]['downloadUrl'])
             self.assertEqual(resolve_from_index(ext_name, target_version='0.2.0')[0], index_data[ext_name][1]['downloadUrl'])
+
+        with IndexPatch(index_data):
+            with self.assertRaisesRegex(NoExtensionCandidatesError, 'Extension with version 0.3.0 not found'):
+                resolve_from_index(ext_name, target_version='0.3.0')
 
 
 class TestResolveFilters(unittest.TestCase):
@@ -80,9 +85,9 @@ class TestResolveFilters(unittest.TestCase):
         self.assertFalse(_is_not_platform_specific(mock_ext('myext-1.1.26.0-py2-none-linux_armv7l.whl')))
 
     def test_greater_than_current(self):
-        self.assertIsNone(_is_greater_than_or_equal_to_cur_version(None))
-        self.assertIsNotNone(_is_greater_than_or_equal_to_cur_version('0.0.1'))
-        filter_func = _is_greater_than_or_equal_to_cur_version('0.0.1')
+        self.assertIsNone(_is_greater_than_cur_version(None))
+        self.assertIsNotNone(_is_greater_than_cur_version('0.0.1'))
+        filter_func = _is_greater_than_cur_version('0.0.1')
         filter_func
         self.assertTrue(filter_func(mock_ext('myext-0.0.2-py2.py3-none-any.whl', '0.0.2')))
         self.assertTrue(filter_func(mock_ext('myext-0.0.1+dev-py2.py3-none-any.whl', '0.0.1+dev')))

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
@@ -84,6 +84,7 @@ class TestResolveFromIndex(unittest.TestCase):
             self.assertEqual(resolve_from_index(ext_name, cur_version='0.1.0')[0], index_data[ext_name][0]['downloadUrl'])
             self.assertEqual(resolve_from_index(ext_name, cur_version='0.2.0')[0], index_data[ext_name][1]['downloadUrl'])
 
+
 class TestResolveFilters(unittest.TestCase):
 
     def test_platform_specific(self):

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
@@ -3,27 +3,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import unittest
-import mock
 
 from azure.cli.core.extension._resolve import (resolve_from_index, resolve_project_url_from_index,
                                                NoExtensionCandidatesError, _is_not_platform_specific,
                                                _is_greater_than_or_equal_to_cur_version)
-
-
-class IndexPatch(object):
-    def __init__(self, data=None):
-        self.patcher = mock.patch('azure.cli.core.extension._resolve.get_index_extensions', return_value=data)
-
-    def __enter__(self):
-        self.patcher.start()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.patcher.stop()
-
-
-def mock_ext(filename, version=None, download_url=None, digest=None, project_url=None):
-    return {'filename': filename, 'metadata': {'version': version, 'extensions': {'python.details': {'project_urls': {'Home': project_url or 'https://github.com/azure/some-extension'}}}}, 'downloadUrl': download_url or 'http://contoso.com/{}'.format(filename), 'sha256Digest': digest}
+from . import IndexPatch, mock_ext
 
 
 class TestResolveFromIndex(unittest.TestCase):

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py
@@ -82,7 +82,7 @@ class TestResolveFromIndex(unittest.TestCase):
 
         with IndexPatch(index_data):
             self.assertEqual(resolve_from_index(ext_name, cur_version='0.1.0')[0], index_data[ext_name][0]['downloadUrl'])
-            self.assertEqual(resolve_from_index(ext_name, cur_version='0.2.0')[0], index_data[ext_name][2]['downloadUrl'])
+            self.assertEqual(resolve_from_index(ext_name, cur_version='0.2.0')[0], index_data[ext_name][1]['downloadUrl'])
 
 class TestResolveFilters(unittest.TestCase):
 

--- a/src/azure-cli/azure/cli/command_modules/extension/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/__init__.py
@@ -70,6 +70,7 @@ class ExtensionCommandsLoader(AzCommandsLoader):
             c.argument('extension_name', completer=extension_name_from_index_completion_list)
             c.argument('source', options_list=['--source', '-s'], help='Filepath or URL to an extension', completer=FilesCompleter())
             c.argument('yes', options_list=['--yes', '-y'], action='store_true', help='Do not prompt for confirmation.')
+            c.argument('version', default='latest', help='The specific version of an extension')
 
         with self.argument_context('extension list-available') as c:
             c.argument('show_details', options_list=['--show-details', '-d'], action='store_true', help='Show the raw data from the extension index.')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Close https://github.com/Azure/azure-cli-extensions/issues/1587.

Azure CLI support install extension from an older version.

**Testing Guide**  
`az extension add -n {EXTENSION_NAME} --version {CERTAIN_VERSION}`

Such as azure-firewall, azure-devops, azure-cli-ml

Test Scenario:
1. Install azure-firewall without version, it will install 0.31.0 by default the latest. Then, install with --version 0.30.0, CLI will reject to install.
2. Install azure-firewall with version 0.30.0, it will install 0.30.0 as expected. Then, install without --version, CLI will reject to install.
3. show extension will show the correct version of azure-firewall

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
