### PR TITLE
{Packaging} Use subprocess for better cross-platform support

### DIFF
--- a/src/azure-cli/az
+++ b/src/azure-cli/az
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import subprocess
 
 dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'src')
 
@@ -16,4 +17,4 @@ else:
 if os.environ.get('AZ_INSTALLER') is None:
     os.environ['AZ_INSTALLER'] = 'PIP'
 
-os.execl(sys.executable, sys.executable, '-m', 'azure.cli', *sys.argv[1:])
+subprocess.run([sys.executable, '-m', 'azure.cli'] + sys.argv[1:])


### PR DESCRIPTION
The entry script `az` added by #10516 introduced 2 issues on Windows-based Linux, like Git Bash, MinGW, Cygwin.

## Quoting issue

Directly calling `os.exec` will result in the quoting issue mentioned in https://github.com/Azure/azure-cli/pull/13774: spaces are used as argument separator.

According to [_exec, _wexec Functions](https://docs.microsoft.com/en-us/cpp/c-runtime-library/exec-wexec-functions?view=vs-2019), this is the expected behavior:

> Spaces embedded in strings may cause unexpected behavior; for example, passing `_exec` the string `"hi there"` will result in the new process getting two arguments, `"hi"` and `"there"`. If the intent was to have the new process open a file named "hi there", the process would fail. You can avoid this by quoting the string: `"\"hi there\""`.

[`subprocess.Popen`](https://docs.python.org/3/library/subprocess.html#subprocess.Popen) on the other hand will pre-process the `args` using the `subprocess.list2cmdline` function so that `args` are preserved when they are sent to [CreateProcess](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw).

## The entry script doesn't wait for `azure.cli` to finish

When the entry script is executed in Git Bash, it will exit before the actual `azure.cli` finishes. Note that the prompt `$` appears in the wrong location:

```sh
user@surface MINGW64 ~
$ az version

user@surface MINGW64 ~
$ {
  "azure-cli": "2.7.0",
  "azure-cli-command-modules-nspkg": "2.0.3",
  "azure-cli-core": "2.7.0",
  "azure-cli-nspkg": "3.0.4",
  "azure-cli-telemetry": "1.0.4",
  "extensions": {
    "application-insights": "0.1.1",
    "interactive": "0.4.4",
    "mesh": "0.10.6",
    "timeseriesinsights": "0.1.2",
    "webapp": "0.2.24"
  }
}
```

According to [_exec, _wexec Functions](https://docs.microsoft.com/en-us/cpp/c-runtime-library/exec-wexec-functions?view=vs-2019), `os.exec` internally uses [CreateProcess](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw) which doesn't wait for the sub-process.

Using [`Popen.wait`](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait), the entry script can wait for `azure.cli` to finish before exiting.

BTW, Linux on the other hand doesn't face these 2 issue.