### PR TITLE
{Identity} Fix playback tests and add tests for logout

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_identity.py
+++ b/src/azure-cli-core/azure/cli/core/_identity.py
@@ -258,7 +258,7 @@ class Identity:
         return decoded
 
     def get_user(self, user_or_sp=None):
-        accounts = self._msal_app.get_accounts(user_or_sp)
+        accounts = self._msal_app.get_accounts(user_or_sp) if user_or_sp else self._msal_app.get_accounts()
         return accounts
 
     def logout_user(self, user_or_sp):

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -62,7 +62,7 @@ class TestProfile(unittest.TestCase):
                                      'state': 'Enabled',
                                      'tenantId': 'microsoft.com',
                                      'user': {
-                                         'homeAccountId': '00000003-0000-0000-0000-000000000000@00000003-0000-0000-0000-000000000000',
+                                         'homeAccountId': '00000003-0000-0000-0000-000000000000.00000003-0000-0000-0000-000000000000',
                                          'name': 'foo@foo.com',
                                          'type': 'user'}}]
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/patches.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/patches.py
@@ -50,6 +50,9 @@ def patch_load_cached_subscriptions(unit_test):
         return [{
             "id": MOCKED_SUBSCRIPTION_ID,
             "user": {
+                # TODO: Azure Identity may remove homeAccountId in the future, since it is internal to MSAL and
+                #   may not be absolutely necessary
+                "homeAccountId": "00000003-0000-0000-0000-000000000000.00000003-0000-0000-0000-000000000000",
                 "name": MOCKED_USER_NAME,
                 "type": "user"
             },
@@ -64,21 +67,17 @@ def patch_load_cached_subscriptions(unit_test):
 
 
 def patch_retrieve_token_for_user(unit_test):
-    def _retrieve_token_for_user(*args, **kwargs):  # pylint: disable=unused-argument
-        import datetime
-        fake_token = 'top-secret-token-for-you'
-        return 'Bearer', fake_token, {
-            "tokenType": "Bearer",
-            "expiresIn": 3600,
-            "expiresOn": (datetime.datetime.now() + datetime.timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S.%f"),
-            "resource": args[3],
-            "accessToken": fake_token,
-            "refreshToken": fake_token
-        }
+    def _mock_get_token(*args, **kwargs):  # pylint: disable=unused-argument
+        from azure.core.credentials import AccessToken
+        import time
+        fake_raw_token = 'top-secret-token-for-you'
+        now = int(time.time())
+        # Mock sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py:230
+        return AccessToken(fake_raw_token, now + 3600)
 
     mock_in_unit_test(unit_test,
-                      'azure.cli.core._profile.CredsCache.retrieve_token_for_user',
-                      _retrieve_token_for_user)
+                      'azure.identity.InteractiveBrowserCredential.get_token',
+                      _mock_get_token)
 
 
 def patch_long_run_operation_delay(unit_test):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
1. Fix recording playback to adapt to Azure Identity `get_token` pattern 
2. Add tests for logout

**Testing Guide**  
1. Use unittest/pytest/`azdev test` to run any test case in playback mode
2. Run `test_logout` and `test_logout_all`
