### PR TITLE
{AppService} Delay importing is_valid_resource_id, parse_resource_id

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 from knack.util import CLIError
-from msrestazure.tools import is_valid_resource_id, parse_resource_id
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from ._client_factory import web_client_factory
 from .utils import _normalize_sku
@@ -20,6 +19,7 @@ def validate_timeout_value(namespace):
 def validate_site_create(cmd, namespace):
     """Validate the SiteName that is being used to create is available
     This API requires that the RG is already created"""
+    from azure.mgmt.core.tools import is_valid_resource_id, parse_resource_id
     client = web_client_factory(cmd.cli_ctx)
     if isinstance(namespace.name, str) and isinstance(namespace.resource_group_name, str) \
             and isinstance(namespace.plan, str):


### PR DESCRIPTION
**Description<!--Mandatory-->**  

`from msrestazure.tools import is_valid_resource_id, parse_resource_id` is slow and can slow down the whole Azure CLI!

![image](https://user-images.githubusercontent.com/4003950/83989078-d18b6f80-a977-11ea-8f88-9dc8a06a83b0.png)

Delay importing them and import then only when absolutely necessary.

Also migrate to `azure.mgmt.core` at the same time. 
