### PR TITLE
[ACR] BREAKING CHANGE: `az acr login --expose-token` does not accept username and password

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -185,6 +185,9 @@ def acr_login(cmd,
               password=None,
               expose_token=False):
     if expose_token:
+        if username or password:
+            raise CLIError("Exposing token for admin users and token users is unsupported.")
+
         login_server, _, password = get_login_credentials(
             cmd=cmd,
             registry_name=registry_name,

--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -186,7 +186,7 @@ def acr_login(cmd,
               expose_token=False):
     if expose_token:
         if username or password:
-            raise CLIError("Exposing token for admin users and token users is unsupported.")
+            raise CLIError("`--expose-token` cannot be combined with `--username` or `--password`.")
 
         login_server, _, password = get_login_credentials(
             cmd=cmd,


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fix #13847
BREAKING CHANGE: The `az acr login --expose-token` now raises error if username or password is specified.

**Testing Guide**  
<!--Example commands with explanations.-->

`az acr login -n myregistry -u username -p password --expose-token`

Before:
![image](https://user-images.githubusercontent.com/8113721/84012123-a9b4ff80-a9a9-11ea-85e3-b38d0743ea12.png)

After:
![image](https://user-images.githubusercontent.com/8113721/84250214-56c08100-ab3e-11ea-9f1f-8e5e60dcf63a.png)



**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
