### PR TITLE
[Storage] `az storage remove`: Fix issue #13459 to raise exception for operation failure

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -76,7 +76,9 @@ class AzCopy(object):
         env_kwargs = {}
         if self.creds and self.creds.token_info:
             env_kwargs = {'AZCOPY_OAUTH_TOKEN_INFO': json.dumps(self.creds.token_info)}
-        subprocess.call(args, env=dict(os.environ, **env_kwargs))
+        result = subprocess.call(args, env=dict(os.environ, **env_kwargs))
+        if result > 0:
+            raise CLIError('Failed to perform {} operation.'.format(args[1]))
 
     def copy(self, source, destination, flags=None):
         flags = flags or []

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_azcopy_scenarios.py
@@ -7,6 +7,7 @@ import shutil
 from azure.cli.testsdk import (StorageAccountPreparer, LiveScenarioTest, JMESPathCheck, ResourceGroupPreparer,
                                api_version_constraint)
 from ..storage_test_util import StorageScenarioMixin, StorageTestFilesPreparer
+from knack.util import CLIError
 
 
 class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
@@ -104,6 +105,10 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
 
         self.cmd('storage remove -c {} -n readme --account-name {}'.format(
             container, storage_account))
+
+        self.cmd('storage remove -c {} -n readme --account-name {}'.format(
+            container, storage_account), expect_failure=True)
+
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 40))
 
@@ -122,19 +127,9 @@ class StorageAzcopyTests(StorageScenarioMixin, LiveScenarioTest):
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 10))
 
-        self.cmd('storage remove -c {} -n duff --account-name {}'.format(
-            container, storage_account))
-        self.cmd('storage blob list -c {} --account-name {}'.format(
-            container, storage_account), checks=JMESPathCheck('length(@)', 10))
-
         # sync directory
         self.cmd('storage blob sync -s "{}" -c {} --account-name {}'.format(
             test_dir, container, storage_account))
-        self.cmd('storage blob list -c {} --account-name {}'.format(
-            container, storage_account), checks=JMESPathCheck('length(@)', 41))
-
-        self.cmd('storage remove -c {} -n butter --account-name {} --recursive --exclude-pattern "file_*"'.format(
-            container, storage_account))
         self.cmd('storage blob list -c {} --account-name {}'.format(
             container, storage_account), checks=JMESPathCheck('length(@)', 41))
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In previous command, when operation failed, the error message will be printed in terminal but no exception raised.

To help DevOps users leverage the exception information, we should raise error when failed.

Fix issue  #13459 

**Testing Guide**  
<!--Example commands with explanations.-->
`az storage remove`

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
