### PR TITLE
{RBAC} Improve help message for `az ad sp create-for-rbac`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -353,6 +353,9 @@ examples:
 helps['ad sp create-for-rbac'] = """
 type: command
 short-summary: Create a service principal and configure its access to Azure resources.
+long-summary: >
+    When --skip-assignment is specified, --scopes will be ignored. You may use `az role assignment create` to create
+    role assignments for this service principal later.
 parameters:
   - name: --name -n
     short-summary: a URI to use as the logic name. It doesn't need to exist. If not present, CLI will generate one.
@@ -369,7 +372,9 @@ parameters:
   - name: --scopes
     short-summary: >
         Space-separated list of scopes the service principal's role assignment applies to.
-        Defaults to the root of the current subscription.
+        Defaults to the root of the current subscription. e.g., /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333,
+        /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup, or
+        /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM
   - name: --role
     short-summary: Role of the service principal.
 examples:

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -353,9 +353,6 @@ examples:
 helps['ad sp create-for-rbac'] = """
 type: command
 short-summary: Create a service principal and configure its access to Azure resources.
-long-summary: >
-    When --skip-assignment is specified, --scopes will be ignored. You may use `az role assignment create` to create
-    role assignments for this service principal later.
 parameters:
   - name: --name -n
     short-summary: a URI to use as the logic name. It doesn't need to exist. If not present, CLI will generate one.

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -81,7 +81,9 @@ def load_arguments(self, _):
         c.argument('scopes', nargs='+')
         c.argument('role', completer=get_role_definition_name_completion_list)
         c.argument('skip_assignment', arg_type=get_three_state_flag(),
-                   help='Skip creating the default assignment, which allows the service principal to access resources under the current subscription')
+                   help='Skip creating the default assignment, which allows the service principal to access resources under the current subscription. '
+                        'When specified, --scopes will be ignored. You may use `az role assignment create` to create '
+                        'role assignments for this service principal later.')
         c.argument('show_auth_for_sdk', options_list='--sdk-auth', help='output result in compatible with Azure SDK auth file', arg_type=get_three_state_flag())
 
     with self.argument_context('ad sp owner list') as c:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Close https://github.com/Azure/azure-cli/issues/11031

Improve help message for `az ad sp create-for-rbac` and  `--scopes` parameter:

```
> az ad sp create-for-rbac -h

...

        When --skip-assignment is specified, --scopes will be ignored. You may use `az role
        assignment create` to create role assignments for this service principal later.

Arguments
    ...
    --scopes           : Space-separated list of scopes the service principal's role assignment
                         applies to. Defaults to the root of the current subscription. e.g.,
                         /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333,
                         /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup,
                         or /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGro
                         up/providers/Microsoft.Compute/virtualMachines/myVM.
    --skip-assignment  : Skip creating the default assignment, which allows the service principal to
                         access resources under the current subscription.  Allowed values: false,
                         true.
```
