### PR TITLE
[AKS] Fix typo in az aks update command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2147,7 +2147,7 @@ def aks_update(cmd, client, resource_group_name, name,
                        '"--load-balancer-outbound-ip-prefixes" or'
                        '"--load-balancer-outbound-ports" or'
                        '"--load-balancer-idle-timeout" or'
-                       '"--attach-acr" or "--dettach-acr" or'
+                       '"--attach-acr" or "--detach-acr" or'
                        '"--uptime-sla" or'
                        '"--"api-server-authorized-ip-ranges')
 


### PR DESCRIPTION
**Description**  

Fixes typo in the error text for az aks update, specially to replace --dettach-acr with --detach-acr. 

Fixes #13555

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
