### PR TITLE
[Compute] Show a warning when a user deploys a VMSS pinned to a specific image version rather than latest

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -2411,6 +2411,10 @@ def create_vmss(cmd, vmss_name, resource_group_name, image=None,
         if computer_name_prefix is not None and isinstance(computer_name_prefix, str):
             naming_prefix = computer_name_prefix
 
+        if os_version and os_version != 'latest':
+            logger.warning('You are deploying VMSS pinned to a specific image version from Azure Marketplace. '
+                           'Consider using "latest" as the image version.')
+
         vmss_resource = build_vmss_resource(
             cmd=cmd, name=vmss_name, naming_prefix=naming_prefix, location=location, tags=tags,
             overprovision=not disable_overprovision, upgrade_policy_mode=upgrade_policy_mode, vm_sku=vm_sku,


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Resolve https://github.com/Azure/azure-cli/issues/13931
Show a warning when a user deploys a VMSS pinned to a specific image version rather than latest
```
You are deploying VMSS pinned to a specific image version from Azure Marketplace. Consider using "latest" as the image version.
```

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
