### PR TITLE
[AKS] Fix typo on VirtualMachineScaleSets and update references to Kubernetes versions

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -207,7 +207,7 @@ parameters:
     short-summary: Size in GB of the OS disk for each node in the node pool. Minimum 30 GB.
   - name: --kubernetes-version -k
     type: string
-    short-summary: Version of Kubernetes to use for creating the cluster, such as "1.11.8" or "1.12.6".
+    short-summary: Version of Kubernetes to use for creating the cluster, such as "1.16.9".
     populator-commands:
       - "`az aks get-versions`"
   - name: --ssh-key-value
@@ -354,12 +354,12 @@ examples:
   - name: Create a Kubernetes cluster with an existing SSH public key.
     text: az aks create -g MyResourceGroup -n MyManagedCluster --ssh-key-value /path/to/publickey
   - name: Create a Kubernetes cluster with a specific version.
-    text: az aks create -g MyResourceGroup -n MyManagedCluster --kubernetes-version 1.12.6
+    text: az aks create -g MyResourceGroup -n MyManagedCluster --kubernetes-version 1.16.9
   - name: Create a Kubernetes cluster with a larger node pool.
     text: az aks create -g MyResourceGroup -n MyManagedCluster --node-count 7
   - name: Create a kubernetes cluster with k8s 1.13.9 but use vmas.
-    text: az aks create -g MyResourceGroup -n MyManagedCluster --kubernetes-version 1.13.9 --vm-set-type AvailabilitySet
-  - name: Create a kubernetes cluster with default kubernetes version, default SKU load balancer (Standard) and default vm set type (VirtualMachineScaleSet).
+    text: az aks create -g MyResourceGroup -n MyManagedCluster --kubernetes-version 1.16.9 --vm-set-type AvailabilitySet
+  - name: Create a kubernetes cluster with default kubernetes version, default SKU load balancer (Standard) and default vm set type (VirtualMachineScaleSets).
     text: az aks create -g MyResourceGroup -n MyManagedCluster
   - name: Create a kubernetes cluster with standard SKU load balancer and two AKS created IPs for the load balancer outbound connection usage.
     text: az aks create -g MyResourceGroup -n MyManagedCluster --load-balancer-managed-outbound-ip-count 2
@@ -614,7 +614,7 @@ parameters:
     short-summary: Number of nodes in the Kubernetes agent pool. After creating a cluster, you can change the size of its node pool with `az aks scale`.
   - name: --kubernetes-version -k
     type: string
-    short-summary: Version of Kubernetes to use for creating the cluster, such as "1.7.12" or "1.8.7".
+    short-summary: Version of Kubernetes to use for creating the cluster, such as "1.16.9".
     populator-commands:
       - "`az aks get-versions`"
   - name: --node-osdisk-size
@@ -717,7 +717,7 @@ short-summary: Upgrade the node pool in a managed Kubernetes cluster.
 parameters:
   - name: --kubernetes-version -k
     type: string
-    short-summary: Version of Kubernetes to upgrade the node pool to, such as "1.11.12".
+    short-summary: Version of Kubernetes to upgrade the node pool to, such as "1.16.9".
 """
 
 helps['aks remove-connector'] = """
@@ -820,7 +820,7 @@ long-summary: "Kubernetes will be unavailable during cluster upgrades."
 parameters:
   - name: --kubernetes-version -k
     type: string
-    short-summary: Version of Kubernetes to upgrade the cluster to, such as "1.11.8" or "1.12.6".
+    short-summary: Version of Kubernetes to upgrade the cluster to, such as "1.16.9".
     populator-commands:
       - "`az aks get-upgrades`"
   - name: --control-plane-only


### PR DESCRIPTION
**Description<!--Mandatory-->**  

Updated the help text to fix one typo that was missing an 's' on VirtualMachineScaleSets. Fixes #13945 

Snapped all references to Kubernetes versions to one that is currently supported. Fixes #13922 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
