### PR TITLE
[Storage] Fix the storage account name in examples

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -30,8 +30,8 @@ long-summary: >
     properties for Storage Analytics and CORS (Cross-Origin Resource
     Sharing) rules.
 examples:
-  - name: Show the properties of the storage account 'MyStorageAccount' in resource group 'MyResourceGroup'.
-    text: az storage account blob-service-properties show -n MyStorageAccount -g MyResourceGroup
+  - name: Show the properties of the storage account 'mystorageaccount' in resource group 'MyResourceGroup'.
+    text: az storage account blob-service-properties show -n mystorageaccount -g MyResourceGroup
 """
 
 helps['storage account blob-service-properties update'] = """
@@ -49,12 +49,12 @@ parameters:
   - name: --delete-retention-days
     short-summary: 'Indicate the number of days that the deleted blob should be retained. The value must be in range [1,365]. It must be provided when `--enable-delete-retention` is true.'
 examples:
-  - name: Enable the change feed for the storage account 'MyStorageAccount' in resource group 'MyResourceGroup'.
-    text: az storage account blob-service-properties update --enable-change-feed true -n MyStorageAccount -g MyResourceGroup
-  - name: Enable delete retention policy and set delete retention days to 100 for the storage account 'MyStorageAccount' in resource group 'MyResourceGroup'.
-    text: az storage account blob-service-properties update --enable-delete-retention true --delete-retention-days 100 -n MyStorageAccount -g MyResourceGroup
-  - name: Enable versioning for the storage account 'MyStorageAccount' in resource group 'MyResourceGroup'.
-    text: az storage account blob-service-properties update --enable-versioning -n MyStorageAccount -g MyResourceGroup
+  - name: Enable the change feed for the storage account 'mystorageaccount' in resource group 'MyResourceGroup'.
+    text: az storage account blob-service-properties update --enable-change-feed true -n mystorageaccount -g MyResourceGroup
+  - name: Enable delete retention policy and set delete retention days to 100 for the storage account 'mystorageaccount' in resource group 'MyResourceGroup'.
+    text: az storage account blob-service-properties update --enable-delete-retention true --delete-retention-days 100 -n mystorageaccount -g MyResourceGroup
+  - name: Enable versioning for the storage account 'mystorageaccount' in resource group 'MyResourceGroup'.
+    text: az storage account blob-service-properties update --enable-versioning -n mystorageaccount -g MyResourceGroup
 """
 
 helps['storage account create'] = """
@@ -412,8 +412,8 @@ short-summary: Revoke all user delegation keys for a storage account.
 examples:
   - name: Revoke all user delegation keys for a storage account by resource ID.
     text: az storage account revoke-delegation-keys --ids /subscriptions/{SubID}/resourceGroups/{ResourceGroup}/providers/Microsoft.Storage/storageAccounts/{StorageAccount}
-  - name: Revoke all user delegation keys for a storage account 'MyStorageAccount' in resource group 'MyResourceGroup' in the West US region with locally redundant storage.
-    text: az storage account revoke-delegation-keys -n MyStorageAccount -g MyResourceGroup
+  - name: Revoke all user delegation keys for a storage account 'mystorageaccount' in resource group 'MyResourceGroup' in the West US region with locally redundant storage.
+    text: az storage account revoke-delegation-keys -n mystorageaccount -g MyResourceGroup
 """
 
 helps['storage account show'] = """


### PR DESCRIPTION
Issue: #10020

**Description<!--Mandatory-->**  
There are two problems in the existing examples:
1. `xxx storage account 'MyStorageAccount'` This style of writing makes the customers think that it is a name rather than a placeholder, so it's value should follow the limitation of storage account name.
2. In the existing examples, some are written as `storage account 'MyStorageAccount'`, some as `storage account 'mystorageaccount'`, and they should be unified

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
