### PR TITLE
[AKS] az aks create: add --enable-aad argument

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -385,6 +385,8 @@ examples:
     text: az aks create -g MyResourceGroup -n MyManagedCluster --outbound-type userDefinedRouting --load-balancer-sku standard --vnet-subnet-id customUserSubnetVnetID
   - name: Create a kubernetes cluster with supporting Windows agent pools.
     text: az aks create -g MyResourceGroup -n MyManagedCluster --load-balancer-sku Standard --vm-set-type VirtualMachineScaleSet --network-plugin azure --windows-admin-username azure --windows-admin-password 'replacePassword1234$'
+  - name: Create a kubernetes cluster with managed AAD enabled.
+    text: az aks create -g MyResourceGroup -n MyManagedCluster --enable-aad --aad-admin-group-object-ids <id-1,id-2> --aad-tenant-id <id>
 """
 
 helps['aks update'] = """
@@ -461,6 +463,8 @@ examples:
     text: az aks update -g MyResourceGroup -n MyManagedCluster --api-server-authorized-ip-ranges ""
   - name: Restrict apiserver traffic in a kubernetes cluster to agentpool nodes.
     text: az aks update -g MyResourceGroup -n MyManagedCluster --api-server-authorized-ip-ranges 0.0.0.0/32
+  - name: Update a AKS-managed AAD cluster with tenant ID or admin group object IDs.
+    text: az aks update -g MyResourceGroup -n MyManagedCluster --aad-admin-group-object-ids <id-1,id-2> --aad-tenant-id <id>
 """
 
 helps['aks delete'] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -222,6 +222,12 @@ parameters:
   - name: --windows-admin-password
     type: string
     short-summary: Password to create on Windows node VMs.
+  - name: --enable-aad
+    type: bool
+    short-summary: Enable managed AAD feature for cluster.
+  - name: --aad-admin-group-object-ids
+    type: string
+    short-summary: Comma seperated list of aad group object IDs that will be set as cluster admin.
   - name: --aad-client-app-id
     type: string
     short-summary: The ID of an Azure Active Directory client application of type "Native". This application is for user login via kubectl.
@@ -350,6 +356,12 @@ parameters:
   - name: --enable-managed-identity
     type: bool
     short-summary: Using a system assigned managed identity to manage cluster resource group.
+  - name: --aad-admin-group-object-ids
+    type: string
+    short-summary: Comma seperated list of aad group object IDs that will be set as cluster admin.
+  - name: --aad-tenant-id
+    type: string
+    short-summary: The ID of an Azure Active Directory tenant.
 examples:
   - name: Create a Kubernetes cluster with an existing SSH public key.
     text: az aks create -g MyResourceGroup -n MyManagedCluster --ssh-key-value /path/to/publickey

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -356,12 +356,6 @@ parameters:
   - name: --enable-managed-identity
     type: bool
     short-summary: Using a system assigned managed identity to manage cluster resource group.
-  - name: --aad-admin-group-object-ids
-    type: string
-    short-summary: Comma seperated list of aad group object IDs that will be set as cluster admin.
-  - name: --aad-tenant-id
-    type: string
-    short-summary: The ID of an Azure Active Directory tenant.
 examples:
   - name: Create a Kubernetes cluster with an existing SSH public key.
     text: az aks create -g MyResourceGroup -n MyManagedCluster --ssh-key-value /path/to/publickey
@@ -444,6 +438,12 @@ parameters:
   - name: --api-server-authorized-ip-ranges
     type: string
     short-summary: Comma seperated list of authorized apiserver IP ranges. Set to "" to allow all traffic on a previously restricted cluster. Set to 0.0.0.0/32 to restrict apiserver traffic to node pools.
+  - name: --aad-admin-group-object-ids
+    type: string
+    short-summary: Comma seperated list of aad group object IDs that will be set as cluster admin.
+  - name: --aad-tenant-id
+    type: string
+    short-summary: The ID of an Azure Active Directory tenant.
 examples:
   - name: Update a kubernetes cluster with standard SKU load balancer to use two AKS created IPs for the load balancer outbound connection usage.
     text: az aks update -g MyResourceGroup -n MyManagedCluster --load-balancer-managed-outbound-ip-count 2

--- a/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
@@ -79,3 +79,11 @@ def _set_outbound_type(outbound_type, vnet_subnet_id, load_balancer_sku, load_ba
             raise CLIError("userDefinedRouting doesn't support customizing a standard load balancer with IP addresses")
 
     return CONST_OUTBOUND_TYPE_USER_DEFINED_ROUTING
+
+
+def _parse_comma_separated_list(text):
+    if text is None:
+        return None
+    if text == "":
+        return []
+    return text.split(",")

--- a/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
@@ -87,4 +87,3 @@ def _parse_comma_separated_list(text):
     if text == "":
         return []
     return text.split(",")
-

--- a/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_helpers.py
@@ -87,3 +87,4 @@ def _parse_comma_separated_list(text):
     if text == "":
         return []
     return text.split(",")
+

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -88,7 +88,7 @@ from ._client_factory import cf_resources
 from ._client_factory import get_resource_by_name
 from ._client_factory import cf_container_registry_service
 
-from ._helpers import _populate_api_server_access_profile, _set_vm_set_type, _set_outbound_type
+from ._helpers import (_populate_api_server_access_profile, _set_vm_set_type, _set_outbound_type, _parse_comma_separated_list)
 
 from ._loadbalancer import (set_load_balancer_sku, is_load_balancer_profile_provided,
                             update_load_balancer_profile, create_load_balancer_profile)
@@ -1692,6 +1692,8 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
                enable_private_cluster=False,
                enable_managed_identity=False,
                attach_acr=None,
+               enable_aad=False,
+               aad_admin_group_object_ids=None,
                no_wait=False):
     _validate_ssh_key(no_ssh_key, ssh_key_value)
     subscription_id = get_subscription_id(cmd.cli_ctx)
@@ -1852,17 +1854,27 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
         _ensure_container_insights_for_monitoring(cmd, addon_profiles['omsagent'])
 
     aad_profile = None
-    if any([aad_client_app_id, aad_server_app_id, aad_server_app_secret, aad_tenant_id]):
-        if aad_tenant_id is None:
-            profile = Profile(cli_ctx=cmd.cli_ctx)
-            _, _, aad_tenant_id = profile.get_login_credentials()
-
+    if enable_aad:
+        if any([aad_client_app_id, aad_server_app_id, aad_server_app_secret]):
+            raise CLIError('"--enable-aad" cannot be used together with '
+                           '"--aad-client-app-id/--aad-server-app-id/--aad-server-app-secret"')
         aad_profile = ManagedClusterAADProfile(
-            client_app_id=aad_client_app_id,
-            server_app_id=aad_server_app_id,
-            server_app_secret=aad_server_app_secret,
+            managed=True,
+            admin_group_object_ids=_parse_comma_separated_list(aad_admin_group_object_ids),
             tenant_id=aad_tenant_id
         )
+    else:
+        if any([aad_client_app_id, aad_server_app_id, aad_server_app_secret, aad_tenant_id]):
+            if aad_tenant_id is None:
+                profile = Profile(cli_ctx=cmd.cli_ctx)
+                _, _, aad_tenant_id = profile.get_login_credentials()
+
+            aad_profile = ManagedClusterAADProfile(
+                client_app_id=aad_client_app_id,
+                server_app_id=aad_server_app_id,
+                server_app_secret=aad_server_app_secret,
+                tenant_id=aad_tenant_id
+            )
 
     api_server_access_profile = None
     if enable_private_cluster and load_balancer_sku.lower() != "standard":
@@ -2126,6 +2138,8 @@ def aks_update(cmd, client, resource_group_name, name,
                attach_acr=None,
                detach_acr=None,
                api_server_authorized_ip_ranges=None,
+               aad_tenant_id=None,
+               aad_admin_group_object_ids=None,
                no_wait=False):
     update_autoscaler = enable_cluster_autoscaler + disable_cluster_autoscaler + update_cluster_autoscaler
     update_lb_profile = is_load_balancer_profile_provided(load_balancer_managed_outbound_ip_count,
@@ -2133,13 +2147,14 @@ def aks_update(cmd, client, resource_group_name, name,
                                                           load_balancer_outbound_ip_prefixes,
                                                           load_balancer_outbound_ports,
                                                           load_balancer_idle_timeout)
-
+    update_aad_profile = not (aad_tenant_id is None and aad_admin_group_object_ids is None)
     # pylint: disable=too-many-boolean-expressions
     if (update_autoscaler != 1 and not update_lb_profile and
             not attach_acr and
             not detach_acr and
             not uptime_sla and
-            api_server_authorized_ip_ranges is None):
+            api_server_authorized_ip_ranges is None and
+            not update_aad_profile):
         raise CLIError('Please specify one or more of "--enable-cluster-autoscaler" or '
                        '"--disable-cluster-autoscaler" or '
                        '"--update-cluster-autoscaler" or '
@@ -2150,7 +2165,9 @@ def aks_update(cmd, client, resource_group_name, name,
                        '"--load-balancer-idle-timeout" or'
                        '"--attach-acr" or "--detach-acr" or'
                        '"--uptime-sla" or'
-                       '"--"api-server-authorized-ip-ranges')
+                       '"--api-server-authorized-ip-ranges" or '
+                       '"--aad-tenant-id" or '
+                       '"--aad-admin-group-object-ids"')
 
     instance = client.get(resource_group_name, name)
     # For multi-agent pool, use the az aks nodepool command
@@ -2234,6 +2251,15 @@ def aks_update(cmd, client, resource_group_name, name,
     if api_server_authorized_ip_ranges is not None:
         instance.api_server_access_profile = \
             _populate_api_server_access_profile(api_server_authorized_ip_ranges, instance=instance)
+
+    if update_aad_profile:
+        if instance.aad_profile is None or not instance.aad_profile.managed:
+            raise CLIError('Cannot specify "--aad-tenant-id/--aad-admin-group-object-ids"'
+                           ' if managed aad not is enabled')
+        if aad_tenant_id is not None:
+            instance.aad_profile.tenant_id = aad_tenant_id
+        if aad_admin_group_object_ids is not None:
+            instance.aad_profile.admin_group_object_ids = _parse_comma_separated_list(aad_admin_group_object_ids)
 
     return sdk_no_wait(no_wait, client.create_or_update, resource_group_name, name, instance)
 

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -88,7 +88,8 @@ from ._client_factory import cf_resources
 from ._client_factory import get_resource_by_name
 from ._client_factory import cf_container_registry_service
 
-from ._helpers import (_populate_api_server_access_profile, _set_vm_set_type, _set_outbound_type, _parse_comma_separated_list)
+from ._helpers import (_populate_api_server_access_profile, _set_vm_set_type, _set_outbound_type,
+                       _parse_comma_separated_list)
 
 from ._loadbalancer import (set_load_balancer_sku, is_load_balancer_profile_provided,
                             update_load_balancer_profile, create_load_balancer_profile)

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_managed_aad.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_managed_aad.yaml
@@ -1,0 +1,1316 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-resource/10.0.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001?api-version=2019-07-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001","name":"clitest000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"product":"azurecli","cause":"automation","date":"2020-06-23T06:33:55Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '313'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2020 06:34:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"availableToOtherTenants": false, "homepage": "https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com",
+      "passwordCredentials": [{"startDate": "2020-06-23T06:34:01.330026Z", "endDate":
+      "2025-06-23T06:34:01.330026Z", "keyId": "4a58d78c-a543-4572-a8fc-fae2df41c5a5",
+      "value": "ReplacedSPPassword123*"}], "displayName": "cliakstest000001", "identifierUris":
+      ["https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com"]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '457'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
+        "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
+        "objectId": "a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "eb11d50c-94a5-4154-bafa-64043fe01fb4",
+        "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
+        false, "displayName": "cliakstest000001", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": "https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com",
+        "identifierUris": ["https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com"],
+        "informationalUrls": {"termsOfService": null, "support": null, "privacy":
+        null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
+        [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
+        "directoryObjects/a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5/Microsoft.DirectoryServices.Application/logo",
+        "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5/Microsoft.DirectoryServices.Application/mainLogo",
+        "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
+        "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
+        "Allow the application to access cliakstest000001 on behalf of the signed-in
+        user.", "adminConsentDisplayName": "Access cliakstest000001", "id": "236fa53d-1bbe-4b5b-bce2-e482053981aa",
+        "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
+        to access cliakstest000001 on your behalf.", "userConsentDisplayName": "Access
+        cliakstest000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
+        {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
+        [{"customKeyIdentifier": null, "endDate": "2025-06-23T06:34:01.330026Z", "keyId":
+        "4a58d78c-a543-4572-a8fc-fae2df41c5a5", "startDate": "2020-06-23T06:34:01.330026Z",
+        "value": "ReplacedSPPassword123*"}], "publicClient": null, "publisherDomain":
+        "microsoft.onmicrosoft.com", "recordConsentConditions": null, "replyUrls":
+        [], "requiredResourceAccess": [], "samlMetadataUrl": null, "signInAudience":
+        "AzureADMyOrg", "tokenEncryptionKeyId": null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2377'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Tue, 23 Jun 2020 06:34:01 GMT
+      duration:
+      - '6881651'
+      expires:
+      - '-1'
+      location:
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5/Microsoft.DirectoryServices.Application
+      ocp-aad-diagnostics-server-name:
+      - 1+8AkM7KDGFSNsGgSa+g4O/Bfwtj5U3jXTxMS3xGgg0=
+      ocp-aad-session-key:
+      - u1X13mcOlFh-893AcL3LJ_I6yceTNEmsJ_gFQp78tXp3WaCgOVexf-h6ynIM6INlnSW8GjazPgISvj-voE-EH0XRSfQsYjNEdlza540D6IRLLhrxHvPlA_et0bfhz3KZKY9TGs9I7K27MkdWPQjIsaEUn4vGFHwXaMJp24tzDoygDAbRmYH6oDozJ1uP61lxmsjlivFTbfNJO7x1aaQgSQ.pKhcfbVhRJoCDlXYim3pRj-QpggZ6y0FKd8rLUU1iXk
+      pragma:
+      - no-cache
+      request-id:
+      - b9df1ffe-dd19-49e4-8db8-9234a692a6d6
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aad-resource-unit:
+      - '1'
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27eb11d50c-94a5-4154-bafa-64043fe01fb4%27&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"eb11d50c-94a5-4154-bafa-64043fe01fb4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cliakstest000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com","identifierUris":["https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cliakstest000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cliakstest000001","id":"236fa53d-1bbe-4b5b-bce2-e482053981aa","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cliakstest000001 on your behalf.","userConsentDisplayName":"Access
+        cliakstest000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2025-06-23T06:34:01.330026Z","keyId":"4a58d78c-a543-4572-a8fc-fae2df41c5a5","startDate":"2020-06-23T06:34:01.330026Z","value":null}],"publicClient":null,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2294'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Tue, 23 Jun 2020 06:34:01 GMT
+      duration:
+      - '445134'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - 4jE1Ny4/KFr6/sIodp8k+HHkvERWRVbZ9ilW0wu+F+w=
+      ocp-aad-session-key:
+      - FxJYdsEL_30XyPPfIrdXiOD5xw71uPyQDhFGWZuFhGFzhtR00BbMuIEVozR-tC826BNZSLirPisRYuH2tWKnmi5q967CRijVJKZFSpLpFG_z0seHiwWREPw76-LL3qG2swwdEgh5Tehm5Wfp8jbsi4UphAs9rNMDmyrJQn-rv3kaBUWQNLt6e9mcCCAd1_MaLuuATGvRJbo1ybChYumNwA.AUvZ5Ywmn-GBH2pP_qSTnxUIFUYLlLkv4QrevzyLkrU
+      pragma:
+      - no-cache
+      request-id:
+      - 20626f84-e737-4b2c-b42a-c87c5736dc1c
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aad-resource-unit:
+      - '2'
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"accountEnabled": "True", "appId": "eb11d50c-94a5-4154-bafa-64043fe01fb4"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"69ad08c4-a456-428c-ae1b-342e99de360f","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cliakstest000001","appId":"eb11d50c-94a5-4154-bafa-64043fe01fb4","applicationTemplateId":null,"appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cliakstest000001","errorUrl":null,"homepage":"https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cliakstest000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cliakstest000001","id":"236fa53d-1bbe-4b5b-bce2-e482053981aa","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cliakstest000001 on your behalf.","userConsentDisplayName":"Access
+        cliakstest000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["eb11d50c-94a5-4154-bafa-64043fe01fb4","https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1784'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Tue, 23 Jun 2020 06:34:01 GMT
+      duration:
+      - '2473243'
+      expires:
+      - '-1'
+      location:
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/69ad08c4-a456-428c-ae1b-342e99de360f/Microsoft.DirectoryServices.ServicePrincipal
+      ocp-aad-diagnostics-server-name:
+      - y5Dw5lLhAyPm6hn/hcEQEOWmYgvijzYyriplCx2qww4=
+      ocp-aad-session-key:
+      - L6g8vYAzfL6_FkxGSMD1cctmDbLxodpKudR9MU_5KOLBU43Khbg7L_TE3aENdoQcBJpIK_5_uXDtfiNnJU8K-VbA1zgeSCbU0W3r0hzI88xaxqD07pCwe0zmXlZiZzStgXE4S6uOWafnOs7ufri4tlbqIFVxvv9NEqNbpyfD0BrBsQdnEflnDJFzA1Xm-9sjD1lvrXAefzI-dZw0S8ep4A.KPPpXxlrCBy8A01eCk5BsImn-f02t8-LtyRAHS_YkoI
+      pragma:
+      - no-cache
+      request-id:
+      - 2bd9481b-a982-4f0b-936d-085c333b0252
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aad-resource-unit:
+      - '1'
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"location": "eastus2", "properties": {"kubernetesVersion": "", "dnsPrefix":
+      "cliakstest-clitestiwmcsudry-8ecadf", "agentPoolProfiles": [{"count": 1, "vmSize":
+      "Standard_DS2_v2", "osType": "Linux", "type": "AvailabilitySet", "mode": "System",
+      "enableNodePublicIP": false, "scaleSetPriority": "Regular", "scaleSetEvictionPolicy":
+      "Delete", "name": "nodepool1"}], "linuxProfile": {"adminUsername": "azureuser",
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V"}]}},
+      "servicePrincipalProfile": {"clientId": "<REDACTED>",
+      "secret": "<REDACTED>"}, "addonProfiles": {}, "enableRBAC": true,
+      "networkProfile": {"networkPlugin": "kubenet", "podCidr": "10.244.0.0/16", "serviceCidr":
+      "10.0.0.0/16", "dnsServiceIP": "10.0.0.10", "dockerBridgeCidr": "172.17.0.1/16",
+      "outboundType": "loadBalancer", "loadBalancerSku": "standard"}, "aadProfile":
+      {"managed": true, "adminGroupObjectIDs": ["00000000-0000-0000-0000-000000000001"]}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1322'
+      Content-Type:
+      - application/json; charset=utf-8
+      Ocp-Aad-Session-Key:
+      - u1X13mcOlFh-893AcL3LJ_I6yceTNEmsJ_gFQp78tXp3WaCgOVexf-h6ynIM6INlnSW8GjazPgISvj-voE-EH0XRSfQsYjNEdlza540D6IRLLhrxHvPlA_et0bfhz3KZKY9TGs9I7K27MkdWPQjIsaEUn4vGFHwXaMJp24tzDoygDAbRmYH6oDozJ1uP61lxmsjlivFTbfNJO7x1aaQgSQ.pKhcfbVhRJoCDlXYim3pRj-QpggZ6y0FKd8rLUU1iXk
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001?api-version=2020-03-01
+  response:
+    body:
+      string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001\"\
+        ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
+        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
+        \  \"provisioningState\": \"Creating\",\n   \"kubernetesVersion\": \"1.15.11\"\
+        ,\n   \"dnsPrefix\": \"cliakstest-clitestiwmcsudry-8ecadf\",\n   \"fqdn\"\
+        : \"cliakstest-clitestiwmcsudry-8ecadf-dd89984b.hcp.eastus2.azmk8s.io\",\n\
+        \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
+        count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
+        : 128,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n    \
+        \ \"provisioningState\": \"Creating\",\n     \"orchestratorVersion\": \"1.15.11\"\
+        ,\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\": {},\n     \"\
+        mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
+        : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
+        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V\"\
+        \n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"\
+        clientId\": \"eb11d50c-94a5-4154-bafa-64043fe01fb4\"\n   },\n   \"addonProfiles\"\
+        : {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n     \"config\": null\n\
+        \    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
+        : \"kubenet\",\n    \"loadBalancerSku\": \"standard\",\n    \"loadBalancerProfile\"\
+        : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     }\n    },\n\
+        \    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\": \"10.0.0.0/16\"\
+        ,\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\": \"172.17.0.1/16\"\
+        ,\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"aadProfile\": {\n \
+        \   \"managed\": true,\n    \"adminGroupObjectIDs\": [\n     \"00000000-0000-0000-0000-000000000001\"\
+        \n    ],\n    \"tenantID\": \"72f988bf-86f1-41af-91ab-2d7cd011db47\"\n   },\n\
+        \   \"maxAgentPools\": 1\n  },\n  \"sku\": {\n   \"name\": \"Basic\",\n  \
+        \ \"tier\": \"Free\"\n  }\n }"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+      cache-control:
+      - no-cache
+      content-length:
+      - '2318'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:34:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:34:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:35:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:35:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:36:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:36:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:37:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:37:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
+        : \"Succeeded\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\",\n  \"\
+        endTime\": \"2020-06-23T06:38:07.1813073Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '170'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:38:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001?api-version=2020-03-01
+  response:
+    body:
+      string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001\"\
+        ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
+        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
+        \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.11\"\
+        ,\n   \"dnsPrefix\": \"cliakstest-clitestiwmcsudry-8ecadf\",\n   \"fqdn\"\
+        : \"cliakstest-clitestiwmcsudry-8ecadf-dd89984b.hcp.eastus2.azmk8s.io\",\n\
+        \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
+        count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
+        : 128,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n    \
+        \ \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"\
+        1.15.11\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\": {},\n\
+        \     \"mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n  \
+        \ \"linuxProfile\": {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\"\
+        : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V\"\
+        \n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"\
+        clientId\": \"eb11d50c-94a5-4154-bafa-64043fe01fb4\"\n   },\n   \"addonProfiles\"\
+        : {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n     \"config\": null\n\
+        \    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
+        : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
+        : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/982d4eba-579e-4570-a63d-9d946e0d8ed9\"\
+        \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
+        : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
+        : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
+        aadProfile\": {\n    \"managed\": true,\n    \"adminGroupObjectIDs\": [\n\
+        \     \"00000000-0000-0000-0000-000000000001\"\n    ],\n    \"tenantID\":\
+        \ \"72f988bf-86f1-41af-91ab-2d7cd011db47\"\n   },\n   \"maxAgentPools\": 1\n\
+        \  },\n  \"sku\": {\n   \"name\": \"Basic\",\n   \"tier\": \"Free\"\n  }\n\
+        \ }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2586'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:38:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --aad-admin-group-object-ids --aad-tenant-id -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001?api-version=2020-03-01
+  response:
+    body:
+      string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001\"\
+        ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
+        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
+        \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.11\"\
+        ,\n   \"dnsPrefix\": \"cliakstest-clitestiwmcsudry-8ecadf\",\n   \"fqdn\"\
+        : \"cliakstest-clitestiwmcsudry-8ecadf-dd89984b.hcp.eastus2.azmk8s.io\",\n\
+        \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
+        count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
+        : 128,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n    \
+        \ \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"\
+        1.15.11\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\": {},\n\
+        \     \"mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n  \
+        \ \"linuxProfile\": {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\"\
+        : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V\"\
+        \n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"\
+        clientId\": \"eb11d50c-94a5-4154-bafa-64043fe01fb4\"\n   },\n   \"addonProfiles\"\
+        : {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n     \"config\": null\n\
+        \    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
+        : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
+        : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/982d4eba-579e-4570-a63d-9d946e0d8ed9\"\
+        \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
+        : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
+        : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
+        aadProfile\": {\n    \"managed\": true,\n    \"adminGroupObjectIDs\": [\n\
+        \     \"00000000-0000-0000-0000-000000000001\"\n    ],\n    \"tenantID\":\
+        \ \"72f988bf-86f1-41af-91ab-2d7cd011db47\"\n   },\n   \"maxAgentPools\": 1\n\
+        \  },\n  \"sku\": {\n   \"name\": \"Basic\",\n   \"tier\": \"Free\"\n  }\n\
+        \ }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2586'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:38:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"location": "eastus2", "properties": {"kubernetesVersion": "1.15.11",
+      "dnsPrefix": "cliakstest-clitestiwmcsudry-8ecadf", "agentPoolProfiles": [{"count":
+      1, "vmSize": "Standard_DS2_v2", "osDiskSizeGB": 128, "maxPods": 110, "osType":
+      "Linux", "type": "AvailabilitySet", "mode": "System", "orchestratorVersion":
+      "1.15.11", "enableNodePublicIP": false, "nodeLabels": {}, "name": "nodepool1"}],
+      "linuxProfile": {"adminUsername": "azureuser", "ssh": {"publicKeys": [{"keyData":
+      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V"}]}},
+      "servicePrincipalProfile": {"clientId": "eb11d50c-94a5-4154-bafa-64043fe01fb4"},
+      "addonProfiles": {"KubeDashboard": {"enabled": true}}, "nodeResourceGroup":
+      "MC_clitest000001_cliakstest000001_eastus2", "enableRBAC": true, "networkProfile":
+      {"networkPlugin": "kubenet", "podCidr": "10.244.0.0/16", "serviceCidr": "10.0.0.0/16",
+      "dnsServiceIP": "10.0.0.10", "dockerBridgeCidr": "172.17.0.1/16", "outboundType":
+      "loadBalancer", "loadBalancerSku": "Standard", "loadBalancerProfile": {"managedOutboundIPs":
+      {"count": 1}, "effectiveOutboundIPs": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/982d4eba-579e-4570-a63d-9d946e0d8ed9"}]}},
+      "aadProfile": {"managed": true, "adminGroupObjectIDs": ["00000000-0000-0000-0000-000000000002"],
+      "tenantID": "00000000-0000-0000-0000-000000000003"}}, "sku": {"name": "Basic",
+      "tier": "Free"}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1808'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group --name --aad-admin-group-object-ids --aad-tenant-id -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001?api-version=2020-03-01
+  response:
+    body:
+      string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001\"\
+        ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
+        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
+        \  \"provisioningState\": \"Updating\",\n   \"kubernetesVersion\": \"1.15.11\"\
+        ,\n   \"dnsPrefix\": \"cliakstest-clitestiwmcsudry-8ecadf\",\n   \"fqdn\"\
+        : \"cliakstest-clitestiwmcsudry-8ecadf-dd89984b.hcp.eastus2.azmk8s.io\",\n\
+        \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
+        count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
+        : 128,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n    \
+        \ \"provisioningState\": \"Updating\",\n     \"orchestratorVersion\": \"1.15.11\"\
+        ,\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\": {},\n     \"\
+        mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
+        : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
+        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V\"\
+        \n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"\
+        clientId\": \"eb11d50c-94a5-4154-bafa-64043fe01fb4\"\n   },\n   \"addonProfiles\"\
+        : {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n     \"config\": null\n\
+        \    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
+        : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
+        : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/982d4eba-579e-4570-a63d-9d946e0d8ed9\"\
+        \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
+        : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
+        : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
+        aadProfile\": {\n    \"managed\": true,\n    \"adminGroupObjectIDs\": [\n\
+        \     \"00000000-0000-0000-0000-000000000002\"\n    ],\n    \"tenantID\":\
+        \ \"00000000-0000-0000-0000-000000000003\"\n   },\n   \"maxAgentPools\": 1\n\
+        \  },\n  \"sku\": {\n   \"name\": \"Basic\",\n   \"tier\": \"Free\"\n  }\n\
+        \ }"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/1b60940f-c389-4509-b7f0-9d5b31ed5b37?api-version=2017-08-31
+      cache-control:
+      - no-cache
+      content-length:
+      - '2584'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:38:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --aad-admin-group-object-ids --aad-tenant-id -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/1b60940f-c389-4509-b7f0-9d5b31ed5b37?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"0f94601b-89c3-0945-b7f0-9d5b31ed5b37\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:38:12.49339Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '124'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:38:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --aad-admin-group-object-ids --aad-tenant-id -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/1b60940f-c389-4509-b7f0-9d5b31ed5b37?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"0f94601b-89c3-0945-b7f0-9d5b31ed5b37\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:38:12.49339Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '124'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:39:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --aad-admin-group-object-ids --aad-tenant-id -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/1b60940f-c389-4509-b7f0-9d5b31ed5b37?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"0f94601b-89c3-0945-b7f0-9d5b31ed5b37\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:38:12.49339Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '124'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:39:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --aad-admin-group-object-ids --aad-tenant-id -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/1b60940f-c389-4509-b7f0-9d5b31ed5b37?api-version=2017-08-31
+  response:
+    body:
+      string: "{\n  \"name\": \"0f94601b-89c3-0945-b7f0-9d5b31ed5b37\",\n  \"status\"\
+        : \"Succeeded\",\n  \"startTime\": \"2020-06-23T06:38:12.49339Z\",\n  \"endTime\"\
+        : \"2020-06-23T06:39:55.5140184Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '168'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:40:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --aad-admin-group-object-ids --aad-tenant-id -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.8.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001?api-version=2020-03-01
+  response:
+    body:
+      string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001\"\
+        ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
+        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
+        \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.11\"\
+        ,\n   \"dnsPrefix\": \"cliakstest-clitestiwmcsudry-8ecadf\",\n   \"fqdn\"\
+        : \"cliakstest-clitestiwmcsudry-8ecadf-dd89984b.hcp.eastus2.azmk8s.io\",\n\
+        \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
+        count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
+        : 128,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n    \
+        \ \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\": \"\
+        1.15.11\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\": {},\n\
+        \     \"mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n  \
+        \ \"linuxProfile\": {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\"\
+        : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V\"\
+        \n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"\
+        clientId\": \"eb11d50c-94a5-4154-bafa-64043fe01fb4\"\n   },\n   \"addonProfiles\"\
+        : {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n     \"config\": null\n\
+        \    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
+        : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
+        : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/982d4eba-579e-4570-a63d-9d946e0d8ed9\"\
+        \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
+        : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
+        : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
+        aadProfile\": {\n    \"managed\": true,\n    \"adminGroupObjectIDs\": [\n\
+        \     \"00000000-0000-0000-0000-000000000002\"\n    ],\n    \"tenantID\":\
+        \ \"00000000-0000-0000-0000-000000000003\"\n   },\n   \"maxAgentPools\": 1\n\
+        \  },\n  \"sku\": {\n   \"name\": \"Basic\",\n   \"tier\": \"Free\"\n  }\n\
+        \ }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2586'
+      content-type:
+      - application/json
+      date:
+      - Tue, 23 Jun 2020 06:40:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_managed_aad.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_managed_aad.yaml
@@ -11,8 +11,8 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-resource/10.0.0 Azure-SDK-For-Python AZURECLI/2.8.0
@@ -22,7 +22,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001","name":"clitest000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"product":"azurecli","cause":"automation","date":"2020-06-23T06:33:55Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001","name":"clitest000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"product":"azurecli","cause":"automation","date":"2020-06-23T07:23:03Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -31,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 23 Jun 2020 06:34:00 GMT
+      - Tue, 23 Jun 2020 07:23:09 GMT
       expires:
       - '-1'
       pragma:
@@ -46,11 +46,11 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"availableToOtherTenants": false, "homepage": "https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com",
-      "passwordCredentials": [{"startDate": "2020-06-23T06:34:01.330026Z", "endDate":
-      "2025-06-23T06:34:01.330026Z", "keyId": "4a58d78c-a543-4572-a8fc-fae2df41c5a5",
+    body: '{"availableToOtherTenants": false, "homepage": "https://ba0def.cliakstest-clitestjz7mn4xco-8ecadf.eastus2.cloudapp.azure.com",
+      "passwordCredentials": [{"startDate": "2020-06-23T07:23:10.082143Z", "endDate":
+      "2025-06-23T07:23:10.082143Z", "keyId": "9cb4d121-4919-4fd1-a987-013128bae14f",
       "value": "ReplacedSPPassword123*"}], "displayName": "cliakstest000001", "identifierUris":
-      ["https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com"]}'
+      ["https://ba0def.cliakstest-clitestjz7mn4xco-8ecadf.eastus2.cloudapp.azure.com"]}'
     headers:
       Accept:
       - application/json
@@ -65,8 +65,8 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.8.0
@@ -78,29 +78,29 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "eb11d50c-94a5-4154-bafa-64043fe01fb4",
+        "objectId": "9897fa9e-8600-4aeb-85b3-4e689db5ce8d", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "7f9d38a7-bd20-44d0-8fb8-54304c3429c1",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
         false, "displayName": "cliakstest000001", "errorUrl": null, "groupMembershipClaims":
-        null, "homepage": "https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com",
-        "identifierUris": ["https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com"],
+        null, "homepage": "https://ba0def.cliakstest-clitestjz7mn4xco-8ecadf.eastus2.cloudapp.azure.com",
+        "identifierUris": ["https://ba0def.cliakstest-clitestjz7mn4xco-8ecadf.eastus2.cloudapp.azure.com"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/9897fa9e-8600-4aeb-85b3-4e689db5ce8d/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/9897fa9e-8600-4aeb-85b3-4e689db5ce8d/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
         "Allow the application to access cliakstest000001 on behalf of the signed-in
-        user.", "adminConsentDisplayName": "Access cliakstest000001", "id": "236fa53d-1bbe-4b5b-bce2-e482053981aa",
+        user.", "adminConsentDisplayName": "Access cliakstest000001", "id": "c491bf6f-ba06-4f59-9709-145fefb37f85",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
         to access cliakstest000001 on your behalf.", "userConsentDisplayName": "Access
         cliakstest000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
-        [{"customKeyIdentifier": null, "endDate": "2025-06-23T06:34:01.330026Z", "keyId":
-        "4a58d78c-a543-4572-a8fc-fae2df41c5a5", "startDate": "2020-06-23T06:34:01.330026Z",
+        [{"customKeyIdentifier": null, "endDate": "2025-06-23T07:23:10.082143Z", "keyId":
+        "9cb4d121-4919-4fd1-a987-013128bae14f", "startDate": "2020-06-23T07:23:10.082143Z",
         "value": "ReplacedSPPassword123*"}], "publicClient": null, "publisherDomain":
         "microsoft.onmicrosoft.com", "recordConsentConditions": null, "replyUrls":
         [], "requiredResourceAccess": [], "samlMetadataUrl": null, "signInAudience":
@@ -117,21 +117,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 23 Jun 2020 06:34:01 GMT
+      - Tue, 23 Jun 2020 07:23:10 GMT
       duration:
-      - '6881651'
+      - '7483010'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/9897fa9e-8600-4aeb-85b3-4e689db5ce8d/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - 1+8AkM7KDGFSNsGgSa+g4O/Bfwtj5U3jXTxMS3xGgg0=
+      - hod2zUe6tlzPV/7Qcw0wIfjUdmgQAArZbuHcT57RAkU=
       ocp-aad-session-key:
-      - u1X13mcOlFh-893AcL3LJ_I6yceTNEmsJ_gFQp78tXp3WaCgOVexf-h6ynIM6INlnSW8GjazPgISvj-voE-EH0XRSfQsYjNEdlza540D6IRLLhrxHvPlA_et0bfhz3KZKY9TGs9I7K27MkdWPQjIsaEUn4vGFHwXaMJp24tzDoygDAbRmYH6oDozJ1uP61lxmsjlivFTbfNJO7x1aaQgSQ.pKhcfbVhRJoCDlXYim3pRj-QpggZ6y0FKd8rLUU1iXk
+      - jntwW9nGW0TB5N-2lkMppQNYbRiTiPQR8u2j3tbc38Jt-RiDrROMwpN-zQ3XGfrx2m6g9Pchen7a0m-0srGlGIB5bA7DowUWlrXVx0ASpA3RaEBVNBNyRjuoF2-8FrjLmCs0FDZgleKTrgRwXWdB5S_qxBPBeaegAx0gczEF6wMXZWoyPeUKjGCQcXDSZxQS-AACkySmax3eKBbK00wCIw.jbNlXq3KeiOdtHW1nM458tuCSZCBIQsHzHFIXboq90w
       pragma:
       - no-cache
       request-id:
-      - b9df1ffe-dd19-49e4-8db8-9234a692a6d6
+      - fa74b643-7cb9-4afd-8b48-5e22b1fa1c98
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aad-resource-unit:
@@ -157,22 +157,22 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27eb11d50c-94a5-4154-bafa-64043fe01fb4%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%277f9d38a7-bd20-44d0-8fb8-54304c3429c1%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"eb11d50c-94a5-4154-bafa-64043fe01fb4","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cliakstest000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com","identifierUris":["https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a35eb2a1-64d0-415d-b41c-f9f1af2bd9b5/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"9897fa9e-8600-4aeb-85b3-4e689db5ce8d","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"7f9d38a7-bd20-44d0-8fb8-54304c3429c1","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cliakstest000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://ba0def.cliakstest-clitestjz7mn4xco-8ecadf.eastus2.cloudapp.azure.com","identifierUris":["https://ba0def.cliakstest-clitestjz7mn4xco-8ecadf.eastus2.cloudapp.azure.com"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/9897fa9e-8600-4aeb-85b3-4e689db5ce8d/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/9897fa9e-8600-4aeb-85b3-4e689db5ce8d/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cliakstest000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cliakstest000001","id":"236fa53d-1bbe-4b5b-bce2-e482053981aa","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cliakstest000001","id":"c491bf6f-ba06-4f59-9709-145fefb37f85","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cliakstest000001 on your behalf.","userConsentDisplayName":"Access
-        cliakstest000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2025-06-23T06:34:01.330026Z","keyId":"4a58d78c-a543-4572-a8fc-fae2df41c5a5","startDate":"2020-06-23T06:34:01.330026Z","value":null}],"publicClient":null,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cliakstest000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2025-06-23T07:23:10.082143Z","keyId":"9cb4d121-4919-4fd1-a987-013128bae14f","startDate":"2020-06-23T07:23:10.082143Z","value":null}],"publicClient":null,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -185,19 +185,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 23 Jun 2020 06:34:01 GMT
+      - Tue, 23 Jun 2020 07:23:10 GMT
       duration:
-      - '445134'
+      - '583025'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 4jE1Ny4/KFr6/sIodp8k+HHkvERWRVbZ9ilW0wu+F+w=
+      - 79erfj1bZXCQ2MHaSiYuJ35RYbxDlt/d/lO45Wj7wDI=
       ocp-aad-session-key:
-      - FxJYdsEL_30XyPPfIrdXiOD5xw71uPyQDhFGWZuFhGFzhtR00BbMuIEVozR-tC826BNZSLirPisRYuH2tWKnmi5q967CRijVJKZFSpLpFG_z0seHiwWREPw76-LL3qG2swwdEgh5Tehm5Wfp8jbsi4UphAs9rNMDmyrJQn-rv3kaBUWQNLt6e9mcCCAd1_MaLuuATGvRJbo1ybChYumNwA.AUvZ5Ywmn-GBH2pP_qSTnxUIFUYLlLkv4QrevzyLkrU
+      - mk8YE5kYdJKq6jyWaiflOQfRSe8LbrU8Labfj_5v-Ad2vxksbmeQOFDGsNfSMHAXIC98qxReBl6T2DJrqStNtgFBSUgRYfyK0fzVqC-J2fBGPFl-GnDp7vDUYXm8AjucmddnhO5pX92pgaEAfMotIU92e4zs4IrOiP_kU-R24g4kfPwOYat9Acy20DEAauKqBa58F4SF7ABvm2Ehf-Pq3w.7VyVUd1Qe_FkFw-L46Rda_XoBqlktp_IAeUI0fQy740
       pragma:
       - no-cache
       request-id:
-      - 20626f84-e737-4b2c-b42a-c87c5736dc1c
+      - 8f49e57f-8764-415b-9d48-8d0ad69936cf
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aad-resource-unit:
@@ -212,7 +212,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"accountEnabled": "True", "appId": "eb11d50c-94a5-4154-bafa-64043fe01fb4"}'
+    body: '{"accountEnabled": "True", "appId": "7f9d38a7-bd20-44d0-8fb8-54304c3429c1"}'
     headers:
       Accept:
       - application/json
@@ -227,8 +227,8 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.8.0
@@ -238,11 +238,11 @@ interactions:
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"69ad08c4-a456-428c-ae1b-342e99de360f","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cliakstest000001","appId":"eb11d50c-94a5-4154-bafa-64043fe01fb4","applicationTemplateId":null,"appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cliakstest000001","errorUrl":null,"homepage":"https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"d55a37d0-1f58-47c9-83a2-4509d6d6013b","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cliakstest000001","appId":"7f9d38a7-bd20-44d0-8fb8-54304c3429c1","applicationTemplateId":null,"appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cliakstest000001","errorUrl":null,"homepage":"https://ba0def.cliakstest-clitestjz7mn4xco-8ecadf.eastus2.cloudapp.azure.com","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cliakstest000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cliakstest000001","id":"236fa53d-1bbe-4b5b-bce2-e482053981aa","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cliakstest000001","id":"c491bf6f-ba06-4f59-9709-145fefb37f85","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cliakstest000001 on your behalf.","userConsentDisplayName":"Access
-        cliakstest000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["eb11d50c-94a5-4154-bafa-64043fe01fb4","https://eb046f.cliakstest-clitestiwmcsudry-8ecadf.eastus2.cloudapp.azure.com"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+        cliakstest000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["7f9d38a7-bd20-44d0-8fb8-54304c3429c1","https://ba0def.cliakstest-clitestjz7mn4xco-8ecadf.eastus2.cloudapp.azure.com"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -255,21 +255,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 23 Jun 2020 06:34:01 GMT
+      - Tue, 23 Jun 2020 07:23:11 GMT
       duration:
-      - '2473243'
+      - '6292079'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/69ad08c4-a456-428c-ae1b-342e99de360f/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/d55a37d0-1f58-47c9-83a2-4509d6d6013b/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - y5Dw5lLhAyPm6hn/hcEQEOWmYgvijzYyriplCx2qww4=
+      - z8RauH3qQhR0oBwqWP4mYtVmoc01xC0To5uPFfPjtEs=
       ocp-aad-session-key:
-      - L6g8vYAzfL6_FkxGSMD1cctmDbLxodpKudR9MU_5KOLBU43Khbg7L_TE3aENdoQcBJpIK_5_uXDtfiNnJU8K-VbA1zgeSCbU0W3r0hzI88xaxqD07pCwe0zmXlZiZzStgXE4S6uOWafnOs7ufri4tlbqIFVxvv9NEqNbpyfD0BrBsQdnEflnDJFzA1Xm-9sjD1lvrXAefzI-dZw0S8ep4A.KPPpXxlrCBy8A01eCk5BsImn-f02t8-LtyRAHS_YkoI
+      - yH5-FjV7HQtp4V_Kcs1c7XE0IU_n5D4vNHR5jeRHaErvaHs5vjdkp0SEiBAP7fXZCKghIwzFkRnBiyOTM1bV9YUSrauZKoa94uwFLZFNex2n0q3Xp1_KmhSTnZ3-S4yyM0qzv85vjJWeEkmQxW03vCDBNhq1L2xQVhUYXcueH0OeKoUzjMf_pbP4IUFILV7KJi4J2v_CJfW9qi3yXkJGIg.IkGkeK3xJU6D-CxxeoAIQHwZhQco2dMB4MjFkk-YrC8
       pragma:
       - no-cache
       request-id:
-      - 2bd9481b-a982-4f0b-936d-085c333b0252
+      - 7912ed68-b3f0-4e5d-a95d-fb7c53d73c30
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aad-resource-unit:
@@ -285,13 +285,13 @@ interactions:
       message: Created
 - request:
     body: '{"location": "eastus2", "properties": {"kubernetesVersion": "", "dnsPrefix":
-      "cliakstest-clitestiwmcsudry-8ecadf", "agentPoolProfiles": [{"count": 1, "vmSize":
+      "cliakstest-clitestjz7mn4xco-8ecadf", "agentPoolProfiles": [{"count": 1, "vmSize":
       "Standard_DS2_v2", "osType": "Linux", "type": "AvailabilitySet", "mode": "System",
       "enableNodePublicIP": false, "scaleSetPriority": "Regular", "scaleSetEvictionPolicy":
       "Delete", "name": "nodepool1"}], "linuxProfile": {"adminUsername": "azureuser",
-      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V"}]}},
-      "servicePrincipalProfile": {"clientId": "<REDACTED>",
-      "secret": "<REDACTED>"}, "addonProfiles": {}, "enableRBAC": true,
+      "ssh": {"publicKeys": [{"keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\n"}]}}, "servicePrincipalProfile": {"clientId": "7f9d38a7-bd20-44d0-8fb8-54304c3429c1",
+      "secret": "secret"}, "addonProfiles": {}, "enableRBAC": true,
       "networkProfile": {"networkPlugin": "kubenet", "podCidr": "10.244.0.0/16", "serviceCidr":
       "10.0.0.0/16", "dnsServiceIP": "10.0.0.10", "dockerBridgeCidr": "172.17.0.1/16",
       "outboundType": "loadBalancer", "loadBalancerSku": "standard"}, "aadProfile":
@@ -306,14 +306,14 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1322'
+      - '1685'
       Content-Type:
       - application/json; charset=utf-8
       Ocp-Aad-Session-Key:
-      - u1X13mcOlFh-893AcL3LJ_I6yceTNEmsJ_gFQp78tXp3WaCgOVexf-h6ynIM6INlnSW8GjazPgISvj-voE-EH0XRSfQsYjNEdlza540D6IRLLhrxHvPlA_et0bfhz3KZKY9TGs9I7K27MkdWPQjIsaEUn4vGFHwXaMJp24tzDoygDAbRmYH6oDozJ1uP61lxmsjlivFTbfNJO7x1aaQgSQ.pKhcfbVhRJoCDlXYim3pRj-QpggZ6y0FKd8rLUU1iXk
+      - jntwW9nGW0TB5N-2lkMppQNYbRiTiPQR8u2j3tbc38Jt-RiDrROMwpN-zQ3XGfrx2m6g9Pchen7a0m-0srGlGIB5bA7DowUWlrXVx0ASpA3RaEBVNBNyRjuoF2-8FrjLmCs0FDZgleKTrgRwXWdB5S_qxBPBeaegAx0gczEF6wMXZWoyPeUKjGCQcXDSZxQS-AACkySmax3eKBbK00wCIw.jbNlXq3KeiOdtHW1nM458tuCSZCBIQsHzHFIXboq90w
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
@@ -328,8 +328,8 @@ interactions:
         ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Creating\",\n   \"kubernetesVersion\": \"1.15.11\"\
-        ,\n   \"dnsPrefix\": \"cliakstest-clitestiwmcsudry-8ecadf\",\n   \"fqdn\"\
-        : \"cliakstest-clitestiwmcsudry-8ecadf-dd89984b.hcp.eastus2.azmk8s.io\",\n\
+        ,\n   \"dnsPrefix\": \"cliakstest-clitestjz7mn4xco-8ecadf\",\n   \"fqdn\"\
+        : \"cliakstest-clitestjz7mn4xco-8ecadf-86fcd6c7.hcp.eastus2.azmk8s.io\",\n\
         \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
         count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
         : 128,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n    \
@@ -337,11 +337,11 @@ interactions:
         ,\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\": {},\n     \"\
         mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
-        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V\"\
-        \n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"\
-        clientId\": \"eb11d50c-94a5-4154-bafa-64043fe01fb4\"\n   },\n   \"addonProfiles\"\
-        : {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n     \"config\": null\n\
-        \    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
+        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
+        : {\n    \"clientId\": \"7f9d38a7-bd20-44d0-8fb8-54304c3429c1\"\n   },\n \
+        \  \"addonProfiles\": {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n\
+        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
         ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
         : \"kubenet\",\n    \"loadBalancerSku\": \"standard\",\n    \"loadBalancerProfile\"\
         : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     }\n    },\n\
@@ -354,15 +354,15 @@ interactions:
         \ \"tier\": \"Free\"\n  }\n }"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/359a8ba7-7b28-48fd-8302-6840e30560f5?api-version=2017-08-31
       cache-control:
       - no-cache
       content-length:
-      - '2318'
+      - '2681'
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:34:07 GMT
+      - Tue, 23 Jun 2020 07:23:17 GMT
       expires:
       - '-1'
       pragma:
@@ -374,7 +374,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -390,18 +390,18 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
         AZURECLI/2.8.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/359a8ba7-7b28-48fd-8302-6840e30560f5?api-version=2017-08-31
   response:
     body:
-      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+      string: "{\n  \"name\": \"a78b9a35-287b-fd48-8302-6840e30560f5\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T07:23:17.9921369Z\"\n }"
     headers:
       cache-control:
       - no-cache
@@ -410,7 +410,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:34:38 GMT
+      - Tue, 23 Jun 2020 07:23:48 GMT
       expires:
       - '-1'
       pragma:
@@ -440,18 +440,18 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
         AZURECLI/2.8.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/359a8ba7-7b28-48fd-8302-6840e30560f5?api-version=2017-08-31
   response:
     body:
-      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+      string: "{\n  \"name\": \"a78b9a35-287b-fd48-8302-6840e30560f5\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T07:23:17.9921369Z\"\n }"
     headers:
       cache-control:
       - no-cache
@@ -460,7 +460,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:35:08 GMT
+      - Tue, 23 Jun 2020 07:24:17 GMT
       expires:
       - '-1'
       pragma:
@@ -490,18 +490,18 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
         AZURECLI/2.8.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/359a8ba7-7b28-48fd-8302-6840e30560f5?api-version=2017-08-31
   response:
     body:
-      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+      string: "{\n  \"name\": \"a78b9a35-287b-fd48-8302-6840e30560f5\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T07:23:17.9921369Z\"\n }"
     headers:
       cache-control:
       - no-cache
@@ -510,7 +510,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:35:38 GMT
+      - Tue, 23 Jun 2020 07:24:47 GMT
       expires:
       - '-1'
       pragma:
@@ -540,18 +540,18 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
         AZURECLI/2.8.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/359a8ba7-7b28-48fd-8302-6840e30560f5?api-version=2017-08-31
   response:
     body:
-      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+      string: "{\n  \"name\": \"a78b9a35-287b-fd48-8302-6840e30560f5\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T07:23:17.9921369Z\"\n }"
     headers:
       cache-control:
       - no-cache
@@ -560,7 +560,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:36:07 GMT
+      - Tue, 23 Jun 2020 07:25:18 GMT
       expires:
       - '-1'
       pragma:
@@ -590,18 +590,18 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
         AZURECLI/2.8.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/359a8ba7-7b28-48fd-8302-6840e30560f5?api-version=2017-08-31
   response:
     body:
-      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
+      string: "{\n  \"name\": \"a78b9a35-287b-fd48-8302-6840e30560f5\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T07:23:17.9921369Z\"\n }"
     headers:
       cache-control:
       - no-cache
@@ -610,7 +610,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:36:38 GMT
+      - Tue, 23 Jun 2020 07:25:48 GMT
       expires:
       - '-1'
       pragma:
@@ -640,119 +640,19 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
         AZURECLI/2.8.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/359a8ba7-7b28-48fd-8302-6840e30560f5?api-version=2017-08-31
   response:
     body:
-      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '126'
-      content-type:
-      - application/json
-      date:
-      - Tue, 23 Jun 2020 06:37:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aks create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
-      User-Agent:
-      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
-        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
-  response:
-    body:
-      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\"\n }"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '126'
-      content-type:
-      - application/json
-      date:
-      - Tue, 23 Jun 2020 06:37:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aks create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
-      User-Agent:
-      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
-        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ff95f698-ccf6-4f88-a842-218c429a35ff?api-version=2017-08-31
-  response:
-    body:
-      string: "{\n  \"name\": \"98f695ff-f6cc-884f-a842-218c429a35ff\",\n  \"status\"\
-        : \"Succeeded\",\n  \"startTime\": \"2020-06-23T06:34:08.1727082Z\",\n  \"\
-        endTime\": \"2020-06-23T06:38:07.1813073Z\"\n }"
+      string: "{\n  \"name\": \"a78b9a35-287b-fd48-8302-6840e30560f5\",\n  \"status\"\
+        : \"Succeeded\",\n  \"startTime\": \"2020-06-23T07:23:17.9921369Z\",\n  \"\
+        endTime\": \"2020-06-23T07:26:18.4475988Z\"\n }"
     headers:
       cache-control:
       - no-cache
@@ -761,7 +661,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:38:08 GMT
+      - Tue, 23 Jun 2020 07:26:18 GMT
       expires:
       - '-1'
       pragma:
@@ -791,8 +691,8 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --resource-group --name --vm-set-type -c --enable-aad --aad-admin-group-object-ids
-        -o
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value --enable-aad
+        --aad-admin-group-object-ids -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
@@ -805,8 +705,8 @@ interactions:
         ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.11\"\
-        ,\n   \"dnsPrefix\": \"cliakstest-clitestiwmcsudry-8ecadf\",\n   \"fqdn\"\
-        : \"cliakstest-clitestiwmcsudry-8ecadf-dd89984b.hcp.eastus2.azmk8s.io\",\n\
+        ,\n   \"dnsPrefix\": \"cliakstest-clitestjz7mn4xco-8ecadf\",\n   \"fqdn\"\
+        : \"cliakstest-clitestjz7mn4xco-8ecadf-86fcd6c7.hcp.eastus2.azmk8s.io\",\n\
         \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
         count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
         : 128,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n    \
@@ -814,15 +714,15 @@ interactions:
         1.15.11\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\": {},\n\
         \     \"mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n  \
         \ \"linuxProfile\": {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\"\
-        : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V\"\
-        \n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"\
-        clientId\": \"eb11d50c-94a5-4154-bafa-64043fe01fb4\"\n   },\n   \"addonProfiles\"\
-        : {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n     \"config\": null\n\
-        \    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
+        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
+        : {\n    \"clientId\": \"7f9d38a7-bd20-44d0-8fb8-54304c3429c1\"\n   },\n \
+        \  \"addonProfiles\": {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n\
+        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
         ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
         : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
         : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
-        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/982d4eba-579e-4570-a63d-9d946e0d8ed9\"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/2862103c-8b9a-4358-a9cb-4d96b313f61b\"\
         \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
         : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
         : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
@@ -835,11 +735,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2586'
+      - '2949'
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:38:08 GMT
+      - Tue, 23 Jun 2020 07:26:18 GMT
       expires:
       - '-1'
       pragma:
@@ -884,8 +784,8 @@ interactions:
         ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.11\"\
-        ,\n   \"dnsPrefix\": \"cliakstest-clitestiwmcsudry-8ecadf\",\n   \"fqdn\"\
-        : \"cliakstest-clitestiwmcsudry-8ecadf-dd89984b.hcp.eastus2.azmk8s.io\",\n\
+        ,\n   \"dnsPrefix\": \"cliakstest-clitestjz7mn4xco-8ecadf\",\n   \"fqdn\"\
+        : \"cliakstest-clitestjz7mn4xco-8ecadf-86fcd6c7.hcp.eastus2.azmk8s.io\",\n\
         \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
         count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
         : 128,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n    \
@@ -893,15 +793,15 @@ interactions:
         1.15.11\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\": {},\n\
         \     \"mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n  \
         \ \"linuxProfile\": {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\"\
-        : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V\"\
-        \n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"\
-        clientId\": \"eb11d50c-94a5-4154-bafa-64043fe01fb4\"\n   },\n   \"addonProfiles\"\
-        : {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n     \"config\": null\n\
-        \    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
+        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
+        : {\n    \"clientId\": \"7f9d38a7-bd20-44d0-8fb8-54304c3429c1\"\n   },\n \
+        \  \"addonProfiles\": {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n\
+        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
         ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
         : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
         : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
-        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/982d4eba-579e-4570-a63d-9d946e0d8ed9\"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/2862103c-8b9a-4358-a9cb-4d96b313f61b\"\
         \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
         : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
         : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
@@ -914,11 +814,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2586'
+      - '2949'
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:38:10 GMT
+      - Tue, 23 Jun 2020 07:26:19 GMT
       expires:
       - '-1'
       pragma:
@@ -938,19 +838,19 @@ interactions:
       message: OK
 - request:
     body: 'b''{"location": "eastus2", "properties": {"kubernetesVersion": "1.15.11",
-      "dnsPrefix": "cliakstest-clitestiwmcsudry-8ecadf", "agentPoolProfiles": [{"count":
+      "dnsPrefix": "cliakstest-clitestjz7mn4xco-8ecadf", "agentPoolProfiles": [{"count":
       1, "vmSize": "Standard_DS2_v2", "osDiskSizeGB": 128, "maxPods": 110, "osType":
       "Linux", "type": "AvailabilitySet", "mode": "System", "orchestratorVersion":
       "1.15.11", "enableNodePublicIP": false, "nodeLabels": {}, "name": "nodepool1"}],
       "linuxProfile": {"adminUsername": "azureuser", "ssh": {"publicKeys": [{"keyData":
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V"}]}},
-      "servicePrincipalProfile": {"clientId": "eb11d50c-94a5-4154-bafa-64043fe01fb4"},
+      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\n"}]}}, "servicePrincipalProfile": {"clientId": "7f9d38a7-bd20-44d0-8fb8-54304c3429c1"},
       "addonProfiles": {"KubeDashboard": {"enabled": true}}, "nodeResourceGroup":
       "MC_clitest000001_cliakstest000001_eastus2", "enableRBAC": true, "networkProfile":
       {"networkPlugin": "kubenet", "podCidr": "10.244.0.0/16", "serviceCidr": "10.0.0.0/16",
       "dnsServiceIP": "10.0.0.10", "dockerBridgeCidr": "172.17.0.1/16", "outboundType":
       "loadBalancer", "loadBalancerSku": "Standard", "loadBalancerProfile": {"managedOutboundIPs":
-      {"count": 1}, "effectiveOutboundIPs": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/982d4eba-579e-4570-a63d-9d946e0d8ed9"}]}},
+      {"count": 1}, "effectiveOutboundIPs": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/2862103c-8b9a-4358-a9cb-4d96b313f61b"}]}},
       "aadProfile": {"managed": true, "adminGroupObjectIDs": ["00000000-0000-0000-0000-000000000002"],
       "tenantID": "00000000-0000-0000-0000-000000000003"}}, "sku": {"name": "Basic",
       "tier": "Free"}}'''
@@ -964,7 +864,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1808'
+      - '2171'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
@@ -983,8 +883,8 @@ interactions:
         ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Updating\",\n   \"kubernetesVersion\": \"1.15.11\"\
-        ,\n   \"dnsPrefix\": \"cliakstest-clitestiwmcsudry-8ecadf\",\n   \"fqdn\"\
-        : \"cliakstest-clitestiwmcsudry-8ecadf-dd89984b.hcp.eastus2.azmk8s.io\",\n\
+        ,\n   \"dnsPrefix\": \"cliakstest-clitestjz7mn4xco-8ecadf\",\n   \"fqdn\"\
+        : \"cliakstest-clitestjz7mn4xco-8ecadf-86fcd6c7.hcp.eastus2.azmk8s.io\",\n\
         \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
         count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
         : 128,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n    \
@@ -992,15 +892,15 @@ interactions:
         ,\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\": {},\n     \"\
         mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n   \"linuxProfile\"\
         : {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\": {\n     \"publicKeys\"\
-        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V\"\
-        \n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"\
-        clientId\": \"eb11d50c-94a5-4154-bafa-64043fe01fb4\"\n   },\n   \"addonProfiles\"\
-        : {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n     \"config\": null\n\
-        \    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        : [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
+        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
+        : {\n    \"clientId\": \"7f9d38a7-bd20-44d0-8fb8-54304c3429c1\"\n   },\n \
+        \  \"addonProfiles\": {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n\
+        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
         ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
         : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
         : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
-        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/982d4eba-579e-4570-a63d-9d946e0d8ed9\"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/2862103c-8b9a-4358-a9cb-4d96b313f61b\"\
         \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
         : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
         : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
@@ -1011,15 +911,15 @@ interactions:
         \ }"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/1b60940f-c389-4509-b7f0-9d5b31ed5b37?api-version=2017-08-31
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ddf663e5-9fda-476b-a5f5-c726cd3ddea7?api-version=2017-08-31
       cache-control:
       - no-cache
       content-length:
-      - '2584'
+      - '2947'
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:38:12 GMT
+      - Tue, 23 Jun 2020 07:26:22 GMT
       expires:
       - '-1'
       pragma:
@@ -1057,20 +957,20 @@ interactions:
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
         AZURECLI/2.8.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/1b60940f-c389-4509-b7f0-9d5b31ed5b37?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ddf663e5-9fda-476b-a5f5-c726cd3ddea7?api-version=2017-08-31
   response:
     body:
-      string: "{\n  \"name\": \"0f94601b-89c3-0945-b7f0-9d5b31ed5b37\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:38:12.49339Z\"\n }"
+      string: "{\n  \"name\": \"e563f6dd-da9f-6b47-a5f5-c726cd3ddea7\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T07:26:22.3578807Z\"\n }"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '124'
+      - '126'
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:38:42 GMT
+      - Tue, 23 Jun 2020 07:26:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1106,20 +1006,20 @@ interactions:
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
         AZURECLI/2.8.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/1b60940f-c389-4509-b7f0-9d5b31ed5b37?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ddf663e5-9fda-476b-a5f5-c726cd3ddea7?api-version=2017-08-31
   response:
     body:
-      string: "{\n  \"name\": \"0f94601b-89c3-0945-b7f0-9d5b31ed5b37\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:38:12.49339Z\"\n }"
+      string: "{\n  \"name\": \"e563f6dd-da9f-6b47-a5f5-c726cd3ddea7\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-06-23T07:26:22.3578807Z\"\n }"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '124'
+      - '126'
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:39:12 GMT
+      - Tue, 23 Jun 2020 07:27:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1155,70 +1055,21 @@ interactions:
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
         AZURECLI/2.8.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/1b60940f-c389-4509-b7f0-9d5b31ed5b37?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/ddf663e5-9fda-476b-a5f5-c726cd3ddea7?api-version=2017-08-31
   response:
     body:
-      string: "{\n  \"name\": \"0f94601b-89c3-0945-b7f0-9d5b31ed5b37\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-23T06:38:12.49339Z\"\n }"
+      string: "{\n  \"name\": \"e563f6dd-da9f-6b47-a5f5-c726cd3ddea7\",\n  \"status\"\
+        : \"Succeeded\",\n  \"startTime\": \"2020-06-23T07:26:22.3578807Z\",\n  \"\
+        endTime\": \"2020-06-23T07:27:44.5535204Z\"\n }"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '124'
+      - '170'
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:39:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aks update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --aad-admin-group-object-ids --aad-tenant-id -o
-      User-Agent:
-      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
-        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/1b60940f-c389-4509-b7f0-9d5b31ed5b37?api-version=2017-08-31
-  response:
-    body:
-      string: "{\n  \"name\": \"0f94601b-89c3-0945-b7f0-9d5b31ed5b37\",\n  \"status\"\
-        : \"Succeeded\",\n  \"startTime\": \"2020-06-23T06:38:12.49339Z\",\n  \"endTime\"\
-        : \"2020-06-23T06:39:55.5140184Z\"\n }"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '168'
-      content-type:
-      - application/json
-      date:
-      - Tue, 23 Jun 2020 06:40:12 GMT
+      - Tue, 23 Jun 2020 07:27:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1261,8 +1112,8 @@ interactions:
         ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
         : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
         \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.11\"\
-        ,\n   \"dnsPrefix\": \"cliakstest-clitestiwmcsudry-8ecadf\",\n   \"fqdn\"\
-        : \"cliakstest-clitestiwmcsudry-8ecadf-dd89984b.hcp.eastus2.azmk8s.io\",\n\
+        ,\n   \"dnsPrefix\": \"cliakstest-clitestjz7mn4xco-8ecadf\",\n   \"fqdn\"\
+        : \"cliakstest-clitestjz7mn4xco-8ecadf-86fcd6c7.hcp.eastus2.azmk8s.io\",\n\
         \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
         count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
         : 128,\n     \"maxPods\": 110,\n     \"type\": \"AvailabilitySet\",\n    \
@@ -1270,15 +1121,15 @@ interactions:
         1.15.11\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\": {},\n\
         \     \"mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n  \
         \ \"linuxProfile\": {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\"\
-        : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpjMMxo6YidpgcxNuptFFZffNPTzBZgvdc9LcmKcfNG3o5FmW6MX8Aej848hN6wAHHicQwzQxzkNhO7zj3EMho0WuDC1d9D9aknZcp+K58tmeh21ZVlULntonv2q7VFkg+j9OJ8UY5QczvAx9ClsbXmI4gpWjc/N7XNm00DipBzfBbyMe9mWI0vl0kpmSltLGDQRbr8H6njD8uWjcTaXYC7Ysx3gdsSES54H3W0IcqqeiPWifbIO/zPr429B4pZKo5/2xkF5m4ez3UKv8ivU9LBAL6mW7np1j0G57L1Q62XJWSyG7JEMQWP4SLlZ7GBBFCPuPEqd3w6WqxUyr0R/+V\"\
-        \n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\": {\n    \"\
-        clientId\": \"eb11d50c-94a5-4154-bafa-64043fe01fb4\"\n   },\n   \"addonProfiles\"\
-        : {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n     \"config\": null\n\
-        \    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
+        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
+        : {\n    \"clientId\": \"7f9d38a7-bd20-44d0-8fb8-54304c3429c1\"\n   },\n \
+        \  \"addonProfiles\": {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n\
+        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
         ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
         : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
         : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
-        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/982d4eba-579e-4570-a63d-9d946e0d8ed9\"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/2862103c-8b9a-4358-a9cb-4d96b313f61b\"\
         \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
         : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
         : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
@@ -1291,11 +1142,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2586'
+      - '2949'
       content-type:
       - application/json
       date:
-      - Tue, 23 Jun 2020 06:40:13 GMT
+      - Tue, 23 Jun 2020 07:27:52 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -1652,6 +1652,38 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         # delete
         self.cmd('aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
 
+    @AllowLargeResponse()
+    @ResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='eastus2')
+    @RoleBasedServicePrincipalPreparer()
+    def test_aks_managed_aad(self, resource_group, resource_group_location):
+        # reset the count so in replay mode the random names will start with 0
+        self.test_resources_count = 0
+        # kwargs for string formatting
+        aks_name = self.create_random_name('cliakstest', 16)
+        self.kwargs.update({
+            'resource_group': resource_group,
+            'name': aks_name
+        })
+
+        create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
+                     '--vm-set-type  AvailabilitySet -c 1 ' \
+                     '--enable-aad --aad-admin-group-object-ids 00000000-0000-0000-0000-000000000001 -o json'
+        self.cmd(create_cmd, checks=[
+            self.check('provisioningState', 'Succeeded'),
+            self.check('aadProfile.managed', True),
+            self.check('aadProfile.adminGroupObjectIds[0]', '00000000-0000-0000-0000-000000000001')
+        ])
+
+        update_cmd = 'aks update --resource-group={resource_group} --name={name} ' \
+                     '--aad-admin-group-object-ids 00000000-0000-0000-0000-000000000002 ' \
+                     '--aad-tenant-id 00000000-0000-0000-0000-000000000003 -o json'
+        self.cmd(update_cmd, checks=[
+            self.check('provisioningState', 'Succeeded'),
+            self.check('aadProfile.managed', True),
+            self.check('aadProfile.adminGroupObjectIds[0]', '00000000-0000-0000-0000-000000000002'),
+            self.check('aadProfile.tenantId', '00000000-0000-0000-0000-000000000003')
+        ])
+
     @classmethod
     def generate_ssh_keys(cls):
         TEST_SSH_KEY_PUB = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ== test@example.com\n"  # pylint: disable=line-too-long

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -1662,11 +1662,12 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         aks_name = self.create_random_name('cliakstest', 16)
         self.kwargs.update({
             'resource_group': resource_group,
-            'name': aks_name
+            'name': aks_name,
+            'ssh_key_value': self.generate_ssh_keys().replace('\\', '\\\\')
         })
 
         create_cmd = 'aks create --resource-group={resource_group} --name={name} ' \
-                     '--vm-set-type  AvailabilitySet -c 1 ' \
+                     '--vm-set-type AvailabilitySet --node-count=1 --ssh-key-value={ssh_key_value} ' \
                      '--enable-aad --aad-admin-group-object-ids 00000000-0000-0000-0000-000000000001 -o json'
         self.cmd(create_cmd, checks=[
             self.check('provisioningState', 'Succeeded'),


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR is to portal the support of creating AKS-managed Azure AD cluster from aks-preview extension. It adds a new argument `--enable-aad` to `az aks create` command. Customers can specify the `--aad-admin-group-object-ids` and `--aad-tenant-id` when creating/updating AKS cluster.

**Testing Guide**  
<!--Example commands with explanations.-->

* Create an AKS-managed Azure AD cluster

```
az aks create -g MyResourceGroup -n MyManagedCluster --enable-aad [--aad-admin-group-object-ids <id>] [--aad-tenant-id <id>]
```

* Update an AKS-managed Azure AD cluster

```
az aks update -g MyResourceGroup -n MyManagedCluster [--aad-admin-group-object-ids <id>] [--aad-tenant-id <id>]
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
