### PR TITLE
{Telemetry} Fix for file move in cloud shell

### DIFF
--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -437,7 +437,7 @@ def _get_azure_subscription_id():
 
 
 def _get_shell_type():
-    ## This method is not accurate and needs improvement, for instance all shells on Windows return 'cmd'.
+    # This method is not accurate and needs improvement, for instance all shells on Windows return 'cmd'.
     if 'ZSH_VERSION' in os.environ:
         return 'zsh'
     if 'BASH_VERSION' in os.environ:

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -437,6 +437,7 @@ def _get_azure_subscription_id():
 
 
 def _get_shell_type():
+    ## This method is not accurate and needs improvement, for instance all shells on Windows return 'cmd'.
     if 'ZSH_VERSION' in os.environ:
         return 'zsh'
     if 'BASH_VERSION' in os.environ:
@@ -445,6 +446,9 @@ def _get_shell_type():
         return 'ksh'
     if 'WINDIR' in os.environ:
         return 'cmd'
+    from azure.cli.core.util import in_cloud_console
+    if in_cloud_console():
+        return 'cloud-shell'
     return _remove_cmd_chars(_remove_symbols(os.environ.get('SHELL')))
 
 

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
@@ -52,7 +52,7 @@ class RecordsCollection(object):
             if stat.S_ISREG(each[1].st_mode):
                 try:
                     # Platform question: if this op is atom
-                    os.rename(os.path.join(folder, each[0]), os.path.join(tmp, each[0]))
+                    shutil.move(os.path.join(folder, each[0]), os.path.join(tmp, each[0]))
                     self._logger.info('Move file %s to %s', os.path.join(folder, each[0]), os.path.join(tmp, each[0]))
                 except IOError as err:
                     self._logger.warning('Fail to move file from %s to %s. Reason: %s.',

--- a/src/azure-cli/azure/cli/command_modules/feedback/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/feedback/custom.py
@@ -513,7 +513,8 @@ def _build_issue_info_tup(command_log_file=None):
     # Get other system information
     format_dict["cli_version"] = _get_az_version_summary()
     format_dict["python_info"] = "Python {}".format(platform.python_version())
-    format_dict["platform"] = "{}".format(platform.platform())
+    platform_info = "{} (Cloud Shell)".format(platform.platform()) if in_cloud_console() else platform.platform()
+    format_dict["platform"] = platform_info
     format_dict["auto_gen_comment"] = _AUTO_GEN_COMMENT
     from azure.cli.core._environment import _ENV_AZ_INSTALLER
     format_dict["installer"] = "Installer: {}".format(os.getenv(_ENV_AZ_INSTALLER) or '')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When sending telemetry notes to application insight on Cloud Shell, the following error occurs in the step of moving `cache.x` file to a tmp directory:

> telemetry.records : Fail to move file from /home/feng/.azure/telemetry/cache.1 to /tmp/tmpdj9u1r70/cache.1. Reason: [Errno 18] Invalid cross-device link: '/home/feng/.azure/telemetry/cache.1' -> '/tmp/tmpdj9u1r70/cache.1'.

`os.rename` only works if source and destination are on the same file system which is not the case in Cloud Shell. [`shutil.move`](https://docs.python.org/3/library/shutil.html#shutil.move) can handle it well by copying src to dst using copy_function and then remove src.

In addition, I added Cloud Shell info to feedback and telemetry. 

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
