### PR TITLE
[Security] Add security regulatory compliance commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/security/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_client_factory.py
@@ -78,11 +78,14 @@ def cf_security_assessment_metadata(cli_ctx, _):
 def cf_security_sub_assessment(cli_ctx, _):
     return _cf_security(cli_ctx).sub_assessments
 
+
 def cf_security_regulatory_compliance_standards(cli_ctx, _):
     return _cf_security(cli_ctx).regulatory_compliance_standards
 
+
 def cf_security_regulatory_compliance_control(cli_ctx, _):
     return _cf_security(cli_ctx).regulatory_compliance_controls
+
 
 def cf_security_regulatory_compliance_assessment(cli_ctx, _):
     return _cf_security(cli_ctx).regulatory_compliance_assessments

--- a/src/azure-cli/azure/cli/command_modules/security/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_client_factory.py
@@ -77,3 +77,12 @@ def cf_security_assessment_metadata(cli_ctx, _):
 
 def cf_security_sub_assessment(cli_ctx, _):
     return _cf_security(cli_ctx).sub_assessments
+
+def cf_security_regulatory_compliance_standards(cli_ctx, _):
+    return _cf_security(cli_ctx).regulatory_compliance_standards
+
+def cf_security_regulatory_compliance_control(cli_ctx, _):
+    return _cf_security(cli_ctx).regulatory_compliance_controls
+
+def cf_security_regulatory_compliance_assessment(cli_ctx, _):
+    return _cf_security(cli_ctx).regulatory_compliance_assessments

--- a/src/azure-cli/azure/cli/command_modules/security/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_help.py
@@ -517,3 +517,72 @@ examples:
     text: >
         az security sub-assessment show --assessed-resource-id '/subscriptions/f8b197db-3b2b-4404-a3a3-0dfec293d0d0/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1' --assessment-name '4fb6c0a0-1137-42c7-a1c7-4bd37c91de8d' -n 'd7c4d9ec-227c-4fb3-acf9-25fdd97c1bf1'
 """
+
+helps['security regulatory-compliance-standards'] = """
+type: group
+short-summary: regulatory compliance standards.
+"""
+
+helps['security regulatory-compliance-standards list'] = """
+type: command
+short-summary: List supported regulatory compliance standards details and state results.
+examples:
+  - name: Get regulatory compliance standards list.
+    text: >
+        az security regulatory-compliance-standards list
+"""
+
+helps['security regulatory-compliance-standards show'] = """
+type: command
+short-summary: Shows a regulatory compliance details state for selected standard.
+examples:
+  - name: Get regulatory compliance standard details.
+    text: >
+        az security regulatory-compliance-standards show -n 'Azure-CIS-1.1.0'
+"""
+
+helps['security regulatory-compliance-controls'] = """
+type: group
+short-summary: regulatory compliance controls.
+"""
+
+helps['security regulatory-compliance-controls list'] = """
+type: command
+short-summary: List supported of regulatory compliance controls details and state for selected standard.
+examples:
+  - name: Get regulatory compliance controls list.
+    text: >
+        az security regulatory-compliance-controls list --standard-name 'Azure-CIS-1.1.0'
+"""
+
+helps['security regulatory-compliance-controls show'] = """
+type: command
+short-summary: Shows a regulatory compliance details state for selected standard.
+examples:
+  - name: Get selected regulatory compliance control details and state.
+    text: >
+        az security regulatory-compliance-controls show --standard-name 'Azure-CIS-1.1.0' -n '1.1'
+"""
+
+helps['security regulatory-compliance-assessments'] = """
+type: group
+short-summary: regulatory compliance assessments.
+"""
+
+helps['security regulatory-compliance-assessments list'] = """
+type: command
+short-summary: Get details and state of assessments mapped to selected regulatory compliance control.
+examples:
+  - name: Get state of mapped assessments.
+    text: >
+        az security regulatory-compliance-assessments list --standard-name 'Azure-CIS-1.1.0' --control-name '1.1'
+"""
+
+helps['security regulatory-compliance-assessments show'] = """
+type: command
+short-summary: Shows supported regulatory compliance details and state for selected assessment.
+examples:
+  - name: Get selected regulatory compliance control details and state.
+    text: >
+        az security regulatory-compliance-assessments show --standard-name 'Azure-CIS-1.1.0' --control-name '1.1' -n '94290b00-4d0c-d7b4-7cea-064a9554e681'
+"""

--- a/src/azure-cli/azure/cli/command_modules/security/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_params.py
@@ -58,6 +58,7 @@ sub_assessment_assessment_name_arg_type = CLIArgumentType(options_list=('--asses
 regulatory_compliance_standard_name = CLIArgumentType(option_list=('--standard-name'), metave='STANDARDNAME', help='The compliance standard name')
 regulatory_compliance_control_name = CLIArgumentType(option_list=('--control-name'), metave='CONTROLNAME', help='The compliance control name')
 
+
 def load_arguments(self, _):
     for scope in ['alert',
                   'atp',

--- a/src/azure-cli/azure/cli/command_modules/security/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_params.py
@@ -54,6 +54,9 @@ assessment_metadata_severity_arg_type = CLIArgumentType(options_list=('--severit
 # Sub Assessment
 sub_assessment_assessment_name_arg_type = CLIArgumentType(options_list=('--assessment-name'), metavar='ASSESSMENTNAME', help='Name of the assessment resource')
 
+# Regulatory Compliance
+regulatory_compliance_standard_name = CLIArgumentType(option_list=('--standard-name'), metave='STANDARDNAME', help='The compliance standard name')
+regulatory_compliance_control_name = CLIArgumentType(option_list=('--control-name'), metave='CONTROLNAME', help='The compliance control name')
 
 def load_arguments(self, _):
     for scope in ['alert',
@@ -71,7 +74,10 @@ def load_arguments(self, _):
                   'workspace-setting',
                   'assessment',
                   'assessment-metadata',
-                  'sub-assessment']:
+                  'sub-assessment',
+                  'regulatory-compliance-standards',
+                  'regulatory-compliance-controls',
+                  'regulatory-compliance-assessments']:
         with self.argument_context('security {}'.format(scope)) as c:
             c.argument(
                 'resource_group_name',
@@ -86,6 +92,21 @@ def load_arguments(self, _):
             c.argument(
                 'storage_account_name',
                 arg_type=storage_account_arg_type)
+
+    for scope in ['regulatory-compliance-controls']:
+        with self.argument_context('security {}'.format(scope)) as c:
+            c.argument(
+                'standard_name',
+                arg_type=regulatory_compliance_standard_name)
+
+    for scope in ['regulatory-compliance-assessments']:
+        with self.argument_context('security {}'.format(scope)) as c:
+            c.argument(
+                'standard_name',
+                arg_type=regulatory_compliance_standard_name)
+            c.argument(
+                'control_name',
+                arg_type=regulatory_compliance_control_name)
 
     for scope in ['alert update']:
         with self.argument_context('security {}'.format(scope)) as c:

--- a/src/azure-cli/azure/cli/command_modules/security/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/security/commands.py
@@ -19,12 +19,30 @@ from ._client_factory import (cf_security_tasks,
                               cf_security_advanced_threat_protection,
                               cf_security_assessment,
                               cf_security_assessment_metadata,
-                              cf_security_sub_assessment)
+                              cf_security_sub_assessment,
+                              cf_security_regulatory_compliance_standards,
+                              cf_security_regulatory_compliance_control,
+                              cf_security_regulatory_compliance_assessment)
 
 
 # pylint: disable=line-too-long
 # pylint: disable=too-many-statements
 def load_command_table(self, _):
+
+    security_regulatory_compliance_standards_sdk = CliCommandType(
+        operations_tmpl='azure.mgmt.security.operations#RegulatoryComplianceStandardsOperations.{}',
+        client_factory=cf_security_regulatory_compliance_standards
+    )
+
+    security_regulatory_compliance_controls_sdk = CliCommandType(
+        operations_tmpl='azure.mgmt.security.operations#RegulatoryComplianceControlsOperations.{}',
+        client_factory=cf_security_regulatory_compliance_control
+    )
+
+    security_regulatory_compliance_assessment_sdk = CliCommandType(
+        operations_tmpl='azure.mgmt.security.operations#RegulatoryComplianceAssessmentsOperations.{}',
+        client_factory=cf_security_regulatory_compliance_assessment
+    )
 
     security_tasks_sdk = CliCommandType(
         operations_tmpl='azure.mgmt.security.operations#TasksOperations.{}',
@@ -117,6 +135,24 @@ def load_command_table(self, _):
         operations_tmpl='azure.mgmt.security.operations#SubAssessmentsOperations.{}',
         client_factory=cf_security_sub_assessment
     )
+
+    with self.command_group('security regulatory-compliance-standards',
+                            security_regulatory_compliance_standards_sdk,
+                            client_factory=cf_security_regulatory_compliance_standards) as g:
+        g.custom_command('list', 'list_regulatory_compliance_standards')
+        g.custom_command('show', 'get_regulatory_compliance_standard')
+
+    with self.command_group('security regulatory-compliance-controls',
+                            security_regulatory_compliance_controls_sdk,
+                            client_factory=cf_security_regulatory_compliance_control) as g:
+        g.custom_command('list', 'list_regulatory_compliance_controls')
+        g.custom_command('show', 'get_regulatory_compliance_control')
+
+    with self.command_group('security regulatory-compliance-assessments',
+                            security_regulatory_compliance_assessment_sdk,
+                            client_factory=cf_security_regulatory_compliance_assessment) as g:
+        g.custom_command('list', 'list_regulatory_compliance_assessments')
+        g.custom_command('show', 'get_regulatory_compliance_assessment')
 
     with self.command_group('security task',
                             security_tasks_sdk,

--- a/src/azure-cli/azure/cli/command_modules/security/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/security/custom.py
@@ -460,6 +460,7 @@ def get_security_sub_assessment(client, resource_name, assessment_name, assessed
 # Security Regulatory Compliance
 # --------------------------------------------------------------------------------------------
 
+
 def list_regulatory_compliance_standards(client):
 
     return client.list()

--- a/src/azure-cli/azure/cli/command_modules/security/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/security/custom.py
@@ -455,3 +455,40 @@ def get_security_sub_assessment(client, resource_name, assessment_name, assessed
     return client.get(sub_assessment_name=resource_name,
                       assessment_name=assessment_name,
                       scope=assessed_resource_id)
+
+# --------------------------------------------------------------------------------------------
+# Security Regulatory Compliance
+# --------------------------------------------------------------------------------------------
+
+def list_regulatory_compliance_standards(client):
+
+    return client.list()
+
+
+def get_regulatory_compliance_standard(client, resource_name):
+
+    return client.get(regulatory_compliance_standard_name=resource_name)
+
+
+def list_regulatory_compliance_controls(client, standard_name):
+
+    return client.list(regulatory_compliance_standard_name=standard_name)
+
+
+def get_regulatory_compliance_control(client, resource_name, standard_name):
+
+    return client.get(regulatory_compliance_standard_name=standard_name,
+                      regulatory_compliance_control_name=resource_name)
+
+
+def list_regulatory_compliance_assessments(client, standard_name, control_name):
+
+    return client.list(regulatory_compliance_standard_name=standard_name,
+                       regulatory_compliance_control_name=control_name)
+
+
+def get_regulatory_compliance_assessment(client, resource_name, standard_name, control_name):
+
+    return client.get(regulatory_compliance_standard_name=standard_name,
+                      regulatory_compliance_control_name=control_name,
+                      regulatory_compliance_assessment_name=resource_name)

--- a/src/azure-cli/azure/cli/command_modules/security/tests/latest/recordings/test_security_compliance.yaml
+++ b/src/azure-cli/azure/cli/command_modules/security/tests/latest/recordings/test_security_compliance.yaml
@@ -1,0 +1,309 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security regulatory-compliance-standards list
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-security/0.4.1
+        Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards?api-version=2019-01-01-preview
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0","name":"Azure-CIS-1.1.0","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":14,"failedControls":10,"skippedControls":0,"unsupportedControls":87}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0-(New)","name":"Azure-CIS-1.1.0-(New)","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":39,"failedControls":22,"skippedControls":0,"unsupportedControls":50}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-Security-Benchmark","name":"Azure-Security-Benchmark","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":5,"failedControls":36,"skippedControls":0,"unsupportedControls":47}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Canada-Federal-PBMM","name":"Canada-Federal-PBMM","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":4,"failedControls":11,"skippedControls":0,"unsupportedControls":332}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/CustomPolicyDemo","name":"CustomPolicyDemo","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":0,"failedControls":1,"skippedControls":0,"unsupportedControls":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/HIPAA-HITRUST","name":"HIPAA-HITRUST","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":1,"failedControls":21,"skippedControls":0,"unsupportedControls":182}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/ISO-27001","name":"ISO-27001","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":5,"failedControls":15,"skippedControls":0,"unsupportedControls":94}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/NIST-SP-800-53-R4","name":"NIST-SP-800-53-R4","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":6,"failedControls":25,"skippedControls":0,"unsupportedControls":739}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/PCI-DSS-3.2.1","name":"PCI-DSS-3.2.1","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":9,"failedControls":36,"skippedControls":0,"unsupportedControls":187}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/SOC-TSP","name":"SOC-TSP","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":1,"failedControls":12,"skippedControls":0,"unsupportedControls":24}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/SWIFT-CSP-CSCF-v2020","name":"SWIFT-CSP-CSCF-v2020","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":3,"failedControls":13,"skippedControls":0,"unsupportedControls":15}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3718'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Jun 2020 08:59:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '749'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security regulatory-compliance-standards show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-security/0.4.1
+        Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0?api-version=2019-01-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0","name":"Azure-CIS-1.1.0","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":14,"failedControls":10,"skippedControls":0,"unsupportedControls":87}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '335'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Jun 2020 09:00:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '749'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security regulatory-compliance-standards show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-security/0.4.1
+        Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0?api-version=2019-01-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0","name":"Azure-CIS-1.1.0","type":"Microsoft.Security/regulatoryComplianceStandards","properties":{"state":"Failed","passedControls":14,"failedControls":10,"skippedControls":0,"unsupportedControls":87}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '335'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Jun 2020 09:00:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '749'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security regulatory-compliance-controls show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --standard-name -n
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-security/0.4.1
+        Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0/regulatoryComplianceControls/1.1?api-version=2019-01-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0/regulatoryComplianceControls/1.1","name":"1.1","type":"Microsoft.Security/regulatoryComplianceStandards/regulatoryComplianceControls","properties":{"description":"Ensure
+        that multi-factor authentication is enabled for all privileged users","state":"Passed","passedAssessments":1,"failedAssessments":0,"skippedAssessments":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '459'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Jun 2020 09:00:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '749'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security regulatory-compliance-assessments list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --standard-name --control-name
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-security/0.4.1
+        Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0/regulatoryComplianceControls/1.1/regulatoryComplianceAssessments?api-version=2019-01-01-preview
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0/regulatoryComplianceControls/1.1/regulatoryComplianceAssessments/94290b00-4d0c-d7b4-7cea-064a9554e681","name":"94290b00-4d0c-d7b4-7cea-064a9554e681","type":"Microsoft.Security/regulatoryComplianceStandards/regulatoryComplianceControls/regulatoryComplianceAssessments","properties":{"description":"MFA
+        should be enabled on accounts with owner permissions on your subscription","state":"Passed","passedResources":1,"failedResources":0,"skippedResources":0,"assessmentType":"AssessmentResult"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '637'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Jun 2020 09:00:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '749'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security regulatory-compliance-assessments show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --standard-name --control-name -n
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-security/0.4.1
+        Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0/regulatoryComplianceControls/1.1/regulatoryComplianceAssessments/94290b00-4d0c-d7b4-7cea-064a9554e681?api-version=2019-01-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/regulatoryComplianceStandards/Azure-CIS-1.1.0/regulatoryComplianceControls/1.1/regulatoryComplianceAssessments/94290b00-4d0c-d7b4-7cea-064a9554e681","name":"94290b00-4d0c-d7b4-7cea-064a9554e681","type":"Microsoft.Security/regulatoryComplianceStandards/regulatoryComplianceControls/regulatoryComplianceAssessments","properties":{"description":"MFA
+        should be enabled on accounts with owner permissions on your subscription","state":"Passed","passedResources":1,"failedResources":0,"skippedResources":0,"assessmentType":"AssessmentResult"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '625'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Jun 2020 09:00:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '749'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/security/tests/latest/test_regulatory_compliance_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/security/tests/latest/test_regulatory_compliance_scenario.py
@@ -1,0 +1,31 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.testsdk import ScenarioTest
+from azure_devtools.scenario_tests import AllowLargeResponse
+
+
+class SecurityCenterRegulatoryComplianceTests(ScenarioTest):
+
+    @AllowLargeResponse()
+    def test_security_compliance(self):
+
+        standards_list = self.cmd('az security regulatory-compliance-standards list').get_output_in_json()
+        assert len(standards_list) > 0
+
+        standard = self.cmd('az security regulatory-compliance-standards show -n "Azure-CIS-1.1.0"').get_output_in_json()
+        assert len(standard) > 0
+
+        controls_list = self.cmd('az security regulatory-compliance-standards show -n "Azure-CIS-1.1.0"').get_output_in_json()
+        assert len(controls_list) > 0
+
+        control = self.cmd('az security regulatory-compliance-controls show --standard-name "Azure-CIS-1.1.0" -n "1.1"').get_output_in_json()
+        assert len(control) > 0
+
+        assessments_list = self.cmd('az security regulatory-compliance-assessments list --standard-name "Azure-CIS-1.1.0" --control-name "1.1"').get_output_in_json()
+        assert len(assessments_list) > 0
+
+        assessment = self.cmd('az security regulatory-compliance-assessments show --standard-name "Azure-CIS-1.1.0" --control-name "1.1" -n "94290b00-4d0c-d7b4-7cea-064a9554e681"').get_output_in_json()
+        assert len(assessment) > 0


### PR DESCRIPTION
**Description<!--Mandatory-->**  
[security] Add regulatory compliance CLI

Add regulatory compliance CLI for assessments, standards and controls ( List and show for all)

- Regulatory Compliance standards- list,show
- Regulatory Compliance controls- list,show
- Regulatory Compliance assessments- list,show

**Testing Guide**  

Users can get a list, single (show) of Regulatory compliance standards, controls and assessment: 

az security regulatory-compliance-standards list
az security regulatory-compliance-standards show -n 'Azure-CIS-1.1.0'
az security regulatory-compliance-controls list --standard-name 'Azure-CIS-1.1.0'
az security regulatory-compliance-controls show --standard-name 'Azure-CIS-1.1.0' -n '1.1'
az security regulatory-compliance-assessments list --standard-name 'Azure-CIS-1.1.0' --control-name '1.1' 
az security regulatory-compliance-assessments show --standard-name 'Azure-CIS-1.1.0' --control-name '1.1' -n '94290b00-4d0c-d7b4-7cea-064a9554e681'

also, tests was added, can be run by: azdev test SecurityCenterRegulatoryComplianceTests --live

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
