### PR TITLE
{Auth} Fix #14072: az account get-access-token: Add support of sn+issuer

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -650,9 +650,11 @@ class Profile(object):
                                                                   tenant_dest, resource)
             else:
                 # Service Principal
+                use_cert_sn_issuer = bool(account[_USER_ENTITY].get(_SERVICE_PRINCIPAL_CERT_SN_ISSUER_AUTH))
                 creds = self._creds_cache.retrieve_token_for_service_principal(username_or_sp_id,
                                                                                resource,
-                                                                               tenant_dest)
+                                                                               tenant_dest,
+                                                                               use_cert_sn_issuer)
         return (creds,
                 None if tenant else str(account[_SUBSCRIPTION_ID]),
                 str(tenant if tenant else account[_TENANT_ID]))

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -832,7 +832,7 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(creds[1], self.raw_token1)
         # the last in the tuple is the whole token entry which has several fields
         self.assertEqual(creds[2]['expiresOn'], self.token_entry1['expiresOn'])
-        mock_get_token.assert_called_once_with(mock.ANY, 'sp1', 'https://foo', self.tenant_id)
+        mock_get_token.assert_called_once_with(mock.ANY, 'sp1', 'https://foo', self.tenant_id, False)
         self.assertEqual(mock_get_token.call_count, 1)
         self.assertEqual(sub, '1')
         self.assertEqual(tenant, self.tenant_id)
@@ -843,7 +843,7 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(creds[0], self.token_entry1['tokenType'])
         self.assertEqual(creds[1], self.raw_token1)
         self.assertEqual(creds[2]['expiresOn'], self.token_entry1['expiresOn'])
-        mock_get_token.assert_called_with(mock.ANY, 'sp1', 'https://foo', self.tenant_id)
+        mock_get_token.assert_called_with(mock.ANY, 'sp1', 'https://foo', self.tenant_id, False)
         self.assertEqual(mock_get_token.call_count, 2)
         self.assertIsNone(sub)
         self.assertEqual(tenant, self.tenant_id)

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile_v2016_06_01.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile_v2016_06_01.py
@@ -747,7 +747,7 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(creds[1], self.raw_token1)
         # the last in the tuple is the whole token entry which has several fields
         self.assertEqual(creds[2]['expiresOn'], self.token_entry1['expiresOn'])
-        mock_get_token.assert_called_once_with(mock.ANY, 'sp1', 'https://foo', self.tenant_id)
+        mock_get_token.assert_called_once_with(mock.ANY, 'sp1', 'https://foo', self.tenant_id, False)
         self.assertEqual(mock_get_token.call_count, 1)
         self.assertEqual(sub, '1')
         self.assertEqual(tenant, self.tenant_id)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Make "az account get-access-token" command work for service principal account using sn+issuer auth.
Obviously when we lighted up the auth flow, we forgot this scenario 

**Testing Guide**  
added a unit test


- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
