### PR TITLE
[Profile] az account get-access-token: Show expiresOn for Managed Identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@
 /src/azure-cli/azure/cli/command_modules/network/ @MyronFanQiu @haroldrandom
 /src/azure-cli/azure/cli/command_modules/privatedns/ @MyronFanQiu @haroldrandom
 /src/azure-cli/azure/cli/command_modules/policyinsights/ @cheggert
-/src/azure-cli/azure/cli/command_modules/profile/ @jiasli @arrownj
+/src/azure-cli/azure/cli/command_modules/profile/ @jiasli @arrownj @qianwens
 /src/azure-cli/azure/cli/command_modules/resource/ @Juliehzl @zhoxing-ms @qianwens
 /src/azure-cli/azure/cli/command_modules/role/ @jiasli
 /src/azure-cli/azure/cli/command_modules/storage/ @Juliehzl @qianwens

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -79,7 +79,7 @@ def get_access_token(cmd, subscription=None, resource=None, resource_type=None, 
     # Unify to UTC `expiresOn`, like "2020-06-30 06:14:41"
     if 'expires_on' in token_entry:
         from datetime import datetime
-        # https://docs.python.org/3.8/library/datetime.html#datetime.date.__str__
+        # https://docs.python.org/3.8/library/datetime.html#datetime.datetime.__str__
         token_entry['expiresOn'] = str(datetime.fromtimestamp(int(token_entry['expires_on'])))
 
     result = {

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -79,8 +79,9 @@ def get_access_token(cmd, subscription=None, resource=None, resource_type=None, 
     # Unify to UTC `expiresOn`, like "2020-06-30 06:14:41"
     if 'expires_on' in token_entry:
         from datetime import datetime
-        # https://docs.python.org/3.8/library/datetime.html#datetime.datetime.__str__
-        token_entry['expiresOn'] = str(datetime.fromtimestamp(int(token_entry['expires_on'])))
+        # https://docs.python.org/3.8/library/datetime.html#strftime-and-strptime-format-codes
+        token_entry['expiresOn'] = datetime.fromtimestamp(int(token_entry['expires_on']))\
+            .strftime("%Y-%m-%d %H:%M:%S.%f")
 
     result = {
         'tokenType': creds[0],

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -74,6 +74,14 @@ def get_access_token(cmd, subscription=None, resource=None, resource_type=None, 
     profile = Profile(cli_ctx=cmd.cli_ctx)
     creds, subscription, tenant = profile.get_raw_token(subscription=subscription, resource=resource, tenant=tenant)
 
+    token_entry = creds[2]
+    # MSIAuthentication's token entry has `expires_on`, while ADAL's token entry has `expiresOn`
+    # Unify to UTC `expiresOn`, like "2020-06-30 06:14:41"
+    if 'expires_on' in token_entry:
+        from datetime import datetime
+        # https://docs.python.org/3.8/library/datetime.html#datetime.date.__str__
+        token_entry['expiresOn'] = str(datetime.fromtimestamp(int(token_entry['expires_on'])))
+
     result = {
         'tokenType': creds[0],
         'accessToken': creds[1],

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -76,7 +76,7 @@ def get_access_token(cmd, subscription=None, resource=None, resource_type=None, 
 
     token_entry = creds[2]
     # MSIAuthentication's token entry has `expires_on`, while ADAL's token entry has `expiresOn`
-    # Unify to UTC `expiresOn`, like "2020-06-30 06:14:41"
+    # Unify to ISO `expiresOn`, like "2020-06-30 06:14:41"
     if 'expires_on' in token_entry:
         from datetime import datetime
         # https://docs.python.org/3.8/library/datetime.html#strftime-and-strptime-format-codes

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -87,7 +87,7 @@ class ProfileCommandTest(unittest.TestCase):
         expected_result = {
             'tokenType': 'bearer',
             'accessToken': 'token123',
-            'expiresOn': '2020-06-30 06:14:41',
+            'expiresOn': '2020-06-30 06:14:41.000000',
             'tenant': tenant_id
         }
         self.assertEqual(result, expected_result)

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -80,6 +80,18 @@ class ProfileCommandTest(unittest.TestCase):
         }
         self.assertEqual(result, expected_result)
 
+        # test get token with Managed Identity
+        get_raw_token_mock.return_value = (['bearer', 'token123', {'expires_on': '1593497681'}], None, tenant_id)
+        result = get_access_token(cmd, tenant=tenant_id)
+        get_raw_token_mock.assert_called_with(mock.ANY, 'https://management.core.windows.net/', None, tenant_id)
+        expected_result = {
+            'tokenType': 'bearer',
+            'accessToken': 'token123',
+            'expiresOn': '2020-06-30 06:14:41',
+            'tenant': tenant_id
+        }
+        self.assertEqual(result, expected_result)
+
     @mock.patch('azure.cli.command_modules.profile.custom.Profile', autospec=True)
     def test_get_login(self, profile_mock):
         invoked = []


### PR DESCRIPTION
## Description
Currently, `az account get-access-token` shows `"expiresOn": "N/A"` for Managed Identity:

```
> az login --identity
> az account get-access-token
{
  "accessToken": "eyJ0eXAi...",
  "expiresOn": "N/A",
  "subscription": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
  "tenant": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "tokenType": "Bearer"
}
```

It works for a user account:

```
> az login
> az account get-access-token
{
  "accessToken": "eyJ0eXAi...",
  "expiresOn": "2020-06-29 17:22:16.443545",
  "subscription": "a18897a6-7e44-457d-9260-f2854c0aca42",
  "tenant": "72f988bf-86f1-41af-91ab-2d7cd011db47",
  "tokenType": "Bearer"
}
```

This is because `msrestazure.azure_active_directory.MSIAuthentication`'s token entry has `expires_on`, while ADAL's token entry has `expiresOn`. 


This PRs fixes this by converting the epoch `expires_on` to ISO `expiresOn`:

```
> az account get-access-token
{
  "accessToken": "eyJ0eXAi...",
  "expiresOn": "2020-06-30 06:14:41.000000",
  "subscription": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
  "tenant": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "tokenType": "Bearer"
}
```

## Testing Guide
```
az login --identity
az account get-access-token
```

## More info

In fact, the REST call in ADAL for token retrieval is:

Request:

```http
POST https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/token HTTP/1.1
```

Response:

```json
{
    "token_type": "Bearer",
    "scope": "user_impersonation",
    "expires_in": "3595",
    "ext_expires_in": "3595",
    "expires_on": "1593413327",
    "not_before": "1593409427",
    "resource": "https://management.core.windows.net/",
    "access_token": "...",
    "refresh_token": "...",
    "foci": "1"
}
```

ADAL ignores `expires_on`, but calculates `expiresOn` based on the current time and `expires_in`.

https://github.com/AzureAD/azure-activedirectory-library-for-python/blob/6f0c4755658fbbacf50de684c16eb378d1dbfb92/adal/oauth2_client.py#L187

```py
now = datetime.now()
soon = timedelta(seconds=expires_in)
wire_response[OAuth2.ResponseParameters.EXPIRES_ON] = str(now + soon)
```

This is why the microsecond `443545` appears in `"expiresOn": "2020-06-29 17:22:16.443545"`, while `expires_on` is an integer `1593413327`.