### PR TITLE
[acr]: deprecate helm2 commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/commands.py
@@ -282,7 +282,9 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         msg += " https://docs.microsoft.com/en-us/azure/container-registry/container-registry-helm-repos"
         return msg
 
-    with self.command_group('acr helm', acr_helm_util, deprecate_info=self.deprecate(redirect="helm v3", message_func=_helm_deprecate_message)) as g:
+    with self.command_group('acr helm', acr_helm_util,
+                            deprecate_info=self.deprecate(redirect="helm v3",
+                                                          message_func=_helm_deprecate_message)) as g:
         g.command('list', 'acr_helm_list', table_transformer=helm_list_output_format)
         g.command('show', 'acr_helm_show', table_transformer=helm_show_output_format)
         g.command('delete', 'acr_helm_delete')

--- a/src/azure-cli/azure/cli/command_modules/acr/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/commands.py
@@ -275,7 +275,14 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.command('show', 'acr_config_retention_show')
         g.command('update', 'acr_config_retention_update')
 
-    with self.command_group('acr helm', acr_helm_util) as g:
+    def _helm_deprecate_message(self):
+        msg = "This {} has been deprecated and will be removed in future release.".format(self.object_type)
+        msg += " Use '{}' instead.".format(self.redirect)
+        msg += " For more information go to"
+        msg += " https://docs.microsoft.com/en-us/azure/container-registry/container-registry-helm-repos"
+        return msg
+
+    with self.command_group('acr helm', acr_helm_util, deprecate_info=self.deprecate(redirect="helm v3", message_func=_helm_deprecate_message)) as g:
         g.command('list', 'acr_helm_list', table_transformer=helm_list_output_format)
         g.command('show', 'acr_helm_show', table_transformer=helm_show_output_format)
         g.command('delete', 'acr_helm_delete')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
deprecate helm2

**Testing Guide**  
n/a


- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
