### PR TITLE
{Graph} Fix #12797: ad app permission grant: Add prerequisite to the help message

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,7 @@
 /src/azure-cli/azure/cli/command_modules/policyinsights/ @cheggert
 /src/azure-cli/azure/cli/command_modules/profile/ @jiasli @arrownj
 /src/azure-cli/azure/cli/command_modules/resource/ @Juliehzl @zhoxing-ms @qianwens
-/src/azure-cli/azure/cli/command_modules/role/ @jiasli
+/src/azure-cli/azure/cli/command_modules/role/ @jiasli @qianwens @arrownj
 /src/azure-cli/azure/cli/command_modules/storage/ @Juliehzl @qianwens
 /src/azure-cli/azure/cli/command_modules/servicefabric/ @QingChenmsft @qwordy
 /src/azure-cli/azure/cli/command_modules/sql/ @jaredmoo @Juliehzl

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -188,7 +188,11 @@ examples:
 helps['ad app permission grant'] = """
 type: command
 short-summary: Grant the app an API Delegated permissions
-long-summary: for Application permissions, please use "ad app permission admin-consent"
+long-summary: >
+    A service principal must exist for the app when running this command. To create a corresponding service
+    principal, use `az ad sp create`.
+    
+    For Application permissions, please use "ad app permission admin-consent"
 examples:
   - name: Grant a native application with permissions to access an existing API with TTL of 2 years
     text: az ad app permission grant --id e042ec79-34cd-498f-9d9f-1234234 --api a0322f79-57df-498f-9d9f-12678 --expires 2

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -190,7 +190,7 @@ type: command
 short-summary: Grant the app an API Delegated permissions
 long-summary: >
     A service principal must exist for the app when running this command. To create a corresponding service
-    principal, use `az ad sp create`.
+    principal, use `az ad sp create --id {appId}`.
 
     For Application permissions, please use "ad app permission admin-consent"
 examples:

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -191,7 +191,7 @@ short-summary: Grant the app an API Delegated permissions
 long-summary: >
     A service principal must exist for the app when running this command. To create a corresponding service
     principal, use `az ad sp create`.
-    
+
     For Application permissions, please use "ad app permission admin-consent"
 examples:
   - name: Grant a native application with permissions to access an existing API with TTL of 2 years


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Fix #12797: Cannot grant admin consent for an app role permission

If `ad app permission grant` is called for an app without a corresponding service principal, it will fail:

```sh
# Create the app
$ appId=$(az ad app create --display-name "myapp0630" --query appId -o tsv)

# Grant permission but it fails due to the lack of service principal 
$ az ad app permission grant --id $appId --api 00000003-0000-0000-c000-000000000000
Operation failed with status: 'Not Found'. Details: 404 Client Error: Not Found for url: https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/oauth2PermissionGrants?$filter=clientId%20eq%20%27c9a8ddb5-d410-4de2-a7ca-0c5d55ff3a6b%27&api-version=1.6
```

To fix it, we need to create a corresponding service principal first:

```sh
# Create corresponding service principal
$ az ad sp create --id $appId

# Now granting permission works
$ az ad app permission grant --id $appId --api 00000003-0000-0000-c000-000000000000
{
  "clientId": "a201d009-477f-41d9-b683-799c29190706",
  "consentType": "AllPrincipals",
  "expiryTime": "2021-06-30T04:23:14.521719",
  "objectId": "CdABon9H2UG2g3mcKRkHBonI76O38TJFngGR4y0QOfQ",
  "odata.metadata": "https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#oauth2PermissionGrants/@Element",
  "odatatype": null,
  "principalId": null,
  "resourceId": "a3efc889-f1b7-4532-9e01-91e32d1039f4",
  "scope": "user_impersonation",
  "startTime": "2020-06-30T04:23:14.521719"
}
```

This PR adds this prerequisite to the help message. 
