### PR TITLE
[Webapp] Bugfix: az webapp log deployment show - return deployment logs instead of log metadata

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -1685,7 +1685,7 @@ examples:
 
 helps['webapp log deployment list'] = """
 type: command
-short-summary: List deployment logs of the deployments associated with web app
+short-summary: List deployments associated with web app
 examples:
   - name: List the deployment logs
     text: az webapp log deployment list --name MyWebApp --resource-group MyResourceGroup

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -187,11 +187,11 @@ def load_command_table(self, _):
         g.custom_command('config', 'config_diagnostics', validator=validate_app_or_slot_exists_in_rg)
         g.custom_show_command('show', 'show_diagnostic_settings', validator=validate_app_or_slot_exists_in_rg)
 
-    with self.command_group('webapp log deployment') as g:
+    with self.command_group('webapp log deployment', is_preview=True) as g:
         g.custom_show_command('show', 'show_deployment_log')
         g.custom_command('list', 'list_deployment_logs')
 
-    with self.command_group('functionapp log deployment') as g:
+    with self.command_group('functionapp log deployment', is_preview=True) as g:
         g.custom_show_command('show', 'show_deployment_log')
         g.custom_command('list', 'list_deployment_logs')
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_show_deployment_logs.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_show_deployment_logs.yaml
@@ -13,15 +13,15 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-resource/10.0.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-06-12T02:26:44Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-06-27T00:56:17Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 12 Jun 2020 02:26:48 GMT
+      - Sat, 27 Jun 2020 00:56:19 GMT
       expires:
       - '-1'
       pragma:
@@ -63,8 +63,8 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: POST
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 12 Jun 2020 02:26:51 GMT
+      - Sat, 27 Jun 2020 00:56:20 GMT
       expires:
       - '-1'
       pragma:
@@ -118,15 +118,15 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/9.0.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-resource/10.0.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-06-12T02:26:44Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-06-27T00:56:17Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -135,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 12 Jun 2020 02:26:51 GMT
+      - Sat, 27 Jun 2020 00:56:20 GMT
       expires:
       - '-1'
       pragma:
@@ -168,8 +168,8 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: PUT
@@ -177,8 +177,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","name":"show-deployment-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        US","properties":{"serverFarmId":19809,"name":"show-deployment-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"5700fc96-77b4-4f8d-afce-c353d8c443bd","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-131_19809","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+        US","properties":{"serverFarmId":35474,"name":"show-deployment-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"5700fc96-77b4-4f8d-afce-c353d8c443bd","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-107_35474","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -187,7 +187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 12 Jun 2020 02:26:58 GMT
+      - Sat, 27 Jun 2020 00:56:29 GMT
       expires:
       - '-1'
       pragma:
@@ -205,7 +205,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -225,8 +225,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: GET
@@ -234,8 +234,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","name":"show-deployment-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        US","properties":{"serverFarmId":19809,"name":"show-deployment-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"5700fc96-77b4-4f8d-afce-c353d8c443bd","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-131_19809","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+        US","properties":{"serverFarmId":35474,"name":"show-deployment-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"5700fc96-77b4-4f8d-afce-c353d8c443bd","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-107_35474","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -244,7 +244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 12 Jun 2020 02:27:00 GMT
+      - Sat, 27 Jun 2020 00:56:30 GMT
       expires:
       - '-1'
       pragma:
@@ -285,8 +285,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: POST
@@ -302,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 12 Jun 2020 02:27:00 GMT
+      - Sat, 27 Jun 2020 00:56:30 GMT
       expires:
       - '-1'
       pragma:
@@ -340,8 +340,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: GET
@@ -349,8 +349,8 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","name":"show-deployment-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
-        US","properties":{"serverFarmId":19809,"name":"show-deployment-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"5700fc96-77b4-4f8d-afce-c353d8c443bd","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
-        US","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-131_19809","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
+        US","properties":{"serverFarmId":35474,"name":"show-deployment-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-WestUSwebspace","subscription":"5700fc96-77b4-4f8d-afce-c353d8c443bd","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-bay-107_35474","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -359,7 +359,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 12 Jun 2020 02:27:01 GMT
+      - Sat, 27 Jun 2020 00:56:29 GMT
       expires:
       - '-1'
       pragma:
@@ -399,8 +399,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: POST
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 12 Jun 2020 02:27:01 GMT
+      - Sat, 27 Jun 2020 00:56:30 GMT
       expires:
       - '-1'
       pragma:
@@ -460,8 +460,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: PUT
@@ -469,20 +469,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-131.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-12T02:27:04.79","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
+        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-107.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-27T00:56:34.63","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
         all","description":"Allow all access"}],"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
-        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.112.243.4","possibleInboundIpAddresses":"40.112.243.4","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193","possibleOutboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193,104.42.73.102,104.210.50.226,104.42.73.183","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-131","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.80.156.205","possibleInboundIpAddresses":"40.80.156.205","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-107.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.80.156.205,40.80.152.218,104.42.156.123,104.42.216.21,40.78.63.47","possibleOutboundIpAddresses":"40.80.156.205,40.80.152.218,104.42.156.123,104.42.216.21,40.78.63.47,40.80.156.103,40.78.62.97,40.80.153.6","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-107","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5972'
+      - '5967'
       content-type:
       - application/json
       date:
-      - Fri, 12 Jun 2020 02:27:21 GMT
+      - Sat, 27 Jun 2020 00:56:51 GMT
       etag:
-      - '"1D64060F6B26715"'
+      - '"1D64C1DCE5EF320"'
       expires:
       - '-1'
       pragma:
@@ -524,8 +524,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: POST
@@ -535,19 +535,19 @@ interactions:
       string: <publishData><publishProfile profileName="show-deployment-webapp000002
         - Web Deploy" publishMethod="MSDeploy" publishUrl="show-deployment-webapp000002.scm.azurewebsites.net:443"
         msdeploySite="show-deployment-webapp000002" userName="$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
         /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-107.ftp.azurewebsites.windows.net/site/wwwroot"
         ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
         /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-107dr.ftp.azurewebsites.windows.net/site/wwwroot"
         ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
         /></publishProfile></publishData>
@@ -559,7 +559,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 12 Jun 2020 02:27:22 GMT
+      - Sat, 27 Jun 2020 00:56:51 GMT
       expires:
       - '-1'
       pragma:
@@ -573,7 +573,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
+      - '11994'
       x-powered-by:
       - ASP.NET
     status:
@@ -593,8 +593,8 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: GET
@@ -602,18 +602,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-131.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-12T02:27:05.3933333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.112.243.4","possibleInboundIpAddresses":"40.112.243.4","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193","possibleOutboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193,104.42.73.102,104.210.50.226,104.42.73.183","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-131","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-107.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-27T00:56:35.41","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.80.156.205","possibleInboundIpAddresses":"40.80.156.205","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-107.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.80.156.205,40.80.152.218,104.42.156.123,104.42.216.21,40.78.63.47","possibleOutboundIpAddresses":"40.80.156.205,40.80.152.218,104.42.156.123,104.42.216.21,40.78.63.47,40.80.156.103,40.78.62.97,40.80.153.6","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-107","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5777'
+      - '5767'
       content-type:
       - application/json
       date:
-      - Fri, 12 Jun 2020 02:27:22 GMT
+      - Sat, 27 Jun 2020 00:56:52 GMT
       etag:
-      - '"1D64060F6B26715"'
+      - '"1D64C1DCE5EF320"'
       expires:
       - '-1'
       pragma:
@@ -653,8 +653,8 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: POST
@@ -664,19 +664,19 @@ interactions:
       string: <publishData><publishProfile profileName="show-deployment-webapp000002
         - Web Deploy" publishMethod="MSDeploy" publishUrl="show-deployment-webapp000002.scm.azurewebsites.net:443"
         msdeploySite="show-deployment-webapp000002" userName="$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
         /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-107.ftp.azurewebsites.windows.net/site/wwwroot"
         ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
         /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-107dr.ftp.azurewebsites.windows.net/site/wwwroot"
         ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
         /></publishProfile></publishData>
@@ -688,7 +688,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 12 Jun 2020 02:27:23 GMT
+      - Sat, 27 Jun 2020 00:56:53 GMT
       expires:
       - '-1'
       pragma:
@@ -724,8 +724,8 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: POST
@@ -733,7 +733,7 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishingcredentials/$show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites/publishingcredentials","location":"West
-        US","properties":{"name":null,"publishingUserName":"$show-deployment-webapp000002","publishingPassword":"AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x","publishingPasswordHash":null,"publishingPasswordHashSalt":null,"metadata":null,"isDeleted":false,"scmUri":"https://$show-deployment-webapp000002:AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x@show-deployment-webapp000002.scm.azurewebsites.net"}}'
+        US","properties":{"name":null,"publishingUserName":"$show-deployment-webapp000002","publishingPassword":"c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg","publishingPasswordHash":null,"publishingPasswordHashSalt":null,"metadata":null,"isDeleted":false,"scmUri":"https://$show-deployment-webapp000002:c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg@show-deployment-webapp000002.scm.azurewebsites.net"}}'
     headers:
       cache-control:
       - no-cache
@@ -742,1278 +742,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 12 Jun 2020 02:27:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.23.0
-    method: GET
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/
-  response:
-    body:
-      string: '[]'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 12 Jun 2020 02:27:25 GMT
-      etag:
-      - '"1745c290"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp deployment source config-zip
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n --src
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/config/publishingcredentials/list?api-version=2019-08-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishingcredentials/$show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites/publishingcredentials","location":"West
-        US","properties":{"name":null,"publishingUserName":"$show-deployment-webapp000002","publishingPassword":"AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x","publishingPasswordHash":null,"publishingPasswordHashSalt":null,"metadata":null,"isDeleted":false,"scmUri":"https://$show-deployment-webapp000002:AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x@show-deployment-webapp000002.scm.azurewebsites.net"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '867'
-      content-type:
-      - application/json
-      date:
-      - Fri, 12 Jun 2020 02:27:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp deployment source config-zip
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --src
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002?api-version=2019-08-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-131.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-12T02:27:05.3933333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.112.243.4","possibleInboundIpAddresses":"40.112.243.4","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193","possibleOutboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193,104.42.73.102,104.210.50.226,104.42.73.183","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-131","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '5777'
-      content-type:
-      - application/json
-      date:
-      - Fri, 12 Jun 2020 02:27:26 GMT
-      etag:
-      - '"1D64060F6B26715"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{}'
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp deployment source config-zip
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -g -n --src
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishxml?api-version=2019-08-01
-  response:
-    body:
-      string: <publishData><publishProfile profileName="show-deployment-webapp000002
-        - Web Deploy" publishMethod="MSDeploy" publishUrl="show-deployment-webapp000002.scm.azurewebsites.net:443"
-        msdeploySite="show-deployment-webapp000002" userName="$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile></publishData>
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1938'
-      content-type:
-      - application/xml
-      date:
-      - Fri, 12 Jun 2020 02:27:27 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: !!binary |
-      UEsDBBQAAAAIAARkUUvBmBSXUwAAAHAAAAAJAAAAdGVzdC5odG1ss1F08XcOiQxwVcgoyc2x4+Wy
-      gdFJ+SmVQBokYmgXlVmg4JJakJNfqVBanJmXruDs42mjD5QAKyiwC8nILFYAopDU4hKwSTb6BRA5
-      fag5QNUggwFQSwECFAAUAAAACAAEZFFLwZgUl1MAAABwAAAACQAAAAAAAAABACAAAAAAAAAAdGVz
-      dC5odG1sUEsFBgAAAAABAAEANwAAAHoAAAAAAA==
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '199'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - AZURECLI/2.7.0
-    method: POST
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/zipdeploy?isAsync=true
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Fri, 12 Jun 2020 02:27:32 GMT
-      expires:
-      - '-1'
-      location:
-      - https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest?deployer=ZipDeploy&time=2020-06-12_02-27-29Z
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
-      x-aspnet-version:
-      - 4.0.30319
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - AZURECLI/2.7.0
-    method: GET
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
-  response:
-    body:
-      string: '{"id":"908dd014be2746d38e17a27f6d30781f","status":1,"status_text":"Building
-        and Deploying ''908dd014be2746d38e17a27f6d30781f''.","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
-        via a push deployment","progress":"Generating deployment script.","received_time":"2020-06-12T02:27:30.5949776Z","start_time":"2020-06-12T02:27:32.5481178Z","end_time":null,"last_success_end_time":null,"complete":false,"active":false,"is_temp":false,"is_readonly":true,"url":null,"log_url":null,"site_name":"show-deployment-webapp000002","provisioningState":null}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '580'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 12 Jun 2020 02:27:38 GMT
-      expires:
-      - '-1'
-      location:
-      - https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
-      x-aspnet-version:
-      - 4.0.30319
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - AZURECLI/2.7.0
-    method: GET
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
-  response:
-    body:
-      string: '{"id":"908dd014be2746d38e17a27f6d30781f","status":1,"status_text":"Building
-        and Deploying ''908dd014be2746d38e17a27f6d30781f''.","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
-        via a push deployment","progress":"Generating deployment script.","received_time":"2020-06-12T02:27:30.5949776Z","start_time":"2020-06-12T02:27:32.5481178Z","end_time":null,"last_success_end_time":null,"complete":false,"active":false,"is_temp":false,"is_readonly":true,"url":null,"log_url":null,"site_name":"show-deployment-webapp000002","provisioningState":null}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '580'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 12 Jun 2020 02:27:43 GMT
-      expires:
-      - '-1'
-      location:
-      - https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
-      x-aspnet-version:
-      - 4.0.30319
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - AZURECLI/2.7.0
-    method: GET
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
-  response:
-    body:
-      string: '{"id":"908dd014be2746d38e17a27f6d30781f","status":1,"status_text":"Building
-        and Deploying ''908dd014be2746d38e17a27f6d30781f''.","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
-        via a push deployment","progress":"Running deployment command...","received_time":"2020-06-12T02:27:30.5949776Z","start_time":"2020-06-12T02:27:32.5481178Z","end_time":null,"last_success_end_time":null,"complete":false,"active":false,"is_temp":false,"is_readonly":true,"url":null,"log_url":null,"site_name":"show-deployment-webapp000002","provisioningState":null}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '580'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 12 Jun 2020 02:27:47 GMT
-      expires:
-      - '-1'
-      location:
-      - https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
-      x-aspnet-version:
-      - 4.0.30319
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - AZURECLI/2.7.0
-    method: GET
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
-  response:
-    body:
-      string: '{"id":"908dd014be2746d38e17a27f6d30781f","status":1,"status_text":"Building
-        and Deploying ''908dd014be2746d38e17a27f6d30781f''.","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
-        via a push deployment","progress":"Running deployment command...","received_time":"2020-06-12T02:27:30.5949776Z","start_time":"2020-06-12T02:27:32.5481178Z","end_time":null,"last_success_end_time":null,"complete":false,"active":false,"is_temp":false,"is_readonly":true,"url":null,"log_url":null,"site_name":"show-deployment-webapp000002","provisioningState":null}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '580'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 12 Jun 2020 02:27:50 GMT
-      expires:
-      - '-1'
-      location:
-      - https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
-      x-aspnet-version:
-      - 4.0.30319
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - AZURECLI/2.7.0
-    method: GET
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
-  response:
-    body:
-      string: '{"id":"908dd014be2746d38e17a27f6d30781f","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
-        via a push deployment","progress":"","received_time":"2020-06-12T02:27:30.5949776Z","start_time":"2020-06-12T02:27:32.5481178Z","end_time":"2020-06-12T02:27:53.3356629Z","last_success_end_time":"2020-06-12T02:27:53.3356629Z","complete":true,"active":true,"is_temp":false,"is_readonly":true,"url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest","log_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest/log","site_name":"show-deployment-webapp000002","provisioningState":null}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '729'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 12 Jun 2020 02:27:54 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp log deployment show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002?api-version=2019-08-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-131.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-12T02:27:05.3933333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.112.243.4","possibleInboundIpAddresses":"40.112.243.4","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193","possibleOutboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193,104.42.73.102,104.210.50.226,104.42.73.183","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-131","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '5777'
-      content-type:
-      - application/json
-      date:
-      - Fri, 12 Jun 2020 02:27:54 GMT
-      etag:
-      - '"1D64060F6B26715"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{}'
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp log deployment show
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishxml?api-version=2019-08-01
-  response:
-    body:
-      string: <publishData><publishProfile profileName="show-deployment-webapp000002
-        - Web Deploy" publishMethod="MSDeploy" publishUrl="show-deployment-webapp000002.scm.azurewebsites.net:443"
-        msdeploySite="show-deployment-webapp000002" userName="$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile></publishData>
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1938'
-      content-type:
-      - application/xml
-      date:
-      - Fri, 12 Jun 2020 02:27:57 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp log deployment show
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/config/publishingcredentials/list?api-version=2019-08-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishingcredentials/$show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites/publishingcredentials","location":"West
-        US","properties":{"name":null,"publishingUserName":"$show-deployment-webapp000002","publishingPassword":"AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x","publishingPasswordHash":null,"publishingPasswordHashSalt":null,"metadata":null,"isDeleted":false,"scmUri":"https://$show-deployment-webapp000002:AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x@show-deployment-webapp000002.scm.azurewebsites.net"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '867'
-      content-type:
-      - application/json
-      date:
-      - Fri, 12 Jun 2020 02:27:58 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.23.0
-    method: GET
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/
-  response:
-    body:
-      string: '[{"id":"908dd014be2746d38e17a27f6d30781f","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
-        via a push deployment","progress":"","received_time":"2020-06-12T02:27:30.5949776Z","start_time":"2020-06-12T02:27:32.5481178Z","end_time":"2020-06-12T02:27:53.3356629Z","last_success_end_time":"2020-06-12T02:27:53.3356629Z","complete":true,"active":true,"is_temp":false,"is_readonly":true,"url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/908dd014be2746d38e17a27f6d30781f","log_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/908dd014be2746d38e17a27f6d30781f/log","site_name":"show-deployment-webapp000002","provisioningState":null}]'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '783'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 12 Jun 2020 02:27:59 GMT
-      etag:
-      - '"8d80e7822b8b759"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp deployment source config-zip
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n --src
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/config/publishingcredentials/list?api-version=2019-08-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishingcredentials/$show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites/publishingcredentials","location":"West
-        US","properties":{"name":null,"publishingUserName":"$show-deployment-webapp000002","publishingPassword":"AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x","publishingPasswordHash":null,"publishingPasswordHashSalt":null,"metadata":null,"isDeleted":false,"scmUri":"https://$show-deployment-webapp000002:AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x@show-deployment-webapp000002.scm.azurewebsites.net"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '867'
-      content-type:
-      - application/json
-      date:
-      - Fri, 12 Jun 2020 02:28:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11996'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp deployment source config-zip
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --src
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002?api-version=2019-08-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-131.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-12T02:27:05.3933333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.112.243.4","possibleInboundIpAddresses":"40.112.243.4","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193","possibleOutboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193,104.42.73.102,104.210.50.226,104.42.73.183","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-131","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '5777'
-      content-type:
-      - application/json
-      date:
-      - Fri, 12 Jun 2020 02:28:01 GMT
-      etag:
-      - '"1D64060F6B26715"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{}'
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp deployment source config-zip
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -g -n --src
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishxml?api-version=2019-08-01
-  response:
-    body:
-      string: <publishData><publishProfile profileName="show-deployment-webapp000002
-        - Web Deploy" publishMethod="MSDeploy" publishUrl="show-deployment-webapp000002.scm.azurewebsites.net:443"
-        msdeploySite="show-deployment-webapp000002" userName="$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile></publishData>
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1938'
-      content-type:
-      - application/xml
-      date:
-      - Fri, 12 Jun 2020 02:28:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: !!binary |
-      UEsDBBQAAAAIAARkUUvBmBSXUwAAAHAAAAAJAAAAdGVzdC5odG1ss1F08XcOiQxwVcgoyc2x4+Wy
-      gdFJ+SmVQBokYmgXlVmg4JJakJNfqVBanJmXruDs42mjD5QAKyiwC8nILFYAopDU4hKwSTb6BRA5
-      fag5QNUggwFQSwECFAAUAAAACAAEZFFLwZgUl1MAAABwAAAACQAAAAAAAAABACAAAAAAAAAAdGVz
-      dC5odG1sUEsFBgAAAAABAAEANwAAAHoAAAAAAA==
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '199'
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - AZURECLI/2.7.0
-    method: POST
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/zipdeploy?isAsync=true
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Fri, 12 Jun 2020 02:28:02 GMT
-      expires:
-      - '-1'
-      location:
-      - https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest?deployer=ZipDeploy&time=2020-06-12_02-28-02Z
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
-      x-aspnet-version:
-      - 4.0.30319
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - AZURECLI/2.7.0
-    method: GET
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
-  response:
-    body:
-      string: '{"id":"f2945d0938314073b48c048fded6db3c","status":1,"status_text":"Building
-        and Deploying ''f2945d0938314073b48c048fded6db3c''.","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
-        via a push deployment","progress":"Running deployment command...","received_time":"2020-06-12T02:28:02.65026Z","start_time":"2020-06-12T02:28:02.9471493Z","end_time":null,"last_success_end_time":null,"complete":false,"active":false,"is_temp":false,"is_readonly":true,"url":null,"log_url":null,"site_name":"show-deployment-webapp000002","provisioningState":null}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '578'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 12 Jun 2020 02:28:05 GMT
-      expires:
-      - '-1'
-      location:
-      - https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
-      x-aspnet-version:
-      - 4.0.30319
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/octet-stream
-      User-Agent:
-      - AZURECLI/2.7.0
-    method: GET
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
-  response:
-    body:
-      string: '{"id":"f2945d0938314073b48c048fded6db3c","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
-        via a push deployment","progress":"","received_time":"2020-06-12T02:28:02.65026Z","start_time":"2020-06-12T02:28:02.9471493Z","end_time":"2020-06-12T02:28:05.7940741Z","last_success_end_time":"2020-06-12T02:28:05.7940741Z","complete":true,"active":true,"is_temp":false,"is_readonly":true,"url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest","log_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest/log","site_name":"show-deployment-webapp000002","provisioningState":null}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '727'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 12 Jun 2020 02:28:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp log deployment show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002?api-version=2019-08-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-131.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-12T02:27:05.3933333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.112.243.4","possibleInboundIpAddresses":"40.112.243.4","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193","possibleOutboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193,104.42.73.102,104.210.50.226,104.42.73.183","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-131","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '5777'
-      content-type:
-      - application/json
-      date:
-      - Fri, 12 Jun 2020 02:28:08 GMT
-      etag:
-      - '"1D64060F6B26715"'
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{}'
-    headers:
-      Accept:
-      - application/xml
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp log deployment show
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishxml?api-version=2019-08-01
-  response:
-    body:
-      string: <publishData><publishProfile profileName="show-deployment-webapp000002
-        - Web Deploy" publishMethod="MSDeploy" publishUrl="show-deployment-webapp000002.scm.azurewebsites.net:443"
-        msdeploySite="show-deployment-webapp000002" userName="$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
-        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
-        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
-        /></publishProfile></publishData>
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1938'
-      content-type:
-      - application/xml
-      date:
-      - Fri, 12 Jun 2020 02:28:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11999'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp log deployment show
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -g -n
-      User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
-      accept-language:
-      - en-US
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/config/publishingcredentials/list?api-version=2019-08-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishingcredentials/$show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites/publishingcredentials","location":"West
-        US","properties":{"name":null,"publishingUserName":"$show-deployment-webapp000002","publishingPassword":"AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x","publishingPasswordHash":null,"publishingPasswordHashSalt":null,"metadata":null,"isDeleted":false,"scmUri":"https://$show-deployment-webapp000002:AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x@show-deployment-webapp000002.scm.azurewebsites.net"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '867'
-      content-type:
-      - application/json
-      date:
-      - Fri, 12 Jun 2020 02:28:08 GMT
+      - Sat, 27 Jun 2020 00:56:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2047,25 +776,23 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.22.0
     method: GET
     uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/
   response:
     body:
-      string: '[{"id":"f2945d0938314073b48c048fded6db3c","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
-        via a push deployment","progress":"","received_time":"2020-06-12T02:28:02.65026Z","start_time":"2020-06-12T02:28:02.9471493Z","end_time":"2020-06-12T02:28:05.7940741Z","last_success_end_time":"2020-06-12T02:28:05.7940741Z","complete":true,"active":true,"is_temp":false,"is_readonly":true,"url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/f2945d0938314073b48c048fded6db3c","log_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/f2945d0938314073b48c048fded6db3c/log","site_name":"show-deployment-webapp000002","provisioningState":null},{"id":"908dd014be2746d38e17a27f6d30781f","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
-        via a push deployment","progress":"","received_time":"2020-06-12T02:27:30.5949776Z","start_time":"2020-06-12T02:27:32.5481178Z","end_time":"2020-06-12T02:27:53.3356629Z","last_success_end_time":"2020-06-12T02:27:53.3356629Z","complete":true,"active":false,"is_temp":false,"is_readonly":true,"url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/908dd014be2746d38e17a27f6d30781f","log_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/908dd014be2746d38e17a27f6d30781f/log","site_name":"show-deployment-webapp000002","provisioningState":null}]'
+      string: '[]'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1564'
+      - '2'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 12 Jun 2020 02:28:09 GMT
+      - Sat, 27 Jun 2020 00:57:03 GMT
       etag:
-      - '"8d80e782a0d1f60"'
+      - '"1745c290"'
       expires:
       - '-1'
       pragma:
@@ -2073,7 +800,716 @@ interactions:
       server:
       - Microsoft-IIS/10.0
       set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
+      - ARRAffinity=3dc77fb80bd837e664f7c23ac8671ceefa834532a6002d2857dcccee3651510b;Path=/;HttpOnly;Domain=show-deployment-webapp5cknvyg7vgeqoav4mv.scm.azurewebsites.net
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deployment source config-zip
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n --src
+      User-Agent:
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/config/publishingcredentials/list?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishingcredentials/$show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites/publishingcredentials","location":"West
+        US","properties":{"name":null,"publishingUserName":"$show-deployment-webapp000002","publishingPassword":"c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg","publishingPasswordHash":null,"publishingPasswordHashSalt":null,"metadata":null,"isDeleted":false,"scmUri":"https://$show-deployment-webapp000002:c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg@show-deployment-webapp000002.scm.azurewebsites.net"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '867'
+      content-type:
+      - application/json
+      date:
+      - Sat, 27 Jun 2020 00:57:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11995'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deployment source config-zip
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --src
+      User-Agent:
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-107.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-27T00:56:35.41","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.80.156.205","possibleInboundIpAddresses":"40.80.156.205","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-107.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.80.156.205,40.80.152.218,104.42.156.123,104.42.216.21,40.78.63.47","possibleOutboundIpAddresses":"40.80.156.205,40.80.152.218,104.42.156.123,104.42.216.21,40.78.63.47,40.80.156.103,40.78.62.97,40.80.153.6","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-107","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5767'
+      content-type:
+      - application/json
+      date:
+      - Sat, 27 Jun 2020 00:57:04 GMT
+      etag:
+      - '"1D64C1DCE5EF320"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp deployment source config-zip
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --src
+      User-Agent:
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishxml?api-version=2019-08-01
+  response:
+    body:
+      string: <publishData><publishProfile profileName="show-deployment-webapp000002
+        - Web Deploy" publishMethod="MSDeploy" publishUrl="show-deployment-webapp000002.scm.azurewebsites.net:443"
+        msdeploySite="show-deployment-webapp000002" userName="$show-deployment-webapp000002"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-107.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-107dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+        /></publishProfile></publishData>
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1938'
+      content-type:
+      - application/xml
+      date:
+      - Sat, 27 Jun 2020 00:57:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11994'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      UEsDBBQAAAAIAARkUUvBmBSXUwAAAHAAAAAJAAAAdGVzdC5odG1ss1F08XcOiQxwVcgoyc2x4+Wy
+      gdFJ+SmVQBokYmgXlVmg4JJakJNfqVBanJmXruDs42mjD5QAKyiwC8nILFYAopDU4hKwSTb6BRA5
+      fag5QNUggwFQSwECFAAUAAAACAAEZFFLwZgUl1MAAABwAAAACQAAAAAAAAABACAAAAAAAAAAdGVz
+      dC5odG1sUEsFBgAAAAABAAEANwAAAHoAAAAAAA==
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - AZURECLI/2.8.0
+    method: POST
+    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/zipdeploy?isAsync=true
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Sat, 27 Jun 2020 00:57:07 GMT
+      expires:
+      - '-1'
+      location:
+      - https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest?deployer=ZipDeploy&time=2020-06-27_00-57-07Z
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      set-cookie:
+      - ARRAffinity=3dc77fb80bd837e664f7c23ac8671ceefa834532a6002d2857dcccee3651510b;Path=/;HttpOnly;Domain=show-deployment-webapp5cknvyg7vgeqoav4mv.scm.azurewebsites.net
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - AZURECLI/2.8.0
+    method: GET
+    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
+  response:
+    body:
+      string: '{"id":"0730f2b8affc4239b85df33b3529d7fc","status":1,"status_text":"Building
+        and Deploying ''0730f2b8affc4239b85df33b3529d7fc''.","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
+        via a push deployment","progress":"Generating deployment script.","received_time":"2020-06-27T00:57:07.5449725Z","start_time":"2020-06-27T00:57:07.7501671Z","end_time":null,"last_success_end_time":null,"complete":false,"active":false,"is_temp":false,"is_readonly":true,"url":null,"log_url":null,"site_name":"show-deployment-webapp000002","provisioningState":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '580'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sat, 27 Jun 2020 00:57:10 GMT
+      expires:
+      - '-1'
+      location:
+      - https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      set-cookie:
+      - ARRAffinity=3dc77fb80bd837e664f7c23ac8671ceefa834532a6002d2857dcccee3651510b;Path=/;HttpOnly;Domain=show-deployment-webapp5cknvyg7vgeqoav4mv.scm.azurewebsites.net
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - AZURECLI/2.8.0
+    method: GET
+    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
+  response:
+    body:
+      string: '{"id":"0730f2b8affc4239b85df33b3529d7fc","status":1,"status_text":"Building
+        and Deploying ''0730f2b8affc4239b85df33b3529d7fc''.","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
+        via a push deployment","progress":"Running deployment command...","received_time":"2020-06-27T00:57:07.5449725Z","start_time":"2020-06-27T00:57:07.7501671Z","end_time":null,"last_success_end_time":null,"complete":false,"active":false,"is_temp":false,"is_readonly":true,"url":null,"log_url":null,"site_name":"show-deployment-webapp000002","provisioningState":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '580'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sat, 27 Jun 2020 00:57:13 GMT
+      expires:
+      - '-1'
+      location:
+      - https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      set-cookie:
+      - ARRAffinity=3dc77fb80bd837e664f7c23ac8671ceefa834532a6002d2857dcccee3651510b;Path=/;HttpOnly;Domain=show-deployment-webapp5cknvyg7vgeqoav4mv.scm.azurewebsites.net
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - AZURECLI/2.8.0
+    method: GET
+    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
+  response:
+    body:
+      string: '{"id":"0730f2b8affc4239b85df33b3529d7fc","status":1,"status_text":"Building
+        and Deploying ''0730f2b8affc4239b85df33b3529d7fc''.","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
+        via a push deployment","progress":"Running deployment command...","received_time":"2020-06-27T00:57:07.5449725Z","start_time":"2020-06-27T00:57:07.7501671Z","end_time":null,"last_success_end_time":null,"complete":false,"active":false,"is_temp":false,"is_readonly":true,"url":null,"log_url":null,"site_name":"show-deployment-webapp000002","provisioningState":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '580'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sat, 27 Jun 2020 00:57:16 GMT
+      expires:
+      - '-1'
+      location:
+      - https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      set-cookie:
+      - ARRAffinity=3dc77fb80bd837e664f7c23ac8671ceefa834532a6002d2857dcccee3651510b;Path=/;HttpOnly;Domain=show-deployment-webapp5cknvyg7vgeqoav4mv.scm.azurewebsites.net
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/octet-stream
+      User-Agent:
+      - AZURECLI/2.8.0
+    method: GET
+    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
+  response:
+    body:
+      string: '{"id":"0730f2b8affc4239b85df33b3529d7fc","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
+        via a push deployment","progress":"","received_time":"2020-06-27T00:57:07.5449725Z","start_time":"2020-06-27T00:57:07.7501671Z","end_time":"2020-06-27T00:57:17.9152789Z","last_success_end_time":"2020-06-27T00:57:17.9152789Z","complete":true,"active":true,"is_temp":false,"is_readonly":true,"url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest","log_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/latest/log","site_name":"show-deployment-webapp000002","provisioningState":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '729'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sat, 27 Jun 2020 00:57:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      set-cookie:
+      - ARRAffinity=3dc77fb80bd837e664f7c23ac8671ceefa834532a6002d2857dcccee3651510b;Path=/;HttpOnly;Domain=show-deployment-webapp5cknvyg7vgeqoav4mv.scm.azurewebsites.net
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp log deployment show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-107.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-27T00:56:35.41","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.80.156.205","possibleInboundIpAddresses":"40.80.156.205","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-107.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.80.156.205,40.80.152.218,104.42.156.123,104.42.216.21,40.78.63.47","possibleOutboundIpAddresses":"40.80.156.205,40.80.152.218,104.42.156.123,104.42.216.21,40.78.63.47,40.80.156.103,40.78.62.97,40.80.153.6","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-107","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5767'
+      content-type:
+      - application/json
+      date:
+      - Sat, 27 Jun 2020 00:57:20 GMT
+      etag:
+      - '"1D64C1DCE5EF320"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp log deployment show
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishxml?api-version=2019-08-01
+  response:
+    body:
+      string: <publishData><publishProfile profileName="show-deployment-webapp000002
+        - Web Deploy" publishMethod="MSDeploy" publishUrl="show-deployment-webapp000002.scm.azurewebsites.net:443"
+        msdeploySite="show-deployment-webapp000002" userName="$show-deployment-webapp000002"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-107.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+        /></publishProfile><publishProfile profileName="show-deployment-webapp000002
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-107dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
+        controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
+        /></publishProfile></publishData>
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1938'
+      content-type:
+      - application/xml
+      date:
+      - Sat, 27 Jun 2020 00:57:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11996'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp log deployment show
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n
+      User-Agent:
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/config/publishingcredentials/list?api-version=2019-08-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishingcredentials/$show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites/publishingcredentials","location":"West
+        US","properties":{"name":null,"publishingUserName":"$show-deployment-webapp000002","publishingPassword":"c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg","publishingPasswordHash":null,"publishingPasswordHashSalt":null,"metadata":null,"isDeleted":false,"scmUri":"https://$show-deployment-webapp000002:c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg@show-deployment-webapp000002.scm.azurewebsites.net"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '867'
+      content-type:
+      - application/json
+      date:
+      - Sat, 27 Jun 2020 00:57:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/
+  response:
+    body:
+      string: '[{"id":"0730f2b8affc4239b85df33b3529d7fc","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
+        via a push deployment","progress":"","received_time":"2020-06-27T00:57:07.5449725Z","start_time":"2020-06-27T00:57:07.7501671Z","end_time":"2020-06-27T00:57:17.9152789Z","last_success_end_time":"2020-06-27T00:57:17.9152789Z","complete":true,"active":true,"is_temp":false,"is_readonly":true,"url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/0730f2b8affc4239b85df33b3529d7fc","log_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/0730f2b8affc4239b85df33b3529d7fc/log","site_name":"show-deployment-webapp000002","provisioningState":null}]'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '783'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sat, 27 Jun 2020 00:57:23 GMT
+      etag:
+      - '"8d81a351d36879f"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      set-cookie:
+      - ARRAffinity=3dc77fb80bd837e664f7c23ac8671ceefa834532a6002d2857dcccee3651510b;Path=/;HttpOnly;Domain=show-deployment-webapp5cknvyg7vgeqoav4mv.scm.azurewebsites.net
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment/log
+  response:
+    body:
+      string: '[{"log_time":"2020-06-27T00:57:07.6386807Z","id":"7bfc66a1-36f6-432c-91c9-55072bf95a50","message":"Updating
+        submodules.","type":0,"details_url":null},{"log_time":"2020-06-27T00:57:07.7168496Z","id":"c923f07b-a5d0-4594-b701-883a6b9e4906","message":"Preparing
+        deployment for commit id ''0730f2b8af''.","type":0,"details_url":null},{"log_time":"2020-06-27T00:57:08.0605864Z","id":"eee6d940-dd5f-4c12-87df-e246936c0c05","message":"Generating
+        deployment script.","type":0,"details_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/0730f2b8affc4239b85df33b3529d7fc/log/eee6d940-dd5f-4c12-87df-e246936c0c05"},{"log_time":"2020-06-27T00:57:13.8903051Z","id":"d2564f53-41f0-4b39-a30e-257b03868c09","message":"Running
+        deployment command...","type":0,"details_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/0730f2b8affc4239b85df33b3529d7fc/log/d2564f53-41f0-4b39-a30e-257b03868c09"},{"log_time":"2020-06-27T00:57:17.6808958Z","id":"391389d1-2da2-4534-8d9c-64da28e66796","message":"Running
+        post deployment command(s)...","type":0,"details_url":null},{"log_time":"2020-06-27T00:57:17.7910281Z","id":"ddd1b39a-5cd6-4c6c-933a-0c12a73a2dfb","message":"Triggering
+        recycle (preview mode disabled).","type":0,"details_url":null},{"log_time":"2020-06-27T00:57:17.900883Z","id":"eae2a18c-8033-461c-989c-0a50e08cd0ca","message":"Deployment
+        successful.","type":0,"details_url":null}]'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1447'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Sat, 27 Jun 2020 00:57:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      set-cookie:
+      - ARRAffinity=3dc77fb80bd837e664f7c23ac8671ceefa834532a6002d2857dcccee3651510b;Path=/;HttpOnly;Domain=show-deployment-webapp5cknvyg7vgeqoav4mv.scm.azurewebsites.net
       vary:
       - Accept-Encoding
       x-aspnet-version:
@@ -2097,8 +1533,8 @@ interactions:
       ParameterSetName:
       - -g -n --deployment-id
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: GET
@@ -2106,18 +1542,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites","kind":"app","location":"West
-        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-131.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-12T02:27:05.3933333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.112.243.4","possibleInboundIpAddresses":"40.112.243.4","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193","possibleOutboundIpAddresses":"40.112.243.4,104.42.74.179,104.210.49.211,104.42.127.7,104.42.120.193,104.42.73.102,104.210.50.226,104.42.73.183","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-131","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
+        US","properties":{"name":"show-deployment-webapp000002","state":"Running","hostNames":["show-deployment-webapp000002.azurewebsites.net"],"webSpace":"clitest.rg000001-WestUSwebspace","selfLink":"https://waws-prod-bay-107.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-WestUSwebspace/sites/show-deployment-webapp000002","repositorySiteName":"show-deployment-webapp000002","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["show-deployment-webapp000002.azurewebsites.net","show-deployment-webapp000002.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"show-deployment-webapp000002.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"show-deployment-webapp000002.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/show-deployment-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-06-27T00:56:35.41","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"show-deployment-webapp000002","trafficManagerHostNames":null,"sku":"Standard","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"A5B12E93C19D795D34DF79C449C2C3BAF58329ACBE54CAAF49EDCD93822ACCE8","kind":"app","inboundIpAddress":"40.80.156.205","possibleInboundIpAddresses":"40.80.156.205","ftpUsername":"show-deployment-webapp000002\\$show-deployment-webapp000002","ftpsHostName":"ftps://waws-prod-bay-107.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.80.156.205,40.80.152.218,104.42.156.123,104.42.216.21,40.78.63.47","possibleOutboundIpAddresses":"40.80.156.205,40.80.152.218,104.42.156.123,104.42.216.21,40.78.63.47,40.80.156.103,40.78.62.97,40.80.153.6","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-107","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"show-deployment-webapp000002.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5777'
+      - '5767'
       content-type:
       - application/json
       date:
-      - Fri, 12 Jun 2020 02:28:09 GMT
+      - Sat, 27 Jun 2020 00:57:24 GMT
       etag:
-      - '"1D64060F6B26715"'
+      - '"1D64C1DCE5EF320"'
       expires:
       - '-1'
       pragma:
@@ -2157,8 +1593,8 @@ interactions:
       ParameterSetName:
       - -g -n --deployment-id
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: POST
@@ -2168,19 +1604,19 @@ interactions:
       string: <publishData><publishProfile profileName="show-deployment-webapp000002
         - Web Deploy" publishMethod="MSDeploy" publishUrl="show-deployment-webapp000002.scm.azurewebsites.net:443"
         msdeploySite="show-deployment-webapp000002" userName="$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
         /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131.ftp.azurewebsites.windows.net/site/wwwroot"
+        - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-107.ftp.azurewebsites.windows.net/site/wwwroot"
         ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
         /></publishProfile><publishProfile profileName="show-deployment-webapp000002
-        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-131dr.ftp.azurewebsites.windows.net/site/wwwroot"
+        - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-bay-107dr.ftp.azurewebsites.windows.net/site/wwwroot"
         ftpPassiveMode="True" userName="show-deployment-webapp000002\$show-deployment-webapp000002"
-        userPWD="AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
+        userPWD="c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg" destinationAppUrl="http://show-deployment-webapp000002.azurewebsites.net"
         SQLServerDBConnectionString="" mySQLDBConnectionString="" hostingProviderForumLink=""
         controlPanelLink="http://windows.azure.com" webSystem="WebSites"><databases
         /></publishProfile></publishData>
@@ -2192,7 +1628,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 12 Jun 2020 02:28:10 GMT
+      - Sat, 27 Jun 2020 00:57:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2228,8 +1664,8 @@ interactions:
       ParameterSetName:
       - -g -n --deployment-id
       User-Agent:
-      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.7.0
+      - python/3.7.2 (Darwin-16.7.0-x86_64-i386-64bit) msrest/0.6.16 msrest_azure/0.6.3
+        azure-mgmt-web/0.46.0 Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: POST
@@ -2237,7 +1673,7 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/show-deployment-webapp000002/publishingcredentials/$show-deployment-webapp000002","name":"show-deployment-webapp000002","type":"Microsoft.Web/sites/publishingcredentials","location":"West
-        US","properties":{"name":null,"publishingUserName":"$show-deployment-webapp000002","publishingPassword":"AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x","publishingPasswordHash":null,"publishingPasswordHashSalt":null,"metadata":null,"isDeleted":false,"scmUri":"https://$show-deployment-webapp000002:AXJmjKmGMQ1osJkJmMHG4A79MuQTcm5drGsND8z5B7pFqqyiPGkjphlNAJ4x@show-deployment-webapp000002.scm.azurewebsites.net"}}'
+        US","properties":{"name":null,"publishingUserName":"$show-deployment-webapp000002","publishingPassword":"c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg","publishingPasswordHash":null,"publishingPasswordHashSalt":null,"metadata":null,"isDeleted":false,"scmUri":"https://$show-deployment-webapp000002:c1j3G8SQCScmfomrbH9aQJuT90ufpu2JKxkdt3onQw51hl4seaer5fnRL2Wg@show-deployment-webapp000002.scm.azurewebsites.net"}}'
     headers:
       cache-control:
       - no-cache
@@ -2246,7 +1682,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 12 Jun 2020 02:28:10 GMT
+      - Sat, 27 Jun 2020 00:57:25 GMT
       expires:
       - '-1'
       pragma:
@@ -2264,7 +1700,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11998'
       x-powered-by:
       - ASP.NET
     status:
@@ -2280,22 +1716,28 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.22.0
     method: GET
-    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment
+    uri: https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/mock-deployment/log
   response:
     body:
-      string: '{"id":"908dd014be2746d38e17a27f6d30781f","status":4,"status_text":"","author_email":"N/A","author":"N/A","deployer":"ZipDeploy","message":"Created
-        via a push deployment","progress":"","received_time":"2020-06-12T02:27:30.5949776Z","start_time":"2020-06-12T02:27:32.5481178Z","end_time":"2020-06-12T02:27:53.3356629Z","last_success_end_time":"2020-06-12T02:27:53.3356629Z","complete":true,"active":false,"is_temp":false,"is_readonly":true,"url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/908dd014be2746d38e17a27f6d30781f","log_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/908dd014be2746d38e17a27f6d30781f/log","site_name":"show-deployment-webapp000002","provisioningState":null}'
+      string: '[{"log_time":"2020-06-27T00:57:07.6386807Z","id":"7bfc66a1-36f6-432c-91c9-55072bf95a50","message":"Updating
+        submodules.","type":0,"details_url":null},{"log_time":"2020-06-27T00:57:07.7168496Z","id":"c923f07b-a5d0-4594-b701-883a6b9e4906","message":"Preparing
+        deployment for commit id ''0730f2b8af''.","type":0,"details_url":null},{"log_time":"2020-06-27T00:57:08.0605864Z","id":"eee6d940-dd5f-4c12-87df-e246936c0c05","message":"Generating
+        deployment script.","type":0,"details_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/0730f2b8affc4239b85df33b3529d7fc/log/eee6d940-dd5f-4c12-87df-e246936c0c05"},{"log_time":"2020-06-27T00:57:13.8903051Z","id":"d2564f53-41f0-4b39-a30e-257b03868c09","message":"Running
+        deployment command...","type":0,"details_url":"https://show-deployment-webapp000002.scm.azurewebsites.net/api/deployments/0730f2b8affc4239b85df33b3529d7fc/log/d2564f53-41f0-4b39-a30e-257b03868c09"},{"log_time":"2020-06-27T00:57:17.6808958Z","id":"391389d1-2da2-4534-8d9c-64da28e66796","message":"Running
+        post deployment command(s)...","type":0,"details_url":null},{"log_time":"2020-06-27T00:57:17.7910281Z","id":"ddd1b39a-5cd6-4c6c-933a-0c12a73a2dfb","message":"Triggering
+        recycle (preview mode disabled).","type":0,"details_url":null},{"log_time":"2020-06-27T00:57:17.900883Z","id":"eae2a18c-8033-461c-989c-0a50e08cd0ca","message":"Deployment
+        successful.","type":0,"details_url":null}]'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '782'
+      - '1447'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 12 Jun 2020 02:28:11 GMT
+      - Sat, 27 Jun 2020 00:57:26 GMT
       expires:
       - '-1'
       pragma:
@@ -2303,7 +1745,7 @@ interactions:
       server:
       - Microsoft-IIS/10.0
       set-cookie:
-      - ARRAffinity=da22f716e6806a50ecd0a769a95b9706b238bacec3912bbfa26fc5b1b4e5e591;Path=/;HttpOnly;Domain=show-deployment-webapp3gwlpnjkeh5bo4lya3.scm.azurewebsites.net
+      - ARRAffinity=3dc77fb80bd837e664f7c23ac8671ceefa834532a6002d2857dcccee3651510b;Path=/;HttpOnly;Domain=show-deployment-webapp5cknvyg7vgeqoav4mv.scm.azurewebsites.net
       vary:
       - Accept-Encoding
       x-aspnet-version:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -2422,19 +2422,11 @@ class FunctionappDeploymentLogsScenarioTest(LiveScenarioTest):
             JMESPathCheck('complete', True)
         ]).get_output_in_json()
         self.cmd('functionapp log deployment show -g {} -n {}'.format(resource_group, functionapp_name), checks=[
-            JMESPathCheck('id', deployment_1['id'])
+            JMESPathCheck('length(@) > `0`', True)
         ])
 
-        deployment_2 = self.cmd('functionapp deployment source config-zip -g {} -n {} --src "{}"'.format(resource_group, functionapp_name, zip_file)).assert_with_checks([
-            JMESPathCheck('status', 4),
-            JMESPathCheck('deployer', 'ZipDeploy'),
-            JMESPathCheck('complete', True)
-        ]).get_output_in_json()
-        self.cmd('functionapp log deployment show -g {} -n {}'.format(resource_group, functionapp_name), checks=[
-            JMESPathCheck('id', deployment_2['id'])
-        ])
-        self.cmd('functionapp log deployment show -g {} -n {} --deployment-id {}'.format(resource_group, functionapp_name, deployment_1['id']), checks=[
-            JMESPathCheck('id', deployment_1['id'])
+        self.cmd('functionapp log deployment show -g {} -n {} --deployment-id={}'.format(resource_group, functionapp_name, deployment_1['id']), checks=[
+            JMESPathCheck('length(@) > `0`', True)
         ])
 
     @ResourceGroupPreparer()
@@ -2485,15 +2477,11 @@ class WebappDeploymentLogsScenarioTest(ScenarioTest):
 
         deployment_1 = self.cmd('webapp deployment source config-zip -g {} -n {} --src "{}"'.format(resource_group, webapp_name, zip_file)).get_output_in_json()
         self.cmd('webapp log deployment show -g {} -n {}'.format(resource_group, webapp_name), checks=[
-            JMESPathCheck('id', deployment_1['id']),
+            JMESPathCheck('length(@) > `0`', True),
         ])
 
-        deployment_2 = self.cmd('webapp deployment source config-zip -g {} -n {} --src "{}"'.format(resource_group, webapp_name, zip_file)).get_output_in_json()
-        self.cmd('webapp log deployment show -g {} -n {}'.format(resource_group, webapp_name), checks=[
-            JMESPathCheck('id', deployment_2['id']),
-        ])
-        self.cmd('webapp log deployment show -g {} -n {} --deployment-id {}'.format(resource_group, webapp_name, deployment_1['id']), checks=[
-            JMESPathCheck('id', deployment_1['id']),
+        self.cmd('webapp log deployment show -g {} -n {} --deployment-id={}'.format(resource_group, webapp_name, deployment_1['id']), checks=[
+            JMESPathCheck('length(@) > `0`', True),
         ])
 
     @ResourceGroupPreparer()


### PR DESCRIPTION
**Description<!--Mandatory-->**  
closes #14099 
- az webapp log deployment show should show actual logs instead of the log info
- Mark commands as in preview

**Testing Guide**  
`az webapp log deployment show`

Should have output of a list of logs similar to:

[
{
"log_time": "2020...",
"id": "id",
"message": "log message",
"type": 0,
"details_url": null
},
{
"log_time": "2020...",
"id": "id",
"message": "log message 2",
"type": 0,
"details_url": null
}
]

Rather than an object similar to

{
    "active": false,
    "author": "N/A",
    "author_email": "N/A",
    "complete": true,
    "deployer": "GITHUB_ZIP_DEPLOY",
    "end_time": "2020-06-25T19:04:18.8758562Z",
    "id": "id",
    "is_readonly": true,
    "is_temp": false,
    "last_success_end_time": "2020-06-25T19:04:18.8758562Z",
    "log_url": "https://calvin-githubactions-webapp.scm.azurewebsites.net/api/deployments/deploymentId/log",
    "message": "Created via a push deployment",
    "progress": "",
    "received_time": "2020-06-25T19:04:00.9811072Z",
    "site_name": "calvin-githubactions-webapp",
    "start_time": "2020-06-25T19:04:01.061354Z",
    "status": 4,
    "status_text": "",
    "url": "https://calvin-githubactions-webapp.scm.azurewebsites.net/api/deployments/deploymentId"
  }

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
