### PR TITLE
[Storage] `az storage share-rm create/update`: add --access-tier to support access tier

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -830,8 +830,9 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
 
     for item in ['create', 'update']:
         with self.argument_context('storage share-rm {}'.format(item), resource_type=ResourceType.MGMT_STORAGE) as c:
-            t_enabled_protocols, t_root_squash = self.get_models('EnabledProtocols', 'RootSquashType',
-                                                                 resource_type=ResourceType.MGMT_STORAGE)
+            t_enabled_protocols, t_root_squash, t_access_tier = \
+                self.get_models('EnabledProtocols', 'RootSquashType', 'ShareAccessTier',
+                                resource_type=ResourceType.MGMT_STORAGE)
             c.argument('share_quota', type=int, options_list=['--quota', '-q'],
                        help='The maximum size of the share in gigabytes. Must be greater than 0, and less than or '
                             'equal to 5TB (5120). For Large File Shares, the maximum size is 102400.')
@@ -844,6 +845,9 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                        'only available for premium file shares (file shares in the FileStorage account type).')
             c.argument('root_squash', arg_type=get_enum_type(t_root_squash), is_preview=True,
                        min_api='2019-06-01', help='Reduction of the access rights for the remote superuser.')
+            c.argument('access_tier', arg_type=get_enum_type(t_access_tier), is_preview=True, min_api='2019-06-01',
+                       help='Access tier for specific share. GpV2 account can choose between TransactionOptimized '
+                       '(default), Hot, and Cool. FileStorage account can choose Premium.')
 
     with self.argument_context('storage share-rm list', resource_type=ResourceType.MGMT_STORAGE) as c:
         c.argument('account_name', storage_account_type, id_part=None)

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
@@ -19,7 +19,7 @@ from azure.cli.core.profiles import ResourceType
 
 
 def create_share_rm(cmd, client, resource_group_name, account_name, share_name, metadata=None, share_quota=None,
-                    enabled_protocols=None, root_squash=None):
+                    enabled_protocols=None, root_squash=None, access_tier=None):
 
     FileShare = cmd.get_models('FileShare', resource_type=ResourceType.MGMT_STORAGE)
 
@@ -32,12 +32,14 @@ def create_share_rm(cmd, client, resource_group_name, account_name, share_name, 
         file_share.root_squash = root_squash
     if metadata is not None:
         file_share.metadata = metadata
+    if access_tier is not None:
+        file_share.access_tier = access_tier
 
     return client.create(resource_group_name=resource_group_name, account_name=account_name, share_name=share_name,
                          file_share=file_share)
 
 
-def update_share_rm(cmd, instance, metadata=None, share_quota=None, root_squash=None):
+def update_share_rm(cmd, instance, metadata=None, share_quota=None, root_squash=None, access_tier=None):
 
     FileShare = cmd.get_models('FileShare', resource_type=ResourceType.MGMT_STORAGE)
 
@@ -46,6 +48,7 @@ def update_share_rm(cmd, instance, metadata=None, share_quota=None, root_squash=
         root_squash=root_squash if root_squash is not None else instance.root_squash,
         metadata=metadata if metadata is not None else instance.metadata,
         enabled_protocols=instance.enabled_protocols,
+        access_tier=access_tier if access_tier is not None else instance.access_tier
     )
 
     return params

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_share_rm_with_access_tier.yaml
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_share_rm_with_access_tier.yaml
@@ -1,0 +1,318 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage share-rm create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --storage-account -g -n
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003","name":"share000003","type":"Microsoft.Storage/storageAccounts/fileServices/shares"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '370'
+      content-type:
+      - application/json
+      date:
+      - Tue, 30 Jun 2020 08:47:15 GMT
+      etag:
+      - '"0x8D81CD2308EBA59"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage share-rm show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --storage-account -g -n
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003","name":"share000003","type":"Microsoft.Storage/storageAccounts/fileServices/shares","etag":"\"0x8D81CD2308EBA59\"","properties":{"lastModifiedTime":"2020-06-30T08:47:15.0000000Z","shareQuota":5120}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '484'
+      content-type:
+      - application/json
+      date:
+      - Tue, 30 Jun 2020 08:47:16 GMT
+      etag:
+      - '"0x8D81CD2308EBA59"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage share-rm update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --storage-account -g -n --access-tier
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003","name":"share000003","type":"Microsoft.Storage/storageAccounts/fileServices/shares","etag":"\"0x8D81CD2308EBA59\"","properties":{"lastModifiedTime":"2020-06-30T08:47:15.0000000Z","shareQuota":5120}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '484'
+      content-type:
+      - application/json
+      date:
+      - Tue, 30 Jun 2020 08:47:17 GMT
+      etag:
+      - '"0x8D81CD2308EBA59"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"shareQuota": 5120, "accessTier": "Hot"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage share-rm update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '57'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --storage-account -g -n --access-tier
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003","name":"share000003","type":"Microsoft.Storage/storageAccounts/fileServices/shares","properties":{"accessTier":"Hot","shareQuota":5120}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '422'
+      content-type:
+      - application/json
+      date:
+      - Tue, 30 Jun 2020 08:47:18 GMT
+      etag:
+      - '"0x8D81CD23215C57A"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1197'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage share-rm show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --storage-account -g -n
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003","name":"share000003","type":"Microsoft.Storage/storageAccounts/fileServices/shares","etag":"\"0x8D81CD23215C57A\"","properties":{"lastModifiedTime":"2020-06-30T08:47:18.0000000Z","shareQuota":5120}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '484'
+      content-type:
+      - application/json
+      date:
+      - Tue, 30 Jun 2020 08:47:18 GMT
+      etag:
+      - '"0x8D81CD23215C57A"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"accessTier": "Hot"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage share-rm create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --storage-account -g -n --access-tier
+      User-Agent:
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000004?api-version=2019-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000004","name":"share000004","type":"Microsoft.Storage/storageAccounts/fileServices/shares","properties":{"accessTier":"Hot"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '404'
+      content-type:
+      - application/json
+      date:
+      - Tue, 30 Jun 2020 08:47:19 GMT
+      etag:
+      - '"0x8D81CD232FFB1B1"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_share_rm_with_access_tier.yaml
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_share_rm_with_access_tier.yaml
@@ -17,8 +17,8 @@ interactions:
       ParameterSetName:
       - --storage-account -g -n
       User-Agent:
-      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-storage/11.1.0
+        Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: PUT
@@ -34,9 +34,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 30 Jun 2020 08:47:15 GMT
+      - Tue, 28 Jul 2020 01:29:49 GMT
       etag:
-      - '"0x8D81CD2308EBA59"'
+      - '"0x8D83295B893CAB9"'
       expires:
       - '-1'
       pragma:
@@ -48,7 +48,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1196'
     status:
       code: 201
       message: Created
@@ -66,15 +66,15 @@ interactions:
       ParameterSetName:
       - --storage-account -g -n
       User-Agent:
-      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-storage/11.1.0
+        Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003?api-version=2019-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003","name":"share000003","type":"Microsoft.Storage/storageAccounts/fileServices/shares","etag":"\"0x8D81CD2308EBA59\"","properties":{"lastModifiedTime":"2020-06-30T08:47:15.0000000Z","shareQuota":5120}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003","name":"share000003","type":"Microsoft.Storage/storageAccounts/fileServices/shares","etag":"\"0x8D83295B893CAB9\"","properties":{"lastModifiedTime":"2020-07-28T01:29:50.0000000Z","shareQuota":5120}}'
     headers:
       cache-control:
       - no-cache
@@ -83,9 +83,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 30 Jun 2020 08:47:16 GMT
+      - Tue, 28 Jul 2020 01:29:50 GMT
       etag:
-      - '"0x8D81CD2308EBA59"'
+      - '"0x8D83295B893CAB9"'
       expires:
       - '-1'
       pragma:
@@ -117,15 +117,15 @@ interactions:
       ParameterSetName:
       - --storage-account -g -n --access-tier
       User-Agent:
-      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-storage/11.1.0
+        Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003?api-version=2019-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003","name":"share000003","type":"Microsoft.Storage/storageAccounts/fileServices/shares","etag":"\"0x8D81CD2308EBA59\"","properties":{"lastModifiedTime":"2020-06-30T08:47:15.0000000Z","shareQuota":5120}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003","name":"share000003","type":"Microsoft.Storage/storageAccounts/fileServices/shares","etag":"\"0x8D83295B893CAB9\"","properties":{"lastModifiedTime":"2020-07-28T01:29:50.0000000Z","shareQuota":5120}}'
     headers:
       cache-control:
       - no-cache
@@ -134,9 +134,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 30 Jun 2020 08:47:17 GMT
+      - Tue, 28 Jul 2020 01:29:51 GMT
       etag:
-      - '"0x8D81CD2308EBA59"'
+      - '"0x8D83295B893CAB9"'
       expires:
       - '-1'
       pragma:
@@ -172,8 +172,8 @@ interactions:
       ParameterSetName:
       - --storage-account -g -n --access-tier
       User-Agent:
-      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-storage/11.1.0
+        Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: PATCH
@@ -189,9 +189,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 30 Jun 2020 08:47:18 GMT
+      - Tue, 28 Jul 2020 01:29:52 GMT
       etag:
-      - '"0x8D81CD23215C57A"'
+      - '"0x8D83295BA36C9AB"'
       expires:
       - '-1'
       pragma:
@@ -207,7 +207,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 200
       message: OK
@@ -225,15 +225,15 @@ interactions:
       ParameterSetName:
       - --storage-account -g -n
       User-Agent:
-      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-storage/11.1.0
+        Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003?api-version=2019-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003","name":"share000003","type":"Microsoft.Storage/storageAccounts/fileServices/shares","etag":"\"0x8D81CD23215C57A\"","properties":{"lastModifiedTime":"2020-06-30T08:47:18.0000000Z","shareQuota":5120}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_tier000001/providers/Microsoft.Storage/storageAccounts/tier000002/fileServices/default/shares/share000003","name":"share000003","type":"Microsoft.Storage/storageAccounts/fileServices/shares","etag":"\"0x8D83295BA36C9AB\"","properties":{"lastModifiedTime":"2020-07-28T01:29:52.0000000Z","shareQuota":5120}}'
     headers:
       cache-control:
       - no-cache
@@ -242,9 +242,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 30 Jun 2020 08:47:18 GMT
+      - Tue, 28 Jul 2020 01:29:53 GMT
       etag:
-      - '"0x8D81CD23215C57A"'
+      - '"0x8D83295BA36C9AB"'
       expires:
       - '-1'
       pragma:
@@ -280,8 +280,8 @@ interactions:
       ParameterSetName:
       - --storage-account -g -n --access-tier
       User-Agent:
-      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-storage/11.1.0 Azure-SDK-For-Python AZURECLI/2.8.0
+      - python/3.7.7 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-storage/11.1.0
+        Azure-SDK-For-Python AZURECLI/2.8.0
       accept-language:
       - en-US
     method: PUT
@@ -297,9 +297,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 30 Jun 2020 08:47:19 GMT
+      - Tue, 28 Jul 2020 01:29:54 GMT
       etag:
-      - '"0x8D81CD232FFB1B1"'
+      - '"0x8D83295BB56C56D"'
       expires:
       - '-1'
       pragma:
@@ -311,7 +311,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_file_rm_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_file_rm_scenarios.py
@@ -177,3 +177,40 @@ class StorageFileShareRmScenarios(StorageScenarioMixin, ScenarioTest):
         self.cmd('storage share-rm list --storage-account {sa} -g {rg}', checks={
             JMESPathCheck('length(@)', 0)
         })
+
+    @api_version_constraint(ResourceType.MGMT_STORAGE, min_api='2019-06-01')
+    @ResourceGroupPreparer(name_prefix="cli_tier", location="eastus")
+    @StorageAccountPreparer(name_prefix="tier", location="eastus", kind='StorageV2')
+    def test_storage_share_rm_with_access_tier(self):
+
+        self.kwargs.update({
+            'share': self.create_random_name('share', 24),
+            'new_share': self.create_random_name('share', 24)
+        })
+
+        # Update with access tier
+        self.cmd('storage share-rm create --storage-account {sa} -g {rg} -n {share}', checks={
+            JMESPathCheck('name', self.kwargs['share']),
+            JMESPathCheck('accessTier', None)
+        })
+
+        self.cmd('storage share-rm show --storage-account {sa} -g {rg} -n {share}', checks={
+            JMESPathCheck('name', self.kwargs['share']),
+            JMESPathCheck('accessTier', 'TransactionOptimized')
+        })
+
+        self.cmd('storage share-rm update --storage-account {sa} -g {rg} -n {share} --access-tier Hot', checks={
+            JMESPathCheck('name', self.kwargs['share']),
+            JMESPathCheck('accessTier', 'Hot')
+        })
+
+        self.cmd('storage share-rm show --storage-account {sa} -g {rg} -n {share}', checks={
+            JMESPathCheck('name', self.kwargs['share']),
+            JMESPathCheck('accessTier', 'Hot')
+        })
+
+        # Create with access tier
+        self.cmd('storage share-rm create --storage-account {sa} -g {rg} -n {new_share} --access-tier Hot', checks={
+            JMESPathCheck('[0].name', self.kwargs['share']),
+            JMESPathCheck('accessTier', 'Hot')
+        })

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_file_rm_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_file_rm_scenarios.py
@@ -5,7 +5,7 @@
 
 import os
 from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer, api_version_constraint,
-                               JMESPathCheck)
+                               JMESPathCheck, JMESPathCheckExists)
 from azure.cli.core.profiles import ResourceType
 from ..storage_test_util import StorageScenarioMixin
 
@@ -206,7 +206,8 @@ class StorageFileShareRmScenarios(StorageScenarioMixin, ScenarioTest):
 
         self.cmd('storage share-rm show --storage-account {sa} -g {rg} -n {share}', checks={
             JMESPathCheck('name', self.kwargs['share']),
-            JMESPathCheck('accessTier', 'Hot')
+            JMESPathCheck('accessTier', 'Hot'),
+            JMESPathCheckExists('accessTierChangeTime')
         })
 
         # Create with access tier


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Support access tier in file share
Today, Azure Files has two tiers: premium, which are served out of the FileStorage storage accounts, and standard, which are served out of general purpose version 2 (GPv2) and general purpose version 1 (GPv1) storage accounts. With this new feature, we're adding two additional new tiers, Hot and Cool, that will be offered from the "standard" (also referred to as "XStore" hardware). Because the Hot and Cool are standard tiers, the existing "standard" tier will be rebranded Transaction Optimized. This means Azure Files will have 4 tiers: 


Tier name | Supported storage account types | Physical storage hardware
-- | -- | --
Premium | FileStorage | StorageFAST   (sometimes called XIO)
Transaction   Optimized | GPv2 and GPv1 | XStore
Hot | GPv2 | XStore
Cool | GPv2 | XStore


**Testing Guide**  
<!--Example commands with explanations.-->
`az storage share-rm create/update` with `--access-tier`

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
