### PR TITLE
{Core} Fix #14175: Load ALWAYS_LOADED_EXTENSIONS correctly

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -31,7 +31,7 @@ EXCLUDED_PARAMS = ['self', 'raw', 'polling', 'custom_headers', 'operation_config
                    'content_version', 'kwargs', 'client', 'no_wait']
 EVENT_FAILED_EXTENSION_LOAD = 'MainLoader.OnFailedExtensionLoad'
 
-# [Reserved]
+# [Reserved, in case of future usage]
 # Modules that will always be loaded. They don't expose commands but hook into CLI core.
 ALWAYS_LOADED_MODULES = []
 # Extensions that will always be loaded if installed. They don't expose commands but hook into CLI core.
@@ -185,11 +185,16 @@ class MainCommandsLoader(CLICommandsLoader):
             get_extensions, get_extension_path, get_extension_modname)
 
         def _update_command_table_from_modules(args, command_modules=None):
-            '''Loads command table(s)
-            When `module_name` is specified, only commands from that module will be loaded.
-            If the module is not found, all commands are loaded.
-            '''
+            """Loads command tables from modules and merge into the main command table.
 
+            :param args: Arguments of the command.
+            :param list command_modules: Command modules to load, in the format like ['resource', 'profile'].
+             If None, will do module discovery and load all modules.
+             If [], only ALWAYS_LOADED_MODULES will be loaded.
+             Otherwise, the list will be extended using ALWAYS_LOADED_MODULES.
+            """
+
+            # As command modules are built-in, the existence of modules in ALWAYS_LOADED_MODULES is NOT checked
             if command_modules is not None:
                 command_modules.extend(ALWAYS_LOADED_MODULES)
             else:
@@ -240,6 +245,15 @@ class MainCommandsLoader(CLICommandsLoader):
                          cumulative_group_count, cumulative_command_count)
 
         def _update_command_table_from_extensions(ext_suppressions, extension_modname=None):
+            """Loads command tables from extensions and merge into the main command table.
+
+            :param ext_suppressions: Extension suppression information.
+            :param extension_modname: Command modules to load, in the format like ['azext_timeseriesinsights'].
+             If None, will do extension discovery and load all extensions.
+             If [], only ALWAYS_LOADED_EXTENSIONS will be loaded.
+             Otherwise, the list will be extended using ALWAYS_LOADED_EXTENSIONS.
+             If the extensions in the list are not installed, it will be skipped.
+            """
 
             from azure.cli.core.extension.operations import check_version_compatibility
 

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -157,7 +157,7 @@ class AzCli(CLI):
 class MainCommandsLoader(CLICommandsLoader):
 
     # Format string for pretty-print the command module table
-    header_mod = "%-20s %10s %9s %9s" % ("Extension", "Load Time", "Groups", "Commands")
+    header_mod = "%-20s %10s %9s %9s" % ("Name", "Load Time", "Groups", "Commands")
     item_format_string = "%-20s %10.3f %9d %9d"
     header_ext = header_mod + "  Directory"
     item_ext_format_string = item_format_string + "  %s"

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -272,12 +272,13 @@ class MainCommandsLoader(CLICommandsLoader):
                 # Extension's name may not be the same as its modname. eg. name: virtual-wan, modname: azext_vwan
                 filtered_extensions = []
                 for ext in extensions:
-                    ext_name = ext.name
-                    ext_dir = ext.path or get_extension_path(ext.name)
-                    ext_mod = get_extension_modname(ext_name, ext_dir=ext_dir)
+                    ext_mod = get_extension_modname(ext.name, ext.path)
                     # Filter the extensions according to the index
                     if ext_mod in extension_modname:
                         filtered_extensions.append(ext)
+                        extension_modname.remove(ext_mod)
+                if extension_modname:
+                    logger.debug("These extensions are not installed and will be skipped: %s", extension_modname)
                 return filtered_extensions
 
             extensions = get_extensions()

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -408,7 +408,6 @@ class TestCommandRegistration(unittest.TestCase):
 
         # Test azext_always_loaded is loaded when command index is rebuilt
         with mock.patch('azure.cli.core.ALWAYS_LOADED_EXTENSIONS', ['azext_always_loaded']):
-            # Call again with the new command index. Irrelevant commands are not loaded
             cmd_tbl = loader.load_command_table(["hello", "mod-only"])
             self.assertEqual(TestCommandRegistration.test_hook, "FAKE_HANDLER")
 
@@ -416,7 +415,6 @@ class TestCommandRegistration(unittest.TestCase):
 
         # Test azext_always_loaded is loaded when command index is used
         with mock.patch('azure.cli.core.ALWAYS_LOADED_EXTENSIONS', ['azext_always_loaded']):
-            # Call again with the new command index. Irrelevant commands are not loaded
             cmd_tbl = loader.load_command_table(["hello", "mod-only"])
             self.assertEqual(TestCommandRegistration.test_hook, "FAKE_HANDLER")
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -408,14 +408,14 @@ class TestCommandRegistration(unittest.TestCase):
 
         # Test azext_always_loaded is loaded when command index is rebuilt
         with mock.patch('azure.cli.core.ALWAYS_LOADED_EXTENSIONS', ['azext_always_loaded']):
-            cmd_tbl = loader.load_command_table(["hello", "mod-only"])
+            loader.load_command_table(["hello", "mod-only"])
             self.assertEqual(TestCommandRegistration.test_hook, "FAKE_HANDLER")
 
         TestCommandRegistration.test_hook = []
 
         # Test azext_always_loaded is loaded when command index is used
         with mock.patch('azure.cli.core.ALWAYS_LOADED_EXTENSIONS', ['azext_always_loaded']):
-            cmd_tbl = loader.load_command_table(["hello", "mod-only"])
+            loader.load_command_table(["hello", "mod-only"])
             self.assertEqual(TestCommandRegistration.test_hook, "FAKE_HANDLER")
 
     def test_argument_with_overrides(self):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Fix #14175: ai-did-you-mean-this extension is not loaded after a first run

Currently, if no extension corresponds to a command like `az account` in Command Index:

```
"account": [
    "azure.cli.command_modules.profile",
    "azure.cli.command_modules.resource"
],
```

`_update_command_table_from_extensions` won't be called, thus left `ALWAYS_LOADED_EXTENSIONS` ignored.

This PR fixes this issue by always calling `_update_command_table_from_modules` and `_update_command_table_from_extensions`.

**Testing Guide**  

```pwsh
> az extension add -n ai-did-you-mean-this

# If you already have ai-did-you-mean-this installed, delete `~/.azure/commandIndex.json`

# Build command index
> az account --debug

# Use command index
> az account --debug
...
[Thoth]: recommend_recovery_options: version: "2.8.0", command: "account", parameters: "['--debug']", extension: "None"
[Thoth]: User must agree to telemetry before failure recovery recommendations can be presented.
```