### PR TITLE
{Packaging, Telemetry} Bump to pywin32==228

### DIFF
--- a/src/azure-cli-core/azure/cli/core/decorators.py
+++ b/src/azure-cli-core/azure/cli/core/decorators.py
@@ -73,7 +73,8 @@ def suppress_all_exceptions(fallback_return=None, **kwargs):  # pylint: disable=
             try:
                 return func(*args, **kwargs)
             except Exception as ex:  # nopa pylint: disable=broad-except
-                get_logger(__name__).info('Suppress exception %s', ex)
+                import traceback
+                get_logger(__name__).info('Suppress exception:\n%s', traceback.format_exc())
                 if fallback_return is not None:
                     return fallback_return
         return _wrapped_func

--- a/src/azure-cli-core/azure/cli/core/decorators.py
+++ b/src/azure-cli-core/azure/cli/core/decorators.py
@@ -72,7 +72,7 @@ def suppress_all_exceptions(fallback_return=None, **kwargs):  # pylint: disable=
         def _wrapped_func(*args, **kwargs):
             try:
                 return func(*args, **kwargs)
-            except Exception as ex:  # nopa pylint: disable=broad-except
+            except Exception:  # nopa pylint: disable=broad-except
                 import traceback
                 get_logger(__name__).info('Suppress exception:\n%s', traceback.format_exc())
                 if fallback_return is not None:

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -115,7 +115,7 @@ pypiwin32==223
 pyreadline==2.1
 python-dateutil==2.8.0
 pytz==2019.1
-pywin32==225
+pywin32==228
 requests==2.22.0
 requests-oauthlib==1.2.0
 scp==0.13.2


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Due to a known issue of `pywin32==225` (https://github.com/mhammond/pywin32/issues/1431). Telemetry is broken on Windows with Python 3.8.

This PR fixes this issue by bumping to `pywin32==228`.

Repro: 

```
> azdev setup -c azure-cli -r azure-cli-extensions
> az version --debug
Suppress exception DLL load failed while importing win32file: The specified module could not be found.
```

After the fix:

```
> ppip install pywin32 --upgrade
> az version --debug
telemetry.save : Save telemetry record of length 2466 in cache
telemetry.check : Returns Positive.
telemetry.main : Begin creating telemetry upload process.
telemetry.process : Creating upload process: "D:\cli\env38\Scripts\python.exe D:\cli\azure-cli\src\azure-cli-telemetry\azure\cli\telemetry\__init__.py C:\Users\xxx\.azure"
telemetry.process : Return from creating process
telemetry.main : Finish creating telemetry upload process.
```

