### PR TITLE
{Core} refine local context message

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -147,8 +147,8 @@ class AzCli(CLI):
             args_str = []
             for name, value in local_context_args:
                 args_str.append('{}: {}'.format(name, value))
-            logger.warning('Your preference of: %s now saved to local context. To learn more, type in az '
-                           'local-context --help', ', '.join(args_str) + ' is' if len(args_str) == 1 else ' are')
+            logger.warning('Your preference of %s now saved to local context. To learn more, type in `az '
+                           'local-context --help`', ', '.join(args_str) + ' is' if len(args_str) == 1 else ' are')
 
 
 class MainCommandsLoader(CLICommandsLoader):

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -147,7 +147,8 @@ class AzCli(CLI):
             args_str = []
             for name, value in local_context_args:
                 args_str.append('{}: {}'.format(name, value))
-            logger.warning('Command argument values saved to local context: %s', ', '.join(args_str))
+            logger.warning('Your preference of: %s now saved to local context. To learn more, type in az '
+                           'local-context --help', ', '.join(args_str) + ' is' if len(args_str) == 1 else ' are')
 
 
 class MainCommandsLoader(CLICommandsLoader):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR is to fix #14015 .

PM want to refine some of local context message. 


**Testing Guide**  

`az local-context on`

> Command group 'local-context' is experimental and not covered by customer support. Please use with discretion.
Local context is turned off, you can run `az local-context on` to turn it on.

`az group create -g xxj -l westus2`
> Local context is turned on. Its information is saved in working directory D:\code\cli\azure-cli. You can run `az local-context off` to turn it off.
Your preference of: --name: xxj, --location: westus2 are now saved to local context. To learn more, type in az local-context --help


**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
