### PR TITLE
{Test} Fix default admin-username

### DIFF
--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -3,6 +3,8 @@
 # This script should be run in a centos8 docker.
 set -exv
 
+export USERNAME=azureuser
+
 yum --nogpgcheck localinstall /mnt/yum/$YUM_NAME -y
 
 yum install git -y


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Some new vm tests are checked in without `--admin-username` for vm/vmss create command, causing issue #14265

As a workaround to fix the tests in docker for rpm package, use a `USERNAME` env var to return as the default admin user name according to: https://github.com/python/cpython/blob/3cbade7d309ab1ea97ec286d19d506df30bd1ab7/Lib/getpass.py#L162-L165


**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
