### PR TITLE
[REST] Fix #14152: `az rest`: Accept ARM URLs without subscription ID

### DIFF
--- a/scripts/ci/credscan/CredScanSuppressions.json
+++ b/scripts/ci/credscan/CredScanSuppressions.json
@@ -371,8 +371,7 @@
     },
     {
       "file": [
-        "src\\azure-cli\\azure\\cli\\command_modules\\resource\\tests\\latest\\test-largesize-parameters.json",
-        "src\\azure-cli\\azure\\cli\\command_modules\\resource\\tests\\latest\\recordings\\test_rest.yaml"
+        "src\\azure-cli\\azure\\cli\\command_modules\\resource\\tests\\latest\\test-largesize-parameters.json"
       ],
       "_justification": "random name and value"
     },
@@ -382,7 +381,7 @@
     },
     {
       "file": [
-        "src/azure-cli/azure/cli/command_modules/util/tests/latest/recordings/test_rest.yaml"
+        "src/azure-cli/azure/cli/command_modules/util/tests/latest/recordings/test_rest_storage.yaml"
       ],
       "_justification": "one-time sas token"
     }

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -301,6 +301,28 @@ class TestUtils(unittest.TestCase):
         request = send_mock.call_args.args[1]
         self.assertDictEqual(dict(request.headers), expected_header_with_auth)
 
+        # Test ARM Subscriptions - List
+        # https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/list
+        # /subscriptions?api-version=2020-01-01
+        send_raw_request(cli_ctx, 'GET', '/subscriptions?api-version=2020-01-01', body=test_body,
+                         generated_client_request_id_name=None)
+
+        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
+        request = send_mock.call_args.args[1]
+        self.assertEqual(request.url, test_arm_endpoint.rstrip('/') + '/subscriptions?api-version=2020-01-01')
+        self.assertDictEqual(dict(request.headers), expected_header_with_auth)
+
+        # Test ARM Tenants - List
+        # https://docs.microsoft.com/en-us/rest/api/resources/tenants/list
+        # /tenants?api-version=2020-01-01
+        send_raw_request(cli_ctx, 'GET', '/tenants?api-version=2020-01-01', body=test_body,
+                         generated_client_request_id_name=None)
+
+        get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
+        request = send_mock.call_args.args[1]
+        self.assertEqual(request.url, test_arm_endpoint.rstrip('/') + '/tenants?api-version=2020-01-01')
+        self.assertDictEqual(dict(request.headers), expected_header_with_auth)
+
         # Test ARM resource ID
         # /subscriptions/00000001-0000-0000-0000-000000000000/resourcegroups/02?api-version=2019-07-01
         send_raw_request(cli_ctx, 'GET', arm_resource_id, body=test_body,

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -739,12 +739,13 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
     if '{subscriptionId}' in url:
         url = url.replace('{subscriptionId}', cli_ctx.data['subscription_id'] or profile.get_subscription_id())
 
+    # Prepare the Bearer token for `Authorization` header
     if not skip_authorization_header and url.lower().startswith('https://'):
-        # Prepare `resource`
+        # Prepare `resource` for `get_raw_token`
         if not resource:
-            # If url starts with ARM endpoint, like https://management.azure.com/,
-            # use active_directory_resource_id for resource.
-            # This follows the same behavior as azure.cli.core.commands.client_factory._get_mgmt_service_client
+            # If url starts with ARM endpoint, like `https://management.azure.com/`,
+            # use `active_directory_resource_id` for resource, like `https://management.core.windows.net/`.
+            # This follows the same behavior as `azure.cli.core.commands.client_factory._get_mgmt_service_client`
             if url.lower().startswith(endpoints.resource_manager.rstrip('/')):
                 resource = endpoints.active_directory_resource_id
             else:
@@ -758,6 +759,7 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
                         resource = value
                         break
         if resource:
+            # Prepare `subscription` for `get_raw_token`
             # If this is an ARM request, try to extract subscription ID from the URL.
             # But there are APIs which don't require subscription ID, like /subscriptions, /tenants
             # TODO: In the future when multi-tenant subscription is supported, we won't be able to uniquely identity

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -762,7 +762,7 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
             # Prepare `subscription` for `get_raw_token`
             # If this is an ARM request, try to extract subscription ID from the URL.
             # But there are APIs which don't require subscription ID, like /subscriptions, /tenants
-            # TODO: In the future when multi-tenant subscription is supported, we won't be able to uniquely identity
+            # TODO: In the future when multi-tenant subscription is supported, we won't be able to uniquely identify
             #   the token from subscription anymore.
             token_subscription = None
             if url.lower().startswith(endpoints.resource_manager.rstrip('/')):

--- a/src/azure-cli/azure/cli/command_modules/util/tests/latest/recordings/test_rest_arm.yaml
+++ b/src/azure-cli/azure/cli/command_modules/util/tests/latest/recordings/test_rest_arm.yaml
@@ -1,0 +1,514 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -u
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: GET
+    uri: https://management.azure.com/subscriptions?api-version=2020-01-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000","authorizationSource":"RoleBased","managedByTenants":[{"tenantId":"2f4a9838-26b7-47ee-be60-ccc1fdec5953"}],"subscriptionId":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","displayName":"AzureSDKTest","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Internal_2014-09-01","quotaId":"Internal_2014-09-01","spendingLimit":"Off"}}],"count":{"type":"Total","value":1}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '490'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 Jul 2020 04:26:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -u
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: GET
+    uri: https://management.azure.com/tenants?api-version=2020-01-01
+  response:
+    body:
+      string: '{"value":[{"id":"/tenants/72f988bf-86f1-41af-91ab-2d7cd011db47","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","countryCode":"US","displayName":"Microsoft","domains":["drawbridge.com","expresslogic.com","euevents.microsoft.com","nonprofits.microsoft.com","benefits.microsoft.com","forzaesports.com","bons.ai","bonsaiai.com","bonsai.ai","mileiq.com","mobiledatalabs.com","azmosa.io","fslogix.com","Howdy.ai","Xoxco.com","Botkit.ai","glintinc.com","maquette.ms","tibazdev.microsoft.com","mail.appcenter.ms","Hexadite.com","lobe.ai","appcenter.ms","github.com","gearspop.com","messages.microsoft.com","flipgrid.com","semanticmachines.com","video2brain.com","averesystems.com","initiativegaming.com","mail1.averesystems.com","seaofthieves.com","Intentional.com","m12.vc","email.bing.com","playfab.com","itsm.microsoft.com","Windows.mail.microsoft.com","smtphost.microsoft.com","exmail.microsoft.com","altvr.com","altspacevr.com","corp.microsoft.com","cyclecomputing.com","cloudyn.com","nuget.org","microsoftsmarthq.com.au","lockbox.microsoft.com","acompli.com","domains.microsoft","service.linkedin.com","microsoft.com","eventscommunication.microsoft.com","deis.com","Lynda.com","Slideshare.com","Newsle.com","linkedin.com","myemailing.microsoft.com","maluuba.com","internal.linkedin.cn","linkedin.biz","microsoftcan.onmicrosoft.com","educatorcommunity.microsoft.com","simplygon.com","MicrosoftAPC.onmicrosoft.com","messages2.microsoft.com","shadmorris.com","MicrosoftEur.onmicrosoft.com","security.microsoft.com","robovm.com","solaircorporate.com","wandlabs.com","azureemail.microsoft.com","genee.me","microsoftstudios.com","MICROSOFTCSR.COM","bigpark.com","bing.com","corp.webtv.net","HaloWaypoint.com","musiwave.com","navic.tv","ntdev.corp.microsoft.com","redmond.corp.microsoft.com","europe.corp.microsoft.com","middleeast.corp.microsoft.com","exchange.corp.microsoft.com","southamerica.corp.microsoft.com","fareast.corp.microsoft.com","winse.corp.microsoft.com","mslpa.corp.microsoft.com","windows.microsoft.com","africa.corp.microsoft.com","ntdev.microsoft.com","wingroup.windeploy.ntdev.microsoft.com","southpacific.corp.microsoft.com","segroup.winse.corp.microsoft.com","northamerica.corp.microsoft.com","service.microsoft.com","exchange.microsoft.com","xbox.com","zune.net","msg.microsoft.com","titanium.microsoft.com","microsoft.mail.onmicrosoft.com","filtering.exchange.microsoft.com","skype.net","hybrid.microsoft.com","fbt.microsoft.com","ageofempiresonline.com","yammer-inc.com","service.fbt.microsoft.com","service.exchange.microsoft.com","mslicense.com","office365.microsoft.com","crm.microsoft.com","mssales.microsoft.com","mssupport.microsoft.com","smc.microsoft.com","sharepointjournaling.exchange.microsoft.com","wingroup.microsoft.com","managed.microsoft.com","serivce.exchange.microsoft.com","primary.exchange.microsoft.com","filtering.service.exchange.microsoft.com","pioneer.exchange.microsoft.com","wmislabcon01.redmond.corp.microsoft.com","winfarmmail.ntdev.corp.microsoft.com","WOSTIX-TEST.NTDEV.corp.microsoft.com","SPSDOG4-27.redmond.corp.microsoft.com","SPSDOG4-34.redmond.corp.microsoft.com","spsdog4-16.redmond.corp.microsoft.com","cyrusb-z400.redmond.corp.microsoft.com","MOSSDOG2982.redmond.corp.microsoft.com","osgwebindex.redmond.corp.microsoft.com","wostcktiis01.redmond.corp.microsoft.com","osgemail.redmond.corp.microsoft.com","extranettest.microsoft.com","pssupport.microsoft.com","extranet.microsoft.com","munich.microsoft.com","news.microsoft.com","mpsd.microsoft.com","gmo.microsoft.com","ims.microsoft.com","partners.extranet.microsoft.com","parttest.extranettest.microsoft.com","mscourseware.com","placeware.com","nokia.microsoft.com","www.surfaceclub.sg","winse.microsoft.com","surface.com","rare.co.uk","screentonic.com","mds.microsoft.com","mail.microsoft.com","mailflowtest.mail.microsoft.com","t-dynmktge.com","aspproject.nl","metricshub.com","ageofempires.com","azure.com","fast.no","microsoft.co.nz","live.co.hu","groupme.com","aquantive.com","fastsearch.com","microsoft.tm.hu","microsoft.ccsctp.com","healthvault.com","perceptivepixel.com","marketingpilot.com","phonefactor.com","lucernepublishing.com","vexcel.co.at","vexscan.com","qik.com","parlano.com","musiwave.net","skype.com","slimbezig.nl","Softricity.com","windows-live.hu","xboxtest.com","groove.net","008.mgd.microsoft.com","vexcel.at","officelive.co.hu","windowslive.co.hu","xbox360.co.hu","xbox.co.hu","winlive.co.hu","windows-live.co.hu","microsoft.eu","datallegro.com","projectspark.com","Storesimple.com","Phonefactor.net","yadata.com","surfaceclub.sg","microsoft.onmicrosoft.com","zone.com","sentillion.com","view012.de","windowsmedia.hu","greenbutton.com","css.one.microsoft.com","proclarity.com","rareware.com","capptain.com","mgd.microsoft.com","064d.mgd.microsoft.com","inmage.net","inmage.com","bingnews.microsoft.com","aorato.com","api.yammer.com","email.microsoft.com","officelabs.microsoft.com","Codenauts.com","codenauts.de","Hockeyapp.com","qa2.parature.net","componentart.com","datazen.com","nuvolarosa.eu","bayiportali.mmdservice.com","inside-r.org","Getliveloop.com","Sunrise.am","incentgames.com","doublelabs.com","Fantasysalesteam.com","clickdimensions.Microsoft.com","volometrix.com","bluestripe.com","time.microsoft.com","revolutionanalytics.com","inside-r.com","revolution-computing.com","fieldone.com","Pioneerinteractive.com","msitsupp.microsoft.com","metanautix.com","dwh.io","pressplay.dk","adxstudio.com","Havok.com","Trinigy.net","Projectanarchy.com","Rocketbox.de","cloudappsecurity.com","email-2.microsoft.com","Swiftkey.com","Swiftkey.net","Swiftmoji.com","Touchtype-online.com","msfts2.onmicrosoft.com","msfts2.mail.onmicrosoft.com","Xamarin.com","secureislands.com","gears.gg","promoteiq.com","sangamemail.microsoft.com","preonboarding.microsoft.com","microsoftprd.onmicrosoft.com","bluetalon.com","citusdata.com","spotfront.com","dcat.microsoft.com","jclarity.com","msftdomains.microsoft.com","msra.microsoft.com","sales.microsoft.com","askhr.microsoft.com","idwebmail.microsoft.com","movere.io","experience.microsoft.com","thefightisinus.org","Unifiedlogic.com","mover.io","msads.microsoft.com"],"tenantCategory":"Home","defaultDomain":"microsoft.onmicrosoft.com","tenantType":"AAD","tenantBrandingLogoUrl":"https://secure.aadcdn.microsoftonline-p.com/dbd5a2dd-n2kxueriy-dm8fhyf0anvulmvhi3kdbkkxqluuekyfc/logintenantbranding/0/bannerlogo?ts=636783560697171089"},{"id":"/tenants/246b1785-9030-40d8-a0f0-d94b15dc002c","tenantId":"246b1785-9030-40d8-a0f0-d94b15dc002c","countryCode":"US","displayName":"Selfhost","domains":["masselfhost.onmicrosoft.com"],"tenantCategory":"Home","defaultDomain":"masselfhost.onmicrosoft.com","tenantType":"AAD"},{"id":"/tenants/2b8e6bbc-631a-4bf6-b0c6-d4947b3c79dd","tenantId":"2b8e6bbc-631a-4bf6-b0c6-d4947b3c79dd","countryCode":"US","displayName":"Fabrikam
+        Managed Services","domains":["fabrikammanagedservices.onmicrosoft.com"],"tenantCategory":"Home","defaultDomain":"fabrikammanagedservices.onmicrosoft.com","tenantType":"AAD"},{"id":"/tenants/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","countryCode":"US","displayName":"AzureSDKTeam","domains":["AzureSDKTeam.onmicrosoft.com","azdevextest.com"],"tenantCategory":"Home","defaultDomain":"AzureSDKTeam.onmicrosoft.com","tenantType":"AAD"},{"id":"/tenants/ca97aaa0-5a12-4ae3-8929-c8fb57dd93d6","tenantId":"ca97aaa0-5a12-4ae3-8929-c8fb57dd93d6","countryCode":"US","displayName":"jlcorp","domains":["jlazcl.onmicrosoft.com"],"tenantCategory":"Home","defaultDomain":"jlazcl.onmicrosoft.com","tenantType":"AAD"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '7586'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 Jul 2020 04:26:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -m -u --body
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rest-rg000001?api-version=2019-10-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rest-rg000001","name":"test-rest-rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 Jul 2020 04:26:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -u
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rest-rg000001?api-version=2019-10-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rest-rg000001","name":"test-rest-rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '237'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 Jul 2020 04:26:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -m -u
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rest-rg000001?api-version=2019-10-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Wed, 15 Jul 2020 04:26:42 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1URVNUOjJEUkVTVDoyRFJHS0tKQkJaSEstRUFTVFVTIiwiam9iTG9jYXRpb24iOiJlYXN0dXMifQ?api-version=2019-10-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14998'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -u
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rest-rg000001?api-version=2019-10-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rest-rg000001","name":"test-rest-rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","properties":{"provisioningState":"Deleting"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 Jul 2020 04:26:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -u
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rest-rg000001?api-version=2019-10-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rest-rg000001","name":"test-rest-rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","properties":{"provisioningState":"Deleting"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 Jul 2020 04:26:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -u
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rest-rg000001?api-version=2019-10-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rest-rg000001","name":"test-rest-rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","properties":{"provisioningState":"Deleting"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 Jul 2020 04:26:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -u
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rest-rg000001?api-version=2019-10-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rest-rg000001","name":"test-rest-rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","properties":{"provisioningState":"Deleting"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 Jul 2020 04:27:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -u
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rest-rg000001?api-version=2019-10-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rest-rg000001","name":"test-rest-rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","properties":{"provisioningState":"Deleting"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 Jul 2020 04:27:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -u
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rest-rg000001?api-version=2019-10-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rest-rg000001","name":"test-rest-rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","properties":{"provisioningState":"Deleting"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 Jul 2020 04:27:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - rest
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -u
+      User-Agent:
+      - AZURECLI/2.9.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rest-rg000001?api-version=2019-10-01
+  response:
+    body:
+      string: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group
+        ''test-rest-rg000001'' could not be found."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '112'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 Jul 2020 04:27:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/util/tests/latest/recordings/test_rest_storage.yaml
+++ b/src/azure-cli/azure/cli/command_modules/util/tests/latest/recordings/test_rest_storage.yaml
@@ -19,7 +19,7 @@ interactions:
       ParameterSetName:
       - -m -u -b
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002?api-version=2019-06-01
   response:
@@ -33,11 +33,11 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Thu, 09 Jul 2020 02:54:18 GMT
+      - Wed, 15 Jul 2020 04:55:10 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/5fcf356c-f2ea-470a-9932-236d6f4bf194?monitor=true&api-version=2019-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/asyncoperations/c5bd41b0-301d-4ed0-9fbe-4ee512be939e?monitor=true&api-version=2019-06-01
       pragma:
       - no-cache
       server:
@@ -47,7 +47,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 202
       message: Accepted
@@ -65,12 +65,12 @@ interactions:
       ParameterSetName:
       - -m -u
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002?api-version=2019-06-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002","name":"tmpst000002","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-09T02:54:17.9090549Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-09T02:54:17.9090549Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"ResolvingDns","creationTime":"2020-07-09T02:54:17.8152553Z","primaryEndpoints":{"blob":"https://tmpst000002.blob.core.windows.net/","queue":"https://tmpst000002.queue.core.windows.net/","table":"https://tmpst000002.table.core.windows.net/","file":"https://tmpst000002.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available"}}'
+      string: '{"sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002","name":"tmpst000002","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-15T04:55:11.0919565Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-15T04:55:11.0919565Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"ResolvingDns","creationTime":"2020-07-15T04:55:10.9981998Z","primaryEndpoints":{"blob":"https://tmpst000002.blob.core.windows.net/","queue":"https://tmpst000002.queue.core.windows.net/","table":"https://tmpst000002.table.core.windows.net/","file":"https://tmpst000002.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -79,7 +79,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 09 Jul 2020 02:54:23 GMT
+      - Wed, 15 Jul 2020 04:55:16 GMT
       expires:
       - '-1'
       pragma:
@@ -111,12 +111,12 @@ interactions:
       ParameterSetName:
       - -m -u
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002?api-version=2019-06-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002","name":"tmpst000002","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-09T02:54:17.9090549Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-09T02:54:17.9090549Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"ResolvingDns","creationTime":"2020-07-09T02:54:17.8152553Z","primaryEndpoints":{"blob":"https://tmpst000002.blob.core.windows.net/","queue":"https://tmpst000002.queue.core.windows.net/","table":"https://tmpst000002.table.core.windows.net/","file":"https://tmpst000002.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available"}}'
+      string: '{"sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002","name":"tmpst000002","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-15T04:55:11.0919565Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-15T04:55:11.0919565Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"ResolvingDns","creationTime":"2020-07-15T04:55:10.9981998Z","primaryEndpoints":{"blob":"https://tmpst000002.blob.core.windows.net/","queue":"https://tmpst000002.queue.core.windows.net/","table":"https://tmpst000002.table.core.windows.net/","file":"https://tmpst000002.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -125,7 +125,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 09 Jul 2020 02:54:29 GMT
+      - Wed, 15 Jul 2020 04:55:22 GMT
       expires:
       - '-1'
       pragma:
@@ -157,12 +157,12 @@ interactions:
       ParameterSetName:
       - -m -u
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002?api-version=2019-06-01
   response:
     body:
-      string: '{"sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002","name":"tmpst000002","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-09T02:54:17.9090549Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-09T02:54:17.9090549Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-07-09T02:54:17.8152553Z","primaryEndpoints":{"blob":"https://tmpst000002.blob.core.windows.net/","queue":"https://tmpst000002.queue.core.windows.net/","table":"https://tmpst000002.table.core.windows.net/","file":"https://tmpst000002.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available"}}'
+      string: '{"sku":{"name":"Standard_GRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002","name":"tmpst000002","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{},"properties":{"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-15T04:55:11.0919565Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2020-07-15T04:55:11.0919565Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2020-07-15T04:55:10.9981998Z","primaryEndpoints":{"blob":"https://tmpst000002.blob.core.windows.net/","queue":"https://tmpst000002.queue.core.windows.net/","table":"https://tmpst000002.table.core.windows.net/","file":"https://tmpst000002.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available","secondaryLocation":"westus","statusOfSecondary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -171,7 +171,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 09 Jul 2020 02:54:35 GMT
+      - Wed, 15 Jul 2020 04:55:28 GMT
       expires:
       - '-1'
       pragma:
@@ -210,21 +210,21 @@ interactions:
       ParameterSetName:
       - -m -u -b
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002/ListAccountSas?api-version=2019-06-01
   response:
     body:
-      string: '{"accountSasToken":"sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=muBwE10Zit9LDlgqoSOjl4b1eeTlgVnHo8Rw5BPNQo8%3D"}'
+      string: '{"accountSasToken":"sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=JkjArgAXeKINVSmkhLp0q6u05F5io%2FZ0MnNnadPpmpA%3D"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '197'
+      - '199'
       content-type:
       - application/json
       date:
-      - Thu, 09 Jul 2020 02:54:38 GMT
+      - Wed, 15 Jul 2020 04:55:30 GMT
       expires:
       - '-1'
       pragma:
@@ -260,9 +260,9 @@ interactions:
       ParameterSetName:
       - -m -u --skip-authorization-header
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: PUT
-    uri: https://tmpst000002.blob.core.windows.net/mycontainer?restype=container&sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=muBwE10Zit9LDlgqoSOjl4b1eeTlgVnHo8Rw5BPNQo8%3D
+    uri: https://tmpst000002.blob.core.windows.net/mycontainer?restype=container&sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=JkjArgAXeKINVSmkhLp0q6u05F5io%2FZ0MnNnadPpmpA%3D
   response:
     body:
       string: ''
@@ -270,11 +270,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 09 Jul 2020 02:54:39 GMT
+      - Wed, 15 Jul 2020 04:55:33 GMT
       etag:
-      - '"0x8D823B36C931A4A"'
+      - '"0x8D8287B4EAA26DE"'
       last-modified:
-      - Thu, 09 Jul 2020 02:54:40 GMT
+      - Wed, 15 Jul 2020 04:55:33 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -296,9 +296,9 @@ interactions:
       ParameterSetName:
       - -m -u --skip-authorization-header
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: HEAD
-    uri: https://tmpst000002.blob.core.windows.net/mycontainer?restype=container&sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=muBwE10Zit9LDlgqoSOjl4b1eeTlgVnHo8Rw5BPNQo8%3D
+    uri: https://tmpst000002.blob.core.windows.net/mycontainer?restype=container&sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=JkjArgAXeKINVSmkhLp0q6u05F5io%2FZ0MnNnadPpmpA%3D
   response:
     body:
       string: ''
@@ -306,11 +306,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 09 Jul 2020 02:54:41 GMT
+      - Wed, 15 Jul 2020 04:55:35 GMT
       etag:
-      - '"0x8D823B36C931A4A"'
+      - '"0x8D8287B4EAA26DE"'
       last-modified:
-      - Thu, 09 Jul 2020 02:54:40 GMT
+      - Wed, 15 Jul 2020 04:55:33 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-lease-state:
@@ -340,11 +340,11 @@ interactions:
       ParameterSetName:
       - -m -u --headers --skip-authorization-header --body
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
       x-ms-blob-type:
       - BlockBlob
     method: PUT
-    uri: https://tmpst000002.blob.core.windows.net/mycontainer/myblob?sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=muBwE10Zit9LDlgqoSOjl4b1eeTlgVnHo8Rw5BPNQo8%3D
+    uri: https://tmpst000002.blob.core.windows.net/mycontainer/myblob?sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=JkjArgAXeKINVSmkhLp0q6u05F5io%2FZ0MnNnadPpmpA%3D
   response:
     body:
       string: ''
@@ -354,11 +354,11 @@ interactions:
       content-md5:
       - XrY7u+Ae7tCTyyK7j1rNww==
       date:
-      - Thu, 09 Jul 2020 02:54:42 GMT
+      - Wed, 15 Jul 2020 04:55:36 GMT
       etag:
-      - '"0x8D823B36E84BA3D"'
+      - '"0x8D8287B5063B7A9"'
       last-modified:
-      - Thu, 09 Jul 2020 02:54:43 GMT
+      - Wed, 15 Jul 2020 04:55:36 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -380,9 +380,9 @@ interactions:
       ParameterSetName:
       - -m -u --skip-authorization-header
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: GET
-    uri: https://tmpst000002.blob.core.windows.net/mycontainer/myblob?sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=muBwE10Zit9LDlgqoSOjl4b1eeTlgVnHo8Rw5BPNQo8%3D
+    uri: https://tmpst000002.blob.core.windows.net/mycontainer/myblob?sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=JkjArgAXeKINVSmkhLp0q6u05F5io%2FZ0MnNnadPpmpA%3D
   response:
     body:
       string: hello world
@@ -396,11 +396,11 @@ interactions:
       content-type:
       - text/plain; charset=UTF-8
       date:
-      - Thu, 09 Jul 2020 02:54:44 GMT
+      - Wed, 15 Jul 2020 04:55:37 GMT
       etag:
-      - '"0x8D823B36E84BA3D"'
+      - '"0x8D8287B5063B7A9"'
       last-modified:
-      - Thu, 09 Jul 2020 02:54:43 GMT
+      - Wed, 15 Jul 2020 04:55:36 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
@@ -428,14 +428,14 @@ interactions:
       ParameterSetName:
       - -m -u --skip-authorization-header
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: GET
-    uri: https://tmpst000002.blob.core.windows.net/mycontainer?restype=container&comp=list&sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=muBwE10Zit9LDlgqoSOjl4b1eeTlgVnHo8Rw5BPNQo8%3D
+    uri: https://tmpst000002.blob.core.windows.net/mycontainer?restype=container&comp=list&sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=JkjArgAXeKINVSmkhLp0q6u05F5io%2FZ0MnNnadPpmpA%3D
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://tmpst000002.blob.core.windows.net/\" ContainerName=\"mycontainer\"><Blobs><Blob><Name>myblob</Name><Properties><Last-Modified>Thu,
-        09 Jul 2020 02:54:43 GMT</Last-Modified><Etag>0x8D823B36E84BA3D</Etag><Content-Length>11</Content-Length><Content-Type>text/plain;
+        ServiceEndpoint=\"https://tmpst000002.blob.core.windows.net/\" ContainerName=\"mycontainer\"><Blobs><Blob><Name>myblob</Name><Properties><Last-Modified>Wed,
+        15 Jul 2020 04:55:36 GMT</Last-Modified><Etag>0x8D8287B5063B7A9</Etag><Content-Length>11</Content-Length><Content-Type>text/plain;
         charset=UTF-8</Content-Type><Content-Encoding /><Content-Language /><Content-MD5>XrY7u+Ae7tCTyyK7j1rNww==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob></Blobs><NextMarker
         /></EnumerationResults>"
@@ -443,7 +443,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Thu, 09 Jul 2020 02:54:46 GMT
+      - Wed, 15 Jul 2020 04:55:39 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -469,9 +469,9 @@ interactions:
       ParameterSetName:
       - -m -u --skip-authorization-header
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: DELETE
-    uri: https://tmpst000002.blob.core.windows.net/mycontainer/myblob?sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=muBwE10Zit9LDlgqoSOjl4b1eeTlgVnHo8Rw5BPNQo8%3D
+    uri: https://tmpst000002.blob.core.windows.net/mycontainer/myblob?sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=JkjArgAXeKINVSmkhLp0q6u05F5io%2FZ0MnNnadPpmpA%3D
   response:
     body:
       string: ''
@@ -479,7 +479,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 09 Jul 2020 02:54:47 GMT
+      - Wed, 15 Jul 2020 04:55:40 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -503,9 +503,9 @@ interactions:
       ParameterSetName:
       - -m -u --skip-authorization-header
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: DELETE
-    uri: https://tmpst000002.blob.core.windows.net/mycontainer?restype=container&sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=muBwE10Zit9LDlgqoSOjl4b1eeTlgVnHo8Rw5BPNQo8%3D
+    uri: https://tmpst000002.blob.core.windows.net/mycontainer?restype=container&sv=2015-04-05&ss=b&srt=sco&sp=rwdlacu&st=2017-05-24T10%3A42%3A03.1567373Z&se=2030-05-24T11%3A42%3A03.1567373Z&spr=https,http&sig=JkjArgAXeKINVSmkhLp0q6u05F5io%2FZ0MnNnadPpmpA%3D
   response:
     body:
       string: ''
@@ -513,7 +513,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 09 Jul 2020 02:54:49 GMT
+      - Wed, 15 Jul 2020 04:55:42 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -537,7 +537,7 @@ interactions:
       ParameterSetName:
       - -m -u
       User-Agent:
-      - AZURECLI/2.8.0
+      - AZURECLI/2.9.0
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_rest000001/providers/Microsoft.Storage/storageAccounts/tmpst000002?api-version=2019-06-01
   response:
@@ -551,7 +551,7 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Thu, 09 Jul 2020 02:54:59 GMT
+      - Wed, 15 Jul 2020 04:55:49 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/util/tests/latest/test_rest.py
+++ b/src/azure-cli/azure/cli/command_modules/util/tests/latest/test_rest.py
@@ -14,8 +14,50 @@ TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 
 class ResourceGroupScenarioTest(ScenarioTest):
 
+    def test_rest_arm(self):
+        from knack.util import CLIError
+
+        self.kwargs.update({
+            'rg': self.create_random_name("test-rest-rg", length=20)
+        })
+
+        # Test ARM Subscriptions - List
+        # https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/list
+        self.cmd('az rest -u /subscriptions?api-version=2020-01-01',
+                 checks=[self.exists("value")])
+
+        # Test ARM Tenants - List
+        # https://docs.microsoft.com/en-us/rest/api/resources/tenants/list
+        self.cmd('az rest -u /tenants?api-version=2020-01-01',
+                 checks=[self.exists("value")])
+
+        # Resource Groups - Create Or Update
+        # https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups/createorupdate
+        self.cmd('az rest -m PUT -u https://management.azure.com/subscriptions/{{subscriptionId}}/resourcegroups/{rg}?api-version=2019-10-01 '
+                 '--body \'{{"location": "eastus"}}\'',
+                 checks=[self.check("name", '{rg}')])
+
+        # Resource Groups - Get
+        # https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups/get
+        self.cmd('az rest -u https://management.azure.com/subscriptions/{{subscriptionId}}/resourcegroups/{rg}?api-version=2019-10-01',
+                 checks=[self.check("name", '{rg}')])
+
+        # Resource Groups - Delete
+        # https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups/delete
+        self.cmd('az rest -m DELETE -u https://management.azure.com/subscriptions/{{subscriptionId}}/resourcegroups/{rg}?api-version=2019-10-01',
+                 checks=[])
+
+        # Resource Groups - Get
+        # Polling for 404
+        # TODO: return 3 for 404
+        with self.assertRaises(CLIError):
+            while True:
+                time.sleep(5)
+                result = self.cmd('az rest -u https://management.azure.com/subscriptions/{{subscriptionId}}/resourcegroups/{rg}?api-version=2019-10-01',
+                                  checks=[])
+
     @ResourceGroupPreparer(name_prefix='cli_test_rest')
-    def test_rest(self, resource_group):
+    def test_rest_storage(self, resource_group):
 
         self.kwargs.update({
             'sa': self.create_random_name("tmpst", length=10),

--- a/src/azure-cli/azure/cli/command_modules/util/tests/latest/test_rest.py
+++ b/src/azure-cli/azure/cli/command_modules/util/tests/latest/test_rest.py
@@ -53,8 +53,8 @@ class ResourceGroupScenarioTest(ScenarioTest):
         with self.assertRaises(CLIError):
             while True:
                 time.sleep(5)
-                result = self.cmd('az rest -u https://management.azure.com/subscriptions/{{subscriptionId}}/resourcegroups/{rg}?api-version=2019-10-01',
-                                  checks=[])
+                self.cmd('az rest -u https://management.azure.com/subscriptions/{{subscriptionId}}/resourcegroups/{rg}?api-version=2019-10-01',
+                         checks=[])
 
     @ResourceGroupPreparer(name_prefix='cli_test_rest')
     def test_rest_storage(self, resource_group):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Fix #14152: No subscription ID specified in the URL

#13782 introduced a bug that `az rest` fails for ARM URLs without subscription ID, like `/subscriptions`, `/tenants`:

https://github.com/Azure/azure-cli/blob/62eb25feac0da927d219321538046faee6882886/src/azure-cli-core/azure/cli/core/util.py#L807-L808

This PR makes `az rest` accept such URLs and retrieve token for the current selected tenant instead.

The debug log is also improved:

```pwsh
> az rest -u /subscriptions?api-version=2020-01-01 --debug

DEBUG: No subscription ID specified in the URL https://management.azure.com/subscriptions?api-version=2020-01-01
DEBUG: Retrieving token for resource https://management.core.windows.net/

> az rest -u /subscriptions/{subscriptionId}/resourcegroups/rg1?api-version=2019-10-01 --debug

DEBUG: Found subscription ID 0b1f6471-1bf0-4dda-aec3-cb9272f09590 in the URL https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/rg1?api-version=2019-10-01
DEBUG: Retrieving token for resource https://management.core.windows.net/, subscription 0b1f6471-1bf0-4dda-aec3-cb9272f09590
```

**Testing Guide**  
```pwsh
az rest -u /subscriptions?api-version=2020-01-01
az rest -u /tenants?api-version=2020-01-01
az rest -u '/subscriptions/{subscriptionId}/resourcegroups/rg1?api-version=2019-10-01'
```
