### PR TITLE
[Network] MACsec Configuration Edits

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -2743,6 +2743,7 @@ examples:
         --macsec-ckn-secret-identifier MacSecCKNSecretID \\
         --macsec-cak-secret-identifier MacSecCAKSecretID \\
         --macsec-cipher gcm-aes-128
+        --macsec-sci-state Enabled
   - name: Enable administrative state of an ExpressRoute Link.
     text: |-
         az network express-route port link update \\

--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -59,7 +59,7 @@ def load_arguments(self, _):
      IPVersion, LoadBalancerSkuName, LoadDistribution, ProbeProtocol, ProcessorArchitecture, Protocol, PublicIPAddressSkuName,
      RouteNextHopType, SecurityRuleAccess, SecurityRuleProtocol, SecurityRuleDirection, TransportProtocol,
      VirtualNetworkGatewaySkuName, VirtualNetworkGatewayType, VpnClientProtocol, VpnType,
-     ExpressRouteLinkMacSecCipher, ExpressRouteLinkAdminState,
+     ExpressRouteLinkMacSecCipher, ExpressRouteLinkMacSecSciState, ExpressRouteLinkAdminState,
      ConnectionMonitorEndpointFilterType, ConnectionMonitorTestConfigurationProtocol,
      PreferredIPVersion, HTTPConfigurationMethod, OutputType) = self.get_models(
          'Access', 'ApplicationGatewayFirewallMode', 'ApplicationGatewayProtocol', 'ApplicationGatewayRedirectType',
@@ -70,7 +70,7 @@ def load_arguments(self, _):
          'IPVersion', 'LoadBalancerSkuName', 'LoadDistribution', 'ProbeProtocol', 'ProcessorArchitecture', 'Protocol', 'PublicIPAddressSkuName',
          'RouteNextHopType', 'SecurityRuleAccess', 'SecurityRuleProtocol', 'SecurityRuleDirection', 'TransportProtocol',
          'VirtualNetworkGatewaySkuName', 'VirtualNetworkGatewayType', 'VpnClientProtocol', 'VpnType',
-         'ExpressRouteLinkMacSecCipher', 'ExpressRouteLinkAdminState',
+         'ExpressRouteLinkMacSecCipher', 'ExpressRouteLinkMacSecSciState', 'ExpressRouteLinkAdminState',
          'ConnectionMonitorEndpointFilterType', 'ConnectionMonitorTestConfigurationProtocol',
          'PreferredIPVersion', 'HTTPConfigurationMethod', 'OutputType')
 
@@ -102,6 +102,7 @@ def load_arguments(self, _):
     ag_servers_type = CLIArgumentType(nargs='+', help='Space-separated list of IP addresses or DNS names corresponding to backend servers.', validator=get_servers_validator())
     app_gateway_name_type = CLIArgumentType(help='Name of the application gateway.', options_list='--gateway-name', completer=get_resource_name_completion_list('Microsoft.Network/applicationGateways'), id_part='name')
     express_route_link_macsec_cipher_type = CLIArgumentType(get_enum_type(ExpressRouteLinkMacSecCipher))
+    express_route_link_macsec_sci_state_type = CLIArgumentType(get_enum_type(ExpressRouteLinkMacSecSciState))
     express_route_link_admin_state_type = CLIArgumentType(get_enum_type(ExpressRouteLinkAdminState))
 
     # region NetworkRoot
@@ -793,6 +794,7 @@ def load_arguments(self, _):
         c.argument('macsec_ckn_secret_identifier',
                    help='The connectivity key name (CKN) that stored in the KeyVault.')
         c.argument('macsec_cipher', arg_type=express_route_link_macsec_cipher_type, help='Cipher Method')
+        c.argument('macsec_sci_state', arg_type=express_route_link_macsec_sci_state_type, help='Sci mode Enabled/Disabled.')
 
     with self.argument_context('network express-route port location', min_api='2018-08-01') as c:
         c.argument('location_name', options_list=['--location', '-l'])

--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -794,7 +794,7 @@ def load_arguments(self, _):
         c.argument('macsec_ckn_secret_identifier',
                    help='The connectivity key name (CKN) that stored in the KeyVault.')
         c.argument('macsec_cipher', arg_type=express_route_link_macsec_cipher_type, help='Cipher Method')
-        c.argument('macsec_sci_state', arg_type=express_route_link_macsec_sci_state_type, help='Sci mode Enabled/Disabled.')
+        c.argument('macsec_sci_state', arg_type=express_route_link_macsec_sci_state_type, help='Enable/Disable MACsec sci mode.')
 
     with self.argument_context('network express-route port location', min_api='2018-08-01') as c:
         c.argument('location_name', options_list=['--location', '-l'])

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2761,12 +2761,8 @@ def update_express_route_port_link(cmd, instance, express_route_port_name, link_
         instance.links[link_index].mac_sec_config.cak_secret_identifier = macsec_cak_secret_identifier
         instance.links[link_index].mac_sec_config.ckn_secret_identifier = macsec_ckn_secret_identifier
 
-        # TODO https://github.com/Azure/azure-rest-api-specs/issues/7569
-        # need to remove this conversion when the issue is fixed.
         if macsec_cipher is not None:
-            macsec_ciphers_tmp = {'gcm-aes-128': 'GcmAes128', 'gcm-aes-256': 'GcmAes256', 'gcm-aes-xpn-128': 'GcmAesXpn128', 'gcm-aes-xpn-256': 'GcmAesXpn128' }
-            macsec_cipher = macsec_ciphers_tmp[macsec_cipher]
-        instance.links[link_index].mac_sec_config.cipher = macsec_cipher
+            instance.links[link_index].mac_sec_config.cipher = macsec_cipher
 
         if macsec_sci_state is not None:
             instance.links[link_index].mac_sec_config.sci_state = macsec_sci_state

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2735,7 +2735,7 @@ def show_express_route_port_identity(cmd, resource_group_name, express_route_por
 
 def update_express_route_port_link(cmd, instance, express_route_port_name, link_name,
                                    macsec_cak_secret_identifier=None, macsec_ckn_secret_identifier=None,
-                                   macsec_cipher=None, admin_state=None):
+                                   macsec_cipher=None, macsec_sci_state=None, admin_state=None):
     """
     :param cmd:
     :param instance: an instance of ExpressRoutePort
@@ -2744,6 +2744,7 @@ def update_express_route_port_link(cmd, instance, express_route_port_name, link_
     :param macsec_cak_secret_identifier:
     :param macsec_ckn_secret_identifier:
     :param macsec_cipher:
+    :param macsec_sci_state:
     :param admin_state:
     :return:
     """
@@ -2763,9 +2764,12 @@ def update_express_route_port_link(cmd, instance, express_route_port_name, link_
         # TODO https://github.com/Azure/azure-rest-api-specs/issues/7569
         # need to remove this conversion when the issue is fixed.
         if macsec_cipher is not None:
-            macsec_ciphers_tmp = {'gcm-aes-128': 'GcmAes128', 'gcm-aes-256': 'GcmAes256'}
+            macsec_ciphers_tmp = {'gcm-aes-128': 'GcmAes128', 'gcm-aes-256': 'GcmAes256', 'gcm-aes-xpn-128': 'GcmAesXpn128', 'gcm-aes-xpn-256': 'GcmAesXpn128' }
             macsec_cipher = macsec_ciphers_tmp[macsec_cipher]
         instance.links[link_index].mac_sec_config.cipher = macsec_cipher
+
+        if macsec_sci_state is not None:
+            instance.links[link_index].mac_sec_config.sci_state = macsec_sci_state
 
     if admin_state is not None:
         instance.links[link_index].admin_state = admin_state


### PR DESCRIPTION
**Description**  
- Fix root cause of [Issue #7569](https://github.com/Azure/azure-rest-api-specs/issues/7569) by removing dashes from cipher values ([sister PR](https://github.com/Azure/azure-rest-api-specs/pull/10181))
- Add sci mode parameter to macsec configuration with Enabled/Disables

**Testing Guide**  
Needs to be tested.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
