### PR TITLE
[AKS] az aks update: Change --enable-aad argument to migrate a RBAC-enabled non-AAD cluster to a AKS-managed AAD cluster

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -468,8 +468,8 @@ examples:
     text: az aks update -g MyResourceGroup -n MyManagedCluster --api-server-authorized-ip-ranges 0.0.0.0/32
   - name: Update a AKS-managed AAD cluster with tenant ID or admin group object IDs.
     text: az aks update -g MyResourceGroup -n MyManagedCluster --aad-admin-group-object-ids <id-1,id-2> --aad-tenant-id <id>
-  - name: Update an existing AKS AAD-Integrated cluster to the new AKS-managed AAD experience.
-    text: az aks update -g MyResourceGroup -n MyManagedCluster --enable-aad
+  - name: Migrate a AKS AAD-Integrated cluster or a non-AAD cluster to a AKS-managed AAD cluster.
+    text: az aks update -g MyResourceGroup -n MyManagedCluster --enable-aad --aad-admin-group-object-ids <id-1,id-2> --aad-tenant-id <id>
 """
 
 helps['aks delete'] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2257,9 +2257,7 @@ def aks_update(cmd, client, resource_group_name, name,
             _populate_api_server_access_profile(api_server_authorized_ip_ranges, instance=instance)
 
     if enable_aad:
-        if instance.aad_profile is None:
-            raise CLIError('Cannot specify "--enable-aad" for a non-AAD cluster')
-        if instance.aad_profile.managed:
+        if instance.aad_profile is not None and instance.aad_profile.managed:
             raise CLIError('Cannot specify "--enable-aad" if managed AAD is already enabled')
         instance.aad_profile = ManagedClusterAADProfile(
             managed=True

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_nonaad_and_update_with_managed_aad.yaml
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/recordings/test_aks_create_nonaad_and_update_with_managed_aad.yaml
@@ -14,23 +14,23 @@ interactions:
       - --resource-group --name --vm-set-type --node-count --ssh-key-value -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
-        msrest_azure/0.6.3 azure-mgmt-resource/10.0.0 Azure-SDK-For-Python AZURECLI/2.8.0
+        msrest_azure/0.6.3 azure-mgmt-resource/10.0.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001?api-version=2019-07-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001","name":"clitest000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2","tags":{"product":"azurecli","cause":"automation","date":"2020-06-24T11:51:19Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001","name":"clitest000001","type":"Microsoft.Resources/resourceGroups","location":"canadacentral","tags":{"product":"azurecli","cause":"automation","date":"2020-07-17T03:51:54Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '313'
+      - '319'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 24 Jun 2020 11:51:24 GMT
+      - Fri, 17 Jul 2020 03:51:59 GMT
       expires:
       - '-1'
       pragma:
@@ -45,11 +45,11 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"availableToOtherTenants": false, "homepage": "https://93a5f8.cliakstest-clitestkhufwgm2s-8ecadf.eastus2.cloudapp.azure.com",
-      "passwordCredentials": [{"startDate": "2020-06-24T11:51:25.269945Z", "endDate":
-      "2025-06-24T11:51:25.269945Z", "keyId": "c5270749-cb87-4493-974b-56605a2a7acf",
+    body: '{"availableToOtherTenants": false, "homepage": "https://f40cec.cliakstest-clitestyywpcmfvu-8ecadf.canadacentral.cloudapp.azure.com",
+      "passwordCredentials": [{"startDate": "2020-07-17T03:52:00.07164Z", "endDate":
+      "2025-07-17T03:52:00.07164Z", "keyId": "7fb4b39a-a2df-441d-b00e-a3770ab572e4",
       "value": "ReplacedSPPassword123*"}], "displayName": "cliakstest000001", "identifierUris":
-      ["https://93a5f8.cliakstest-clitestkhufwgm2s-8ecadf.eastus2.cloudapp.azure.com"]}'
+      ["https://f40cec.cliakstest-clitestyywpcmfvu-8ecadf.canadacentral.cloudapp.azure.com"]}'
     headers:
       Accept:
       - application/json
@@ -60,14 +60,14 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '457'
+      - '467'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --resource-group --name --vm-set-type --node-count --ssh-key-value -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.8.0
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
@@ -76,29 +76,29 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "3f49e319-0fe6-4abe-b435-e3594c5c7f24", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "1722e39a-e7b8-40b2-ba52-dd5177e1156d",
+        "objectId": "fe027a13-16fa-42d6-ac88-f0b6f399761f", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "9f5f60ec-1c7e-4bc3-841f-3164bad7321e",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
         false, "displayName": "cliakstest000001", "errorUrl": null, "groupMembershipClaims":
-        null, "homepage": "https://93a5f8.cliakstest-clitestkhufwgm2s-8ecadf.eastus2.cloudapp.azure.com",
-        "identifierUris": ["https://93a5f8.cliakstest-clitestkhufwgm2s-8ecadf.eastus2.cloudapp.azure.com"],
+        null, "homepage": "https://f40cec.cliakstest-clitestyywpcmfvu-8ecadf.canadacentral.cloudapp.azure.com",
+        "identifierUris": ["https://f40cec.cliakstest-clitestyywpcmfvu-8ecadf.canadacentral.cloudapp.azure.com"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/3f49e319-0fe6-4abe-b435-e3594c5c7f24/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/fe027a13-16fa-42d6-ac88-f0b6f399761f/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/3f49e319-0fe6-4abe-b435-e3594c5c7f24/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/fe027a13-16fa-42d6-ac88-f0b6f399761f/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
         "Allow the application to access cliakstest000001 on behalf of the signed-in
-        user.", "adminConsentDisplayName": "Access cliakstest000001", "id": "b90da056-e295-41e2-8fe3-f273b6fcf60e",
+        user.", "adminConsentDisplayName": "Access cliakstest000001", "id": "6adce726-a546-4c1c-bdbe-5afe2fd2f94e",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
         to access cliakstest000001 on your behalf.", "userConsentDisplayName": "Access
         cliakstest000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
-        [{"customKeyIdentifier": null, "endDate": "2025-06-24T11:51:25.269945Z", "keyId":
-        "c5270749-cb87-4493-974b-56605a2a7acf", "startDate": "2020-06-24T11:51:25.269945Z",
+        [{"customKeyIdentifier": null, "endDate": "2025-07-17T03:52:00.07164Z", "keyId":
+        "7fb4b39a-a2df-441d-b00e-a3770ab572e4", "startDate": "2020-07-17T03:52:00.07164Z",
         "value": "ReplacedSPPassword123*"}], "publicClient": null, "publisherDomain":
         "microsoft.onmicrosoft.com", "recordConsentConditions": null, "replyUrls":
         [], "requiredResourceAccess": [], "samlMetadataUrl": null, "signInAudience":
@@ -109,27 +109,27 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2377'
+      - '2387'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Wed, 24 Jun 2020 11:51:25 GMT
+      - Fri, 17 Jul 2020 03:51:59 GMT
       duration:
-      - '6983108'
+      - '8213323'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/3f49e319-0fe6-4abe-b435-e3594c5c7f24/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/fe027a13-16fa-42d6-ac88-f0b6f399761f/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - KU5yfpn9xMxhi0mTcc0/Dzz4bjAVkQilyO63Vctl4gA=
+      - bqbTTkiOyxxImiMC//2Hh2UQaIEesgoMiknd+hhNh80=
       ocp-aad-session-key:
-      - 394IFuu39UXj_uopU-ec-YslBx5aJc61OkEpM3Lh3QaTXP7fLYKxvr_jHMXDb3z61JuJ1UbY258MAoLG3a4CK9b81kh8kBFjoWwSHfLzCC2UXqjXIb8UjUV0cqkk4gBn95KqLAPHc6zEEgsfoyLsYDD4u6rz9U6_4qYyTfETSLf-0exweQtxk6-fq1kcX2peH49okxo809AhQdJclqstsg.gtk_449xaWL5gyxgUalBx6MITMzD1eWZdJvrKTApZPA
+      - Fqh5iBbFFWfL91AQ3lJ1970UO2nnnNA17qyNEwHFNcUQxlyxaorPotEAAv9OdBFo5JGjGXoE3m5o2iaxWVJ8xnMkIkc1VSjdRinmqomQ7Lt7Ru2h9FKNJKriT03Twt0z_8Rzk1A9u8zIJKPvRvwS3fFPNRgMCWq_1MQ6kuoPSFg.tdS16YwlbAhmgKfaTKo2CdzXlYmC0g6FbRB3XD5DBxM
       pragma:
       - no-cache
       request-id:
-      - d55d3b1e-ef98-4a21-923c-5dd565f4205b
+      - c9bda746-27ca-493c-a612-1f34d720cb69
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aad-resource-unit:
@@ -158,43 +158,43 @@ interactions:
       - --resource-group --name --vm-set-type --node-count --ssh-key-value -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.8.0
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%271722e39a-e7b8-40b2-ba52-dd5177e1156d%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%279f5f60ec-1c7e-4bc3-841f-3164bad7321e%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"3f49e319-0fe6-4abe-b435-e3594c5c7f24","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"1722e39a-e7b8-40b2-ba52-dd5177e1156d","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cliakstest000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://93a5f8.cliakstest-clitestkhufwgm2s-8ecadf.eastus2.cloudapp.azure.com","identifierUris":["https://93a5f8.cliakstest-clitestkhufwgm2s-8ecadf.eastus2.cloudapp.azure.com"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/3f49e319-0fe6-4abe-b435-e3594c5c7f24/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/3f49e319-0fe6-4abe-b435-e3594c5c7f24/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"fe027a13-16fa-42d6-ac88-f0b6f399761f","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"9f5f60ec-1c7e-4bc3-841f-3164bad7321e","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cliakstest000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://f40cec.cliakstest-clitestyywpcmfvu-8ecadf.canadacentral.cloudapp.azure.com","identifierUris":["https://f40cec.cliakstest-clitestyywpcmfvu-8ecadf.canadacentral.cloudapp.azure.com"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/fe027a13-16fa-42d6-ac88-f0b6f399761f/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/fe027a13-16fa-42d6-ac88-f0b6f399761f/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cliakstest000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cliakstest000001","id":"b90da056-e295-41e2-8fe3-f273b6fcf60e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cliakstest000001","id":"6adce726-a546-4c1c-bdbe-5afe2fd2f94e","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cliakstest000001 on your behalf.","userConsentDisplayName":"Access
-        cliakstest000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2025-06-24T11:51:25.269945Z","keyId":"c5270749-cb87-4493-974b-56605a2a7acf","startDate":"2020-06-24T11:51:25.269945Z","value":null}],"publicClient":null,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cliakstest000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2025-07-17T03:52:00.07164Z","keyId":"7fb4b39a-a2df-441d-b00e-a3770ab572e4","startDate":"2020-07-17T03:52:00.07164Z","value":null}],"publicClient":null,"publisherDomain":"microsoft.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2294'
+      - '2304'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Wed, 24 Jun 2020 11:51:25 GMT
+      - Fri, 17 Jul 2020 03:52:00 GMT
       duration:
-      - '522839'
+      - '536026'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - QOSZ8ydmwLqZlvH82M8Ldz9lnMrkSAZyM8ecM5ASlZg=
+      - x3fer71Jd40m4hVkLjML0/sXP9cUtERrxVyLFIuVOJ4=
       ocp-aad-session-key:
-      - xaMkA2kC7aCGW1Qt4mvqcjb_uRsRkdcVGUDMcBMNIzUpWDaHPTPEd4jaRPXuNd8IHk39bepyFNKykZYl_Ty5JCJLs82eJI9TCvNEnSNf4chufvOv7TfVY4ymADTLlV3reetcHMjKRhRoUNzOCmfVkDG5Pve61jjmqPtQTxSi_zM1MEM4e7nUgj06C_EQtCVF9TQTaWKjF2-dtJGQ9mOHMg.DW5mIQf8Vco8bVqS48vS8HitgVijg3l3UMIgrQkAE-A
+      - Fzf5HfQMPilh7qvI7HXUbFo7DYzCcESwc4YJNDom8ewmQura7H2J4rJcrsNFC5e4kjixj07eIGqBZyoeLWcfphY-cflGnQqmEUljJedg2utZcgz2wJ1FgGPr-RrBLZoLp_0v7W0C4ubTWwbO7I_ykgShp5Hc_pcHP2YMzdNjJmM.nDx6_V1p5ft2CfPY77v-M1orvZmyl13ZfX1Ufq8ZFDs
       pragma:
       - no-cache
       request-id:
-      - af11708f-7c42-4e1d-83c7-cdc944d01b7d
+      - 929738f9-25a8-4e82-9eca-aa840ffdd5e9
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aad-resource-unit:
@@ -209,7 +209,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"accountEnabled": "True", "appId": "1722e39a-e7b8-40b2-ba52-dd5177e1156d"}'
+    body: '{"accountEnabled": "True", "appId": "9f5f60ec-1c7e-4bc3-841f-3164bad7321e"}'
     headers:
       Accept:
       - application/json
@@ -227,45 +227,45 @@ interactions:
       - --resource-group --name --vm-set-type --node-count --ssh-key-value -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.8.0
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"37294bce-c8ff-4131-865f-d2027c419902","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cliakstest000001","appId":"1722e39a-e7b8-40b2-ba52-dd5177e1156d","applicationTemplateId":null,"appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cliakstest000001","errorUrl":null,"homepage":"https://93a5f8.cliakstest-clitestkhufwgm2s-8ecadf.eastus2.cloudapp.azure.com","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"9da497b5-3673-4727-a0a5-12de054a995b","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cliakstest000001","appId":"9f5f60ec-1c7e-4bc3-841f-3164bad7321e","applicationTemplateId":null,"appOwnerTenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cliakstest000001","errorUrl":null,"homepage":"https://f40cec.cliakstest-clitestyywpcmfvu-8ecadf.canadacentral.cloudapp.azure.com","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cliakstest000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cliakstest000001","id":"b90da056-e295-41e2-8fe3-f273b6fcf60e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cliakstest000001","id":"6adce726-a546-4c1c-bdbe-5afe2fd2f94e","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cliakstest000001 on your behalf.","userConsentDisplayName":"Access
-        cliakstest000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["1722e39a-e7b8-40b2-ba52-dd5177e1156d","https://93a5f8.cliakstest-clitestkhufwgm2s-8ecadf.eastus2.cloudapp.azure.com"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+        cliakstest000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["9f5f60ec-1c7e-4bc3-841f-3164bad7321e","https://f40cec.cliakstest-clitestyywpcmfvu-8ecadf.canadacentral.cloudapp.azure.com"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '1784'
+      - '1796'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Wed, 24 Jun 2020 11:51:26 GMT
+      - Fri, 17 Jul 2020 03:52:01 GMT
       duration:
-      - '3696568'
+      - '3847556'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/37294bce-c8ff-4131-865f-d2027c419902/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/9da497b5-3673-4727-a0a5-12de054a995b/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - oSVXKlJJcWgwwPQpzo+77hpkjPr6gNvk308r+pzFYwQ=
+      - dOBeIlNR63xfABhi+BfDw+KqRe5/8YtxHHZc1IKYRKM=
       ocp-aad-session-key:
-      - rmmolUX903eOJboLfypZmpvurIa0t22pdcdpNWq9jg1ZkzSentN5qbg4L71mpG0vuao1jd7wNs1rTUS90FwX_Pk9ekqOOaoMDrivFFbV6qYh7lrHrFX0aTgOTUcNrRaDjDvtj8u0OZ37wT7CoUJ85zs8FsYUeoUqHzSylZ_ye8ZjGh7BxenNeRzQsmwa-O19q2VHB_1vse89ZBMJD3-jTw.qFTqK0U0GlqbehSWwkA0_XT6hsR269roC6vG3jgfdOc
+      - xtY4OcL3BPwZp6W9OKm9iqsfL0DrxcgOgorIys4JTqDfalAGLkngbUXfgfPcWPr3fRDKpi27JXh6DOII1SOTdpx6gme_-bAojkLSTonfhkS-niH_soTYPzrA3ZZCsPKKbYFpveo56AzOm90AaPKdRm2cACCVEyt8R-e9-dqW_48.mpzN0L1BsYWC2l0MHAOlbiAf3X0bdTmy09adIuc77aM
       pragma:
       - no-cache
       request-id:
-      - ecb63b6d-1d17-4d97-9618-763697334ab5
+      - 5a9a5af1-6354-4da2-9465-3ecc6a7c9f7e
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aad-resource-unit:
@@ -280,8 +280,8 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"location": "eastus2", "properties": {"kubernetesVersion": "", "dnsPrefix":
-      "cliakstest-clitestkhufwgm2s-8ecadf", "agentPoolProfiles": [{"count": 1, "vmSize":
+    body: '{"location": "canadacentral", "properties": {"kubernetesVersion": "", "dnsPrefix":
+      "cliakstest-clitestyywpcmfvu-8ecadf", "agentPoolProfiles": [{"count": 1, "vmSize":
       "Standard_DS2_v2", "osType": "Linux", "type": "VirtualMachineScaleSets", "mode":
       "System", "enableNodePublicIP": false, "scaleSetPriority": "Regular", "scaleSetEvictionPolicy":
       "Delete", "name": "nodepool1"}], "linuxProfile": {"adminUsername": "azureuser",
@@ -301,17 +301,17 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1595'
+      - '1601'
       Content-Type:
       - application/json; charset=utf-8
       Ocp-Aad-Session-Key:
-      - 394IFuu39UXj_uopU-ec-YslBx5aJc61OkEpM3Lh3QaTXP7fLYKxvr_jHMXDb3z61JuJ1UbY258MAoLG3a4CK9b81kh8kBFjoWwSHfLzCC2UXqjXIb8UjUV0cqkk4gBn95KqLAPHc6zEEgsfoyLsYDD4u6rz9U6_4qYyTfETSLf-0exweQtxk6-fq1kcX2peH49okxo809AhQdJclqstsg.gtk_449xaWL5gyxgUalBx6MITMzD1eWZdJvrKTApZPA
+      - Fqh5iBbFFWfL91AQ3lJ1970UO2nnnNA17qyNEwHFNcUQxlyxaorPotEAAv9OdBFo5JGjGXoE3m5o2iaxWVJ8xnMkIkc1VSjdRinmqomQ7Lt7Ru2h9FKNJKriT03Twt0z_8Rzk1A9u8zIJKPvRvwS3fFPNRgMCWq_1MQ6kuoPSFg.tdS16YwlbAhmgKfaTKo2CdzXlYmC0g6FbRB3XD5DBxM
       ParameterSetName:
       - --resource-group --name --vm-set-type --node-count --ssh-key-value -o
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
+        AZURECLI/2.9.1
       accept-language:
       - en-US
     method: PUT
@@ -319,23 +319,23 @@ interactions:
   response:
     body:
       string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001\"\
-        ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
-        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
-        \  \"provisioningState\": \"Creating\",\n   \"kubernetesVersion\": \"1.15.11\"\
-        ,\n   \"dnsPrefix\": \"cliakstest-clitestkhufwgm2s-8ecadf\",\n   \"fqdn\"\
-        : \"cliakstest-clitestkhufwgm2s-8ecadf-9db9f174.hcp.eastus2.azmk8s.io\",\n\
-        \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
-        count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
+        ,\n  \"location\": \"canadacentral\",\n  \"name\": \"cliakstest000001\",\n\
+        \  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\"\
+        : {\n   \"provisioningState\": \"Creating\",\n   \"kubernetesVersion\": \"\
+        1.16.10\",\n   \"dnsPrefix\": \"cliakstest-clitestyywpcmfvu-8ecadf\",\n  \
+        \ \"fqdn\": \"cliakstest-clitestyywpcmfvu-8ecadf-bcdc86dd.hcp.canadacentral.azmk8s.io\"\
+        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
         : 128,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\"\
         ,\n     \"provisioningState\": \"Creating\",\n     \"orchestratorVersion\"\
-        : \"1.15.11\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\":\
+        : \"1.16.10\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\":\
         \ {},\n     \"mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n\
         \   \"linuxProfile\": {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\"\
         : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
         \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
-        : {\n    \"clientId\": \"1722e39a-e7b8-40b2-ba52-dd5177e1156d\"\n   },\n \
+        : {\n    \"clientId\": \"9f5f60ec-1c7e-4bc3-841f-3164bad7321e\"\n   },\n \
         \  \"addonProfiles\": {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n\
-        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_canadacentral\"\
         ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
         : \"kubenet\",\n    \"loadBalancerSku\": \"standard\",\n    \"loadBalancerProfile\"\
         : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     }\n    },\n\
@@ -346,15 +346,15 @@ interactions:
         \ }"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/001c8aa6-cb07-4390-85dd-1f53ff11c4b4?api-version=2017-08-31
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/c5beed64-b209-4dd2-9a0d-3f7fd4f571c2?api-version=2016-03-30
       cache-control:
       - no-cache
       content-length:
-      - '2510'
+      - '2528'
       content-type:
       - application/json
       date:
-      - Wed, 24 Jun 2020 11:51:29 GMT
+      - Fri, 17 Jul 2020 03:52:10 GMT
       expires:
       - '-1'
       pragma:
@@ -386,13 +386,13 @@ interactions:
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
+        AZURECLI/2.9.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/001c8aa6-cb07-4390-85dd-1f53ff11c4b4?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/c5beed64-b209-4dd2-9a0d-3f7fd4f571c2?api-version=2016-03-30
   response:
     body:
-      string: "{\n  \"name\": \"a68a1c00-07cb-9043-85dd-1f53ff11c4b4\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-24T11:51:30.2045616Z\"\n }"
+      string: "{\n  \"name\": \"64edbec5-09b2-d24d-9a0d-3f7fd4f571c2\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-07-17T03:52:09.7298328Z\"\n }"
     headers:
       cache-control:
       - no-cache
@@ -401,97 +401,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 24 Jun 2020 11:52:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aks create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --vm-set-type --node-count --ssh-key-value -o
-      User-Agent:
-      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
-        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/001c8aa6-cb07-4390-85dd-1f53ff11c4b4?api-version=2017-08-31
-  response:
-    body:
-      string: "{\n  \"name\": \"a68a1c00-07cb-9043-85dd-1f53ff11c4b4\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-24T11:51:30.2045616Z\"\n }"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '126'
-      content-type:
-      - application/json
-      date:
-      - Wed, 24 Jun 2020 11:52:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aks create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --vm-set-type --node-count --ssh-key-value -o
-      User-Agent:
-      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
-        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/001c8aa6-cb07-4390-85dd-1f53ff11c4b4?api-version=2017-08-31
-  response:
-    body:
-      string: "{\n  \"name\": \"a68a1c00-07cb-9043-85dd-1f53ff11c4b4\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-24T11:51:30.2045616Z\"\n }"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '126'
-      content-type:
-      - application/json
-      date:
-      - Wed, 24 Jun 2020 11:52:59 GMT
+      - Fri, 17 Jul 2020 03:52:40 GMT
       expires:
       - '-1'
       pragma:
@@ -525,13 +435,13 @@ interactions:
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
+        AZURECLI/2.9.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/001c8aa6-cb07-4390-85dd-1f53ff11c4b4?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/c5beed64-b209-4dd2-9a0d-3f7fd4f571c2?api-version=2016-03-30
   response:
     body:
-      string: "{\n  \"name\": \"a68a1c00-07cb-9043-85dd-1f53ff11c4b4\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-24T11:51:30.2045616Z\"\n }"
+      string: "{\n  \"name\": \"64edbec5-09b2-d24d-9a0d-3f7fd4f571c2\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-07-17T03:52:09.7298328Z\"\n }"
     headers:
       cache-control:
       - no-cache
@@ -540,7 +450,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 24 Jun 2020 11:53:30 GMT
+      - Fri, 17 Jul 2020 03:53:10 GMT
       expires:
       - '-1'
       pragma:
@@ -574,13 +484,13 @@ interactions:
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
+        AZURECLI/2.9.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/001c8aa6-cb07-4390-85dd-1f53ff11c4b4?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/c5beed64-b209-4dd2-9a0d-3f7fd4f571c2?api-version=2016-03-30
   response:
     body:
-      string: "{\n  \"name\": \"a68a1c00-07cb-9043-85dd-1f53ff11c4b4\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-24T11:51:30.2045616Z\"\n }"
+      string: "{\n  \"name\": \"64edbec5-09b2-d24d-9a0d-3f7fd4f571c2\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-07-17T03:52:09.7298328Z\"\n }"
     headers:
       cache-control:
       - no-cache
@@ -589,7 +499,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 24 Jun 2020 11:54:00 GMT
+      - Fri, 17 Jul 2020 03:53:40 GMT
       expires:
       - '-1'
       pragma:
@@ -623,13 +533,13 @@ interactions:
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
+        AZURECLI/2.9.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/001c8aa6-cb07-4390-85dd-1f53ff11c4b4?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/c5beed64-b209-4dd2-9a0d-3f7fd4f571c2?api-version=2016-03-30
   response:
     body:
-      string: "{\n  \"name\": \"a68a1c00-07cb-9043-85dd-1f53ff11c4b4\",\n  \"status\"\
-        : \"InProgress\",\n  \"startTime\": \"2020-06-24T11:51:30.2045616Z\"\n }"
+      string: "{\n  \"name\": \"64edbec5-09b2-d24d-9a0d-3f7fd4f571c2\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-07-17T03:52:09.7298328Z\"\n }"
     headers:
       cache-control:
       - no-cache
@@ -638,7 +548,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 24 Jun 2020 11:54:30 GMT
+      - Fri, 17 Jul 2020 03:54:10 GMT
       expires:
       - '-1'
       pragma:
@@ -672,14 +582,210 @@ interactions:
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
+        AZURECLI/2.9.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/001c8aa6-cb07-4390-85dd-1f53ff11c4b4?api-version=2017-08-31
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/c5beed64-b209-4dd2-9a0d-3f7fd4f571c2?api-version=2016-03-30
   response:
     body:
-      string: "{\n  \"name\": \"a68a1c00-07cb-9043-85dd-1f53ff11c4b4\",\n  \"status\"\
-        : \"Succeeded\",\n  \"startTime\": \"2020-06-24T11:51:30.2045616Z\",\n  \"\
-        endTime\": \"2020-06-24T11:54:38.4358972Z\"\n }"
+      string: "{\n  \"name\": \"64edbec5-09b2-d24d-9a0d-3f7fd4f571c2\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-07-17T03:52:09.7298328Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Jul 2020 03:54:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.9.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/c5beed64-b209-4dd2-9a0d-3f7fd4f571c2?api-version=2016-03-30
+  response:
+    body:
+      string: "{\n  \"name\": \"64edbec5-09b2-d24d-9a0d-3f7fd4f571c2\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-07-17T03:52:09.7298328Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Jul 2020 03:55:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.9.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/c5beed64-b209-4dd2-9a0d-3f7fd4f571c2?api-version=2016-03-30
+  response:
+    body:
+      string: "{\n  \"name\": \"64edbec5-09b2-d24d-9a0d-3f7fd4f571c2\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-07-17T03:52:09.7298328Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Jul 2020 03:55:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.9.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/c5beed64-b209-4dd2-9a0d-3f7fd4f571c2?api-version=2016-03-30
+  response:
+    body:
+      string: "{\n  \"name\": \"64edbec5-09b2-d24d-9a0d-3f7fd4f571c2\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-07-17T03:52:09.7298328Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Jul 2020 03:56:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --vm-set-type --node-count --ssh-key-value -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.9.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/c5beed64-b209-4dd2-9a0d-3f7fd4f571c2?api-version=2016-03-30
+  response:
+    body:
+      string: "{\n  \"name\": \"64edbec5-09b2-d24d-9a0d-3f7fd4f571c2\",\n  \"status\"\
+        : \"Succeeded\",\n  \"startTime\": \"2020-07-17T03:52:09.7298328Z\",\n  \"\
+        endTime\": \"2020-07-17T03:56:15.9698777Z\"\n }"
     headers:
       cache-control:
       - no-cache
@@ -688,7 +794,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 24 Jun 2020 11:55:00 GMT
+      - Fri, 17 Jul 2020 03:56:41 GMT
       expires:
       - '-1'
       pragma:
@@ -722,33 +828,33 @@ interactions:
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
+        AZURECLI/2.9.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001?api-version=2020-03-01
   response:
     body:
       string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001\"\
-        ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
-        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
-        \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.11\"\
-        ,\n   \"dnsPrefix\": \"cliakstest-clitestkhufwgm2s-8ecadf\",\n   \"fqdn\"\
-        : \"cliakstest-clitestkhufwgm2s-8ecadf-9db9f174.hcp.eastus2.azmk8s.io\",\n\
-        \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
-        count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
+        ,\n  \"location\": \"canadacentral\",\n  \"name\": \"cliakstest000001\",\n\
+        \  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\"\
+        : {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"\
+        1.16.10\",\n   \"dnsPrefix\": \"cliakstest-clitestyywpcmfvu-8ecadf\",\n  \
+        \ \"fqdn\": \"cliakstest-clitestyywpcmfvu-8ecadf-bcdc86dd.hcp.canadacentral.azmk8s.io\"\
+        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
         : 128,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\"\
         ,\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\"\
-        : \"1.15.11\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\":\
+        : \"1.16.10\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\":\
         \ {},\n     \"mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n\
         \   \"linuxProfile\": {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\"\
         : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
         \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
-        : {\n    \"clientId\": \"1722e39a-e7b8-40b2-ba52-dd5177e1156d\"\n   },\n \
+        : {\n    \"clientId\": \"9f5f60ec-1c7e-4bc3-841f-3164bad7321e\"\n   },\n \
         \  \"addonProfiles\": {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n\
-        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_canadacentral\"\
         ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
         : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
         : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
-        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/56dc5d94-f97c-4cd5-9393-992b7057a7a7\"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_canadacentral/providers/Microsoft.Network/publicIPAddresses/271ac8b4-8dee-4116-b70a-b51214465b44\"\
         \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
         : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
         : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
@@ -758,11 +864,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2778'
+      - '2802'
       content-type:
       - application/json
       date:
-      - Wed, 24 Jun 2020 11:55:00 GMT
+      - Fri, 17 Jul 2020 03:56:42 GMT
       expires:
       - '-1'
       pragma:
@@ -797,7 +903,7 @@ interactions:
       User-Agent:
       - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
         msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
-        AZURECLI/2.8.0
+        AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
@@ -805,27 +911,27 @@ interactions:
   response:
     body:
       string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001\"\
-        ,\n  \"location\": \"eastus2\",\n  \"name\": \"cliakstest000001\",\n  \"type\"\
-        : \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\": {\n \
-        \  \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"1.15.11\"\
-        ,\n   \"dnsPrefix\": \"cliakstest-clitestkhufwgm2s-8ecadf\",\n   \"fqdn\"\
-        : \"cliakstest-clitestkhufwgm2s-8ecadf-9db9f174.hcp.eastus2.azmk8s.io\",\n\
-        \   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n     \"\
-        count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
+        ,\n  \"location\": \"canadacentral\",\n  \"name\": \"cliakstest000001\",\n\
+        \  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\"\
+        : {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"\
+        1.16.10\",\n   \"dnsPrefix\": \"cliakstest-clitestyywpcmfvu-8ecadf\",\n  \
+        \ \"fqdn\": \"cliakstest-clitestyywpcmfvu-8ecadf-bcdc86dd.hcp.canadacentral.azmk8s.io\"\
+        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
         : 128,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\"\
         ,\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\"\
-        : \"1.15.11\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\":\
+        : \"1.16.10\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\":\
         \ {},\n     \"mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n\
         \   \"linuxProfile\": {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\"\
         : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
         \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
-        : {\n    \"clientId\": \"1722e39a-e7b8-40b2-ba52-dd5177e1156d\"\n   },\n \
+        : {\n    \"clientId\": \"9f5f60ec-1c7e-4bc3-841f-3164bad7321e\"\n   },\n \
         \  \"addonProfiles\": {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n\
-        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_eastus2\"\
+        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_canadacentral\"\
         ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
         : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
         : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
-        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_eastus2/providers/Microsoft.Network/publicIPAddresses/56dc5d94-f97c-4cd5-9393-992b7057a7a7\"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_canadacentral/providers/Microsoft.Network/publicIPAddresses/271ac8b4-8dee-4116-b70a-b51214465b44\"\
         \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
         : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
         : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
@@ -835,11 +941,344 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2778'
+      - '2802'
       content-type:
       - application/json
       date:
-      - Wed, 24 Jun 2020 11:55:02 GMT
+      - Fri, 17 Jul 2020 03:56:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: 'b''{"location": "canadacentral", "properties": {"kubernetesVersion": "1.16.10",
+      "dnsPrefix": "cliakstest-clitestyywpcmfvu-8ecadf", "agentPoolProfiles": [{"count":
+      1, "vmSize": "Standard_DS2_v2", "osDiskSizeGB": 128, "maxPods": 110, "osType":
+      "Linux", "type": "VirtualMachineScaleSets", "mode": "System", "orchestratorVersion":
+      "1.16.10", "enableNodePublicIP": false, "nodeLabels": {}, "name": "nodepool1"}],
+      "linuxProfile": {"adminUsername": "azureuser", "ssh": {"publicKeys": [{"keyData":
+      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
+      test@example.com\\n"}]}}, "servicePrincipalProfile": {"clientId": "9f5f60ec-1c7e-4bc3-841f-3164bad7321e"},
+      "addonProfiles": {"KubeDashboard": {"enabled": true}}, "nodeResourceGroup":
+      "MC_clitest000001_cliakstest000001_canadacentral", "enableRBAC": true, "networkProfile":
+      {"networkPlugin": "kubenet", "podCidr": "10.244.0.0/16", "serviceCidr": "10.0.0.0/16",
+      "dnsServiceIP": "10.0.0.10", "dockerBridgeCidr": "172.17.0.1/16", "outboundType":
+      "loadBalancer", "loadBalancerSku": "Standard", "loadBalancerProfile": {"managedOutboundIPs":
+      {"count": 1}, "effectiveOutboundIPs": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_canadacentral/providers/Microsoft.Network/publicIPAddresses/271ac8b4-8dee-4116-b70a-b51214465b44"}]}},
+      "aadProfile": {"managed": true, "adminGroupObjectIDs": ["00000000-0000-0000-0000-000000000001"],
+      "tenantID": "00000000-0000-0000-0000-000000000002"}}, "sku": {"name": "Basic",
+      "tier": "Free"}}'''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2197'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group --name --enable-aad --aad-admin-group-object-ids --aad-tenant-id
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.9.1
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001?api-version=2020-03-01
+  response:
+    body:
+      string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001\"\
+        ,\n  \"location\": \"canadacentral\",\n  \"name\": \"cliakstest000001\",\n\
+        \  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\"\
+        : {\n   \"provisioningState\": \"Updating\",\n   \"kubernetesVersion\": \"\
+        1.16.10\",\n   \"dnsPrefix\": \"cliakstest-clitestyywpcmfvu-8ecadf\",\n  \
+        \ \"fqdn\": \"cliakstest-clitestyywpcmfvu-8ecadf-bcdc86dd.hcp.canadacentral.azmk8s.io\"\
+        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
+        : 128,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\"\
+        ,\n     \"provisioningState\": \"Updating\",\n     \"orchestratorVersion\"\
+        : \"1.16.10\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\":\
+        \ {},\n     \"mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n\
+        \   \"linuxProfile\": {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\"\
+        : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
+        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
+        : {\n    \"clientId\": \"9f5f60ec-1c7e-4bc3-841f-3164bad7321e\"\n   },\n \
+        \  \"addonProfiles\": {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n\
+        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_canadacentral\"\
+        ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
+        : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
+        : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_canadacentral/providers/Microsoft.Network/publicIPAddresses/271ac8b4-8dee-4116-b70a-b51214465b44\"\
+        \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
+        : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
+        : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
+        aadProfile\": {\n    \"managed\": true,\n    \"adminGroupObjectIDs\": [\n\
+        \     \"00000000-0000-0000-0000-000000000001\"\n    ],\n    \"tenantID\":\
+        \ \"00000000-0000-0000-0000-000000000002\"\n   },\n   \"maxAgentPools\": 100\n\
+        \  },\n  \"sku\": {\n   \"name\": \"Basic\",\n   \"tier\": \"Free\"\n  }\n\
+        \ }"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/a4d95f14-a29a-4a56-9298-d8d3d964da28?api-version=2016-03-30
+      cache-control:
+      - no-cache
+      content-length:
+      - '2981'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Jul 2020 03:56:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --enable-aad --aad-admin-group-object-ids --aad-tenant-id
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.9.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/a4d95f14-a29a-4a56-9298-d8d3d964da28?api-version=2016-03-30
+  response:
+    body:
+      string: "{\n  \"name\": \"145fd9a4-9aa2-564a-9298-d8d3d964da28\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-07-17T03:56:47.3817833Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Jul 2020 03:57:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --enable-aad --aad-admin-group-object-ids --aad-tenant-id
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.9.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/a4d95f14-a29a-4a56-9298-d8d3d964da28?api-version=2016-03-30
+  response:
+    body:
+      string: "{\n  \"name\": \"145fd9a4-9aa2-564a-9298-d8d3d964da28\",\n  \"status\"\
+        : \"InProgress\",\n  \"startTime\": \"2020-07-17T03:56:47.3817833Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '126'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Jul 2020 03:57:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --enable-aad --aad-admin-group-object-ids --aad-tenant-id
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.9.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/canadacentral/operations/a4d95f14-a29a-4a56-9298-d8d3d964da28?api-version=2016-03-30
+  response:
+    body:
+      string: "{\n  \"name\": \"145fd9a4-9aa2-564a-9298-d8d3d964da28\",\n  \"status\"\
+        : \"Succeeded\",\n  \"startTime\": \"2020-07-17T03:56:47.3817833Z\",\n  \"\
+        endTime\": \"2020-07-17T03:58:02.2877034Z\"\n }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '170'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Jul 2020 03:58:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aks update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --enable-aad --aad-admin-group-object-ids --aad-tenant-id
+        -o
+      User-Agent:
+      - python/3.7.5 (Linux-5.3.0-1028-azure-x86_64-with-Ubuntu-18.04-bionic) msrest/0.6.9
+        msrest_azure/0.6.3 azure-mgmt-containerservice/9.0.1 Azure-SDK-For-Python
+        AZURECLI/2.9.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001?api-version=2020-03-01
+  response:
+    body:
+      string: "{\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest000001/providers/Microsoft.ContainerService/managedClusters/cliakstest000001\"\
+        ,\n  \"location\": \"canadacentral\",\n  \"name\": \"cliakstest000001\",\n\
+        \  \"type\": \"Microsoft.ContainerService/ManagedClusters\",\n  \"properties\"\
+        : {\n   \"provisioningState\": \"Succeeded\",\n   \"kubernetesVersion\": \"\
+        1.16.10\",\n   \"dnsPrefix\": \"cliakstest-clitestyywpcmfvu-8ecadf\",\n  \
+        \ \"fqdn\": \"cliakstest-clitestyywpcmfvu-8ecadf-bcdc86dd.hcp.canadacentral.azmk8s.io\"\
+        ,\n   \"agentPoolProfiles\": [\n    {\n     \"name\": \"nodepool1\",\n   \
+        \  \"count\": 1,\n     \"vmSize\": \"Standard_DS2_v2\",\n     \"osDiskSizeGB\"\
+        : 128,\n     \"maxPods\": 110,\n     \"type\": \"VirtualMachineScaleSets\"\
+        ,\n     \"provisioningState\": \"Succeeded\",\n     \"orchestratorVersion\"\
+        : \"1.16.10\",\n     \"enableNodePublicIP\": false,\n     \"nodeLabels\":\
+        \ {},\n     \"mode\": \"System\",\n     \"osType\": \"Linux\"\n    }\n   ],\n\
+        \   \"linuxProfile\": {\n    \"adminUsername\": \"azureuser\",\n    \"ssh\"\
+        : {\n     \"publicKeys\": [\n      {\n       \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==\
+        \ test@example.com\\n\"\n      }\n     ]\n    }\n   },\n   \"servicePrincipalProfile\"\
+        : {\n    \"clientId\": \"9f5f60ec-1c7e-4bc3-841f-3164bad7321e\"\n   },\n \
+        \  \"addonProfiles\": {\n    \"KubeDashboard\": {\n     \"enabled\": true,\n\
+        \     \"config\": null\n    }\n   },\n   \"nodeResourceGroup\": \"MC_clitest000001_cliakstest000001_canadacentral\"\
+        ,\n   \"enableRBAC\": true,\n   \"networkProfile\": {\n    \"networkPlugin\"\
+        : \"kubenet\",\n    \"loadBalancerSku\": \"Standard\",\n    \"loadBalancerProfile\"\
+        : {\n     \"managedOutboundIPs\": {\n      \"count\": 1\n     },\n     \"\
+        effectiveOutboundIPs\": [\n      {\n       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_clitest000001_cliakstest000001_canadacentral/providers/Microsoft.Network/publicIPAddresses/271ac8b4-8dee-4116-b70a-b51214465b44\"\
+        \n      }\n     ]\n    },\n    \"podCidr\": \"10.244.0.0/16\",\n    \"serviceCidr\"\
+        : \"10.0.0.0/16\",\n    \"dnsServiceIP\": \"10.0.0.10\",\n    \"dockerBridgeCidr\"\
+        : \"172.17.0.1/16\",\n    \"outboundType\": \"loadBalancer\"\n   },\n   \"\
+        aadProfile\": {\n    \"managed\": true,\n    \"adminGroupObjectIDs\": [\n\
+        \     \"00000000-0000-0000-0000-000000000001\"\n    ],\n    \"tenantID\":\
+        \ \"00000000-0000-0000-0000-000000000002\"\n   },\n   \"maxAgentPools\": 100\n\
+        \  },\n  \"sku\": {\n   \"name\": \"Basic\",\n   \"tier\": \"Free\"\n  }\n\
+        \ }"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2983'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Jul 2020 03:58:19 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -1726,7 +1726,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         ])
 
     @AllowLargeResponse()
-    @ResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='eastus2')
+    @ResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='canadacentral')
     @RoleBasedServicePrincipalPreparer()
     def test_aks_create_nonaad_and_update_with_managed_aad(self, resource_group, resource_group_location):
         # reset the count so in replay mode the random names will start with 0
@@ -1751,7 +1751,12 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
                      '--enable-aad ' \
                      '--aad-admin-group-object-ids 00000000-0000-0000-0000-000000000001 ' \
                      '--aad-tenant-id 00000000-0000-0000-0000-000000000002 -o json'
-        self.cmd(update_cmd, expect_failure=True)
+        self.cmd(update_cmd, checks=[
+            self.check('provisioningState', 'Succeeded'),
+            self.check('aadProfile.managed', True),
+            self.check('aadProfile.adminGroupObjectIds[0]', '00000000-0000-0000-0000-000000000001'),
+            self.check('aadProfile.tenantId', '00000000-0000-0000-0000-000000000002')
+        ])
 
     @classmethod
     def generate_ssh_keys(cls):


### PR DESCRIPTION


**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR is to port https://github.com/Azure/azure-cli-extensions/pull/2017 from azure-cli-extension to azure-cli, which supports migrating a RBAC-enabled non-AAD cluster to a AKS-managed AAD cluster.

**Testing Guide**  
<!--Example commands with explanations.-->

1. Create RBAC-enabled non-AAD cluster.

    ```
    az aks create -g MyResourceGroup -n MyManagedCluster 
    ```

2. Migrate the cluster to the new AKS-managed AAD experience.

    ```
    az aks update -g MyResourceGroup -n MyManagedCluster --enable-aad
    ```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
