### PR TITLE
{App Service} Bugfix: When deploying python apps, avoid deploying .env file

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
@@ -45,13 +45,13 @@ def zip_contents_from_dir(dirPath, lang):
             elif lang.lower() == PYTHON_RUNTIME_NAME:
                 subdirs[:] = [d for d in subdirs if 'env' not in d]  # Ignores dir that contain env
 
-            filtered_files = []
-            for filename in files:
-                if filename == '.env':
-                    logger.warning("Skipping file: %s/%s", dirname, filename)
-                else:
-                    filtered_files.append(filename)
-            files[:] = filtered_files
+                filtered_files = []
+                for filename in files:
+                    if filename == '.env':
+                        logger.info("Skipping file: %s/%s", dirname, filename)
+                    else:
+                        filtered_files.append(filename)
+                files[:] = filtered_files
 
             for filename in files:
                 absname = os.path.abspath(os.path.join(dirname, filename))

--- a/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
@@ -44,6 +44,13 @@ def zip_contents_from_dir(dirPath, lang):
                 subdirs[:] = [d for d in subdirs if d not in ['obj', 'bin']]
             elif lang.lower() == PYTHON_RUNTIME_NAME:
                 subdirs[:] = [d for d in subdirs if 'env' not in d]  # Ignores dir that contain env
+            def filterFunc(f):
+                if f == '.env':
+                    logger.warning("Skipping file: {}/{}".format(dirname, f))
+                    return False
+                else:
+                    return True
+            files = filter(filterFunc, files)
             for filename in files:
                 absname = os.path.abspath(os.path.join(dirname, filename))
                 arcname = absname[len(abs_src) + 1:]

--- a/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
@@ -44,13 +44,15 @@ def zip_contents_from_dir(dirPath, lang):
                 subdirs[:] = [d for d in subdirs if d not in ['obj', 'bin']]
             elif lang.lower() == PYTHON_RUNTIME_NAME:
                 subdirs[:] = [d for d in subdirs if 'env' not in d]  # Ignores dir that contain env
-            def filterFunc(f):
-                if f == '.env':
-                    logger.warning("Skipping file: {}/{}".format(dirname, f))
-                    return False
+
+            filtered_files = []
+            for filename in files:
+                if filename == '.env':
+                    logger.warning("Skipping file: %s/%s", dirname, filename)
                 else:
-                    return True
-            files = filter(filterFunc, files)
+                    filtered_files.append(filename)
+            files[:] = filtered_files
+
             for filename in files:
                 absname = os.path.abspath(os.path.join(dirname, filename))
                 arcname = absname[len(abs_src) + 1:]


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Fixes #14306 
When deploying python apps through `az webapp up`, don't include .env(dotenv) files since they usually contain secrets. 

**Testing Guide**  
Clone test app: https://github.com/Azure-Samples/python-docs-hello-world
Go into cloned directory
Add a .env file(s) anywhere in the directory
Run `az webapp up -n WebappName`

Expect: .env files are not included in the zip deploy

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
