### PR TITLE
{Linter} replace command with show comamnd and custom command with custom show command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/commands.py
@@ -189,7 +189,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.command('list', 'acr_repository_list')
         g.command('show-tags', 'acr_repository_show_tags')
         g.command('show-manifests', 'acr_repository_show_manifests')
-        g.command('show', 'acr_repository_show')
+        g.show_command('show', 'acr_repository_show')
         g.command('update', 'acr_repository_update')
         g.command('delete', 'acr_repository_delete')
         g.command('untag', 'acr_repository_untag')
@@ -263,16 +263,16 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
     with self.command_group('acr taskrun', acr_taskrun_util, is_preview=True) as g:
         g.command('list', 'acr_taskrun_list')
         g.command('delete', 'acr_taskrun_delete')
-        g.command('show', 'acr_taskrun_show')
+        g.show_command('show', 'acr_taskrun_show')
         g.command('logs', 'acr_taskrun_logs', client_factory=cf_acr_runs,
                   table_transformer=None)
 
     with self.command_group('acr config content-trust', acr_policy_util) as g:
-        g.command('show', 'acr_config_content_trust_show')
+        g.show_command('show', 'acr_config_content_trust_show')
         g.command('update', 'acr_config_content_trust_update')
 
     with self.command_group('acr config retention', acr_policy_util, is_preview=True) as g:
-        g.command('show', 'acr_config_retention_show')
+        g.show_command('show', 'acr_config_retention_show')
         g.command('update', 'acr_config_retention_update')
 
     def _helm_deprecate_message(self):
@@ -286,7 +286,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
                             deprecate_info=self.deprecate(redirect="helm v3",
                                                           message_func=_helm_deprecate_message)) as g:
         g.command('list', 'acr_helm_list', table_transformer=helm_list_output_format)
-        g.command('show', 'acr_helm_show', table_transformer=helm_show_output_format)
+        g.show_command('show', 'acr_helm_show', table_transformer=helm_show_output_format)
         g.command('delete', 'acr_helm_delete')
         g.command('push', 'acr_helm_push')
         g.command('repo add', 'acr_helm_repo_add')
@@ -304,14 +304,14 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.command('create', 'acr_scope_map_create')
         g.command('delete', 'acr_scope_map_delete')
         g.command('update', 'acr_scope_map_update')
-        g.command('show', 'acr_scope_map_show')
+        g.show_command('show', 'acr_scope_map_show')
         g.command('list', 'acr_scope_map_list')
 
     with self.command_group('acr token', acr_token_util, is_preview=True) as g:
         g.command('create', 'acr_token_create')
         g.command('delete', 'acr_token_delete')
         g.command('update', 'acr_token_update')
-        g.command('show', 'acr_token_show')
+        g.show_command('show', 'acr_token_show')
         g.command('list', 'acr_token_list')
         g.command('credential delete', 'acr_token_credential_delete')
 
@@ -336,10 +336,10 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.command('list', 'list_private_link_resources')
 
     with self.command_group('acr identity', acr_custom_util) as g:
-        g.command('show', 'show_identity')
+        g.show_command('show', 'show_identity')
         g.command('assign', 'assign_identity')
         g.command('remove', 'remove_identity')
 
     with self.command_group('acr encryption', acr_custom_util) as g:
-        g.command('show', 'show_encryption')
+        g.show_command('show', 'show_encryption')
         g.command('rotate-key', "rotate_key")

--- a/src/azure-cli/azure/cli/command_modules/ams/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/commands.py
@@ -31,7 +31,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         )
 
     with self.command_group('ams account', get_sdk('Mediaservices', get_mediaservices_client)) as g:
-        g.custom_command('show', 'get_mediaservice',
+        g.custom_show_command('show', 'get_mediaservice',
                          custom_command_type=get_custom_sdk('account', get_mediaservices_client))
         g.command('delete', 'delete')
         g.generic_update_command('update',
@@ -60,13 +60,13 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                          custom_command_type=get_custom_sdk('sp', get_mediaservices_client))
 
     with self.command_group('ams account mru', get_sdk('Mediaservices', get_mediaservices_client)) as g:
-        g.custom_command('show', 'get_mru',
+        g.custom_show_command('show', 'get_mru',
                          custom_command_type=get_custom_sdk('mru', None))
         g.custom_command('set', 'set_mru',
                          custom_command_type=get_custom_sdk('mru', None))
 
     with self.command_group('ams transform', get_sdk('Transforms', get_transforms_client)) as g:
-        g.custom_command('show', 'get_transform',
+        g.custom_show_command('show', 'get_transform',
                          custom_command_type=get_custom_sdk('transform', get_transforms_client))
         g.command('list', 'list')
         g.command('delete', 'delete')
@@ -85,7 +85,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                          custom_command_type=get_custom_sdk('transform', get_transforms_client))
 
     with self.command_group('ams asset', get_sdk('Assets', get_assets_client)) as g:
-        g.custom_command('show', 'get_asset', custom_command_type=get_custom_sdk('asset', get_assets_client))
+        g.custom_show_command('show', 'get_asset', custom_command_type=get_custom_sdk('asset', get_assets_client))
         g.command('list', 'list')
         g.command('delete', 'delete')
         g.command('list-streaming-locators', 'list_streaming_locators')
@@ -101,7 +101,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
     with self.command_group('ams asset-filter', get_sdk('AssetFilters', get_asset_filters_client)) as g:
         g.command('list', 'list')
-        g.custom_command('show', 'get_asset_filter',
+        g.custom_show_command('show', 'get_asset_filter',
                          custom_command_type=get_custom_sdk('asset_filter', get_asset_filters_client))
         g.command('delete', 'delete')
         g.custom_command('create', 'create_asset_filter',
@@ -111,7 +111,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                                  custom_func_type=get_custom_sdk('asset_filter', get_mediaservices_client))
 
     with self.command_group('ams job', get_sdk('Jobs', get_jobs_client)) as g:
-        g.custom_command('show', 'get_job',
+        g.custom_show_command('show', 'get_job',
                          custom_command_type=get_custom_sdk('job', get_jobs_client))
         g.command('list', 'list')
         g.command('delete', 'delete')
@@ -127,7 +127,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
     with self.command_group('ams content-key-policy', get_sdk('ContentKeyPolicies', get_content_key_policies_client)) as g:
         g.custom_command('create', 'create_content_key_policy',
                          custom_command_type=get_custom_sdk('content_key_policy', get_content_key_policies_client))
-        g.custom_command('show', 'show_content_key_policy',
+        g.custom_show_command('show', 'show_content_key_policy',
                          custom_command_type=get_custom_sdk('content_key_policy', get_content_key_policies_client))
         g.command('delete', 'delete')
         g.command('list', 'list')
@@ -150,7 +150,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.custom_command('create', 'create_streaming_locator',
                          custom_command_type=get_custom_sdk('streaming_locator', get_streaming_locators_client))
         g.command('list', 'list')
-        g.custom_command('show', 'get_streaming_locator',
+        g.custom_show_command('show', 'get_streaming_locator',
                          custom_command_type=get_custom_sdk('streaming_locator', get_streaming_locators_client))
         g.command('delete', 'delete')
         g.command('get-paths', 'list_paths')
@@ -161,7 +161,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.custom_command('create', 'create_streaming_policy',
                          custom_command_type=get_custom_sdk('streaming_policy', get_streaming_policies_client))
         g.command('list', 'list')
-        g.custom_command('show', 'get_streaming_policy',
+        g.custom_show_command('show', 'get_streaming_policy',
                          custom_command_type=get_custom_sdk('streaming_policy', get_streaming_policies_client))
         g.command('delete', 'delete')
 
@@ -182,7 +182,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                                  custom_func_name='update_streaming_endpoint',
                                  custom_func_type=get_custom_sdk('streaming_endpoint', get_streaming_endpoints_client),
                                  supports_no_wait=True)
-        g.custom_command('show', 'get_streaming_endpoint',
+        g.custom_show_command('show', 'get_streaming_endpoint',
                          custom_command_type=get_custom_sdk('streaming_endpoint', get_streaming_endpoints_client))
         g.command('delete', 'delete')
         g.command('scale', 'scale')
@@ -207,7 +207,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.custom_command('reset', 'reset',
                          custom_command_type=get_custom_sdk('live_event', get_live_events_client),
                          supports_no_wait=True)
-        g.custom_command('show', 'get_live_event',
+        g.custom_show_command('show', 'get_live_event',
                          custom_command_type=get_custom_sdk('live_event', get_live_events_client))
         g.command('delete', 'delete')
         g.command('list', 'list')
@@ -221,7 +221,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
     with self.command_group('ams live-output', get_sdk('LiveOutputs', get_live_outputs_client)) as g:
         g.custom_command('create', 'create_live_output',
                          custom_command_type=get_custom_sdk('live_output', get_live_outputs_client))
-        g.custom_command('show', 'get_live_output',
+        g.custom_show_command('show', 'get_live_output',
                          custom_command_type=get_custom_sdk('live_output', get_live_outputs_client))
         g.command('list', 'list')
         g.command('delete', 'delete')
@@ -229,7 +229,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
     with self.command_group('ams account-filter', get_sdk('AccountFilters', get_account_filters_client)) as g:
         g.custom_command('create', 'create_account_filter',
                          custom_command_type=get_custom_sdk('account_filter', get_account_filters_client))
-        g.custom_command('show', 'get_account_filter',
+        g.custom_show_command('show', 'get_account_filter',
                          custom_command_type=get_custom_sdk('account_filter', get_account_filters_client))
         g.command('list', 'list')
         g.command('delete', 'delete')

--- a/src/azure-cli/azure/cli/command_modules/ams/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/commands.py
@@ -61,7 +61,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
     with self.command_group('ams account mru', get_sdk('Mediaservices', get_mediaservices_client)) as g:
         g.custom_show_command('show', 'get_mru',
-                         custom_command_type=get_custom_sdk('mru', None))
+                              custom_command_type=get_custom_sdk('mru', None))
         g.custom_command('set', 'set_mru',
                          custom_command_type=get_custom_sdk('mru', None))
 
@@ -222,7 +222,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.custom_command('create', 'create_live_output',
                          custom_command_type=get_custom_sdk('live_output', get_live_outputs_client))
         g.custom_show_command('show', 'get_live_output',
-                         custom_command_type=get_custom_sdk('live_output', get_live_outputs_client))
+                              custom_command_type=get_custom_sdk('live_output', get_live_outputs_client))
         g.command('list', 'list')
         g.command('delete', 'delete')
 

--- a/src/azure-cli/azure/cli/command_modules/ams/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/commands.py
@@ -32,7 +32,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
     with self.command_group('ams account', get_sdk('Mediaservices', get_mediaservices_client)) as g:
         g.custom_show_command('show', 'get_mediaservice',
-                         custom_command_type=get_custom_sdk('account', get_mediaservices_client))
+                              custom_command_type=get_custom_sdk('account', get_mediaservices_client))
         g.command('delete', 'delete')
         g.generic_update_command('update',
                                  getter_name='mediaservice_update_getter',
@@ -67,7 +67,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
     with self.command_group('ams transform', get_sdk('Transforms', get_transforms_client)) as g:
         g.custom_show_command('show', 'get_transform',
-                         custom_command_type=get_custom_sdk('transform', get_transforms_client))
+                              custom_command_type=get_custom_sdk('transform', get_transforms_client))
         g.command('list', 'list')
         g.command('delete', 'delete')
         g.custom_command('create', 'create_transform',
@@ -102,7 +102,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
     with self.command_group('ams asset-filter', get_sdk('AssetFilters', get_asset_filters_client)) as g:
         g.command('list', 'list')
         g.custom_show_command('show', 'get_asset_filter',
-                         custom_command_type=get_custom_sdk('asset_filter', get_asset_filters_client))
+                              custom_command_type=get_custom_sdk('asset_filter', get_asset_filters_client))
         g.command('delete', 'delete')
         g.custom_command('create', 'create_asset_filter',
                          custom_command_type=get_custom_sdk('asset_filter', get_asset_filters_client))
@@ -112,7 +112,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
     with self.command_group('ams job', get_sdk('Jobs', get_jobs_client)) as g:
         g.custom_show_command('show', 'get_job',
-                         custom_command_type=get_custom_sdk('job', get_jobs_client))
+                              custom_command_type=get_custom_sdk('job', get_jobs_client))
         g.command('list', 'list')
         g.command('delete', 'delete')
         g.custom_command('cancel', 'cancel_job',
@@ -128,7 +128,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.custom_command('create', 'create_content_key_policy',
                          custom_command_type=get_custom_sdk('content_key_policy', get_content_key_policies_client))
         g.custom_show_command('show', 'show_content_key_policy',
-                         custom_command_type=get_custom_sdk('content_key_policy', get_content_key_policies_client))
+                              custom_command_type=get_custom_sdk('content_key_policy', get_content_key_policies_client))
         g.command('delete', 'delete')
         g.command('list', 'list')
         g.generic_update_command('update',
@@ -151,7 +151,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                          custom_command_type=get_custom_sdk('streaming_locator', get_streaming_locators_client))
         g.command('list', 'list')
         g.custom_show_command('show', 'get_streaming_locator',
-                         custom_command_type=get_custom_sdk('streaming_locator', get_streaming_locators_client))
+                              custom_command_type=get_custom_sdk('streaming_locator', get_streaming_locators_client))
         g.command('delete', 'delete')
         g.command('get-paths', 'list_paths')
         g.custom_command('list-content-keys', 'list_content_keys',
@@ -162,7 +162,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                          custom_command_type=get_custom_sdk('streaming_policy', get_streaming_policies_client))
         g.command('list', 'list')
         g.custom_show_command('show', 'get_streaming_policy',
-                         custom_command_type=get_custom_sdk('streaming_policy', get_streaming_policies_client))
+                              custom_command_type=get_custom_sdk('streaming_policy', get_streaming_policies_client))
         g.command('delete', 'delete')
 
     with self.command_group('ams streaming-endpoint', get_sdk('StreamingEndpoints', get_streaming_endpoints_client)) as g:
@@ -183,7 +183,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                                  custom_func_type=get_custom_sdk('streaming_endpoint', get_streaming_endpoints_client),
                                  supports_no_wait=True)
         g.custom_show_command('show', 'get_streaming_endpoint',
-                         custom_command_type=get_custom_sdk('streaming_endpoint', get_streaming_endpoints_client))
+                              custom_command_type=get_custom_sdk('streaming_endpoint', get_streaming_endpoints_client))
         g.command('delete', 'delete')
         g.command('scale', 'scale')
         g.wait_command('wait')
@@ -208,7 +208,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                          custom_command_type=get_custom_sdk('live_event', get_live_events_client),
                          supports_no_wait=True)
         g.custom_show_command('show', 'get_live_event',
-                         custom_command_type=get_custom_sdk('live_event', get_live_events_client))
+                              custom_command_type=get_custom_sdk('live_event', get_live_events_client))
         g.command('delete', 'delete')
         g.command('list', 'list')
         g.generic_update_command('update',
@@ -230,7 +230,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.custom_command('create', 'create_account_filter',
                          custom_command_type=get_custom_sdk('account_filter', get_account_filters_client))
         g.custom_show_command('show', 'get_account_filter',
-                         custom_command_type=get_custom_sdk('account_filter', get_account_filters_client))
+                              custom_command_type=get_custom_sdk('account_filter', get_account_filters_client))
         g.command('list', 'list')
         g.command('delete', 'delete')
         g.generic_update_command('update',

--- a/src/azure-cli/azure/cli/command_modules/appconfig/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/commands.py
@@ -56,7 +56,7 @@ def load_command_table(self, _):
         g.command('delete', 'delete_configstore')
         g.command('update', 'update_configstore')
         g.command('list', 'list_configstore')
-        g.command('show', 'show_configstore')
+        g.show_command('show', 'show_configstore')
 
     with self.command_group('appconfig credential', configstore_credential_util) as g:
         g.command('list', 'list_credential')
@@ -65,7 +65,7 @@ def load_command_table(self, _):
     with self.command_group('appconfig identity', configstore_identity_util, is_preview=True) as g:
         g.command('assign', 'assign_managed_identity')
         g.command('remove', 'remove_managed_identity')
-        g.command('show', 'show_managed_identity')
+        g.show_command('show', 'show_managed_identity')
 
     with self.command_group('appconfig revision', configstore_keyvalue_util) as g:
         g.command('list', 'list_revision')
@@ -74,7 +74,7 @@ def load_command_table(self, _):
     with self.command_group('appconfig kv', configstore_keyvalue_util) as g:
         g.command('set', 'set_key')
         g.command('delete', 'delete_key')
-        g.command('show', 'show_key')
+        g.show_command('show', 'show_key')
         g.command('list', 'list_key')
         g.command('lock', 'lock_key')
         g.command('unlock', 'unlock_key')
@@ -91,7 +91,7 @@ def load_command_table(self, _):
                             is_preview=True) as g:
         g.custom_command('set', 'set_feature')
         g.custom_command('delete', 'delete_feature')
-        g.custom_command('show', 'show_feature')
+        g.custom_show_command('show', 'show_feature')
         g.custom_command('list', 'list_feature')
         g.custom_command('lock', 'lock_feature')
         g.custom_command('unlock', 'unlock_feature')
@@ -104,5 +104,5 @@ def load_command_table(self, _):
                                                                featurefilter_entry_format)) as g:
         g.custom_command('add', 'add_filter')
         g.custom_command('delete', 'delete_filter')
-        g.custom_command('show', 'show_filter')
+        g.custom_show_command('show', 'show_filter')
         g.custom_command('list', 'list_filter')

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -107,7 +107,7 @@ def load_command_table(self, _):
     with self.command_group('webapp cors') as g:
         g.custom_command('add', 'add_cors')
         g.custom_command('remove', 'remove_cors')
-        g.custom_command('show', 'show_cors')
+        g.custom_show_command('show', 'show_cors')
 
     with self.command_group('webapp config') as g:
         g.custom_command('set', 'update_site_configs')
@@ -319,7 +319,7 @@ def load_command_table(self, _):
     with self.command_group('functionapp cors') as g:
         g.custom_command('add', 'add_cors')
         g.custom_command('remove', 'remove_cors')
-        g.custom_command('show', 'show_cors')
+        g.custom_show_command('show', 'show_cors')
 
     with self.command_group('functionapp plan', appservice_plan_sdk) as g:
         g.custom_command('create', 'create_functionapp_app_service_plan', exception_handler=ex_handler_factory())
@@ -349,13 +349,13 @@ def load_command_table(self, _):
         g.custom_command('create', 'create_functionapp_slot', exception_handler=ex_handler_factory())
 
     with self.command_group('webapp config access-restriction', custom_command_type=webapp_access_restrictions, is_preview=True) as g:
-        g.custom_command('show', 'show_webapp_access_restrictions')
+        g.custom_show_command('show', 'show_webapp_access_restrictions')
         g.custom_command('add', 'add_webapp_access_restriction')
         g.custom_command('remove', 'remove_webapp_access_restriction')
         g.custom_command('set', 'set_webapp_access_restriction')
 
     with self.command_group('functionapp config access-restriction', custom_command_type=webapp_access_restrictions, is_preview=True) as g:
-        g.custom_command('show', 'show_webapp_access_restrictions')
+        g.custom_show_command('show', 'show_webapp_access_restrictions')
         g.custom_command('add', 'add_webapp_access_restriction')
         g.custom_command('remove', 'remove_webapp_access_restriction')
         g.custom_command('set', 'set_webapp_access_restriction')
@@ -364,7 +364,7 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_appserviceenvironments')
         g.custom_command('list-addresses', 'list_appserviceenvironment_addresses')
         g.custom_command('list-plans', 'list_appserviceenvironment_plans')
-        g.custom_command('show', 'show_appserviceenvironment')
+        g.custom_show_command('show', 'show_appserviceenvironment')
         g.custom_command('create', 'create_appserviceenvironment_arm', supports_no_wait=True)
         g.custom_command('update', 'update_appserviceenvironment', supports_no_wait=True)
         g.custom_command('delete', 'delete_appserviceenvironment', supports_no_wait=True, confirmation=True)

--- a/src/azure-cli/azure/cli/command_modules/batch/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/commands.py
@@ -51,7 +51,7 @@ def load_command_table(self, _):
     # Mgmt Account Operations
     with self.command_group('batch account', get_mgmt_type('batch_account'), client_factory=get_mgmt_factory('batch_account')) as g:
         g.custom_command('list', 'list_accounts', table_transformer=account_list_table_format)
-        g.custom_command('show', 'get_account')
+        g.custom_show_command('show', 'get_account')
         g.custom_command('create', 'create_account', supports_no_wait=True)
         g.custom_command('set', 'update_account')
         g.command('delete', 'delete', supports_no_wait=True, confirmation=True)

--- a/src/azure-cli/azure/cli/command_modules/botservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/commands.py
@@ -51,13 +51,13 @@ def load_command_table(self, _):
         g.custom_command('prepare-deploy', 'prepare_webapp_deploy')
 
     with self.command_group('bot', botServices_commandType) as g:
-        g.custom_command('show', 'get_bot')
+        g.custom_show_command('show', 'get_bot')
         g.command('delete', 'delete')
 
     # Begin "bot authsetting" command registration
     with self.command_group('bot authsetting', botConnections_commandType) as g:
         g.command('list', 'list_by_bot_service')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('delete', 'delete')
 
     with self.command_group('bot authsetting', botOperations_commandType) as g:
@@ -74,11 +74,11 @@ def load_command_table(self, _):
                 g.command('update', '{}_update'.format(channel))
 
         with self.command_group('bot {}'.format(channel), channelOperations_commandType, is_preview=True) as g:
-            g.command('show', '{}_get'.format(channel))
+            g.show_command('show', '{}_get'.format(channel))
             g.command('delete', '{}_delete'.format(channel))
 
     with self.command_group('bot webchat', channelOperations_commandType) as g:
-        g.command('show', 'webchat_get')
+        g.show_command('show', 'webchat_get')
 
     with self.command_group('bot'):
         pass

--- a/src/azure-cli/azure/cli/command_modules/cognitiveservices/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/cognitiveservices/commands.py
@@ -40,4 +40,4 @@ def load_command_table(self, _):
     with self.command_group('cognitiveservices account identity', mgmt_type, client_factory=cf_accounts) as g:
         g.custom_command('assign', 'identity_assign')
         g.custom_command('remove', 'identity_remove')
-        g.custom_command('show', 'identity_show')
+        g.custom_show_command('show', 'identity_show')

--- a/src/azure-cli/azure/cli/command_modules/configure/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/commands.py
@@ -16,12 +16,12 @@ def load_command_table(self, _):
 
     with self.command_group('cache', configure_custom, is_preview=True) as g:
         g.command('list', 'list_cache_contents')
-        g.command('show', 'show_cache_contents')  #pylint: disable=show-command
+        g.command('show', 'show_cache_contents')
         g.command('delete', 'delete_cache_contents')
         g.command('purge', 'purge_cache_contents')
 
     with self.command_group('local-context', configure_custom, is_experimental=True) as g:
         g.command('on', 'turn_local_context_on')
         g.command('off', 'turn_local_context_off')
-        g.command('show', 'show_local_context', validator=validate_local_context)  #pylint: disable=show-command
+        g.command('show', 'show_local_context', validator=validate_local_context)
         g.command('delete', 'delete_local_context', validator=validate_local_context_for_delete)

--- a/src/azure-cli/azure/cli/command_modules/configure/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/commands.py
@@ -16,12 +16,12 @@ def load_command_table(self, _):
 
     with self.command_group('cache', configure_custom, is_preview=True) as g:
         g.command('list', 'list_cache_contents')
-        g.command('show', 'show_cache_contents')
+        g.command('show', 'show_cache_contents')  #pylint: disable=show-command
         g.command('delete', 'delete_cache_contents')
         g.command('purge', 'purge_cache_contents')
 
     with self.command_group('local-context', configure_custom, is_experimental=True) as g:
         g.command('on', 'turn_local_context_on')
         g.command('off', 'turn_local_context_off')
-        g.command('show', 'show_local_context', validator=validate_local_context)
+        g.command('show', 'show_local_context', validator=validate_local_context)  #pylint: disable=show-command
         g.command('delete', 'delete_local_context', validator=validate_local_context_for_delete)

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/commands.py
@@ -106,7 +106,7 @@ def load_command_table(self, _):
         g.custom_command('create', 'cli_cosmosdb_sql_database_create')
         g.custom_command('exists', 'cli_cosmosdb_sql_database_exists')
         g.command('list', 'list_sql_databases')
-        g.command('show', 'get_sql_database')
+        g.show_command('show', 'get_sql_database')
         g.command('delete', 'delete_sql_database', confirmation=True)
 
     with self.command_group('cosmosdb sql container', cosmosdb_sql_sdk, client_factory=cf_sql_resources) as g:
@@ -114,28 +114,28 @@ def load_command_table(self, _):
         g.custom_command('update', 'cli_cosmosdb_sql_container_update')
         g.custom_command('exists', 'cli_cosmosdb_sql_container_exists')
         g.command('list', 'list_sql_containers')
-        g.command('show', 'get_sql_container')
+        g.show_command('show', 'get_sql_container')
         g.command('delete', 'delete_sql_container', confirmation=True)
 
     with self.command_group('cosmosdb sql stored-procedure', cosmosdb_sql_sdk, client_factory=cf_sql_resources) as g:
         g.custom_command('create', 'cli_cosmosdb_sql_stored_procedure_create_update')
         g.custom_command('update', 'cli_cosmosdb_sql_stored_procedure_create_update')
         g.command('list', 'list_sql_stored_procedures')
-        g.command('show', 'get_sql_stored_procedure')
+        g.show_command('show', 'get_sql_stored_procedure')
         g.command('delete', 'delete_sql_stored_procedure', confirmation=True)
 
     with self.command_group('cosmosdb sql trigger', cosmosdb_sql_sdk, client_factory=cf_sql_resources) as g:
         g.custom_command('create', 'cli_cosmosdb_sql_trigger_create')
         g.custom_command('update', 'cli_cosmosdb_sql_trigger_update')
         g.command('list', 'list_sql_triggers')
-        g.command('show', 'get_sql_trigger')
+        g.show_command('show', 'get_sql_trigger')
         g.command('delete', 'delete_sql_trigger', confirmation=True)
 
     with self.command_group('cosmosdb sql user-defined-function', cosmosdb_sql_sdk, client_factory=cf_sql_resources) as g:
         g.custom_command('create', 'cli_cosmosdb_sql_user_defined_function_create_update')
         g.custom_command('update', 'cli_cosmosdb_sql_user_defined_function_create_update')
         g.command('list', 'list_sql_user_defined_functions')
-        g.command('show', 'get_sql_user_defined_function')
+        g.show_command('show', 'get_sql_user_defined_function')
         g.command('delete', 'delete_sql_user_defined_function', confirmation=True)
 
     # MongoDB api
@@ -145,7 +145,7 @@ def load_command_table(self, _):
         g.custom_command('create', 'cli_cosmosdb_mongodb_database_create')
         g.custom_command('exists', 'cli_cosmosdb_mongodb_database_exists')
         g.command('list', 'list_mongo_db_databases')
-        g.command('show', 'get_mongo_db_database')
+        g.show_command('show', 'get_mongo_db_database')
         g.command('delete', 'delete_mongo_db_database', confirmation=True)
 
     with self.command_group('cosmosdb mongodb collection', cosmosdb_mongo_sdk, client_factory=cf_mongo_db_resources) as g:
@@ -153,7 +153,7 @@ def load_command_table(self, _):
         g.custom_command('update', 'cli_cosmosdb_mongodb_collection_update')
         g.custom_command('exists', 'cli_cosmosdb_mongodb_collection_exists')
         g.command('list', 'list_mongo_db_collections')
-        g.command('show', 'get_mongo_db_collection')
+        g.show_command('show', 'get_mongo_db_collection')
         g.command('delete', 'delete_mongo_db_collection', confirmation=True)
 
     # Cassandra api
@@ -163,7 +163,7 @@ def load_command_table(self, _):
         g.custom_command('create', 'cli_cosmosdb_cassandra_keyspace_create')
         g.custom_command('exists', 'cli_cosmosdb_cassandra_keyspace_exists')
         g.command('list', 'list_cassandra_keyspaces')
-        g.command('show', 'get_cassandra_keyspace')
+        g.show_command('show', 'get_cassandra_keyspace')
         g.command('delete', 'delete_cassandra_keyspace', confirmation=True)
 
     with self.command_group('cosmosdb cassandra table', cosmosdb_cassandra_sdk, client_factory=cf_cassandra_resources) as g:
@@ -171,7 +171,7 @@ def load_command_table(self, _):
         g.custom_command('update', 'cli_cosmosdb_cassandra_table_update')
         g.custom_command('exists', 'cli_cosmosdb_cassandra_table_exists')
         g.command('list', 'list_cassandra_tables')
-        g.command('show', 'get_cassandra_table')
+        g.show_command('show', 'get_cassandra_table')
         g.command('delete', 'delete_cassandra_table', confirmation=True)
 
     # Gremlin api
@@ -181,7 +181,7 @@ def load_command_table(self, _):
         g.custom_command('create', 'cli_cosmosdb_gremlin_database_create')
         g.custom_command('exists', 'cli_cosmosdb_gremlin_database_exists')
         g.command('list', 'list_gremlin_databases')
-        g.command('show', 'get_gremlin_database')
+        g.show_command('show', 'get_gremlin_database')
         g.command('delete', 'delete_gremlin_database', confirmation=True)
 
     with self.command_group('cosmosdb gremlin graph', cosmosdb_gremlin_sdk, client_factory=cf_gremlin_resources) as g:
@@ -189,7 +189,7 @@ def load_command_table(self, _):
         g.custom_command('update', 'cli_cosmosdb_gremlin_graph_update')
         g.custom_command('exists', 'cli_cosmosdb_gremlin_graph_exists')
         g.command('list', 'list_gremlin_graphs')
-        g.command('show', 'get_gremlin_graph')
+        g.show_command('show', 'get_gremlin_graph')
         g.command('delete', 'delete_gremlin_graph', confirmation=True)
 
     # Table api
@@ -197,44 +197,44 @@ def load_command_table(self, _):
         g.custom_command('create', 'cli_cosmosdb_table_create')
         g.custom_command('exists', 'cli_cosmosdb_table_exists')
         g.command('list', 'list_tables')
-        g.command('show', 'get_table')
+        g.show_command('show', 'get_table')
         g.command('delete', 'delete_table', confirmation=True)
 
     # Offer throughput
     with self.command_group('cosmosdb sql database throughput', cosmosdb_sql_sdk, client_factory=cf_sql_resources) as g:
-        g.command('show', 'get_sql_database_throughput')
+        g.show_command('show', 'get_sql_database_throughput')
         g.custom_command('update', 'cli_cosmosdb_sql_database_throughput_update')
 
     with self.command_group('cosmosdb sql container throughput', cosmosdb_sql_sdk, client_factory=cf_sql_resources) as g:
-        g.command('show', 'get_sql_container_throughput')
+        g.show_command('show', 'get_sql_container_throughput')
         g.custom_command('update', 'cli_cosmosdb_sql_container_throughput_update')
 
     with self.command_group('cosmosdb mongodb database throughput', cosmosdb_mongo_sdk, client_factory=cf_mongo_db_resources) as g:
-        g.command('show', 'get_mongo_db_database_throughput')
+        g.show_command('show', 'get_mongo_db_database_throughput')
         g.custom_command('update', 'cli_cosmosdb_mongodb_database_throughput_update')
 
     with self.command_group('cosmosdb mongodb collection throughput', cosmosdb_mongo_sdk, client_factory=cf_mongo_db_resources) as g:
-        g.command('show', 'get_mongo_db_collection_throughput')
+        g.show_command('show', 'get_mongo_db_collection_throughput')
         g.custom_command('update', 'cli_cosmosdb_mongodb_collection_throughput_update')
 
     with self.command_group('cosmosdb cassandra keyspace throughput', cosmosdb_cassandra_sdk, client_factory=cf_cassandra_resources) as g:
-        g.command('show', 'get_cassandra_keyspace_throughput')
+        g.show_command('show', 'get_cassandra_keyspace_throughput')
         g.custom_command('update', 'cli_cosmosdb_cassandra_keyspace_throughput_update')
 
     with self.command_group('cosmosdb cassandra table throughput', cosmosdb_cassandra_sdk, client_factory=cf_cassandra_resources) as g:
-        g.command('show', 'get_cassandra_table_throughput')
+        g.show_command('show', 'get_cassandra_table_throughput')
         g.custom_command('update', 'cli_cosmosdb_cassandra_table_throughput_update')
 
     with self.command_group('cosmosdb gremlin database throughput', cosmosdb_gremlin_sdk, client_factory=cf_gremlin_resources) as g:
-        g.command('show', 'get_gremlin_database_throughput')
+        g.show_command('show', 'get_gremlin_database_throughput')
         g.custom_command('update', 'cli_cosmosdb_gremlin_database_throughput_update')
 
     with self.command_group('cosmosdb gremlin graph throughput', cosmosdb_gremlin_sdk, client_factory=cf_gremlin_resources) as g:
-        g.command('show', 'get_gremlin_graph_throughput')
+        g.show_command('show', 'get_gremlin_graph_throughput')
         g.custom_command('update', 'cli_cosmosdb_gremlin_graph_throughput_update')
 
     with self.command_group('cosmosdb table throughput', cosmosdb_table_sdk, client_factory=cf_table_resources) as g:
-        g.command('show', 'get_table_throughput')
+        g.show_command('show', 'get_table_throughput')
         g.custom_command('update', 'cli_cosmosdb_table_throughput_update')
 
     # virtual network rules

--- a/src/azure-cli/azure/cli/command_modules/deploymentmanager/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/deploymentmanager/commands.py
@@ -40,7 +40,7 @@ def load_command_table(self, _):
     with self.command_group('deploymentmanager artifact-source', artifact_sources) as g:
         g.custom_command('create', 'cli_artifact_source_create')
         g.command('delete', 'delete', confirmation="There might be rollouts referencing the artifact source. Do you want to delete?")
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('list', 'list')
         g.generic_update_command(
             'update',
@@ -51,7 +51,7 @@ def load_command_table(self, _):
     with self.command_group('deploymentmanager service-topology', service_topologies) as g:
         g.custom_command('create', 'cli_service_topology_create')
         g.command('delete', 'delete')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('list', 'list')
         g.generic_update_command(
             'update',
@@ -62,7 +62,7 @@ def load_command_table(self, _):
     with self.command_group('deploymentmanager service', services) as g:
         g.custom_command('create', 'cli_service_create')
         g.command('delete', 'delete')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('list', 'list')
         g.generic_update_command(
             'update',
@@ -73,7 +73,7 @@ def load_command_table(self, _):
     with self.command_group('deploymentmanager service-unit', service_units) as g:
         g.custom_command('create', 'cli_service_unit_create')
         g.command('delete', 'delete')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('list', 'list')
         g.generic_update_command(
             'update',
@@ -84,7 +84,7 @@ def load_command_table(self, _):
     with self.command_group('deploymentmanager step', steps) as g:
         g.custom_command('create', 'cli_step_create')
         g.command('delete', 'delete')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('list', 'list')
         g.generic_update_command(
             'update',
@@ -93,7 +93,7 @@ def load_command_table(self, _):
             custom_func_type=deployment_manager_custom)
 
     with self.command_group('deploymentmanager rollout', rollouts) as g:
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('list', 'list')
         g.command('stop', 'cancel', confirmation="Do you want to cancel the rollout?")
         g.custom_command(

--- a/src/azure-cli/azure/cli/command_modules/deploymentmanager/tests/latest/test_deploymentmanager_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/deploymentmanager/tests/latest/test_deploymentmanager_scenario.py
@@ -155,7 +155,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager service-topology delete -g {rg} -n {st_name}')
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager service-topology show -n {st_name} -g {rg}')
 
         self.kwargs = {
@@ -166,7 +166,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager service-topology delete -g {rg} -n {st_name}')
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager service-topology show -n {st_name} -g {rg}')
 
     def services_validations(
@@ -236,11 +236,11 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager service delete -g {rg} --service-topology-name {st_name} -n {s_name}')
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager service show -g {rg} --service-topology-name {st_name} -n {s_name}')
 
         self.cmd('deploymentmanager service delete -g {rg} --service-topology-name {st_name} -n {s2_name}')
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager service show -g {rg} --service-topology-name {st_name} -n {s2_name}')
 
     def service_units_validations(
@@ -333,7 +333,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager service-unit delete -g {rg} --service-topology-name {st_name} --service-name {s_name} -n {su_name}')
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager service-unit show -g {rg} --service-topology-name {st_name} --service-name {s_name} -n {su_name}')
 
         self.kwargs = {
@@ -344,7 +344,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager service-unit delete -g {rg} --service-topology-name {st_name} --service-name {s_name} -n {su_name}')
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager service-unit show -g {rg} --service-topology-name {st_name} --service-name {s_name} -n {su_name}')
 
     def steps_validations(
@@ -406,7 +406,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager step delete -g {rg} -n {step_name}')
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager step show -g {rg} -n {step_name}')
 
     def healthcheck_step_validations(
@@ -485,7 +485,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager step delete -g {rg} -n {step_name}')
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager step show -g {rg} -n {step_name}')
 
         self.kwargs = {
@@ -494,7 +494,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager step delete -g {rg} -n {step2_name}')
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager step show -g {rg} -n {step2_name}')
 
     def rollouts_validations(
@@ -600,9 +600,9 @@ class DeploymentManagerTests(ScenarioTest):
         self.cmd('deploymentmanager rollout delete -g {rg} -n {failed_rollout_name}')
         self.cmd('deploymentmanager rollout delete -g {rg} -n {rollout_name}')
 
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager rollout show -g {rg} -n {failed_rollout_name}')
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager rollout show -g {rg} -n {rollout_name}')
 
     def set_managed_identity(self, subscription_id, resource_group_name):
@@ -805,7 +805,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
         self.cmd('deploymentmanager artifact-source delete -n {name} -g {rg} --yes')
 
-        with self.assertRaisesRegexp(CloudError, 'not found'):
+        with self.assertRaisesRegexp(SystemExit, '3'):
             self.cmd('deploymentmanager artifact-source show -n {name} -g {rg}')
 
     def upload_blob(self, storage_account_info, storage_container_name, file_path, file_name):

--- a/src/azure-cli/azure/cli/command_modules/iot/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/commands.py
@@ -113,13 +113,13 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
     with self.command_group('iot hub consumer-group', client_factory=iot_hub_service_factory) as g:
         g.custom_command('create', 'iot_hub_consumer_group_create')
         g.custom_command('list', 'iot_hub_consumer_group_list')
-        g.custom_command('show', 'iot_hub_consumer_group_get')
+        g.custom_show_command('show', 'iot_hub_consumer_group_get')
         g.custom_command('delete', 'iot_hub_consumer_group_delete')
 
     # iot hub policy commands
     with self.command_group('iot hub policy', client_factory=iot_hub_service_factory) as g:
         g.custom_command('list', 'iot_hub_policy_list')
-        g.custom_command('show', 'iot_hub_policy_get')
+        g.custom_show_command('show', 'iot_hub_policy_get')
         g.custom_command('create', 'iot_hub_policy_create', transform=PolicyUpdateResultTransform(self.cli_ctx))
         g.custom_command('delete', 'iot_hub_policy_delete', transform=PolicyUpdateResultTransform(self.cli_ctx))
         g.custom_command('renew-key', 'iot_hub_policy_key_renew', supports_no_wait=True)
@@ -128,7 +128,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
     with self.command_group('iot hub routing-endpoint', client_factory=iot_hub_service_factory) as g:
         g.custom_command('create', 'iot_hub_routing_endpoint_create',
                          transform=EndpointUpdateResultTransform(self.cli_ctx))
-        g.custom_command('show', 'iot_hub_routing_endpoint_show')
+        g.custom_show_command('show', 'iot_hub_routing_endpoint_show')
         g.custom_command('list', 'iot_hub_routing_endpoint_list')
         g.custom_command('delete', 'iot_hub_routing_endpoint_delete',
                          transform=EndpointUpdateResultTransform(self.cli_ctx))
@@ -144,7 +144,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
     # iot hub route commands
     with self.command_group('iot hub route', client_factory=iot_hub_service_factory) as g:
         g.custom_command('create', 'iot_hub_route_create', transform=RouteUpdateResultTransform(self.cli_ctx))
-        g.custom_command('show', 'iot_hub_route_show')
+        g.custom_show_command('show', 'iot_hub_route_show')
         g.custom_command('list', 'iot_hub_route_list')
         g.custom_command('delete', 'iot_hub_route_delete', transform=RouteUpdateResultTransform(self.cli_ctx))
         g.custom_command('update', 'iot_hub_route_update', transform=RouteUpdateResultTransform(self.cli_ctx))
@@ -153,7 +153,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
     # iot hub device stream commands
     with self.command_group('iot hub devicestream', client_factory=iot_hub_service_factory,
                             min_api="2019-07-01-preview") as g:
-        g.custom_command('show', 'iot_hub_devicestream_show')
+        g.custom_show_command('show', 'iot_hub_devicestream_show')
 
     with self.command_group('iot central app', iot_central_sdk, client_factory=iot_central_service_factory,
                             is_preview=True) as g:

--- a/src/azure-cli/azure/cli/command_modules/iotcentral/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iotcentral/commands.py
@@ -25,7 +25,7 @@ def load_command_table(self, _):
     with self.command_group('iotcentral app', iotcentral_sdk, client_factory=iotcentral_service_factory) as g:
         g.custom_command('create', 'iotcentral_app_create')
         g.custom_command('list', 'iotcentral_app_list')
-        g.custom_command('show', 'iotcentral_app_get')
+        g.custom_show_command('show', 'iotcentral_app_get')
         g.generic_update_command('update', getter_name='iotcentral_app_get',
                                  setter_name='iotcentral_app_update', command_type=update_custom_util)
         g.custom_command('delete', 'iotcentral_app_delete')

--- a/src/azure-cli/azure/cli/command_modules/managedservices/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/managedservices/commands.py
@@ -22,10 +22,10 @@ def load_command_table(self, _):
         g.custom_command('create', 'cli_definition_create')
         g.custom_command('list', 'cli_definition_list')
         g.custom_command('delete', 'cli_definition_delete')
-        g.custom_command('show', 'cli_definition_get')
+        g.custom_show_command('show', 'cli_definition_get')
 
     with self.command_group('managedservices assignment', msp_registration_assignments, client_factory=cf_registration_assignments) as g:
         g.custom_command('create', 'cli_assignment_create')
-        g.custom_command('show', 'cli_assignment_get')
+        g.custom_show_command('show', 'cli_assignment_get')
         g.custom_command('delete', 'cli_assignment_delete')
         g.custom_command('list', 'cli_assignment_list')

--- a/src/azure-cli/azure/cli/command_modules/monitor/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/commands.py
@@ -375,7 +375,7 @@ def load_command_table(self, _):
         g.custom_command('create', 'create_metric_alert', custom_command_type=alert_custom)
         g.command('delete', 'delete')
         g.custom_command('list', 'list_metric_alerts', custom_command_type=alert_custom)
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.generic_update_command('update', custom_func_name='update_metric_alert', custom_func_type=alert_custom)
 
     with self.command_group('monitor log-analytics workspace', log_analytics_workspace_sdk, custom_command_type=log_analytics_workspace_custom) as g:

--- a/src/azure-cli/azure/cli/command_modules/network/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/commands.py
@@ -462,7 +462,7 @@ def load_command_table(self, _):
 
     with self.command_group('network application-gateway rewrite-rule', network_ag_sdk, min_api='2018-12-01') as g:
         g.custom_command('create', 'create_ag_rewrite_rule', supports_no_wait=True)
-        g.custom_command('show', 'show_ag_rewrite_rule')
+        g.custom_show_command('show', 'show_ag_rewrite_rule')
         g.custom_command('list', 'list_ag_rewrite_rules')
         g.custom_command('delete', 'delete_ag_rewrite_rule', supports_no_wait=True)
         g.generic_update_command('update', command_type=network_ag_sdk, supports_no_wait=True,
@@ -473,7 +473,7 @@ def load_command_table(self, _):
 
     with self.command_group('network application-gateway rewrite-rule condition', network_ag_sdk, min_api='2018-12-01') as g:
         g.custom_command('create', 'create_ag_rewrite_rule_condition', supports_no_wait=True)
-        g.custom_command('show', 'show_ag_rewrite_rule_condition')
+        g.custom_show_command('show', 'show_ag_rewrite_rule_condition')
         g.custom_command('list', 'list_ag_rewrite_rule_conditions')
         g.custom_command('delete', 'delete_ag_rewrite_rule_condition', supports_no_wait=True)
         g.generic_update_command('update', command_type=network_ag_sdk, supports_no_wait=True,
@@ -1198,7 +1198,7 @@ def load_command_table(self, _):
 
     with self.command_group('network vnet-gateway aad', network_vgw_sdk, min_api='2019-04-01') as g:
         g.custom_command('assign', 'assign_vnet_gateway_aad', supports_no_wait=True)
-        g.custom_command('show', 'show_vnet_gateway_aad')
+        g.custom_show_command('show', 'show_vnet_gateway_aad')
         g.custom_command('remove', 'remove_vnet_gateway_aad', supports_no_wait=True)
     # endregion
 

--- a/src/azure-cli/azure/cli/command_modules/policyinsights/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/policyinsights/commands.py
@@ -53,4 +53,4 @@ def load_command_table(self, _):
 
     with self.command_group('policy metadata', policy_metadata_sdk, client_factory=policy_metadata_operations) as g:
         g.custom_command('list', 'list_policy_metadata')
-        g.custom_command('show', 'show_policy_metadata')
+        g.custom_show_command('show', 'show_policy_metadata')

--- a/src/azure-cli/azure/cli/command_modules/redis/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/commands.py
@@ -36,24 +36,24 @@ def load_command_table(self, _):
         g.custom_command('list', 'cli_redis_list_cache')
         g.command('list-keys', 'list_keys')
         g.command('regenerate-keys', 'regenerate_key')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.generic_update_command('update', setter_name='update', custom_func_name='cli_redis_update')
 
     with self.command_group('redis patch-schedule', redis_patch) as g:
         g.command('create', 'create_or_update')
         g.command('update', 'create_or_update')
         g.command('delete', 'delete')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
 
     with self.command_group('redis firewall-rules', redis_firewall_rules) as g:
         g.command('create', 'create_or_update')
         g.command('update', 'create_or_update')
         g.command('delete', 'delete')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('list', 'list_by_redis_resource')
 
     with self.command_group('redis server-link', redis_linked_server) as g:
         g.custom_command('create', 'cli_redis_create_server_link', client_factory=cf_linked_server)
         g.command('delete', 'delete')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('list', 'list')

--- a/src/azure-cli/azure/cli/command_modules/role/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/role/commands.py
@@ -188,7 +188,7 @@ def load_command_table(self, _):
 
     with self.command_group('ad signed-in-user', signed_in_users_sdk, exception_handler=graph_err_handler,
                             transform=transform_graph_objects_with_cred) as g:
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.custom_command('list-owned-objects', 'list_owned_objects', client_factory=get_graph_client_signed_in_users)
 
     with self.command_group('ad group', role_group_sdk, exception_handler=graph_err_handler) as g:

--- a/src/azure-cli/azure/cli/command_modules/security/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/security/commands.py
@@ -186,50 +186,50 @@ def load_command_table(self, _):
                             security_regulatory_compliance_standards_sdk,
                             client_factory=cf_security_regulatory_compliance_standards) as g:
         g.custom_command('list', 'list_regulatory_compliance_standards')
-        g.custom_command('show', 'get_regulatory_compliance_standard')
+        g.custom_show_command('show', 'get_regulatory_compliance_standard')
 
     with self.command_group('security regulatory-compliance-controls',
                             security_regulatory_compliance_controls_sdk,
                             client_factory=cf_security_regulatory_compliance_control) as g:
         g.custom_command('list', 'list_regulatory_compliance_controls')
-        g.custom_command('show', 'get_regulatory_compliance_control')
+        g.custom_show_command('show', 'get_regulatory_compliance_control')
 
     with self.command_group('security regulatory-compliance-assessments',
                             security_regulatory_compliance_assessment_sdk,
                             client_factory=cf_security_regulatory_compliance_assessment) as g:
         g.custom_command('list', 'list_regulatory_compliance_assessments')
-        g.custom_command('show', 'get_regulatory_compliance_assessment')
+        g.custom_show_command('show', 'get_regulatory_compliance_assessment')
 
     with self.command_group('security task',
                             security_tasks_sdk,
                             client_factory=cf_security_tasks) as g:
         g.custom_command('list', 'list_security_tasks')
-        g.custom_command('show', 'get_security_task')
+        g.custom_show_command('show', 'get_security_task')
 
     with self.command_group('security atp storage',
                             security_advanced_threat_protection_sdk,
                             client_factory=cf_security_advanced_threat_protection) as g:
-        g.custom_command('show', 'get_atp_setting')
+        g.custom_show_command('show', 'get_atp_setting')
         g.custom_command('update', 'update_atp_setting')
 
     with self.command_group('security alert',
                             security_alerts_sdk,
                             client_factory=cf_security_alerts) as g:
         g.custom_command('list', 'list_security_alerts')
-        g.custom_command('show', 'get_security_alert')
+        g.custom_show_command('show', 'get_security_alert')
         g.custom_command('update', 'update_security_alert')
 
     with self.command_group('security setting',
                             security_settings_sdk,
                             client_factory=cf_security_settings) as g:
         g.custom_command('list', 'list_security_settings')
-        g.custom_command('show', 'get_security_setting')
+        g.custom_show_command('show', 'get_security_setting')
 
     with self.command_group('security contact',
                             security_contacts_sdk,
                             client_factory=cf_security_contacts) as g:
         g.custom_command('list', 'list_security_contacts')
-        g.custom_command('show', 'get_security_contact')
+        g.custom_show_command('show', 'get_security_contact')
         g.custom_command('create', 'create_security_contact')
         g.custom_command('delete', 'delete_security_contact')
 
@@ -237,51 +237,51 @@ def load_command_table(self, _):
                             security_auto_provisioning_settings_sdk,
                             client_factory=cf_security_auto_provisioning_settings) as g:
         g.custom_command('list', 'list_security_auto_provisioning_settings')
-        g.custom_command('show', 'get_security_auto_provisioning_setting')
+        g.custom_show_command('show', 'get_security_auto_provisioning_setting')
         g.custom_command('update', 'update_security_auto_provisioning_setting')
 
     with self.command_group('security discovered-security-solution',
                             security_discovered_security_solutions_sdk,
                             client_factory=cf_security_discovered_security_solutions) as g:
         g.custom_command('list', 'list_security_discovered_security_solutions')
-        g.custom_command('show', 'get_security_discovered_security_solution')
+        g.custom_show_command('show', 'get_security_discovered_security_solution')
 
     with self.command_group('security external-security-solution',
                             security_external_security_solutions_sdk,
                             client_factory=cf_security_external_security_solutions) as g:
         g.custom_command('list', 'list_security_external_security_solutions')
-        g.custom_command('show', 'get_security_external_security_solution')
+        g.custom_show_command('show', 'get_security_external_security_solution')
 
     with self.command_group('security jit-policy',
                             security_jit_network_access_policies_sdk,
                             client_factory=cf_security_jit_network_access_policies) as g:
         g.custom_command('list', 'list_security_jit_network_access_policies')
-        g.custom_command('show', 'get_security_jit_network_access_policy')
+        g.custom_show_command('show', 'get_security_jit_network_access_policy')
 
     with self.command_group('security location',
                             security_locations_sdk,
                             client_factory=cf_security_locations) as g:
         g.custom_command('list', 'list_security_locations')
-        g.custom_command('show', 'get_security_location')
+        g.custom_show_command('show', 'get_security_location')
 
     with self.command_group('security pricing',
                             security_pricings_sdk,
                             client_factory=cf_security_pricings) as g:
         g.custom_command('list', 'list_security_pricings')
-        g.custom_command('show', 'get_security_pricing')
+        g.custom_show_command('show', 'get_security_pricing')
         g.custom_command('create', 'create_security_pricing')
 
     with self.command_group('security topology',
                             security_topology_sdk,
                             client_factory=cf_security_topology) as g:
         g.custom_command('list', 'list_security_topology')
-        g.custom_command('show', 'get_security_topology')
+        g.custom_show_command('show', 'get_security_topology')
 
     with self.command_group('security workspace-setting',
                             security_workspace_settings_sdk,
                             client_factory=cf_security_workspace_settings) as g:
         g.custom_command('list', 'list_security_workspace_settings')
-        g.custom_command('show', 'get_security_workspace_setting')
+        g.custom_show_command('show', 'get_security_workspace_setting')
         g.custom_command('create', 'create_security_workspace_setting')
         g.custom_command('delete', 'delete_security_workspace_setting')
 
@@ -289,7 +289,7 @@ def load_command_table(self, _):
                             security_assessment_sdk,
                             client_factory=cf_security_assessment) as g:
         g.custom_command('list', 'list_security_assessments')
-        g.custom_command('show', 'get_security_assessment')
+        g.custom_show_command('show', 'get_security_assessment')
         g.custom_command('create', 'create_security_assessment')
         g.custom_command('delete', 'delete_security_assessment')
 
@@ -297,7 +297,7 @@ def load_command_table(self, _):
                             security_assessment_metadata_sdk,
                             client_factory=cf_security_assessment_metadata) as g:
         g.custom_command('list', 'list_security_assessment_metadata')
-        g.custom_command('show', 'get_security_assessment_metadata')
+        g.custom_show_command('show', 'get_security_assessment_metadata')
         g.custom_command('create', 'create_security_assessment_metadata')
         g.custom_command('delete', 'delete_security_assessment_metadata')
 
@@ -305,25 +305,25 @@ def load_command_table(self, _):
                             security_sub_assessment_sdk,
                             client_factory=cf_security_sub_assessment) as g:
         g.custom_command('list', 'list_security_sub_assessments')
-        g.custom_command('show', 'get_security_sub_assessment')
+        g.custom_show_command('show', 'get_security_sub_assessment')
 
     with self.command_group('security adaptive-application-controls',
                             security_adaptive_application_controls_sdk,
                             client_factory=cf_security_adaptive_application_controls) as g:
         g.custom_command('list', 'list_security_adaptive_application_controls')
-        g.custom_command('show', 'get_security_adaptive_application_controls')
+        g.custom_show_command('show', 'get_security_adaptive_application_controls')
 
     with self.command_group('security adaptive_network_hardenings',
                             security_adaptive_network_hardenings_sdk,
                             client_factory=cf_security_adaptive_network_hardenings) as g:
-        g.custom_command('show', 'get_security_adaptive_network_hardenings')
+        g.custom_show_command('show', 'get_security_adaptive_network_hardenings')
         g.custom_command('list', 'list_security_adaptive_network_hardenings')
 
     with self.command_group('security allowed_connections',
                             security_allowed_connections_sdk,
                             client_factory=cf_security_allowed_connections) as g:
         g.custom_command('list', 'list_security_allowed_connections')
-        g.custom_command('show', 'get_security_allowed_connections')
+        g.custom_show_command('show', 'get_security_allowed_connections')
 
     with self.command_group('security iot-solution',
                             security_iot_solution_sdk,
@@ -338,7 +338,7 @@ def load_command_table(self, _):
                             security_iot_analytics_sdk,
                             client_factory=cf_security_iot_analytics) as g:
         g.custom_command('list', 'list_security_iot_analytics')
-        g.custom_command('show', 'show_security_iot_analytics')
+        g.custom_show_command('show', 'show_security_iot_analytics')
 
     with self.command_group('security iot-alerts',
                             security_iot_alerts_sdk,

--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -295,7 +295,7 @@ def load_command_table(self, _):
                             client_factory=get_sql_database_sensitivity_labels_operations) as g:
 
         g.command('list', 'list_current_by_database')
-        g.custom_command('show', 'db_sensitivity_label_show')
+        g.custom_show_command('show', 'db_sensitivity_label_show')
         g.command('delete', 'delete')
         g.custom_command('update', 'db_sensitivity_label_update')
 
@@ -392,7 +392,7 @@ def load_command_table(self, _):
         operations_tmpl='azure.mgmt.sql.operations#FailoverGroupsOperations.{}',
         client_factory=get_sql_failover_groups_operations)
     with self.command_group('sql failover-group', failover_groups_operations, client_factory=get_sql_failover_groups_operations) as g:
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('list', 'list_by_server')
         g.custom_command('create', 'failover_group_create')
         g.generic_update_command('update', custom_func_name='failover_group_update')
@@ -557,7 +557,7 @@ def load_command_table(self, _):
     with self.command_group('sql mi op', managed_instance_operations_operations) as g:
 
         g.command('list', 'list_by_managed_instance')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('cancel', 'cancel')
 
     managed_instances_operations = CliCommandType(
@@ -643,7 +643,7 @@ def load_command_table(self, _):
             'update_short_term_retention_mi',
             supports_no_wait=True,
             is_preview=True)
-        g.custom_command('show', 'get_short_term_retention_mi', is_preview=True)
+        g.custom_show_command('show', 'get_short_term_retention_mi', is_preview=True)
 
     managed_database_long_term_retention_policies_operations = CliCommandType(
         operations_tmpl='azure.mgmt.sql.operations#ManagedInstanceLongTermRetentionPoliciesOperations.{}',
@@ -663,7 +663,7 @@ def load_command_table(self, _):
     with self.command_group('sql midb ltr-backup',
                             managed_database_long_term_retention_backups_operations,
                             client_factory=get_sql_managed_database_long_term_retention_backups_operations) as g:
-        g.custom_command('show', 'get_long_term_retention_mi_backup', is_preview=True)
+        g.custom_show_command('show', 'get_long_term_retention_mi_backup', is_preview=True)
         g.custom_command(
             'list',
             'list_long_term_retention_mi_backups', is_preview=True)
@@ -703,7 +703,7 @@ def load_command_table(self, _):
         operations_tmpl='azure.mgmt.sql.operations#InstanceFailoverGroupsOperations.{}',
         client_factory=get_sql_instance_failover_groups_operations)
     with self.command_group('sql instance-failover-group', instance_failover_groups_operations, client_factory=get_sql_instance_failover_groups_operations) as g:
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.custom_command('create', 'instance_failover_group_create')
         g.generic_update_command('update', custom_func_name='instance_failover_group_update')
         g.command('delete', 'delete')

--- a/src/azure-cli/azure/cli/command_modules/sqlvm/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sqlvm/commands.py
@@ -38,7 +38,7 @@ def load_command_table(self, _):
                             sqlvm_vm_operations,
                             client_factory=get_sqlvirtualmachine_sql_virtual_machines_operations) as g:
         g.generic_update_command('update', custom_func_name='sqlvm_update', transform=transform_sqlvm_output)
-        g.command('show', 'get', transform=transform_sqlvm_output)
+        g.show_command('show', 'get', transform=transform_sqlvm_output)
         g.custom_command('list', 'sqlvm_list', transform=transform_sqlvm_list)
         g.custom_command('add-to-group', 'sqlvm_add_to_group', transform=transform_sqlvm_output)
         g.custom_command('remove-from-group', 'sqlvm_remove_from_group', transform=transform_sqlvm_output)
@@ -58,7 +58,7 @@ def load_command_table(self, _):
                             sqlvm_group_operations,
                             client_factory=get_sqlvirtualmachine_sql_virtual_machine_groups_operations) as g:
         g.generic_update_command('update', custom_func_name='sqlvm_group_update', transform=transform_sqlvm_group_output)
-        g.command('show', 'get', transform=transform_sqlvm_group_output)
+        g.show_command('show', 'get', transform=transform_sqlvm_group_output)
         g.custom_command('list', 'sqlvm_group_list', transform=transform_sqlvm_group_list)
         g.command('delete', 'delete', confirmation=True)
         g.custom_command('create', 'sqlvm_group_create', transform=transform_sqlvm_group_output, table_transformer=deployment_validate_table_format, exception_handler=handle_template_based_exception)
@@ -76,7 +76,7 @@ def load_command_table(self, _):
                             sqlvm_agl_operations,
                             client_factory=get_sqlvirtualmachine_availability_group_listeners_operations) as g:
         g.generic_update_command('update', custom_func_name='aglistener_update', transform=transform_aglistener_output)
-        g.command('show', 'get', transform=transform_aglistener_output)
+        g.show_command('show', 'get', transform=transform_aglistener_output)
         g.command('list', 'list_by_group', transform=transform_aglistener_list)
         g.command('delete', 'delete', confirmation=True)
         g.custom_command('create', 'sqlvm_aglistener_create', transform=transform_aglistener_output, table_transformer=deployment_validate_table_format, exception_handler=handle_template_based_exception)

--- a/src/azure-cli/azure/cli/command_modules/storage/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands.py
@@ -195,7 +195,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                             resource_type=ResourceType.MGMT_STORAGE, min_api='2019-06-01') as g:
         from ._validators import validate_private_endpoint_connection_id
         g.command('delete', 'delete', confirmation=True, validator=validate_private_endpoint_connection_id)
-        g.command('show', 'get', validator=validate_private_endpoint_connection_id)
+        g.show_command('show', 'get', validator=validate_private_endpoint_connection_id)
         g.custom_command('approve', 'approve_private_endpoint_connection',
                          validator=validate_private_endpoint_connection_id)
         g.custom_command('reject', 'reject_private_endpoint_connection',

--- a/src/azure-cli/azure/cli/command_modules/storage/commands_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands_azure_stack.py
@@ -191,7 +191,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                             resource_type=ResourceType.MGMT_STORAGE, min_api='2019-06-01') as g:
         from ._validators import validate_private_endpoint_connection_id
         g.command('delete', 'delete', confirmation=True, validator=validate_private_endpoint_connection_id)
-        g.command('show', 'get', validator=validate_private_endpoint_connection_id)
+        g.show_command('show', 'get', validator=validate_private_endpoint_connection_id)
         g.custom_command('approve', 'approve_private_endpoint_connection',
                          validator=validate_private_endpoint_connection_id)
         g.custom_command('reject', 'reject_private_endpoint_connection',

--- a/src/azure-cli/azure/cli/command_modules/vm/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/commands.py
@@ -229,7 +229,7 @@ def load_command_table(self, _):
     with self.command_group('image builder', image_builder_image_templates_sdk, custom_command_type=image_builder_custom) as g:
         g.custom_command('create', 'create_image_template', supports_no_wait=True, supports_local_cache=True, validator=process_image_template_create_namespace)
         g.custom_command('list', 'list_image_templates')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('delete', 'delete')
         g.generic_update_command('update', 'create_or_update', supports_local_cache=True)  # todo Update fails for now as service does not support updates
         g.wait_command('wait')
@@ -459,7 +459,7 @@ def load_command_table(self, _):
 
     with self.command_group('sig', compute_galleries_sdk, operation_group='galleries', min_api='2018-06-01') as g:
         g.custom_command('create', 'create_image_gallery')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.custom_command('list', 'list_image_galleries')
         g.command('delete', 'delete')
         g.generic_update_command('update', setter_arg_name='gallery')
@@ -467,13 +467,13 @@ def load_command_table(self, _):
     with self.command_group('sig image-definition', compute_gallery_images_sdk, operation_group='gallery_images', min_api='2018-06-01') as g:
         g.custom_command('create', 'create_gallery_image')
         g.command('list', 'list_by_gallery')
-        g.command('show', 'get')
+        g.show_command('show', 'get')
         g.command('delete', 'delete')
         g.generic_update_command('update', setter_arg_name='gallery_image')
 
     with self.command_group('sig image-version', compute_gallery_image_versions_sdk, operation_group='gallery_image_versions', min_api='2018-06-01') as g:
         g.command('delete', 'delete')
-        g.command('show', 'get', table_transformer='{Name:name, ResourceGroup:resourceGroup, ProvisioningState:provisioningState, TargetRegions: publishingProfile.targetRegions && join(`, `, publishingProfile.targetRegions[*].name), ReplicationState:replicationStatus.aggregatedState}')
+        g.show_command('show', 'get', table_transformer='{Name:name, ResourceGroup:resourceGroup, ProvisioningState:provisioningState, TargetRegions: publishingProfile.targetRegions && join(`, `, publishingProfile.targetRegions[*].name), ReplicationState:replicationStatus.aggregatedState}')
         g.command('list', 'list_by_gallery_image')
         g.custom_command('create', 'create_image_version', supports_no_wait=True)
         g.generic_update_command('update', setter_arg_name='gallery_image_version', setter_name='update_image_version', setter_type=compute_custom, supports_no_wait=True)


### PR DESCRIPTION
`show` command should use `show_command` or `custom_show_command`.

Compared to `command` and `custom_command`, `show_command` and `custom_show_command` have extra error handler which should be harmless.
