### PR TITLE
[AKS] az aks install-cli: Add --kubelogin-version and --kubelogin-install-location arguments to install kubelogin

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -558,7 +558,7 @@ examples:
 
 helps['aks install-cli'] = """
 type: command
-short-summary: Download and install kubectl, the Kubernetes command-line tool.
+short-summary: Download and install kubectl, the Kubernetes command-line tool. Download and install kubelogin, a client-go credential (exec) plugin implementing azure authentication.
 """
 
 helps['aks install-connector'] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -17,7 +17,7 @@ from knack.arguments import CLIArgumentType
 from ._completers import (
     get_vm_size_completion_list, get_k8s_versions_completion_list, get_k8s_upgrades_completion_list)
 from ._validators import (
-    validate_create_parameters, validate_k8s_client_version, validate_k8s_version, validate_linux_host_name,
+    validate_create_parameters, validate_kubectl_version, validate_kubelogin_version, validate_k8s_version, validate_linux_host_name,
     validate_list_of_integers, validate_ssh_key, validate_connector_name, validate_max_pods, validate_nodes_count,
     validate_nodepool_name, validate_vm_set_type, validate_load_balancer_sku, validate_load_balancer_outbound_ips,
     validate_load_balancer_outbound_ip_prefixes, validate_taints, validate_ip_ranges, validate_acr, validate_nodepool_tags,
@@ -245,8 +245,10 @@ def load_arguments(self, _):
 
     for scope in ['aks', 'acs kubernetes', 'acs dcos']:
         with self.argument_context('{} install-cli'.format(scope)) as c:
-            c.argument('client_version', validator=validate_k8s_client_version, help='Version of the client to install.')
+            c.argument('client_version', validator=validate_kubectl_version, help='Version of kubectl to install.')
             c.argument('install_location', default=_get_default_install_location('kubectl'), help='Path at which to install kubectl.')
+            c.argument('kubelogin_version', validator=validate_kubelogin_version, help='Version of kubelogin to install.')
+            c.argument('kubelogin_install_location', default=_get_default_install_location('kubelogin'), help='Path at which to install kubelogin.')
 
     with self.argument_context('aks install-connector') as c:
         c.argument('aci_resource_group', help='The resource group to create the ACI container groups')

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -127,7 +127,7 @@ def validate_nodepool_name(namespace):
             raise CLIError('--nodepool-name should contain only alphanumeric characters')
 
 
-def validate_k8s_client_version(namespace):
+def validate_kubectl_version(namespace):
     """Validates a string as a possible Kubernetes version."""
     k8s_release_regex = re.compile(r'^[v|V]?(\d+\.\d+\.\d+.*|latest)$')
     found = k8s_release_regex.findall(namespace.client_version)
@@ -136,6 +136,17 @@ def validate_k8s_client_version(namespace):
     else:
         raise CLIError('--client-version should be the full version number '
                        '(such as "1.11.8" or "1.12.6") or "latest"')
+
+
+def validate_kubelogin_version(namespace):
+    """Validates a string as a possible kubelogin version."""
+    kubelogin_regex = re.compile(r'^[v|V]?(\d+\.\d+\.\d+.*|latest)$')
+    found = kubelogin_regex.findall(namespace.kubelogin_version)
+    if found:
+        namespace.kubelogin_version = found[0]
+    else:
+        raise CLIError('--kubelogin-version should be the full version number '
+                       '(such as "0.0.4") or "latest"')
 
 
 def validate_linux_host_name(namespace):

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -13,6 +13,7 @@ import os.path
 import platform
 import random
 import re
+import shutil
 import ssl
 import stat
 import string
@@ -277,6 +278,17 @@ def _urlretrieve(url, filename):
         f.write(req.read())
 
 
+def _unzip(src, dest):
+    logger.debug('Extracting %s to %s.', src, dest)
+    system = platform.system()
+    if system in ('Linux', 'Darwin', 'Windows'):
+        import zipfile
+        with zipfile.ZipFile(src, 'r') as zipObj:
+            zipObj.extractall(dest)
+    else:
+        raise CLIError('The current system is not supported.')
+
+
 def dcos_install_cli(cmd, install_location=None, client_version='1.8'):
     """
     Downloads the dcos command line from Mesosphere
@@ -307,8 +319,16 @@ def dcos_install_cli(cmd, install_location=None, client_version='1.8'):
         raise CLIError('Connection error while attempting to download client ({})'.format(err))
 
 
-def k8s_install_cli(cmd, client_version='latest', install_location=None):
-    """Install kubectl, a command-line interface for Kubernetes clusters."""
+def k8s_install_cli(cmd, client_version='latest', install_location=None,
+                    kubelogin_version='latest', kubelogin_install_location=None):
+    k8s_install_kubectl(cmd, client_version, install_location)
+    k8s_install_kubelogin(cmd, kubelogin_version, kubelogin_install_location)
+
+
+def k8s_install_kubectl(cmd, client_version='latest', install_location=None):
+    """
+    Install kubectl, a command-line interface for Kubernetes clusters.
+    """
 
     source_url = "https://storage.googleapis.com/kubernetes-release/release"
     cloud_name = cmd.cli_ctx.cloud.name
@@ -348,6 +368,73 @@ def k8s_install_cli(cmd, client_version='latest', install_location=None):
                  os.stat(install_location).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     except IOError as ex:
         raise CLIError('Connection error while attempting to download client ({})'.format(ex))
+
+    if system == 'Windows':  # be verbose, as the install_location likely not in Windows's search PATHs
+        env_paths = os.environ['PATH'].split(';')
+        found = next((x for x in env_paths if x.lower().rstrip('\\') == install_dir.lower()), None)
+        if not found:
+            # pylint: disable=logging-format-interpolation
+            logger.warning('Please add "{0}" to your search PATH so the `{1}` can be found. 2 options: \n'
+                           '    1. Run "set PATH=%PATH%;{0}" or "$env:path += \'{0}\'" for PowerShell. '
+                           'This is good for the current command session.\n'
+                           '    2. Update system PATH environment variable by following '
+                           '"Control Panel->System->Advanced->Environment Variables", and re-open the command window. '
+                           'You only need to do it once'.format(install_dir, cli))
+    else:
+        logger.warning('Please ensure that %s is in your search PATH, so the `%s` command can be found.',
+                       install_dir, cli)
+
+
+def k8s_install_kubelogin(cmd, client_version='latest', install_location=None):
+    """
+    Install kubelogin, a client-go credential (exec) plugin implementing azure authentication.
+    """
+
+    source_url = 'https://github.com/Azure/kubelogin/releases/download'
+    cloud_name = cmd.cli_ctx.cloud.name
+    if cloud_name.lower() == 'azurechinacloud':
+        source_url = 'https://mirror.azure.cn/kubernetes/kubelogin'
+
+    if client_version == 'latest':
+        context = _ssl_context()
+        latest_release_url = 'https://api.github.com/repos/Azure/kubelogin/releases/latest'
+        if cloud_name.lower() == 'azurechinacloud':
+            latest_release_url = 'https://mirror.azure.cn/kubernetes/kubelogin/latest'
+        latest_release = urlopen(latest_release_url, context=context).read()
+        client_version = json.loads(latest_release)['tag_name'].strip()
+    else:
+        client_version = "v%s" % client_version
+
+    base_url = source_url + '/{}/kubelogin.zip'
+    file_url = base_url.format(client_version)
+
+    # ensure installation directory exists
+    install_dir, cli = os.path.dirname(install_location), os.path.basename(install_location)
+    if not os.path.exists(install_dir):
+        os.makedirs(install_dir)
+
+    system = platform.system()
+    if system == 'Windows':
+        sub_dir, binary_name = 'windows_amd64', 'kubelogin.exe'
+    elif system == 'Linux':
+        # TODO: Support ARM CPU here
+        sub_dir, binary_name = 'linux_amd64', 'kubelogin'
+    elif system == 'Darwin':
+        sub_dir, binary_name = 'darwin_amd64', 'kubelogin'
+    else:
+        raise CLIError('Proxy server ({}) does not exist on the cluster.'.format(system))
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        try:
+            download_path = os.path.join(tmp_dir, 'kubelogin.zip')
+            logger.warning('Downloading client to "%s" from "%s"', download_path, file_url)
+            _urlretrieve(file_url, download_path)
+        except IOError as ex:
+            raise CLIError('Connection error while attempting to download client ({})'.format(ex))
+        _unzip(download_path, tmp_dir)
+        download_path = os.path.join(tmp_dir, 'bin', sub_dir, binary_name)
+        shutil.move(download_path, install_location)
+    os.chmod(install_location, os.stat(install_location).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     if system == 'Windows':  # be verbose, as the install_location likely not in Windows's search PATHs
         env_paths = os.environ['PATH'].split(';')

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -20,7 +20,8 @@ from azure.cli.command_modules.acs._params import (regions_in_preview,
 from azure.cli.command_modules.acs.custom import (merge_kubernetes_configurations, list_acs_locations,
                                                   _acs_browse_internal, _add_role_assignment, _get_default_dns_prefix,
                                                   create_application, _update_addons,
-                                                  _ensure_container_insights_for_monitoring, k8s_install_cli)
+                                                  _ensure_container_insights_for_monitoring,
+                                                  k8s_install_kubectl, k8s_install_kubelogin)
 from azure.mgmt.containerservice.models import (ContainerServiceOrchestratorTypes,
                                                 ContainerService,
                                                 ContainerServiceOrchestratorProfile)
@@ -640,32 +641,69 @@ class AcsCustomCommandTest(unittest.TestCase):
 
     @mock.patch('azure.cli.command_modules.acs.custom._urlretrieve')
     @mock.patch('azure.cli.command_modules.acs.custom.logger')
-    def test_k8s_install_cli_emit_warnings(self, logger_mock, mock_url_retrieve):
+    def test_k8s_install_kubectl_emit_warnings(self, logger_mock, mock_url_retrieve):
         mock_url_retrieve.side_effect = lambda _, install_location: open(install_location, 'a').close()
         try:
             temp_dir = tempfile.mkdtemp()  # tempfile.TemporaryDirectory() is no available on 2.7
-            test_location = os.path.join(temp_dir, 'kubectl.exe')
-            k8s_install_cli(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
+            test_location = os.path.join(temp_dir, 'kubectl')
+            k8s_install_kubectl(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
             self.assertEqual(mock_url_retrieve.call_count, 1)
             # 2 warnings, 1st for download result; 2nd for updating PATH
             self.assertEqual(logger_mock.warning.call_count, 2)  # 2 warnings, one for download result
-
-            if platform.system() == 'Windows':
-                # try again with install location in PATH, we should only get one more warning
-                os.environ['PATH'] += ';' + temp_dir
-                k8s_install_cli(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
-                self.assertEqual(logger_mock.warning.call_count, 3)
         finally:
             shutil.rmtree(temp_dir)
 
     @mock.patch('azure.cli.command_modules.acs.custom._urlretrieve')
     @mock.patch('azure.cli.command_modules.acs.custom.logger')
-    def test_k8s_install_cli_create_installation_dir(self, logger_mock, mock_url_retrieve):
+    def test_k8s_install_kubectl_create_installation_dir(self, logger_mock, mock_url_retrieve):
         mock_url_retrieve.side_effect = lambda _, install_location: open(install_location, 'a').close()
         try:
             temp_dir = tempfile.mkdtemp()  # tempfile.TemporaryDirectory() is no available on 2.7
-            test_location = os.path.join(temp_dir, 'foo', 'kubectl.exe')
-            k8s_install_cli(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
+            test_location = os.path.join(temp_dir, 'foo', 'kubectl')
+            k8s_install_kubectl(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
             self.assertTrue(os.path.exists(test_location))
         finally:
             shutil.rmtree(temp_dir)
+
+    @mock.patch('azure.cli.command_modules.acs.custom._urlretrieve')
+    @mock.patch('azure.cli.command_modules.acs.custom.logger')
+    def test_k8s_install_kubelogin_emit_warnings(self, logger_mock, mock_url_retrieve):
+        mock_url_retrieve.side_effect = create_kubelogin_zip
+        try:
+            temp_dir = tempfile.mkdtemp()  # tempfile.TemporaryDirectory() is no available on 2.7
+            test_location = os.path.join(temp_dir, 'kubelogin')
+            k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location)
+            self.assertEqual(mock_url_retrieve.call_count, 1)
+            # 2 warnings, 1st for download result; 2nd for updating PATH
+            self.assertEqual(logger_mock.warning.call_count, 2)  # 2 warnings, one for download result
+        finally:
+            shutil.rmtree(temp_dir)
+
+    @mock.patch('azure.cli.command_modules.acs.custom._urlretrieve')
+    @mock.patch('azure.cli.command_modules.acs.custom.logger')
+    def test_k8s_install_kubelogin_create_installation_dir(self, logger_mock, mock_url_retrieve):
+        mock_url_retrieve.side_effect = create_kubelogin_zip
+        try:
+            temp_dir = tempfile.mkdtemp()  # tempfile.TemporaryDirectory() is no available on 2.7
+            test_location = os.path.join(temp_dir, 'foo', 'kubelogin')
+            k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location)
+            self.assertTrue(os.path.exists(test_location))
+        finally:
+            shutil.rmtree(temp_dir)
+
+
+def create_kubelogin_zip(file_url, download_path):
+    import zipfile
+    try:
+        cwd = os.getcwd()
+        temp_dir = tempfile.mkdtemp()
+        os.chdir(temp_dir)
+        bin_dir = 'bin/linux_amd64'
+        os.makedirs(bin_dir)
+        bin_location = os.path.join(bin_dir, 'kubelogin')
+        open(bin_location, 'a').close()
+        with zipfile.ZipFile(download_path, 'w', zipfile.ZIP_DEFLATED) as outZipFile:
+            outZipFile.write(bin_location)
+    finally:
+        os.chdir(cwd)
+        shutil.rmtree(temp_dir)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR is to install `kubelogin` using `az aks install-cli`. The user can use `--kubelogin-version` and `--kubelogin-install-location` to specify the kubelogin version and install location.

**Testing Guide**  
<!--Example commands with explanations.-->

1. Run `az aks install-cli`.
2. kubelogin will be installed.
3. Run `kubelogin -h` to check the version.
4. Run `which kubelogin` to check the install location.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
