### PR TITLE
{CI} Pin azdev to latest version

### DIFF
--- a/.azure-pipelines/templates/automation_test.yml
+++ b/.azure-pipelines/templates/automation_test.yml
@@ -7,7 +7,7 @@ steps:
     inputs:
       versionSpec: ${{ parameters.pythonVersion }}
       displayName: "Use Python ${{ parameters.pythonVersion }}"
-  - template: .azure-pipelines/templates/azdev_setup.yml
+  - template: ./azdev_setup.yml
   - bash: |
       set -ev
 

--- a/.azure-pipelines/templates/automation_test.yml
+++ b/.azure-pipelines/templates/automation_test.yml
@@ -7,18 +7,7 @@ steps:
     inputs:
       versionSpec: ${{ parameters.pythonVersion }}
       displayName: "Use Python ${{ parameters.pythonVersion }}"
-  - bash: |
-      set -ev
-
-      python -m venv env
-      chmod +x env/bin/activate
-      source env/bin/activate
-
-      pip install -q azdev
-      azdev --version
-
-      azdev setup -c ./
-    displayName: Setup Env
+  - template: .azure-pipelines/templates/azdev_setup.yml
   - bash: |
       set -ev
 

--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -14,7 +14,7 @@ steps:
       chmod +x env/bin/activate
       . env/bin/activate
 
-      pip install -q azdev
+      pip install -q azdev=0.1.22
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then

--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -14,7 +14,7 @@ steps:
       chmod +x env/bin/activate
       . env/bin/activate
 
-      pip install -q azdev=0.1.22
+      pip install -q azdev==0.1.22
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then


### PR DESCRIPTION
There is a PR https://github.com/Azure/azure-cli/pull/14438 that we have to release azdev and fix CI at the same time. I don't want to create a broken status for our CI system. Let's pin azdev version first.