### PR TITLE
[CloudShell] Capture HTTPError 400 in Cloud Shell

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -389,10 +389,17 @@ class Profile:
 
     def _get_token_from_cloud_shell(self, resource):  # pylint: disable=no-self-use
         from azure.cli.core.adal_authentication import MSIAuthenticationWrapper
-        auth = MSIAuthenticationWrapper(resource=resource)
-        auth.set_token()
-        token_entry = auth.token
-        return (token_entry['token_type'], token_entry['access_token'], token_entry)
+        import requests
+        try:
+            auth = MSIAuthenticationWrapper(resource=resource)
+            auth.set_token()
+            token_entry = auth.token
+            return (token_entry['token_type'], token_entry['access_token'], token_entry)
+        except requests.exceptions.HTTPError:
+            import traceback
+            msg = "Failed to retrieve a token in Cloud Shell for resource {}. Please run `az login` and try again.\n\n" \
+                  "{}".format(resource, traceback.format_exc())
+            raise CLIError(msg)
 
     def _set_subscriptions(self, new_subscriptions, merge=True, secondary_key_name=None):
 

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -397,8 +397,8 @@ class Profile:
             return (token_entry['token_type'], token_entry['access_token'], token_entry)
         except requests.exceptions.HTTPError:
             import traceback
-            msg = "Failed to retrieve a token in Cloud Shell for resource {}. Please run `az login` and try again.\n\n" \
-                  "{}".format(resource, traceback.format_exc())
+            msg = "Failed to retrieve a token in Cloud Shell for resource {}. Please run `az login` and try " \
+                  "again.\n\n{}".format(resource, traceback.format_exc())
             raise CLIError(msg)
 
     def _set_subscriptions(self, new_subscriptions, merge=True, secondary_key_name=None):


### PR DESCRIPTION
## Description

This is _temporary_ mitigation for #12757: **Cloud Shell fails with `400 Client Error` for non-supported resources/audiences/scopes**, like

- `https://ossrdbms-aad.database.windows.net`
- `https://digitaltwins.azure.net`

Currently Azure CLI will show an ugly error message:

```
$ az account get-access-token --resource https://digitaltwins.azure.net

The command failed with an unexpected error. Here is the traceback:

400 Client Error: Bad Request for url: http://localhost:50342/oauth2/token
Traceback (most recent call last):
  File "/home/user1/env383/lib/python3.8/site-packages/knack/cli.py", line 215, in invoke
    cmd_result = self.invocation.execute(args)
  ...
  File "/home/user1/azure-cli/src/azure-cli-core/azure/cli/core/_profile.py", line 392, in _get_token_from_cloud_shell
    auth = MSIAuthenticationWrapper(resource=resource)
  File "/home/user1/env383/lib/python3.8/site-packages/msrestazure/azure_active_directory.py", line 592, in __init__
    self.set_token()
  File "/home/user1/env383/lib/python3.8/site-packages/msrestazure/azure_active_directory.py", line 598, in set_token
    self.scheme, _, self.token = get_msi_token(self.resource, self.port, self.msi_conf)
  File "/home/user1/env383/lib/python3.8/site-packages/msrestazure/azure_active_directory.py", line 486, in get_msi_token
    result.raise_for_status()
  File "/home/user1/env383/lib/python3.8/site-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: http://localhost:50342/oauth2/token
```

With this PR, an instruction is shown as a workaround:

> Failed to retrieve a token in Cloud Shell for resource https://digitaltwins.azure.net. Please run `az login` and try again.

```
$ az account get-access-token --resource https://digitaltwins.azure.net
Failed to retrieve a token in Cloud Shell for resource https://digitaltwins.azure.net. Please run `az login` and try again.

Traceback (most recent call last):
  File "/home/user1/azure-cli/src/azure-cli-core/azure/cli/core/_profile.py", line 394, in _get_token_from_cloud_shell
    auth = MSIAuthenticationWrapper(resource=resource)
  File "/home/user1/env383/lib/python3.8/site-packages/msrestazure/azure_active_directory.py", line 592, in __init__
    self.set_token()
  File "/home/user1/env383/lib/python3.8/site-packages/msrestazure/azure_active_directory.py", line 598, in set_token
    self.scheme, _, self.token = get_msi_token(self.resource, self.port, self.msi_conf)
  File "/home/user1/env383/lib/python3.8/site-packages/msrestazure/azure_active_directory.py", line 486, in get_msi_token
    result.raise_for_status()
  File "/home/user1/env383/lib/python3.8/site-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: http://localhost:50342/oauth2/token
```

However, this is only a temporarily fix. **For long-term, Cloud Shell needs to remove the allowlist and make all resources/audiences/scopes available.**

⚠ Side effect: This will hide **intermittent 400 failures for supported resources** (#11749) , such as `https://management.core.windows.net/`. If the user follows the instruction to run `az login` as a workaround, the actual problem will be unreported. So I am not sure if this PR is a good choice.

## Testing Guide

In Cloud Shell, follow #13567 to install Python 3.8 and checkout Azure CLI from source code. Then run 

```
az account get-access-token --resource https://digitaltwins.azure.net
```
