### PR TITLE
{App Service} Bugfix: az webapp create error when name is a substring of existing webapp

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
@@ -305,7 +305,7 @@ def get_site_availability(cmd, name):
 
 def get_app_details(cmd, name):
     client = web_client_factory(cmd.cli_ctx)
-    data = (list(filter(lambda x: name.lower() in x.name.lower(), client.web_apps.list())))
+    data = (list(filter(lambda x: name.lower() == x.name.lower(), client.web_apps.list())))
     _num_items = len(data)
     if _num_items > 0:
         return data[0]


### PR DESCRIPTION
**Description<!--Mandatory-->**  

When creating a webapp with a name that is a substring of an existing webapp in your subscription, CLI throws error:

`Webapp 'name_that_is_substring' already exists. The command will use the existing app's settings.
Cannot acquire exclusive lock to create, update or delete this site. Retry the request later.`

This is due to CLI using 'in' instead of '==' when comparing app names, and CLI thinks the app with the name that is a substring already exists when it doesn't. 

**Testing Guide**  
- Creating two webapps, with second webapp name as a substring of first webapp name (ex. TestApp1, TestApp) should work. Currently, if you create webapp TestApp1 then try to create TestApp, the command thinks TestApp exists already since it's a substring of TestApp1. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
