### PR TITLE
[Backup] Trigger AFS container/item discovery only when needed

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
@@ -42,18 +42,18 @@ def enable_for_AzureFileShare(cmd, client, resource_group_name, vault_name, afs_
             # refresh containers in the vault
             protection_containers_client = protection_containers_cf(cmd.cli_ctx)
             filter_string = helper.get_filter_string({'backupManagementType': "AzureStorage"})
-            
-            refresh_result = protection_containers_client.refresh(vault_name, resource_group_name, fabric_name, 
+
+            refresh_result = protection_containers_client.refresh(vault_name, resource_group_name, fabric_name,
                                                                   filter=filter_string, raw=True)
             helper.track_refresh_operation(cmd.cli_ctx, refresh_result, vault_name, resource_group_name)
-            
+
             # refetch the protectable containers after refresh
             unregistered_containers = list_protectable_containers(cmd.cli_ctx, resource_group_name, vault_name)
             storage_account = _get_storage_account_from_list(unregistered_containers, storage_account_name)
-            
+
             if storage_account is None:
                 raise CLIError("Storage account not found or not supported.")
-            
+
         # register storage account
         protection_containers_client = protection_containers_cf(cmd.cli_ctx)
         properties = AzureStorageContainer(backup_management_type="AzureStorage",
@@ -104,18 +104,19 @@ def _get_protectable_item_for_afs(cli_ctx, vault_name, resource_group_name, afs_
 
     protectable_item = _try_get_protectable_item_for_afs(cli_ctx, vault_name, resource_group_name,
                                                          afs_name, storage_account_name)
-    
+
     if protectable_item is None:
-        
+
         filter_string = helper.get_filter_string({'workloadType': "AzureFileShare"})
         result = protection_containers_client.inquire(vault_name, resource_group_name, fabric_name,
                                                       storage_account.name, filter=filter_string, raw=True)
-        
+
         helper.track_inquiry_operation(cli_ctx, result, vault_name, resource_group_name, storage_account.name)
-        
+
         protectable_item = _try_get_protectable_item_for_afs(cli_ctx, vault_name, resource_group_name, afs_name,
                                                              storage_account_name)
     return protectable_item
+
 
 def _try_get_protectable_item_for_afs(cli_ctx, vault_name, resource_group_name, afs_name, storage_account_name):
     backup_protectable_items_client = backup_protectable_items_cf(cli_ctx)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_afs.py
@@ -26,28 +26,34 @@ workload_type = "AzureFileShare"
 
 def enable_for_AzureFileShare(cmd, client, resource_group_name, vault_name, afs_name,
                               storage_account_name, policy_name):
-    # refresh containers in the vault
-    protection_containers_client = protection_containers_cf(cmd.cli_ctx)
-    filter_string = helper.get_filter_string({
-        'backupManagementType': "AzureStorage"})
-
-    refresh_result = protection_containers_client.refresh(vault_name, resource_group_name, fabric_name,
-                                                          filter=filter_string, raw=True)
-    helper.track_refresh_operation(cmd.cli_ctx, refresh_result, vault_name, resource_group_name)
 
     # get registered storage accounts
     storage_account = None
     containers_client = backup_protection_containers_cf(cmd.cli_ctx)
     registered_containers = common.list_containers(containers_client, resource_group_name, vault_name, "AzureStorage")
     storage_account = _get_storage_account_from_list(registered_containers, storage_account_name)
+
     # get unregistered storage accounts
     if storage_account is None:
         unregistered_containers = list_protectable_containers(cmd.cli_ctx, resource_group_name, vault_name)
         storage_account = _get_storage_account_from_list(unregistered_containers, storage_account_name)
 
         if storage_account is None:
-            raise CLIError("Storage account not found or not supported.")
-
+            # refresh containers in the vault
+            protection_containers_client = protection_containers_cf(cmd.cli_ctx)
+            filter_string = helper.get_filter_string({'backupManagementType': "AzureStorage"})
+            
+            refresh_result = protection_containers_client.refresh(vault_name, resource_group_name, fabric_name, 
+                                                                  filter=filter_string, raw=True)
+            helper.track_refresh_operation(cmd.cli_ctx, refresh_result, vault_name, resource_group_name)
+            
+            # refetch the protectable containers after refresh
+            unregistered_containers = list_protectable_containers(cmd.cli_ctx, resource_group_name, vault_name)
+            storage_account = _get_storage_account_from_list(unregistered_containers, storage_account_name)
+            
+            if storage_account is None:
+                raise CLIError("Storage account not found or not supported.")
+            
         # register storage account
         protection_containers_client = protection_containers_cf(cmd.cli_ctx)
         properties = AzureStorageContainer(backup_management_type="AzureStorage",
@@ -95,21 +101,21 @@ def _get_backup_request(retain_until):
 def _get_protectable_item_for_afs(cli_ctx, vault_name, resource_group_name, afs_name, storage_account):
     storage_account_name = storage_account.name
     protection_containers_client = protection_containers_cf(cli_ctx)
+
     protectable_item = _try_get_protectable_item_for_afs(cli_ctx, vault_name, resource_group_name,
                                                          afs_name, storage_account_name)
-    filter_string = helper.get_filter_string({
-        'workloadType': "AzureFileShare"})
-
+    
     if protectable_item is None:
+        
+        filter_string = helper.get_filter_string({'workloadType': "AzureFileShare"})
         result = protection_containers_client.inquire(vault_name, resource_group_name, fabric_name,
                                                       storage_account.name, filter=filter_string, raw=True)
-
+        
         helper.track_inquiry_operation(cli_ctx, result, vault_name, resource_group_name, storage_account.name)
-
-    protectable_item = _try_get_protectable_item_for_afs(cli_ctx, vault_name, resource_group_name, afs_name,
-                                                         storage_account_name)
+        
+        protectable_item = _try_get_protectable_item_for_afs(cli_ctx, vault_name, resource_group_name, afs_name,
+                                                             storage_account_name)
     return protectable_item
-
 
 def _try_get_protectable_item_for_afs(cli_ctx, vault_name, resource_group_name, afs_name, storage_account_name):
     backup_protectable_items_client = backup_protectable_items_cf(cli_ctx)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
 Improving AFS container/item discovery experience
       * Now Discover protection containers only when it's not already registered/discovered.
       * Trigger item inquiry only if it is not already discovered.

**Testing Guide**  
<!--Example commands with explanations.-->
az backup protection enable-for-azurefileshare --azure-file-share fileShareName -p policyName --storage-account stAccName -g resourceGroupName -v vaultName

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [Yes] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [Yes] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
