### PR TITLE
{Profile} az login: Refine error message when tenant is not found

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -998,3 +998,12 @@ def get_linux_distro():
             release_info[k.lower()] = v.strip('"')
 
     return release_info.get('name', None), release_info.get('version_id', None)
+
+
+def is_guid(guid):
+    import uuid
+    try:
+        uuid.UUID(guid)
+        return True
+    except ValueError:
+        return False

--- a/src/azure-cli/azure/cli/command_modules/profile/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_validators.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import uuid
-
 from azure.cli.core.util import should_disable_connection_verify
 from knack.log import get_logger
 

--- a/src/azure-cli/azure/cli/command_modules/profile/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_validators.py
@@ -11,20 +11,13 @@ from knack.log import get_logger
 logger = get_logger(__name__)
 
 
-def _is_guid(guid):
-    try:
-        uuid.UUID(guid)
-        return True
-    except ValueError:
-        return False
-
-
 def validate_tenant(cmd, namespace):
     """
     Make sure tenant is a GUID. If domain name is provided, resolve to GUID.
     https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#fetch-the-openid-connect-metadata-document
     """
-    if namespace.tenant is not None and not _is_guid(namespace.tenant):
+    from azure.cli.core.util import is_guid
+    if namespace.tenant is not None and not is_guid(namespace.tenant):
         import requests
         active_directory_endpoint = cmd.cli_ctx.cloud.endpoints.active_directory
         url = '{}/{}/.well-known/openid-configuration'.format(active_directory_endpoint, namespace.tenant)

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -8,6 +8,7 @@ import mock
 
 from azure.cli.command_modules.profile.custom import list_subscriptions, get_access_token, login
 from azure.cli.core.mock import DummyCli
+from knack.util import CLIError
 
 
 class ProfileCommandTest(unittest.TestCase):
@@ -111,3 +112,42 @@ class ProfileCommandTest(unittest.TestCase):
 
         # assert
         self.assertTrue(invoked)
+
+    def test_login_validate_tenant(self):
+        from azure.cli.command_modules.profile._validators import validate_tenant
+
+        cmd = mock.MagicMock()
+        cmd.cli_ctx = DummyCli()
+        namespace = mock.MagicMock()
+
+        microsoft_tenant_id = '72f988bf-86f1-41af-91ab-2d7cd011db47'
+
+        # Test tenant is unchanged for None
+        namespace.tenant = None
+        validate_tenant(cmd, namespace)
+        self.assertEqual(namespace.tenant, None)
+
+        # Test tenant is unchanged for GUID
+        namespace.tenant = microsoft_tenant_id
+        validate_tenant(cmd, namespace)
+        self.assertEqual(namespace.tenant, microsoft_tenant_id)
+
+        # Test tenant is resolved for canonical name
+        namespace.tenant = "microsoft.onmicrosoft.com"
+        validate_tenant(cmd, namespace)
+        self.assertEqual(namespace.tenant, microsoft_tenant_id)
+
+        # Test tenant is resolved for domain name
+        namespace.tenant = "microsoft.com"
+        validate_tenant(cmd, namespace)
+        self.assertEqual(namespace.tenant, microsoft_tenant_id)
+
+        # Test error is raised for non-existing tenant
+        namespace.tenant = "non-existing-tenant"
+        with self.assertRaisesRegex(CLIError, 'Failed to resolve tenant'):
+            validate_tenant(cmd, namespace)
+
+        # Test error is raised for non-existing tenant
+        namespace.tenant = "non-existing-tenant.onmicrosoft.com"
+        with self.assertRaisesRegex(CLIError, 'Failed to resolve tenant'):
+            validate_tenant(cmd, namespace)

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1714,14 +1714,6 @@ def _resolve_object_id(cli_ctx, assignee, fallback_to_object_id=False):
         raise
 
 
-def is_guid(guid):
-    try:
-        uuid.UUID(guid)
-        return True
-    except ValueError:
-        return False
-
-
 def _get_object_stubs(graph_client, assignees):
     from azure.graphrbac.models import GetObjectsParameters
     result = []

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -24,7 +24,7 @@ from knack.util import CLIError, todict
 from azure.cli.core.profiles import ResourceType, get_api_version
 from azure.graphrbac.models import GraphErrorException
 
-from azure.cli.core.util import get_file_json, shell_safe_json_parse
+from azure.cli.core.util import get_file_json, shell_safe_json_parse, is_guid
 
 from azure.graphrbac.models import (ApplicationCreateParameters, ApplicationUpdateParameters, AppRole,
                                     PasswordCredential, KeyCredential, UserCreateParameters, PasswordProfile,
@@ -373,7 +373,7 @@ def _backfill_assignments_for_co_admins(cli_ctx, auth_client, assignee=None):
     co_admins = [x for x in co_admins if x.email_address]
     graph_client = _graph_client_factory(cli_ctx)
     if assignee:  # apply assignee filter if applicable
-        if _is_guid(assignee):
+        if is_guid(assignee):
             try:
                 result = _get_object_stubs(graph_client, [assignee])
                 if not result:
@@ -518,7 +518,7 @@ def _resolve_role_id(role, scope, definitions_client):
                 role, re.I):
         role_id = role
     else:
-        if _is_guid(role):
+        if is_guid(role):
             role_id = '/subscriptions/{}/providers/Microsoft.Authorization/roleDefinitions/{}'.format(
                 definitions_client.config.subscription_id, role)
         if not role_id:  # retrieve role id
@@ -651,7 +651,7 @@ def update_user(client, upn_or_object_id, display_name=None, force_change_passwo
 
 def get_user_member_groups(cmd, upn_or_object_id, security_enabled_only=False):
     graph_client = _graph_client_factory(cmd.cli_ctx)
-    if not _is_guid(upn_or_object_id):
+    if not is_guid(upn_or_object_id):
         upn_or_object_id = graph_client.users.get(upn_or_object_id).object_id
 
     results = list(graph_client.users.get_member_groups(
@@ -721,7 +721,7 @@ def remove_group_owner(cmd, owner_object_id, group_id):
 
 
 def _resolve_group(client, identifier):
-    if not _is_guid(identifier):
+    if not is_guid(identifier):
         res = list(list_groups(client, display_name=identifier))
         if not res:
             raise CLIError('Group {} is not found in Graph '.format(identifier))
@@ -1076,7 +1076,7 @@ def delete_application(client, identifier):
 def _resolve_application(client, identifier):
     result = list(client.list(filter="identifierUris/any(s:s eq '{}')".format(identifier)))
     if not result:
-        if _is_guid(identifier):
+        if is_guid(identifier):
             # it is either app id or object id, let us verify
             result = list(client.list(filter="appId eq '{}'".format(identifier)))
         else:
@@ -1129,7 +1129,7 @@ def _create_service_principal(cli_ctx, identifier, resolve_app=True):
     client = _graph_client_factory(cli_ctx)
     app_id = identifier
     if resolve_app:
-        if _is_guid(identifier):
+        if is_guid(identifier):
             result = list(client.applications.list(filter="appId eq '{}'".format(identifier)))
         else:
             result = list(client.applications.list(
@@ -1234,7 +1234,7 @@ def _resolve_service_principal(client, identifier):
     result = list(client.list(filter="servicePrincipalNames/any(c:c eq '{}')".format(identifier)))
     if result:
         return result[0].object_id
-    if _is_guid(identifier):
+    if is_guid(identifier):
         return identifier  # assume an object id
     error = CLIError("Service principal '{}' doesn't exist".format(identifier))
     error.status_code = 404  # Make sure CLI returns 3
@@ -1698,7 +1698,7 @@ def _resolve_object_id(cli_ctx, assignee, fallback_to_object_id=False):
         if not result:
             result = list(client.service_principals.list(
                 filter="servicePrincipalNames/any(c:c eq '{}')".format(assignee)))
-        if not result and _is_guid(assignee):  # assume an object id, let us verify it
+        if not result and is_guid(assignee):  # assume an object id, let us verify it
             result = _get_object_stubs(client, [assignee])
 
         # 2+ matches should never happen, so we only check 'no match' here
@@ -1709,12 +1709,12 @@ def _resolve_object_id(cli_ctx, assignee, fallback_to_object_id=False):
 
         return result[0].object_id
     except (CloudError, GraphErrorException):
-        if fallback_to_object_id and _is_guid(assignee):
+        if fallback_to_object_id and is_guid(assignee):
             return assignee
         raise
 
 
-def _is_guid(guid):
+def is_guid(guid):
     try:
         uuid.UUID(guid)
         return True


### PR DESCRIPTION
**Description<!--Mandatory-->**  

Resolve #14096

In `az login`, when `--tenant` is not a valid GUID, CLI will try to query the tenant information from AAD - [Fetch the OpenID Connect metadata document](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#fetch-the-openid-connect-metadata-document) (#10418).

If the tenant is not found, CLI shows error

```
> az login -t non-existing-tenant.onmicrosoft.com
usage: az login [-h] [--verbose] [--debug] [--only-show-errors]
                [--output {json,jsonc,yaml,yamlc,table,tsv,none}]
                [--query JMESPATH] [--username USERNAME] [--password PASSWORD]
                [--service-principal] [--tenant TENANT]
                [--allow-no-subscriptions] [-i] [--use-device-code]
                [--use-cert-sn-issuer]
az login: error: 'issuer'
```

This is not intuitive. 

This PR exposes the real error message:

```
> az login -t non-existing-tenant.onmicrosoft.com
Failed to resolve tenant 'non-existing-tenant.onmicrosoft.com'.

Error detail: {"error":"invalid_tenant","error_description":"AADSTS90002: Tenant 'non-existing-tenant.onmicrosoft.com' 
not found. This may happen if there are no active subscriptions for the tenant. Check to make sure you have the correct 
tenant ID. Check with your subscription administrator.\r\nTrace ID: 94a33bd9-6457-4f89-89f2-1b9144120200\r\nCorrelation 
ID: 652bdb39-211a-423c-aadf-95e4c6401159\r\nTimestamp: 2020-07-24 07:57:38Z","error_codes":[90002],
"timestamp":"2020-07-24 07:57:38Z","trace_id":"94a33bd9-6457-4f89-89f2-1b9144120200","correlation_id":
"652bdb39-211a-423c-aadf-95e4c6401159","error_uri":"https://login.microsoftonline.com/error?code=90002"}
```

**Testing Guide**  
```sh
# Valid tenant 
az login -t azuresdkteam.onmicrosoft.com

# Invalid tenant
az login -t non-existing-tenant.onmicrosoft.com
```