### PR TITLE
{Role} Remove redundant --id parameter from example

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -36,7 +36,7 @@ examples:
         }]
   - name: Create an application with a role
     text: |
-        az ad app create --id e042ec79-34cd-498f-9d9f-123456781234 --display-name mytestapp --identifier-uris https://mytestapp.websites.net --app-roles @manifest.json
+        az ad app create --display-name mytestapp --identifier-uris https://mytestapp.websites.net --app-roles @manifest.json
         ("manifest.json" contains the following content)
         [{
             "allowedMemberTypes": [


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Fix #14043: Create operation example refers to ambiguous `--id` parameter

As `--id` is not a valid parameter of `az ad app create`, it is recognized as `--identifier-uris` due to [Argument abbreviations (prefix matching)](https://docs.python.org/3/library/argparse.html#argument-abbreviations-prefix-matching).

Also because `argparse.py` doesn't check duplicated parameters (same parameter provided twice) in `_StoreAction`,

https://github.com/python/cpython/blob/c82dda1e08c4b74ca24f88d6a549d93108c319cf/Lib/argparse.py#L928-L929

```py
    def __call__(self, parser, namespace, values, option_string=None):
        setattr(namespace, self.dest, values)
```

the second `--identifier-uris https://mytestapp.websites.net` overwrites the first `--id e042ec79-34cd-498f-9d9f-123456781234`. So `--id e042ec79-34cd-498f-9d9f-123456781234` never makes its way into the actual execution of the command. 

