### PR TITLE
{Docs} Fix typos under /doc folder

### DIFF
--- a/doc/authoring_command_modules/README.md
+++ b/doc/authoring_command_modules/README.md
@@ -208,7 +208,7 @@ History notes are auto-generated based on PR titles and descriptions starting fr
     * If the component name is `Core`, the message will be written in `src/azure-cli-core/HISTORY.rst`. Otherwise, the message will be written in `src/azure-cli/HISTORY.rst`.
 2. [**Mandatory**] If it's a breaking change, the second part should be `BREAKING CHANGE` followed by a colon. In the case of hotfix, put `Hotfix` in this part. If it's related to fixing an issue, put `Fix #number` in this part. For other cases, this part could be empty.
 3. [**Recommendation**] If the change can be mapped into a command, then the next part could be the command name starting with `az`, followed by a colon.
-4. [**Recommendation**] Use the right verb with **present-tense** in **base form** and **capitalized first letter** to descibe what is done:
+4. [**Recommendation**] Use the right verb with **present-tense** in **base form** and **capitalized first letter** to describe what is done:
     * **Add** for new features.
     * **Change** for changes in existing functionality.
     * **Deprecate** for once-stable features removed in upcoming releases.

--- a/doc/authoring_command_modules/authoring_commands.md
+++ b/doc/authoring_command_modules/authoring_commands.md
@@ -74,7 +74,7 @@ Note that `MGMT_MYTYPE` will need to be added to the `azure\cli\core\profiles\_s
 ```Python
 class ResourceType(Enum):  # pylint: disable=too-few-public-methods
     ...
-    MGMT_MYTYPE = ('azure.mgmt.mytype', 'MyTypeManagmenentClient')
+    MGMT_MYTYPE = ('azure.mgmt.mytype', 'MyTypeManagementClient')
     ...
 ```
 
@@ -151,7 +151,7 @@ Any kwargs that are not specified will be pulled from the `command_type` kwarg, 
 
 ***custom_command***
 
-The signature for `custom_command` is exactly the same as `command`. The only difference is that, whereas `command` uses `command_type` as the fallback for missings kwargs, `custom_command` relies on `custom_command_type`.
+The signature for `custom_command` is exactly the same as `command`. The only difference is that, whereas `command` uses `command_type` as the fallback for missing kwargs, `custom_command` relies on `custom_command_type`.
 
 ***generic_update_command***
 
@@ -159,7 +159,7 @@ See the section on [Generic Update Commands](#generic-update-commands)
 
 ***wait_command***
 
-The generic wait command provides a templated solution for polling Azure resources until specific conditions are met.
+The generic wait command provides a template solution for polling Azure resources until specific conditions are met.
 
 ```Python
 wait_command(self, name, getter_name='get', **kwargs)
@@ -176,7 +176,7 @@ Since most wait commands rely on a simple GET call from the SDK, most of these e
 
 ***custom_wait_command***
 
-Similar to `custom_command` and `command`, the signature for `custom_wait_command` is exactly the same as `wait_command` but uses `custom_command_type` as the fallback for missings kwargs.
+Similar to `custom_command` and `command`, the signature for `custom_wait_command` is exactly the same as `wait_command` but uses `custom_command_type` as the fallback for missing kwargs.
 
 ***show_command***
 
@@ -193,7 +193,7 @@ show_command(self, name, getter_name='get', **kwargs)
 
 ***custom_show_command***
 
-Similar to `custom_command` and `command`, the signature for `custom_show_command` is exactly the same as `show_command` but uses `custom_command_type` as the fallback for missings kwargs.
+Similar to `custom_command` and `command`, the signature for `custom_show_command` is exactly the same as `show_command` but uses `custom_command_type` as the fallback for missing kwargs.
 
 **(4) Supporting --no-wait**
 
@@ -348,7 +348,7 @@ From the diagram you can see that any kwargs supplied when creating the `AzComma
 
 While kwargs are inherited from higher levels on the diagram, they can be overridden at a lower level. For example, if `custom_command_type=foo` is used as a module-level kwarg in the `AzCommandLoader.__init__` method and `custom_command_type=bar` is passed for a call to `command_group`, then `bar` will be used for all calls to `custom_command` within that command group.
 
-Addtionally, you can see that kwargs registered on a command group *do not* carry over to argument contexts, so you must apply the kwargs in both places if necessary.
+Additionally, you can see that kwargs registered on a command group *do not* carry over to argument contexts, so you must apply the kwargs in both places if necessary.
 
 ****Command Group****
 
@@ -359,7 +359,7 @@ The following special kwargs are supported by command group and its helper metho
 - `validator` - See section on [Validators](#validators)
 - `confirmation` - During interactive use, will prompt the user to confirm their choice to proceed. Supply a value of True to use the default prompt, or supply a string to use a custom prompt message. If the command is invoked in non-interactive scenarios and the --yes/-y parameter is not supplied, the command will fail.
 - `transform` - Accepts a callable that takes a command result, which can be manipulated as desired. The transformed result is then returned. In general, output formats should closely mirror those returned by the service, and so this should be infrequently used. The modifies the output *regardless of the output format type*.
-- `deprecate_info` - See [Deprecating Commands and Arugments](https://github.com/Azure/azure-cli/blob/dev/doc/authoring_command_modules/authoring_commands.md#deprecating-commands-and-arguments)
+- `deprecate_info` - See [Deprecating Commands and Arguments](https://github.com/Azure/azure-cli/blob/dev/doc/authoring_command_modules/authoring_commands.md#deprecating-commands-and-arguments)
 - `formatter_class` - Advanced. Accepts a custom class that derives from `argparse.HelpFormatter` to modify the help document generation.
 - `argument_loader` - Advanced. Accepts a callable that takes no parameters which will be used in place of the default argument loader.
 - `description_loader` - Advanced. Accepts a callable that takes no parameters which will be used in place of the default description loader.
@@ -780,7 +780,7 @@ class MyCommandsLoader(AzCommandsLoader):
 
 ## Deprecating Commands and Arguments
 
-The CLI has built-in support for deprecating the following: commands, command groups, arguments, option values. Deprecated items will appear with a warning in the help system or when invoked. The following keyword arugments are supported when deprecating an item:
+The CLI has built-in support for deprecating the following: commands, command groups, arguments, option values. Deprecated items will appear with a warning in the help system or when invoked. The following keyword arguments are supported when deprecating an item:
 
 - `target`: The thing being deprecated. This is often not needed as in most cases the CLI can figure out what is being deprecated.
 - `redirect`: This is the alternative that should be used in lieu of the deprecated thing. If not provided, the item is expected to be removed in the future with no replacement.

--- a/doc/configuring_your_machine.md
+++ b/doc/configuring_your_machine.md
@@ -17,14 +17,14 @@ The Azure Python CLI projects sources are located on GitHub (https://github.com/
 
 ## Configuring your IDE
 #### Visual Studio (Windows only)
-1. Both VS 2015 and 2017 support Python development, but VS 2015 is more relible, particular on the intellisense and "Test Explorer". VS 2019's Python support is being actively improved, and we will recommend it here once the evalution result is promising.  
+1. Both VS 2015 and 2017 support Python development, but VS 2015 is more reliable, particular on the intellisense and "Test Explorer". VS 2019's Python support is being actively improved, and we will recommend it here once the evaluation result is promising.  
 2. Steps to setup VS 2015:
 
    - You can install VS 2015 from https://visualstudio.microsoft.com/vs/older-downloads/#visual-studio-2015-family
    - Click menu "View->Other Windows->Python Environment" and create a new one by pointing to a local installed Python like 3.7.0.
    - Click menu "File->New Project", and in the dialog select "Python->From Existing Python Code". This will create a project from your local clone.
    - Go through the wizard
-   - Once the project gets populated in the solution explorer, for better IDE performance, exlude folders not interested such as "bin", "build_scripts", "doc", etc. For ther same performance reason, under \<root\>\src\azure-cli\azure\cli\command_modules exlude all unrelated command modules.
+   - Once the project gets populated in the solution explorer, for better IDE performance, exclude folders not interested such as "bin", "build_scripts", "doc", etc. For the same performance reason, under \<root\>\src\azure-cli\azure\cli\command_modules exclude all unrelated command modules.
    - In solution explorer, right click "Python Environments", and invoke "Add Virtual Environment".
    - Save the new project and solution.
    - Back to the command prompt, activate the virtual environment by running "env\scripts\activate".

--- a/doc/debug/debug_in_vs_code.md
+++ b/doc/debug/debug_in_vs_code.md
@@ -20,7 +20,7 @@ The `launch.json` under `.vscode` folder has already been pre-configured to enab
 
 1. Set `false` to `stopOnEntry` property to break at the first break point you specified.
 2. Update the `args` array to run specified command. You need to make sure the arguments are split by space. 
-3. Choose between external termninal and integrated termninal. The latter can be toggle by Ctrl + `
+3. Choose between external terminal and integrated terminal. The latter can be toggle by Ctrl + `
 
 ## Reference
 - `launch.json` schema: https://code.visualstudio.com/Docs/editor/debugging

--- a/doc/extensions/authoring.md
+++ b/doc/extensions/authoring.md
@@ -69,7 +69,7 @@ The `.whl` is the artifact that can be installed with the `az extension add` com
 
 ### Trying out your extension
 
-Normally, you will have you extension installed in dev mode and your code changes will be immediately testable. However, if you want to test a generated WHL file specfically, follow these directions.
+Normally, you will have you extension installed in dev mode and your code changes will be immediately testable. However, if you want to test a generated WHL file specifically, follow these directions.
 
 **(Step 1)** Build the extension to generate a WHL file.
 

--- a/doc/install_troubleshooting.md
+++ b/doc/install_troubleshooting.md
@@ -24,7 +24,7 @@ use `stretch`. Distributions released before Ubuntu Trusty and Debian Wheezy are
 Install on RHEL 7.6 or other YUM-managed systems without Python 3
 -----------------------------------------------------------------
 
-If you can, please upgrade your system to a verison with official support for `python3` package. Otherwise, you need to first install a `python3` package, either [build from source](https://github.com/linux-on-ibm-z/docs/wiki/Building-Python-3.6.x) or install through some [additional repo](https://developers.redhat.com/blog/2018/08/13/install-python3-rhel/). Then you can download the package and install it without dependency.
+If you can, please upgrade your system to a version with official support for `python3` package. Otherwise, you need to first install a `python3` package, either [build from source](https://github.com/linux-on-ibm-z/docs/wiki/Building-Python-3.6.x) or install through some [additional repo](https://developers.redhat.com/blog/2018/08/13/install-python3-rhel/). Then you can download the package and install it without dependency.
 ```bash
 $ sudo yum install yum-utils
 $ sudo yumdownloader azure-cli
@@ -35,7 +35,7 @@ $ sudo rpm -ivh --nodeps azure-cli-*.rpm
 Install on SLES 12 or other other zypper-managed systems without Python 3.6
 ---------------------------------------------------------------------------
 
-On SLES 12, the defualt `python3` package is 3.4 and not supported by Azure CLI. You can first build a higher version `python3` from source. Then you can download the Azure CLI package and install it without dependency.
+On SLES 12, the default `python3` package is 3.4 and not supported by Azure CLI. You can first build a higher version `python3` from source. Then you can download the Azure CLI package and install it without dependency.
 ```bash
 $ sudo zypper install -y gcc gcc-c++ make ncurses patch wget tar zlib-devel zlib
 # Download Python source code

--- a/doc/onboarding_guide.md
+++ b/doc/onboarding_guide.md
@@ -14,7 +14,7 @@ One of the key decisions you will need to make is whether to create your command
 | Release separate from the CLI release schedule | Requires dedicated installation (az extension add …) |
 | Higher velocity fixes possible                 | Can be broken by changes to the azure-cli-core       |
 | Experimental UX is permissible                 |                                                      |
-| Leverage CLI code generator to genreate code   |                                                      |
+| Leverage CLI code generator to generate code   |                                                      |
 
 #### CLI Modules
 

--- a/doc/private_endpoint_connection_command_guideline.md
+++ b/doc/private_endpoint_connection_command_guideline.md
@@ -33,9 +33,9 @@ Add enough test cases for your new service into this [file](https://github.com/A
     - Delete the private endpoint connection.
 
 
-## Depracted
+## Deprecated
 
-The following documentations are depracated.
+The following documentations are deprecated.
 
 #### Private Endpoint Connection
 
@@ -106,7 +106,7 @@ namespace.resource_group = result['resource_group']
 namespace.endpoint = result['name']
 namespace.name = result['child_name_1']
 ```
-The best practice to support extra `--id` is to add extra argument in `_param.py`. Then you can use the `parse_proxy_resource_id` to parse the `--id` and delete this extra argument from the namspace. Storage's PR is a good example.
+The best practice to support extra `--id` is to add extra argument in `_param.py`. Then you can use the `parse_proxy_resource_id` to parse the `--id` and delete this extra argument from the namespace. Storage's PR is a good example.
 ```
 with self.argument_context('storage account private-endpoint-connection {}'.format(item), resource_type=ResourceType.MGMT_STORAGE) as c:
      c.extra('connection_id', options_list=['--id'], help='help='The ID of the private endpoint connection associated with the Storage Account.')

--- a/doc/use_cli_with_git_bash.md
+++ b/doc/use_cli_with_git_bash.md
@@ -15,7 +15,7 @@ $ az vm show --ids "/subscriptions/00000000-0000-0000-0000-000000000000/resource
 
 invalid resource ID: C:/Program Files/Git/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm
 ```
-To disable the path conversion. You can set enviroment variable `MSYS_NO_PATHCONV=1` or set it temporarily when a running command:
+To disable the path conversion. You can set environment variable `MSYS_NO_PATHCONV=1` or set it temporarily when a running command:
 ```
 $ MSYS_NO_PATHCONV=1 az vm show --ids "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm"
 ```
@@ -25,7 +25,7 @@ More discussions [here](https://stackoverflow.com/questions/7250130/how-to-stop-
 ### Issues with pip-installed az
 
 #### Quoting Issues
-The double quotes will be stripped in the value and cause trouble when there are spaces inside the quotes since Git Bash will treat each parts separated by spaces as an invividual command option.
+The double quotes will be stripped in the value and cause trouble when there are spaces inside the quotes since Git Bash will treat each parts separated by spaces as an individual command option.
 ```
 $ az find "vm create"
 $ Command arguments: ['find', 'vm', 'create', '--debug']

--- a/doc/version_management.md
+++ b/doc/version_management.md
@@ -8,7 +8,7 @@ Azure CLI 2 was used for branding as compared to Azure classic CLI. We intended 
 Starting from version 2.1.0, Azure CLI updates:  
 * MAJOR version for core changes that break commands' behavior globally;  
 * MINOR version for general backward compatible feature changes and service command breaking changes;  
-* PATCH verison for bug fixes.
+* PATCH version for bug fixes.
 
 ## Backward Compatibility
 Considering Azure CLI is a command line tool for Azure Services, we tend to just bump the MINOR version for breaking changes in a service command module. All breaking changes for commands will be marked as **BREAKING CHANGE** in [release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli?view=azure-cli-latest).


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Fix typos under `/doc` folder.
