### PR TITLE
{KeyVault} Add deprecate info for --enable-soft-delete

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -79,7 +79,8 @@ def load_arguments(self, _):
         c.argument('enabled_for_disk_encryption', arg_type=get_three_state_flag())
         c.argument('enabled_for_template_deployment', arg_type=get_three_state_flag())
         c.argument('enable_rbac_authorization', arg_type=get_three_state_flag(), is_preview=True)
-        c.argument('enable_soft_delete', arg_type=get_three_state_flag())
+        c.argument('enable_soft_delete', arg_type=get_three_state_flag(),
+                   deprecate_info=c.deprecate(expiration='2.11.0', hide='2.11.0'))
         c.argument('enable_purge_protection', arg_type=get_three_state_flag())
 
     with self.argument_context('keyvault', arg_group='Network Rule', min_api='2018-02-14') as c:
@@ -92,7 +93,6 @@ def load_arguments(self, _):
         c.argument('sku', arg_type=get_enum_type(SkuName, default=SkuName.standard.value))
         c.argument('no_self_perms', arg_type=get_three_state_flag(), help="Don't add permissions for the current user/service principal in the new vault.")
         c.argument('location', validator=get_default_location_from_resource_group)
-        c.argument('enable_soft_delete', arg_type=get_three_state_flag())
         c.argument('retention_days', help='Soft delete data retention days. It accepts >=7 and <=90.', default='90')
 
     with self.argument_context('keyvault create', arg_group='Network Rule') as c:
@@ -104,7 +104,8 @@ def load_arguments(self, _):
                                                          'Vnet/subnet pairs or subnet resource ids.')
 
     with self.argument_context('keyvault update') as c:
-        c.argument('enable_soft_delete', arg_type=get_three_state_flag())
+        c.argument('enable_soft_delete', arg_type=get_three_state_flag(),
+                   deprecate_info=c.deprecate(expiration='2.11.0', hide='2.11.0'))
         c.argument('retention_days', help='Soft delete data retention days. It accepts >=7 and <=90.')
 
     with self.argument_context('keyvault recover') as c:


### PR DESCRIPTION
The service team will disable the ability for users to disable soft delete, which will be always on.
Add deprecate info for `--enable_soft_delete` in this sprint first.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
