### PR TITLE
{Core} Print traceback to debug log when handle_exception is called

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -58,6 +58,11 @@ def handle_exception(ex):  # pylint: disable=too-many-return-statements
     from azure.cli.core.azlogging import CommandLoggerContext
     from azure.common import AzureException
     from azure.core.exceptions import AzureError
+    import traceback
+
+    logger.debug("azure.cli.core.util.handle_exception is called with an exception:")
+    # Print the traceback and exception message
+    logger.debug(traceback.format_exc())
 
     with CommandLoggerContext(logger):
         if isinstance(ex, JMESPathTypeError):


### PR DESCRIPTION
**Description<!--Mandatory-->**  

Print traceback to debug log when `azure.cli.core.util.handle_exception` is called. This can help identify where the exception is generated and thrown.

**Testing Guide**  

Notice the location `westu` is wrong (should be `westus`):

```
> az group create -n rg1 -l westu --debug
...
azure.cli.core.util.handle_exception is called with an exception:
Traceback (most recent call last):
  File "D:\cli\env38\lib\site-packages\knack\cli.py", line 215, in invoke
    cmd_result = self.invocation.execute(args)
  File "d:\cli\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 654, in execute
    raise ex
  File "d:\cli\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 718, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "d:\cli\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 711, in _run_job
    six.reraise(*sys.exc_info())
  File "D:\cli\env38\lib\site-packages\six.py", line 703, in reraise
    raise value
  File "d:\cli\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 688, in _run_job
    result = cmd_copy(params)
  File "d:\cli\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 325, in __call__
    return self.handler(*args, **kwargs)
  File "d:\cli\azure-cli\src\azure-cli-core\azure\cli\core\__init__.py", line 776, in default_command_handler
    return op(**command_args)
  File "d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\resource\custom.py", line 1082, in create_resource_group
    return rcf.resource_groups.create_or_update(rg_name, parameters)
  File "d:\cli\env38\lib\site-packages\azure\mgmt\resource\resources\v2020_06_01\operations\_resource_groups_operations.py", line 154, in create_or_update
    raise exp
msrestazure.azure_exceptions.CloudError: Azure Error: LocationNotAvailableForResourceGroup
Message: The provided location 'westu' is not available for resource group. List of available regions is 'centralus,eastasia,southeastasia,eastus,eastus2,westus,westus2,northcentralus,southcentralus,westcentralus,northeurope,westeurope,japaneast,japanwest,brazilsouth,australiasoutheast,australiaeast,westindia,southindia,centralindia,canadacentral,canadaeast,uksouth,ukwest,koreacentral,koreasouth,francecentral,southafricanorth,uaenorth,australiacentral,switzerlandnorth,germanywestcentral,norwayeast,eastus2euap,centraluseuap'.
```
