### PR TITLE
[RBAC] BREAKING CHANGE: az ad sp create-for-rbac: change default permission of created certificate

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -373,7 +373,7 @@ parameters:
     short-summary: Certificate to use for credentials.
     long-summary: When used with `--keyvault,` indicates the name of the cert to use or create. Otherwise, supply a PEM or DER formatted public certificate string. Use `@{path}` to load from a file. Do not include private key info.
   - name: --create-cert
-    short-summary: Create a self-signed certificate to use for the credential.
+    short-summary: Create a self-signed certificate to use for the credential. Only current system user has read/write permission to this certificate.
     long-summary: Use with `--keyvault` to create the certificate in Key Vault. Otherwise, a certificate will be created locally.
   - name: --keyvault
     short-summary: Name or ID of a KeyVault to use for creating or retrieving certificates.

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -373,7 +373,7 @@ parameters:
     short-summary: Certificate to use for credentials.
     long-summary: When used with `--keyvault,` indicates the name of the cert to use or create. Otherwise, supply a PEM or DER formatted public certificate string. Use `@{path}` to load from a file. Do not include private key info.
   - name: --create-cert
-    short-summary: Create a self-signed certificate to use for the credential. Only current user has read/write permission to this certificate.
+    short-summary: Create a self-signed certificate to use for the credential. Only current OS user has read/write permission to this certificate.
     long-summary: Use with `--keyvault` to create the certificate in Key Vault. Otherwise, a certificate will be created locally.
   - name: --keyvault
     short-summary: Name or ID of a KeyVault to use for creating or retrieving certificates.

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -373,7 +373,7 @@ parameters:
     short-summary: Certificate to use for credentials.
     long-summary: When used with `--keyvault,` indicates the name of the cert to use or create. Otherwise, supply a PEM or DER formatted public certificate string. Use `@{path}` to load from a file. Do not include private key info.
   - name: --create-cert
-    short-summary: Create a self-signed certificate to use for the credential. Only current OS user has read/write permission to this certificate.
+    short-summary: Create a self-signed certificate to use for the credential. Only the current OS user has read/write permission to this certificate.
     long-summary: Use with `--keyvault` to create the certificate in Key Vault. Otherwise, a certificate will be created locally.
   - name: --keyvault
     short-summary: Name or ID of a KeyVault to use for creating or retrieving certificates.

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -373,7 +373,7 @@ parameters:
     short-summary: Certificate to use for credentials.
     long-summary: When used with `--keyvault,` indicates the name of the cert to use or create. Otherwise, supply a PEM or DER formatted public certificate string. Use `@{path}` to load from a file. Do not include private key info.
   - name: --create-cert
-    short-summary: Create a self-signed certificate to use for the credential. Only current system user has read/write permission to this certificate.
+    short-summary: Create a self-signed certificate to use for the credential. Only current user has read/write permission to this certificate.
     long-summary: Use with `--keyvault` to create the certificate in Key Vault. Otherwise, a certificate will be created locally.
   - name: --keyvault
     short-summary: Name or ID of a KeyVault to use for creating or retrieving certificates.

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1499,7 +1499,7 @@ def _create_self_signed_cert(start_date, end_date):  # pylint: disable=too-many-
         with open(cert_file, "rt") as f:
             cert_string = f.read()
             cf.write(cert_string)
-    os.chmod(creds_file, 0o600)
+    os.chmod(creds_file, 0o600)  # make the file readable/writable only for current user
 
     # get rid of the header and tails for upload to AAD: ----BEGIN CERT....----
     cert_string = re.sub(r'\-+[A-z\s]+\-+', '', cert_string).strip()

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1499,6 +1499,7 @@ def _create_self_signed_cert(start_date, end_date):  # pylint: disable=too-many-
         with open(cert_file, "rt") as f:
             cert_string = f.read()
             cf.write(cert_string)
+    os.chmod(creds_file, 0o600)
 
     # get rid of the header and tails for upload to AAD: ----BEGIN CERT....----
     cert_string = re.sub(r'\-+[A-z\s]+\-+', '', cert_string).strip()


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR is to fix #13312 

Currently, if user use `az ad sp create-for-rbac --name <name> --create-cert` to generate a cert(.pem) file, the default mod for this file is 644, which is global readable.

This PR is to update the default mod from 644 to 600.

**Testing Guide**  
`az ad sp create-for-rbac --name <name> --create-cert` 
> check the mod of created cert file(usually under your home folder, file name example: tmpfdqsp0jg.pem)

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
