### PR TITLE
[RBAC] az role definition create: print human readable message instead of exception when assignableScope is an empty array

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -99,7 +99,7 @@ def _create_update_role_definition(cmd, role_definition, for_update):
         if not role_name:
             raise CLIError("please provide role name")
 
-    if not for_update and not('assignableScopes' in role_definition and role_definition['assignableScopes']):
+    if not for_update and not role_definition.get('assignableScopes', None):
         raise CLIError("please provide 'assignableScopes'")
 
     return worker.create_role_definition(definitions_client, role_name, role_id, role_definition)

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -99,7 +99,7 @@ def _create_update_role_definition(cmd, role_definition, for_update):
         if not role_name:
             raise CLIError("please provide role name")
 
-    if not for_update and 'assignableScopes' not in role_definition:
+    if not for_update and not('assignableScopes' in role_definition and role_definition['assignableScopes']):
         raise CLIError("please provide 'assignableScopes'")
 
     return worker.create_role_definition(definitions_client, role_name, role_id, role_definition)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR is to fix #13610 

Currently, if the role definition is below json:
>{
  "Name": "ACS Resource Provider",
  "IsCustom": true,
  "Description": "Act as the Azure Communication Services resource provider service",
  "Actions": [
    "Microsoft.Communication/*/read"
  ],
  "NotActions": [],
  "DataActions": [],
  "NotDataActions": [],
  "AssignableScopes": []
}
CLI will throw an exception and print the stack trace out directly.

The code actually has a check for `AssignableScopes`, however not handle the empty array case.

This fix is just add check for this case.

**Testing Guide**  
1. create a json file which has above content, call it `role.json` under current workspace.

2. run `az role definition create --role-deifnition ./role.json`

Expected output:
>please provide 'assignableScopes'

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
