### PR TITLE
[RBAC] az ad group create: support specify description when creating a group

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -146,6 +146,7 @@ def load_arguments(self, _):
         c.argument('mail_nickname', help='Mail nickname')
         c.argument('force', arg_type=get_three_state_flag(),
                    help='always create a new group instead of updating the one with same display and mail nickname')
+        c.argument('description', help='Group description')
 
     with self.argument_context('ad group show') as c:
         c.extra('cmd')

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -678,7 +678,7 @@ def create_group(cmd, display_name, mail_nickname, force=None, description=None)
                 raise CLIError(err.format(', '.join([x.object_id for x in matches])))
             logger.warning('A group with the same display name and mail nickname already exists, returning.')
             return matches[0]
-        group_create_parameters = GroupCreateParameters(display_name=display_name,mail_nickname=mail_nickname)
+        group_create_parameters = GroupCreateParameters(display_name=display_name, mail_nickname=mail_nickname)
         if description is not None:
             group_create_parameters.additional_properties = {'description': description}
     group = graph_client.groups.create(group_create_parameters)

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -664,7 +664,7 @@ def get_user_member_groups(cmd, upn_or_object_id, security_enabled_only=False):
     return [{'objectId': x, 'displayName': stubs.get(x)} for x in results]
 
 
-def create_group(cmd, display_name, mail_nickname, force=None):
+def create_group(cmd, display_name, mail_nickname, force=None, description=None):
     graph_client = _graph_client_factory(cmd.cli_ctx)
 
     # workaround to ensure idempotent even AAD graph service doesn't support it
@@ -678,8 +678,10 @@ def create_group(cmd, display_name, mail_nickname, force=None):
                 raise CLIError(err.format(', '.join([x.object_id for x in matches])))
             logger.warning('A group with the same display name and mail nickname already exists, returning.')
             return matches[0]
-    group = graph_client.groups.create(GroupCreateParameters(display_name=display_name,
-                                                             mail_nickname=mail_nickname))
+        group_create_parameters = GroupCreateParameters(display_name=display_name,mail_nickname=mail_nickname)
+        if description is not None:
+            group_create_parameters.additional_properties = {'description': description}
+    group = graph_client.groups.create(group_create_parameters)
 
     return group
 

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_graph_group_scenario.yaml
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_graph_group_scenario.yaml
@@ -19,15 +19,15 @@ interactions:
       ParameterSetName:
       - --display-name --password --user-principal-name
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"8745687b-4581-4644-9bd8-1e21380c20fc","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2020-03-05T10:18:11Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"deleteme1","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"deleteme1","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2020-03-05T10:18:11.1262718Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/8745687b-4581-4644-9bd8-1e21380c20fc/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"deleteme1@example.com","userState":null,"userStateChangedOn":null,"userType":"Member"}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"0c0d56b6-cc82-4969-8f7b-493c0e151d75","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2020-08-05T09:36:23Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"deleteme1","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"deleteme1","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2020-08-05T09:36:23.5584977Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/0c0d56b6-cc82-4969-8f7b-493c0e151d75/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"deleteme1@example.com","userState":null,"userStateChangedOn":null,"userType":"Member"}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -40,27 +40,29 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:10 GMT
+      - Wed, 05 Aug 2020 09:36:23 GMT
       duration:
-      - '6590356'
+      - '6713189'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/8745687b-4581-4644-9bd8-1e21380c20fc/Microsoft.DirectoryServices.User
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/0c0d56b6-cc82-4969-8f7b-493c0e151d75/Microsoft.DirectoryServices.User
       ocp-aad-diagnostics-server-name:
-      - /MqF//zpEvPiBK1as8E839YgI6Xdlgfh5ZeVqeOK9CI=
+      - 36LDubY7nJC/vY3gTMr8VE1Q2g2ARMYGQXXSKBzluxE=
       ocp-aad-session-key:
-      - kLGKgaNQ98kRADyxCcHT-n4YGQfEYMjsJXluRIrhXSfJTRG_Ndi_fOhul7SZ2w4y6APnBYILNp2-KsyczDONbKMsjzl4XVB7D5iWofr0SiQdeZ3bDFsfyjtr7-VEJK_9dldRMC_P8ygXKrbPIgHXSOoX8B7MSkTphZscPXJ8Ubk.4D-vtFmIqpbHFlJ3Qot5wKnFtVHUe5YVFfNr7syT99o
+      - YAgEPMshpIdwMrj8oaKDMNr_4ASbiQf3H5_jvbp1pbOZy_ESEM2wzwlKGDTadb1-yZfJUOss9u47AKJdEUQm9ibKutkXOrBD24rCrrB2jPq0QqVqBnIuMoLH7CjvU35jlGJfmc-oS3XCIqOvn8AVACbjwyob3YXUWUL-QA2mMD0.lfBjUxLPOr2bRHOuVzQKxTU9XmQVnbgCK_xbKDqZiTA
       pragma:
       - no-cache
       request-id:
-      - 2791f3e6-0871-40c6-a1d6-fff1117ad9b1
+      - 43901c12-613c-436d-8f83-cb62962a408c
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -85,8 +87,8 @@ interactions:
       ParameterSetName:
       - --display-name --account-enabled --id --mail-nickname
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: PATCH
@@ -100,25 +102,27 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 05 Mar 2020 10:18:12 GMT
+      - Wed, 05 Aug 2020 09:36:24 GMT
       duration:
-      - '5118637'
+      - '5672053'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - mSLP0F096HcWgZ27mIj4ffYCwKZWjtsGTOzQkmYcskU=
+      - Podp68ik3n5KAHE8KiAPatLWIoKKcMWL56HJ/iBbvR0=
       ocp-aad-session-key:
-      - vQWk-6z5bD3UHuMZSoDmRup14gRpw2ays8xA2-9XposS1aMJWtSSdCYx9SraO3R7nLp6qH2mpROjLpANXIorpDTIiIrHMpCbzxMMmctzHkSDJt55-sAnSc8CAH4nEKi-ABL5lEkcBw-ZFKky5f98U71QXY-vhMHu1tkYN6ejXMo.tHHHIOYwjo8J7mV4kR41jI3rhoqzAs8T6e93MPP8TC8
+      - enrLmDR6gvvpsTWwrJ95Ubtw4Ahbx1ae1NN2Ejrz9QUy0elo36g2Q-GLSkIahO32xvS-97B9Ip8rvHcL0vNlRURgSKaMW9e6PCpnO2YDDpoUkI5xINCxpVUKiaDoBXFlysd2l8ZddWNxD_CIjoBQwxqDgIqTUiz341x7DI38-ec.VawIIw0FjknUd59nyI7i9pEobOYQIMLkv-YvCUzrM4w
       pragma:
       - no-cache
       request-id:
-      - ef8762a6-e437-4eeb-87b4-62334c345133
+      - 5f0cae98-9ffd-486b-b2e8-68b1783dcf14
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -138,15 +142,15 @@ interactions:
       ParameterSetName:
       - --upn-or-object-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users/deleteme1%40example.com?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"8745687b-4581-4644-9bd8-1e21380c20fc","deletionTimestamp":null,"accountEnabled":false,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2020-03-05T10:18:11Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"deleteme1_new","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"deleteme11","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2020-03-05T10:18:11Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/8745687b-4581-4644-9bd8-1e21380c20fc/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"deleteme1@example.com","userState":null,"userStateChangedOn":null,"userType":"Member"}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"0c0d56b6-cc82-4969-8f7b-493c0e151d75","deletionTimestamp":null,"accountEnabled":false,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2020-08-05T09:36:23Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"deleteme1_new","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"deleteme11","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2020-08-05T09:36:23Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/0c0d56b6-cc82-4969-8f7b-493c0e151d75/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"deleteme1@example.com","userState":null,"userStateChangedOn":null,"userType":"Member"}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -159,25 +163,27 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:13 GMT
+      - Wed, 05 Aug 2020 09:36:24 GMT
       duration:
-      - '2291065'
+      - '2460162'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - NNURuwbjM4Vsv/I+iFV9O3qMNsxQ77QeV00joROAyGY=
+      - 51iBJpC99VT0XE2E+kBdfS8ZboPQ82X4Ya2wf9P8Ew0=
       ocp-aad-session-key:
-      - LL4J1rfVQczzjiHudqM9oArLg1jdner5hbORYj_vLLAGaaLvLFPLsguOu24WB5rlvNXbg6cMxPzK2pWaYMjXmzpxOguVa_ItZqo41g4_QxKkEUSdLMQfaniiWbbysxlHB7GdWibqymFPnp-bWbjaQN1s4SKF7X-5oBOYEdmahGo.7QrOttU5pDP0yyExzgmJfbeGynLEvJHfqFnvMdieK-o
+      - eOv5oTzrWnq5g0NPw8Psk6LTJ10G7WHD3ia9Ga9sQotbwL1SNqKuSZ0ixcSX-dIHD8N4n7vfPa8VSgueNahV6OJCEuAMUVqyjxpeYqqeJP87VrqIyUIOuB_6j8nVMBdxs_twAf7pxnnUBn35-NPGLtKUI6qEFT8jn79bZXefwAM.L2mGN67PCQjylUCATqmo1a3BvSD_nTsPT3ulMMXd7Q0
       pragma:
       - no-cache
       request-id:
-      - 7883a1e3-55dd-42bf-b14f-824bd3403aa6
+      - 455d74f7-d883-4c8f-bbe9-db0671d5daea
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -201,8 +207,8 @@ interactions:
       ParameterSetName:
       - --id --password
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: PATCH
@@ -216,25 +222,27 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 05 Mar 2020 10:18:14 GMT
+      - Wed, 05 Aug 2020 09:36:26 GMT
       duration:
-      - '6215003'
+      - '6672112'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - BZxBQGZq6Fop2S61otC1It1OG7czCt09h85PRPm5rp4=
+      - mLFv5iEcu0ZFLhgcUh+01kFjJRXqF0zQox5e53xuxjc=
       ocp-aad-session-key:
-      - nGuxOrG_7yyJAuAFp71q5b2q8bY36C0MUpM0yQuLAiqAlKHvdKTOcvcNoX1eTVBKbG6O_mQgfTZKmBIRLXNiV9J2r18HAX_smXrQ7yJFGFd8d1VLb2L3lu6_X02IWyxRkJzjSOmt14w8nk1OtnLHvRmeY_BHjo6RrHbiOqmYf6w.UAbcLcAMXxw31NpNIoJCwxMmaN2F0Sn031TQ29MG5tc
+      - 0mQE_9TvUbRHif0AZn1H-PpmfuxFhKQIO2W7zNCsXxnnu1eG0axTmz7wsVvi9h4qpt_EvwZN9F053q5akDKklUudJMhcFb1myp8tdvMXwUK1NydpRPp8WCHHfA8qvY2lFqx-815QMQY0eG0DldE2y9LtrPGwgGXb38EcSxL63js.yjnW3p9zrcb_TS2AZRgT9pmAmBijB9WfbSOk1uDOnKs
       pragma:
       - no-cache
       request-id:
-      - 635a19b5-b2f1-4cfb-9bee-203869733162
+      - dc1daa26-8e24-4218-a498-e1582517a6a2
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -259,8 +267,8 @@ interactions:
       ParameterSetName:
       - --id --password --force-change-password-next-login
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: PATCH
@@ -274,25 +282,27 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 05 Mar 2020 10:18:15 GMT
+      - Wed, 05 Aug 2020 09:36:27 GMT
       duration:
-      - '6155678'
+      - '6018813'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - ZqlWrBNqZNeLvFpNSdF5DrbUFs642LZtA/ISeq+OZRM=
+      - Fh94VYLX1lwgFeLErI9c1l+Vt23tXdSSBVaAvHw6yWk=
       ocp-aad-session-key:
-      - TZ8G1pTJVe0wwk_ONhZ0Nh7BeVxZttD-wyBC_a1vDB-3605mFAjBRchtfp_WNh3JNbh5PO2BqZWEMBIne6R7Q8IVibQWUV-bSMpD3yzYHIbVi0MPMd6QFLBxpqgufFZxH5ooHQwAI05oHHYR304O-Lg0DQ4omiwci20OT92yGns.NGEVlykzBSMQAECnlSGUquZeRgl6J5Sv7OD-enMzuok
+      - ON7xYaXCApDeViPWy82U5bLh4JMHo0cpB69YhVcUOJLdFkwAExkmuEUOiNIRlFKy8TE9Tnry7_5x6GLc33n30H6z-DJAp2cKwGvWXnCTeg-gX4Bbl4HNZrzDX_ncCCw70XBsv2JRdgdD6lyPs8QBcVuFUy4M49SVljcDWtVDSzQ.9LxMkaCBJl9z1fwv-ka_Pd4MQB3R29OyZ9FIH7NbQpU
       pragma:
       - no-cache
       request-id:
-      - 0f2fd906-cc02-44e9-a7d9-b54fd67ce86a
+      - f877aeb0-1b21-463c-acbf-418d232a99ee
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -318,15 +328,15 @@ interactions:
       ParameterSetName:
       - --display-name --password --user-principal-name
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"53eb3c12-5fea-44f5-b085-b7e0a161e16f","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2020-03-05T10:18:17Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"deleteme2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"deleteme2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2020-03-05T10:18:17.2547596Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/53eb3c12-5fea-44f5-b085-b7e0a161e16f/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"deleteme2@example.com","userState":null,"userStateChangedOn":null,"userType":"Member"}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"01c804a4-baa4-48af-8086-f72ae25919d0","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2020-08-05T09:36:28Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"deleteme2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"deleteme2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2020-08-05T09:36:28.3869972Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/01c804a4-baa4-48af-8086-f72ae25919d0/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"deleteme2@example.com","userState":null,"userStateChangedOn":null,"userType":"Member"}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -339,27 +349,29 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:17 GMT
+      - Wed, 05 Aug 2020 09:36:27 GMT
       duration:
-      - '6216636'
+      - '6396042'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/53eb3c12-5fea-44f5-b085-b7e0a161e16f/Microsoft.DirectoryServices.User
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/01c804a4-baa4-48af-8086-f72ae25919d0/Microsoft.DirectoryServices.User
       ocp-aad-diagnostics-server-name:
-      - 1lVR5teXsZbdZmPF11gm59KMWRaNjPR269e9leNdeAg=
+      - jAY6tweZL71h4Zs/fSXIbbKUblkE4vI7Xhf6+Ag18Ok=
       ocp-aad-session-key:
-      - V4WreZOcsjCaid_jZ2O2Cm5qcBvYZfptd-2UsPtADQyxQpyzDmq-OvIWuLff1dftWIa5T3_C3bRlSBj1hApO2aYdsCO1c1NbDCank3WaJXAyrnUPkA_rGOS9CoLgSz1R8nFq35o5z2rbFAp8SCHwc6BJnGaCFjIyFbjgeqodJWs.dUQCsvh-wudzirsy6bYT7dXPBIGxeuNdKgcr-nwK7mo
+      - YN6j5PD6u8hRZcbrN8j4eNyR_A2DzcJSBqJvv5Gy7A_Os35JpWNxab3ExvV8FQyMoKKWdCxrB-Z9QcBnpLNm76bzI0PUETErbVZOMwbDqcQJ8q7Nr0IT0k1eEY-7b4Jw-8ADLLptvWUImQnVkWnNh7RNA04U3ujQx342KAjq2t0.PMCeoT5zFRLxxuy1FP4erBpHqYIfnpCfsPAgiQ_wyzs
       pragma:
       - no-cache
       request-id:
-      - f323287d-4d94-4c4d-8d8a-d00d3c34e6ea
+      - c3e5aa08-5968-4a02-8d22-76a7140b5133
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -377,10 +389,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --display-name --mail-nickname
+      - --display-name --mail-nickname --description
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
@@ -400,33 +412,35 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:17 GMT
+      - Wed, 05 Aug 2020 09:36:29 GMT
       duration:
-      - '3374541'
+      - '2411515'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - QF+2Kom5kdqiaMnyIX2qvy7RneHOkkB0ozKS2e4Q0lc=
+      - QyUYQSZ8AVNnKcHAsqrnSstFWuxh8zjH1SxEOVKmmsk=
       ocp-aad-session-key:
-      - dY1Q3EgOkIYhCbTBScosOlchqpwV2fCZ5tel6SwCK-nEavqpOE-O5oQ7g5JJQmtzyldNIWjMZvBTtl5IQhu8xSyR_idcgjVymgT2oacqPaTGSQk5fD_n0wqAzBtoHaLeg2gIdZTfyTf0pZ_XM5ZwR5AdOWRC1PC0AoMZcGpvFro.aPLnI3Gc1nzhoYEUG2nyLMBfAR_4dP7AYLOt9erpCXw
+      - OSqiUXpTToJkx5daNw3QWC2RecYFmZkUoSjvRVZnoOIWp0yqrcinEu9WogncUNibT3TXjrGOi5qE2VZZAOQ8CnRMjZtEuAT9CtSLS1XOh6quYlQPdjNS8rpnVXyECWXEPELuaY82foa4ocfdpnJWFNKTRCel_rSpUPVOFHD19U8.UT7yWaC9Bc6g2Dypoyhbwyi678V6orq9WTqEzTAQgT4
       pragma:
       - no-cache
       request-id:
-      - d59705bc-f82c-4225-8657-56828d91aad9
+      - d6da35ab-8350-442b-8d11-1e799dfaa70b
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"displayName": "deleteme_g", "mailEnabled": false, "mailNickname": "deleteme_g",
-      "securityEnabled": true}'
+    body: '{"description": "deleteme_g", "displayName": "deleteme_g", "mailEnabled":
+      false, "mailNickname": "deleteme_g", "securityEnabled": true}'
     headers:
       Accept:
       - application/json
@@ -437,54 +451,56 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '106'
+      - '135'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - --display-name --mail-nickname
+      - --display-name --mail-nickname --description
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '607'
+      - '615'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:19 GMT
+      - Wed, 05 Aug 2020 09:36:29 GMT
       duration:
-      - '5118898'
+      - '6985955'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/9bc4cf98-7951-4b6d-9883-b640b10698ad/Microsoft.DirectoryServices.Group
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/e4238422-2920-4437-991d-2097edb1ac61/Microsoft.DirectoryServices.Group
       ocp-aad-diagnostics-server-name:
-      - BZxBQGZq6Fop2S61otC1It1OG7czCt09h85PRPm5rp4=
+      - LYzAcq7V3eLxMoJD8VBflwEorAlQCAHjPijhfeZyV1w=
       ocp-aad-session-key:
-      - N2wmKDC85dOh8OpB1pWBPA9pNl8cbtrefL2tM7s1Y6eauUBFFRqPl3UsCpOhyuVBttJx9CkMz47bjbxKrXzMFiyxi14xbKb_a82kY9M1EDxjEhED6NJP3wrgxUsuEPDPruUYs8FcABAH5BDY8UM0GHgf9MAx1nHyoReLgsERrto.mrAbDZWUITLz4OKPq0qWjFmlaUXhJZfYiUKW8r8sQg0
+      - WPBnvMtsrOJpRJbYU2wS734wDkz0Xmw5c7CjKJSlssQ1ANZVhveOOKoy9AZURR1yR-9MyN1z3PfRU4UvS_IRStlrNecDew-rL0JEGyHEIEEw5SKxO58YhNNH156PMHd6wzdAkihsWBGn7q3zw-kQtc3R32IzjJWKr0YPRCmq6Rk.FlSRTnFJMVE2qibuHE41PM6bCTcWz6gUzrN2Th-qNzY
       pragma:
       - no-cache
       request-id:
-      - b6070221-2d91-4713-8a0f-4cd40c16b6c6
+      - dd8f4ea3-8c65-43fa-9b36-33431d2f309b
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -504,53 +520,55 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=displayName%20eq%20%27deleteme_g%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:20 GMT
+      - Wed, 05 Aug 2020 09:36:30 GMT
       duration:
-      - '2420187'
+      - '2473458'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 3FI+PF+MkCFqWcUa1Fedr2Mi0nzUSo0QEs/pQ0mB0TE=
+      - hhJdfLW66JLi2nEcbTnUgI+AxnSecUxb4zj7RAMm+V0=
       ocp-aad-session-key:
-      - wSq2zaZ5pPbXhg9b7Ffc9pUMAeGWx22kZqzmbZKU2FTCvSdqLFJSQFFyBxv2G38g_wS-2s2oB0u_EHK99u2nLJbR1B71QATVb3ILw5W5jM8F7VJPHUDnb5cGS5B8OfzOKAiBtWw4qfz6ZBWq_ZHA6pHvOmTmLJDul4jztnScwXg.OIRTDanwObQJDpjorEEvjrdYFx5THkm6I_jskuYG4Os
+      - nuc9w0hAZQF7WUFzM3P6vphNK4pjuO0aMMn-66RYvtXM3-K3eanFTgS11SXqevb2-5JJ1WbRhSwUKPVqlq7yAcr-Y1Dl811NvHftnD1t6rEs2ZH23FAiRJWvW4Oc3CJhFC4WarLzLccU1BdbWzGKxoXAWs9JJrM5TRPTacuh01k.68b8At-ToVGAW-1iLMUqZRis-NhpVDO5ktz5Mab9reI
       pragma:
       - no-cache
       request-id:
-      - a427cde0-0cef-43f7-9707-b39fb8648a55
+      - 47718415-7e89-45aa-bf8e-e87b3c21b830
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"url": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/8745687b-4581-4644-9bd8-1e21380c20fc"}'
+    body: '{"url": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/0c0d56b6-cc82-4969-8f7b-493c0e151d75"}'
     headers:
       Accept:
       - application/json
@@ -567,12 +585,12 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/9bc4cf98-7951-4b6d-9883-b640b10698ad/$links/members?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/e4238422-2920-4437-991d-2097edb1ac61/$links/members?api-version=1.6
   response:
     body:
       string: ''
@@ -582,25 +600,27 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 05 Mar 2020 10:18:21 GMT
+      - Wed, 05 Aug 2020 09:36:31 GMT
       duration:
-      - '5304683'
+      - '5492466'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 26JYzEj1KAujzamlU8eWwpzZ/9HTI+y7gakRbWjTnUk=
+      - 7568EnW9GTxA04TYWo6l23IQ5AR8DMR0g3NLEKJchIc=
       ocp-aad-session-key:
-      - GS1taV8cirIppzCpvJQr2kbytA1KvakeKe5bedKW2dtegQqckGLXFt89TfPyua2v7tvQFQn_DQcr61o9oPNZNZODpVTNrkGXCd8ePC2Ff3g-rqEPUJWe5BbifMO5QpUCIkChv50Kp460QXlWWK_aUdR48EBkE87PelctfYpqa04.lnPnPKGxx8apSTwwOQk9q-WqEGFiChsXqYXeBTM_s0k
+      - K9MaOFX_3l6seS2f_m5SDsHTOr8GajA8hLlAhivWDmrGtc0xSxhD1mpxbYpS1AYlq1cc823RDLbhK8M4LP9PJ_rZHhkQzqapySlXks7N8RGdR-uY9kuSuD7Qopu9UmURyZSZ0cASqEp7eX-YkqEZid-ziT-wETr1ZwHp-xEZ0YM.cw0f-n44sopSUnKr7lfVHWRXvYMjSXVXZ-gTvQPmOzQ
       pragma:
       - no-cache
       request-id:
-      - 352fee07-5340-4b66-837d-f56842142ffa
+      - fcc3dd81-7c45-46dd-b213-65c640128124
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -620,53 +640,55 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=displayName%20eq%20%27deleteme_g%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:22 GMT
+      - Wed, 05 Aug 2020 09:36:31 GMT
       duration:
-      - '4597144'
+      - '2445692'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - xguPw8Z/ZczT5yPbDDvGkQM2Upn8A70k96nygYpoTFs=
+      - zvwu3VMocUBIMruC0KJDTTeZTxwwXXMwR9v6B15ODBw=
       ocp-aad-session-key:
-      - LacItQd-f-G8D31KjR6yr7Vy_bA4DKJdVkzZWclDBRntF9I2sXzG676BsZRSO2OOX7xX3edt2RYLSStAq9adhJ-y2DNqJk6G5ddk-P4tWcCOQkIq6PJa7A1VEONnciA_sAxfw6x3C72qngj4L88CdPTpddq4X_Suc14sXM_peU8.U8JOmJsn94k0aWfcEXXyOI1z3sr8m2tY7enkYBigR2o
+      - FT0YFppBbKdfewcKUmAHOhdNFdvk8pLKuEsP_2tTTxPbERfqles1ugYJXumeM0-LEAx5X4Weh8C_p4Hxvmp5AMmlEWO82C39LFczzfvbiQUk_kr_yF_o-ulL_kVN5emWDwJGGybOfJR3P0BI61zlploE8lo_ZLMp45O9XYUtqZQ.zpzjCU-n6Pnyj5oZsJhk4xE1MQseT2wt6OSG4o5vM5E
       pragma:
       - no-cache
       request-id:
-      - d570bf7e-e52e-42af-a7a5-d3b58278a822
+      - 1cb3a9a3-ab96-475a-94b5-cb9ea8475210
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"url": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/53eb3c12-5fea-44f5-b085-b7e0a161e16f"}'
+    body: '{"url": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/01c804a4-baa4-48af-8086-f72ae25919d0"}'
     headers:
       Accept:
       - application/json
@@ -683,12 +705,12 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/9bc4cf98-7951-4b6d-9883-b640b10698ad/$links/members?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/e4238422-2920-4437-991d-2097edb1ac61/$links/members?api-version=1.6
   response:
     body:
       string: ''
@@ -698,25 +720,27 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 05 Mar 2020 10:18:23 GMT
+      - Wed, 05 Aug 2020 09:36:32 GMT
       duration:
-      - '5193154'
+      - '5110640'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - wa7XLTE+/p7laYRXAZUltYgvhndklofPlRXpYDhC3dg=
+      - 7L6qvQY6BC1PMaTFRFzf9mmB1efuiTo4MZUmBynFEzo=
       ocp-aad-session-key:
-      - 7SwcwbfpSZ-cU8Wuph5LgkwmoDGBCKD3YgmEQOiDkZ_ahrC2JfXnsthY1V9rha9RBYiXoFZ15g6YcYK5zWLmCM_xZNl5gdWQJXcBdChPSWyR1DYkIpyYRQcmQZsKdXqPU7uDCaWMXXCKiXR0xMsgZpGkLhSLje3uJx0YgxVVS7E.ovaq_5uQ9LZzvEfPE2XACqaOZK-JRfDF9xihThDiz6I
+      - gNXu6Wo_l9OstnR_NMnnG1vybqHfcVKaPFPrF0zINqFYhQjo0CSEq1ndATxkqsETe_D0ZQkFXSyHDkqlnYi951BGDto9dM4ZtffNxAgnZ1SpvALJRNOM01V6XBIGDHp-W39pmntWCeMxDrlL9LbCNOC24L7CBJ2Mw803oVzFmUE.QnG0z3HYgZgn1POB574pemZGdgLHtJBBP3JgScDJhOw
       pragma:
       - no-cache
       request-id:
-      - 849ff97d-3f60-4f28-9feb-e735bc23ac9e
+      - 8dab8389-0508-432a-89db-b40f301769ac
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -740,15 +764,15 @@ interactions:
       ParameterSetName:
       - --upn-or-object-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users/8745687b-4581-4644-9bd8-1e21380c20fc/getMemberGroups?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users/0c0d56b6-cc82-4969-8f7b-493c0e151d75/getMemberGroups?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#Collection(Edm.String)","value":["9bc4cf98-7951-4b6d-9883-b640b10698ad"]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#Collection(Edm.String)","value":["e4238422-2920-4437-991d-2097edb1ac61"]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -761,32 +785,34 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:24 GMT
+      - Wed, 05 Aug 2020 09:36:33 GMT
       duration:
-      - '5106214'
+      - '4432796'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - AscZYHsQ8u0JvtqinizkQA/qY/LnqKUVJTwRL3s3mKc=
+      - zvWoFjuE2ehmMVgbV3Cg2Jr+3wQYeCjyzG9gzD1iIS8=
       ocp-aad-session-key:
-      - xPORWUCATKH7SwxRqnFOuDjSNEI7evs9rd9yhpAjpjerPHhdYC2QRKN7OwbNifQM13LK0BRrg9CbcUI8e5XEH1aTb5XdfL5b74MItBRPh3khN_ZpmEmFbUVOD7DbIIHFaplHJ6nLt0WFzxNpoCbcFJlNtUyHw1bdoVP7QEupZ8A.y4YZHfIXv0LIB7_6Slr7DfiPI_WW4jJOScY2NdwOfZY
+      - u-amYIRC6PeuRsd4F84fFdFkalCIPIyw-DyLdn2BZCyRW5bO_SISO_4qpxXkFqoPagG-k8BNYtOl7quBcgDfNF6tRcUy8vhbzpL11Jpdgzivulw1A5IDL28gxVTwtiyDjyHI3-xmQJc8eWYKQR9FHJue5FRLG_L2qrdW0Kf2IXk.7JhfrboqBvgqSdxZpbjEhvmrP9EZf1P-1KYlURklYCI
       pragma:
       - no-cache
       request-id:
-      - 99072c70-2e00-49b3-bb72-3632cf56ad1f
+      - 3f6dc158-1ac8-4757-88e4-828c2fdb3fa1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '2'
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"objectIds": ["9bc4cf98-7951-4b6d-9883-b640b10698ad"], "includeDirectoryObjectReferences":
+    body: '{"objectIds": ["e4238422-2920-4437-991d-2097edb1ac61"], "includeDirectoryObjectReferences":
       true}'
     headers:
       Accept:
@@ -804,46 +830,48 @@ interactions:
       ParameterSetName:
       - --upn-or-object-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/getObjectsByObjectIds?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:25 GMT
+      - Wed, 05 Aug 2020 09:36:34 GMT
       duration:
-      - '4816156'
+      - '4105682'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - xa3gNdMzDnJ7bp2/5v3OwiE/rXSqowIisMDamPujzyk=
+      - yjFpNiVH7H4hNgUCg7e4viVgl8ghPqdy05PYLJHsfOI=
       ocp-aad-session-key:
-      - fTzeOHKHCiD6lB-ScryqWAEpwMG1b8sns-9sqom8M-TH2ijUoPPUawz75VVf3Wlj6uHyS0G72-Iq71-XMtutZtIDj_9HCYSxpONUQQDOefO5xq0dEw5omBOxns-zoFUyh3zoaWzqnYQVHyTQTtGbPZ7l4_HC4KWcPDAScH9PSeM.hFLVteOP9WZ7iDy3M-D6cC5yDrlSQDbhh8JxePJTEJQ
+      - 5hLGJIuCNo_NJs95Wm-axgcsD8HMSaMiDshSrn6RCidoGuOLOxd7tdYCTPSZX-VkO1udSRKjnjpCnV0Lygv9RXdxsSy7fFV_uQUMYwBmll0t3eAWD1jEDERr02sy6HmQwkus-x2Jf1ZHb3-Ndd-pqzVuGs712TNVMmV7sRClcIE._6hD-eLesvoEiqQOG5B2OQ53mFpG7HidDHEm_58vmZA
       pragma:
       - no-cache
       request-id:
-      - 5cf2591f-5706-45f8-b4c9-02c73eae1ebe
+      - d87fd369-edae-408f-b564-5d04c4d6afef
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '3'
       x-powered-by:
       - ASP.NET
     status:
@@ -863,46 +891,48 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=displayName%20eq%20%27deleteme_g%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:26 GMT
+      - Wed, 05 Aug 2020 09:36:35 GMT
       duration:
-      - '2300195'
+      - '2373062'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 0ZbuF/yYBA1CXgEt1RbGoyPTKRzrWs3Qz6WDALDz5eY=
+      - 5aglZegLKIoSH8+p/BYGbK1SiTprU5InRiYqvkDNAcE=
       ocp-aad-session-key:
-      - TvWNwrkS8cS0F88Fu-a7-kP4Q7Bol3BRSjXBTcPkkeSmCpbpPYNpvlnoYUhTo8-itUU5TKR8-OkQvmxISN_bo8-dQMGwkytX43K2hGvGSIS6snHVyGA7rpv0J9jNGxxNo_8LlwV_1DaSbRM0Da4WFwDsSfoU8-Qr73OV7cYl0eM.aoS1RDRRx8KfH0A6AnwL7h0iAffiCwqx53NzLSMQlqo
+      - PVzmA-Atvc6NKoBvr9YvqfDR6KEzm-3p5m83LHqctuRRPj_ANWSXQYnKu3gu3n-8PV9XYDKjh1fvsrvGTIJl1meXyfu0VM6BM6pNdWe3_ELhURlQWnpydQyEcUG7A9g0EsnA6kDc9aubOSAS68a8SEB73Co6HDBcUu5nPJYRNqA.gLNuRApme6mFHcssNTAqocUaRRW8DoilTr2shUyS98g
       pragma:
       - no-cache
       request-id:
-      - 0bfdd4cb-7d9a-4155-93d2-40876938c215
+      - ae237771-0415-42d1-84bb-b2c88a004828
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -922,46 +952,48 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/9bc4cf98-7951-4b6d-9883-b640b10698ad?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/e4238422-2920-4437-991d-2097edb1ac61?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '607'
+      - '615'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:27 GMT
+      - Wed, 05 Aug 2020 09:36:35 GMT
       duration:
-      - '2267710'
+      - '2304750'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 26JYzEj1KAujzamlU8eWwpzZ/9HTI+y7gakRbWjTnUk=
+      - 6eWRldv9g7Kbr6p0CJwJUzmZ3OuepNgUj4k4OS5gWUI=
       ocp-aad-session-key:
-      - hLo5rmZU4RmERXvu1xMG2oITQjB0QrBq1W-mEaTPULqrFIiiLDijAuwkL20snrXWhQxQPQvcmOr6DWBpr1BdEvPBJ2R0pntIDN3ikdev6jp9wvAqpwJOgcVN-T1ADaTn9n1dTWzcgL3hEQvGYrOIgSwWDvJIk1ZvDkBfRB2lOnk.cucIIpzr3Qc-T7C18QPEENpN4LGE7EzWgCGHS9g9dHs
+      - s7yjBwh6cPrre-u1HOgIZbfB6_Xxs33Ud_cY8a3pkSgMIMKj3LjrAOpJ0CqOyiSr2Ej-g_wTtWk7fYjf0R6ruavix4IkAyYmJ-g_Hwpfj3TiB6R8Q0gswPdNFGSfzmyCE1qjQEUj5MXOC8SISe1ldN9Q0N2OpkB57_2brZeSNoQ.vGR1iLLAtWOIZukXboAZVJpDGDkE_jnQb6eTMrQPbF0
       pragma:
       - no-cache
       request-id:
-      - 806d92fd-6b8e-4b61-982e-a7c06fc2577b
+      - 9871699a-bcf9-4a4c-af8c-c7ec613a49e4
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -981,46 +1013,48 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=displayName%20eq%20%27deleteme_g%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:28 GMT
+      - Wed, 05 Aug 2020 09:36:36 GMT
       duration:
-      - '2516609'
+      - '2558404'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - JV2ET7nG1M9wymdAYtodzeQeqat4Q3EuT+TCiSJN3ZA=
+      - OdGMxGQXjcsEi1Ni8TYUlnct7L7Q1SWuomHGX99xfas=
       ocp-aad-session-key:
-      - S52PE6145q3i5y2zfT85HfYBGEfJ-blqLyQCRmiXttmd20UzGwXZN-39H81n7obh8mhxSANcTdWQSYLnmsXCoPW57fwzn6K5_nNhDbpvEygqfs0WNS1yZC7dG_ELMJF5442iMx5C5yXXvZ-KCDOUr4T9fJHREp7OGM6DNxUvczM.YmlvxLAvxDEj9v58Bn61-nK4dYzhS0WVrN_vcj0Am20
+      - cNRYW4Q3EwvFRYUKd9nyJnb31VLhMNjdJ-FqEkJETXZYE9oGhl8wF9VrF2FYJuoDoumrB9v0QK3aOoSb1yb_Hg6lVJ_bF9ky9kVEz6aqetIrCcEH_ZAo_DklYxx5owV_Aqaj8N1rf-9JML_vN9lrYlGJRwRan7ph2GXE7VFL9ZQ.jx2aD3hjobCArA9f_Xi5vZm6-D0DSVyoE683t8WRboU
       pragma:
       - no-cache
       request-id:
-      - f1519bda-4ec6-4c73-963f-ff3484f07e11
+      - b7f1e0d1-d44f-408e-8122-1b4cc4289a34
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -1040,46 +1074,48 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/9bc4cf98-7951-4b6d-9883-b640b10698ad?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/e4238422-2920-4437-991d-2097edb1ac61?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '607'
+      - '615'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:29 GMT
+      - Wed, 05 Aug 2020 09:36:36 GMT
       duration:
-      - '2277391'
+      - '2484140'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - o4mtn766BqWnqnmAzDoh8d9QF3zgpqV7Ffz6nTebetU=
+      - GlkybnsV9uBghg0cQ2pPuohZkGc8oYrn/4rXbfcdAf8=
       ocp-aad-session-key:
-      - w5Qi5Mo56fGmC_dMeb1NT2Tme9WzxuHDl3x-ge9Lb3yDjoinW6dcU_dxJPS7puCYbicBM0CRzvlHzENlj6ZywoIBQ7yq2xEhG6Y0ZbE2J1muhD2yx6r6_sUN9CkkhISzU82CJmDIdKGQ0EsQmpotwtkjyXP0N85nd3XZsdjtf9M.BtHp-4bNgNx3_cGU6565_5bn6VOvZpuuOsp2vhDRGtw
+      - U-XIiAY4jCYSa6lo4gIRw2Fz-SBp_SoQEcZrk2JFq7QgZc11Mh8zu_n62_qOY92cqymmZ9rjxnJpx1SgNZRIZU-LS74FPbAv1FzC8kFdcWeb77s8S-DU6oJGxobnKqdxnv3GPGnTs0cSdZQtoDy0cko16sCTXLDm-mf1XbS-znw.PNRAahxvKQtqug7Hs0mK4hzAsktxvxWFva3qy_ahAmQ
       pragma:
       - no-cache
       request-id:
-      - d97da7a6-b5d8-4ce2-9819-a31e94483e14
+      - f118c1a4-059c-4141-bf94-4b8ff44c595a
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -1099,46 +1135,48 @@ interactions:
       ParameterSetName:
       - --display-name
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=startswith%28displayName%2C%27deleteme_g%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:30 GMT
+      - Wed, 05 Aug 2020 09:36:37 GMT
       duration:
-      - '2659117'
+      - '2567424'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - AscZYHsQ8u0JvtqinizkQA/qY/LnqKUVJTwRL3s3mKc=
+      - e5MAjDK2Hmt19/OeTnUBvxrfgqBq9IulPEDrRV1myd8=
       ocp-aad-session-key:
-      - GulszTEHaIPTOugfP9Axks_xs0urbItk6zsC7DbYV-BfoFLzPYbkismk_P1YDfXmXFCifuGE2J5XFvrbrotMBw0ewMlT4YZNCxqKbmLnoVc2ZdKhaCIZ8Mj3YE3xYCGDzRgYzy3ZbdOfg3YA-lYiP4aFP64Kuhlc6dPJAyeN2Mk.-7mYl3qGjlAavdDs8YKog2h3zBhbBQoJgOtR8IzPotQ
+      - lWyPE1QCZOT3OvRsL8ORpxKkFGhZpJOJX63I6Xp5RdiqmNz_1q5vu0CEbNzU9rtTOqVIoVhVdiy406TokcPLo77gQBH521PZ9k1iP9GuIsFV-Tz1rIPdUEHmSurRn2FPwiVjzPG0QKGDwbnCDg78CsLp7Sj48Yus_DxNkTeNw14.Xw52htzJ2L80xetiESoITZbU9xQszn8_7nH-qD6CWT8
       pragma:
       - no-cache
       request-id:
-      - 4223e8a7-8414-4d5d-8bd3-76e7aeed92e8
+      - 12a3cedb-352e-468d-a80f-5e32bff280fb
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -1158,46 +1196,48 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=displayName%20eq%20%27deleteme_g%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:31 GMT
+      - Wed, 05 Aug 2020 09:36:38 GMT
       duration:
-      - '2529984'
+      - '2412647'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - zUe8ZYaKatjoHb/aHXtCthgIcK4iubnaPZXyP1+ZA+Q=
+      - 1EZEas7RB8WuLQK4uxaATXJriMYz71rNa3nzGi5EjbA=
       ocp-aad-session-key:
-      - ZAYGWssenYjwLBE7Bhl6DBwCN3UcACJlI-SlbNgVInGfOv51VEMF2HLypbC2J80PFfk39t_WVx5CWiksJ_Bc6CJcArYAK6818NFOIZm1U0P3P3DTbzH0BuLv7Twf3J2_bHQH_RvF9eux9MN74Pkpu42Hdbs9GmaM4WoP6leJZY0.Fn0xbiJmoKkO09dRPhPT32zKfjHcGqbjJGa7-Lj-xjU
+      - _DduPPM37Dv6Po554E_p8USPBZUnx9pPpU-moEnddp_seoZrIVDrFBANFB-8SwNUBT9j0oqdfHDvlpXKQ2J_SZ8vcYtDMbyGZGSKp4QNDrtdfx7OHlKnwmB1jf6PFNlx5VeKvJD9x_UeKanQk-WF60ehLb3pCzrotsyhvSW_Kcc.hAkfwZO8e8BxoiBsUGfTGCio9VpDD8PPHJ1RLBMpcl4
       pragma:
       - no-cache
       request-id:
-      - ba3fe6b5-09bb-4b1f-acc6-e64fd28c852d
+      - cdf4f605-ffce-4c0b-8a5c-615a224380ce
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -1221,12 +1261,12 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/9bc4cf98-7951-4b6d-9883-b640b10698ad/getMemberGroups?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/e4238422-2920-4437-991d-2097edb1ac61/getMemberGroups?api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#Collection(Edm.String)","value":[]}'
@@ -1242,25 +1282,27 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:32 GMT
+      - Wed, 05 Aug 2020 09:36:39 GMT
       duration:
-      - '4299623'
+      - '4128334'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - O7pP+dOHYyO4qyTRplHZ2APLBSM71WyEOHgyiadgxzQ=
+      - w4viU0SAUaGwPZCk7ugfs1wrda74oS3d1e7RSlJYkpk=
       ocp-aad-session-key:
-      - q-_gE8Xd6a1DJQxs_zFn1mnHO62X0skCiVyCbCRm9nRS64tQjFnkBaVpK93FzIM5S8eRtnTj3v37AkZd1F35Y12EN_hw5Tw7uczIP1M1inL_fichbR9GFQJat-OZrnW9-tVufu0MTKJy1-_1wD9qTImnXBdZz1zT50TptCLogMU.wuzlKEVpJBJqKHuSgDI-lnGys81iSqRMsRdSHOS1QSk
+      - Bbrzd8abyNQBMmpwX-EZm4JwWQ99BIVMnEvNA1-anGs7BJKznhrSWGlcMMuJBYHafH5sbkH4Vo9f3wnO8iWGLRiOddvbeRMN4YSAk6mgJ9E0isu5UZdR9VbhxTD4TibRElbPna5V6JvB0qDhaKXvxaS61J7merYSbFsrOw8uKRQ.mUY-paFnQ4ybUaY62ep3KDcpSdCH__eIHi6wkeI9Cnw
       pragma:
       - no-cache
       request-id:
-      - af55a8c7-d6fd-401d-8844-e640444bc0b9
+      - 2dd3ceed-5c76-4db2-89e7-ddb706c51ef0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '2'
       x-powered-by:
       - ASP.NET
     status:
@@ -1280,53 +1322,55 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=displayName%20eq%20%27deleteme_g%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:34 GMT
+      - Wed, 05 Aug 2020 09:36:40 GMT
       duration:
-      - '2302599'
+      - '2623168'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - /MqF//zpEvPiBK1as8E839YgI6Xdlgfh5ZeVqeOK9CI=
+      - s8b3SINXiq4yUQ7D+hkzg34bDluxs7CTY+E2hkr8Adc=
       ocp-aad-session-key:
-      - 8hJpZwH_Ac-6vlnsAyb8WIno_xBUEpTCN5MQJyiz3v5WmkKRmXtODhE8bhh34EEgNZG2U_y7weAls4WZY-GolFvu56kw2E3w74dpVrm973N3tS39pFeSVI7jv4FgwVPsTgDVLxO1_UMc5H1JObToLfAmW3bFIJDhaWDvbfI9NcQ.JDM7RMcgBxPRarNmsRiyY1hj99H30qBHZxaMVWI-JPo
+      - 083L3vO9Vh33nS977a4wPtrY5ciLYQuspjVu_HMOshyxTA62qRqktZy78ef4SmHcTw5GzK2vcFiOIEGksJJaYrTy-pkJVCsbIJJyGQJXfOuGfmu4IjMC44R9h7uMrXZ4mFzApIU0URVh1PVnOKxRJvOikcw8MqyRgwH528Ve-hI.VMkANO0W_i4zN6M7jhmZWIRRZKnB0hJjnflN5AO444g
       pragma:
       - no-cache
       request-id:
-      - eaa2be95-9e1a-4b0b-ae05-f4c042779bea
+      - 1d602ada-c1c1-4144-8686-89dc142a27fd
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"groupId": "9bc4cf98-7951-4b6d-9883-b640b10698ad", "memberId": "8745687b-4581-4644-9bd8-1e21380c20fc"}'
+    body: '{"groupId": "e4238422-2920-4437-991d-2097edb1ac61", "memberId": "0c0d56b6-cc82-4969-8f7b-493c0e151d75"}'
     headers:
       Accept:
       - application/json
@@ -1343,8 +1387,8 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
@@ -1364,25 +1408,27 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:34 GMT
+      - Wed, 05 Aug 2020 09:36:40 GMT
       duration:
-      - '4352329'
+      - '4333267'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - gVYeWZfSX9mkzriipUjAD9i6IZAJ5eI2PiGNN2hB0oU=
+      - hYcM8xGo3UDnolVC93y3QsXQUHmcq33QIFHDssXymn4=
       ocp-aad-session-key:
-      - E-244RsYNCJKxnDo1x1Tez0XPqk5IvDPlfcV14S-buDTtaugwJ35QASP4RVq43FH43i-uvcB5LQlnB1FVt2OT1lR5j478eB2CXtwZLXhHN9-4zjuYyRJl5WNDODSHhedZYDZTRkCyG3RnE3BmRGj2zW1DP4x7eIzJrTFYSgGHk4.9PxH8KzvSjZHZ7ZVxrng_-VFO8YiRZPsOLFNOFWJg8s
+      - jsoQmuOyXOHB8p7aF1l-ro70Nu2jg5EnZScvNQjNARkkDA56TSI6CkGKfGiBbUbt9kPlj_NUr01k1lyCSOT-_TGA1BhddDYV8U9_TbiYP_m0qpbyGyoNok9hYwYSPmuwrkdWzNRxv5paPalyujjt1Y1kAfcgk3Pr9D35OkobHIU.MolT5G9XQCF2oHWXCePpZFgk_V_roK9mgnlhILy_vS0
       pragma:
       - no-cache
       request-id:
-      - 65a36a59-dbc5-444e-8143-cc3ad78a4203
+      - 344333c8-acca-40ac-a329-92b6c79c8eb3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '4'
       x-powered-by:
       - ASP.NET
     status:
@@ -1402,53 +1448,55 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=displayName%20eq%20%27deleteme_g%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:35 GMT
+      - Wed, 05 Aug 2020 09:36:41 GMT
       duration:
-      - '2264675'
+      - '2212661'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - TDZAGBecobGZ+vWQ2KTi3URBXNSatGDNYjgtJnpnCpg=
+      - xrnPLznA23meHhZzFa2Edu396zvIR7uuLIlswwA4JEA=
       ocp-aad-session-key:
-      - z1L9oXmBh-E0sQVwhuWUJZvL97RKrbAil1bTX7CSi_AS_3G43pcOaGp6E5PNDjtn4l574GPyT_Dzz56JM7Vs8nF6gNuO1PoK54AS0bFuGEwHMWpUEyUeyV6Ks80H_Xz8R7QW5fGldRonX0paLzgVSSBWaMl7TJzAJAdjUZ3Q0fE.DPH6m_5-nL3UZSRmUcOmMXvMnI-3ggWlPOkyPcZGWQs
+      - sxwbDr_eTS0JSOMf0uDaJcjMXH7GZxyblHQGBR2H3SKa5n_Jfyegcw8ZK71-A_X8TPHYoql6Czxc1Chs_nByt4wbXwkKQekA5R1hqtzjrh0KoAZ97SyNzFwc3Sa5nuP2dciqf6wBZxrPd2ublLlnI4dsOMLu9DNOKaEBuYH9QhI.xPeetdSlg_B6XR85o3YGsEaTcqjVNcaKLxKk06vg2Q0
       pragma:
       - no-cache
       request-id:
-      - d780d5bf-0e01-4b16-8a59-cbc7aae964ef
+      - 364e2722-c945-4317-b8eb-6398c5a41263
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"groupId": "9bc4cf98-7951-4b6d-9883-b640b10698ad", "memberId": "53eb3c12-5fea-44f5-b085-b7e0a161e16f"}'
+    body: '{"groupId": "e4238422-2920-4437-991d-2097edb1ac61", "memberId": "01c804a4-baa4-48af-8086-f72ae25919d0"}'
     headers:
       Accept:
       - application/json
@@ -1465,8 +1513,8 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
@@ -1486,25 +1534,27 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:36 GMT
+      - Wed, 05 Aug 2020 09:36:41 GMT
       duration:
-      - '4328660'
+      - '4330323'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - wa7XLTE+/p7laYRXAZUltYgvhndklofPlRXpYDhC3dg=
+      - OS67lugwC3axKEDuKahlzc3A7B9gdUN8+n6mNFx65Jk=
       ocp-aad-session-key:
-      - uvWKpGk1EThr2dBDNjubx92dKFrLB0PJnaGnkE_57I4wSTcnpw3doEjIySZ9prD9VcXYf9JNzrBG86CKg_tD8iWNndSRDC2UpMVba5-plp_1qOPZb983daBJW43U1NDx1nO-Mrapia36KrIHcArnRS8sadVwnRe29FlTJw6Ag8A.6FPqa28NNi7tI97d_r42cuvCY61jeN2AKs5KvgjzBJ8
+      - Pj3xmrVckMbX-JajkHEkYjjcZ6A3soRfjZHUuq0RQ8CSlTU_-OUhSieQLr0vQSmm_0iosj3xQi83abglN03WQ5ktDYiDySyKPWdJUe1CX8QPboyRaoXqrapAba7v_Q2dLpnTegbl1P0tNWP430YuQaFMbjPgoWaTO16Sy0LWWaY.eayufGdaNqJoor4E0HDpaXY4a5ItwCGbtolj_4rJ8U0
       pragma:
       - no-cache
       request-id:
-      - 3d9c97ed-8766-4ce5-acb0-6c02ca822427
+      - 269513dd-2fd4-4a34-ac2b-e9b849e7e073
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '4'
       x-powered-by:
       - ASP.NET
     status:
@@ -1524,46 +1574,48 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=displayName%20eq%20%27deleteme_g%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:37 GMT
+      - Wed, 05 Aug 2020 09:36:42 GMT
       duration:
-      - '2595028'
+      - '2434428'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 4dYZ1x59KpvPnfg8gEGe7Et40rOFLuoCyqMAAOutonQ=
+      - CjIgzOeKjlit0wRtnNPM2+AnvnBvskiNqq2iDTQZLzI=
       ocp-aad-session-key:
-      - Y0cEK9s1zt3fSnJSXMuY89HTMWxuOX_v1FWEXOWFeq7oL5JfMXrZ70cnUcQp7xMkjdw69QyyM58Swzrq2Kp3kuuHcDMep5mwHIC-xdaVCJxfuIaU1AYxstR7gx6_1CsC39vHKKQhP9l4laP30B2lEymufPe_p0qA9X7UAIg_Vzg.DQElQ4ZZu_WlekT0p7kXThuOsak_kFe_H7dRJzC24mE
+      - cu84unL8J9rIpzOcJlKmt24HnZqvzDbHClrXk34hfWwzCWrIx2Aka86VKaz3cQK-zMfY_zLWZm2NmiaqLCxkoOatsu84g8TwSIANVZh03vAzZZArAJYxMVUsn7z_MuIDSVqQod20ctcKK1SxDHZjD88YdGow_R5J0GP1I2Zd43k.3QKnU3Mcp6KIbpFOvhSrK8vi63vVAgDfqlg4LnyjKZU
       pragma:
       - no-cache
       request-id:
-      - 0320ba8d-f235-4ac9-bb52-072f981e60bc
+      - f3c37861-9ba0-45b5-a7c6-79a41567205b
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -1583,15 +1635,15 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/9bc4cf98-7951-4b6d-9883-b640b10698ad/members?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/e4238422-2920-4437-991d-2097edb1ac61/members?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"8745687b-4581-4644-9bd8-1e21380c20fc","deletionTimestamp":null,"accountEnabled":false,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2020-03-05T10:18:11Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"deleteme1_new","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"deleteme11","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":{"password":null,"forceChangePasswordNextLogin":true,"enforceChangePasswordPolicy":false},"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2020-03-05T10:18:15Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/8745687b-4581-4644-9bd8-1e21380c20fc/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"deleteme1@example.com","userState":null,"userStateChangedOn":null,"userType":"Member"},{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"53eb3c12-5fea-44f5-b085-b7e0a161e16f","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2020-03-05T10:18:17Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"deleteme2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"deleteme2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2020-03-05T10:18:17Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/53eb3c12-5fea-44f5-b085-b7e0a161e16f/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"deleteme2@example.com","userState":null,"userStateChangedOn":null,"userType":"Member"}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"0c0d56b6-cc82-4969-8f7b-493c0e151d75","deletionTimestamp":null,"accountEnabled":false,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2020-08-05T09:36:23Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"deleteme1_new","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"deleteme11","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":{"password":null,"forceChangePasswordNextLogin":true,"enforceChangePasswordPolicy":false},"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2020-08-05T09:36:27Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/0c0d56b6-cc82-4969-8f7b-493c0e151d75/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"deleteme1@example.com","userState":null,"userStateChangedOn":null,"userType":"Member"},{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"01c804a4-baa4-48af-8086-f72ae25919d0","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2020-08-05T09:36:28Z","creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"deleteme2","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":null,"mailNickname":"deleteme2","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2020-08-05T09:36:28Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/01c804a4-baa4-48af-8086-f72ae25919d0/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"deleteme2@example.com","userState":null,"userStateChangedOn":null,"userType":"Member"}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1604,25 +1656,27 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:38 GMT
+      - Wed, 05 Aug 2020 09:36:43 GMT
       duration:
-      - '2389206'
+      - '2570621'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - xa3gNdMzDnJ7bp2/5v3OwiE/rXSqowIisMDamPujzyk=
+      - a2IvgnFhp0V1rHNtSspnziA7fb53giIMAHNWWiZxpVI=
       ocp-aad-session-key:
-      - YJQw_iBOLWNEm9BIs2wNMDCqU9EIgVbpYtTVRNREC014elLDHkB5ZGreVvxL_b1HIsEFdjw1qoETAEE9Ar3HOKS9qHaQqCJ_ha6bITE3mgw_gBRsAmFHUWevJ-CiHwcBKyLIz3WUMSCL-ssjO2zWyKHrx7ha3ZsHStj9tdBfI1M.H77D80efSPf7FzjfIw1CBWOuYiMbmOq-73TW4wnZfIk
+      - qUSBIGexk6eL_IIQLoiqrZA_i29eP2yKtgZ-HpDl2DFM7djFDaSS1O04qlrktiZ5p5i4CWzkNK96XNVnDAZkTAkb-umDDypxFx1kOhA9vHXtFYXQ7dgpP1jjmM7iPjmZzzAVY2JBQEz3u2Y7OFUUJG7q0iswA9-MeqLw75gJrOY.qzgjfk-ZmiQWf3oV64_PR5tK4djxyuRvaOGh2B6lras
       pragma:
       - no-cache
       request-id:
-      - 7ba63020-17fc-4c7c-90c2-444e0fffab35
+      - 7e03377a-e862-4c58-a9d1-3d9dad1b7bd9
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '3'
       x-powered-by:
       - ASP.NET
     status:
@@ -1642,46 +1696,48 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=displayName%20eq%20%27deleteme_g%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:39 GMT
+      - Wed, 05 Aug 2020 09:36:43 GMT
       duration:
-      - '2282167'
+      - '2317387'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - AscZYHsQ8u0JvtqinizkQA/qY/LnqKUVJTwRL3s3mKc=
+      - ynIRd5JY8qcIhkIg/e9b4w1eCSyYJcADy6kDdSDrYhg=
       ocp-aad-session-key:
-      - e4FsA3uJ394LVHJKneq0_7Nd7S6mWIzOu3fDWzqzeXvv3kpPlUTzlwlQ6_Mo7i6lXGyTpjIKNtH768_du8q8RYJej6Z51Kx4J6AF94UqRRsmvQrvZ0RhqDWfPV1-C1xhdHHVKbBDJuEz2Agm18BPunpP4XOxo85fAO5OwEWO6rk.JakRCxoFWQp-oGfGtLfEIrMTVPsPpmcq0dvHXThXxZE
+      - 8v9c6RXwsdeXLJGpl-b74m0MdMvhkklIJD_5voIVsoaHcaNfM4sWMx3cRI-gO8FBntXTH3apTv7nIpHnLumIHwe2EzOP0JBu2EIQ-BXuBWJcAzJ65kSwZNKcMIdxhV3SoU9MmW_hd9cST0xP6d_dOHR1YRTlNGX8WGPMnYwJ1RU.fiNmKTuFlkXTcxPbMrEew4FUvL1_BOTTtsq0Nc9f62c
       pragma:
       - no-cache
       request-id:
-      - e25d0d5e-730e-475f-a8f9-a0da0630b8aa
+      - b1c6815e-ffe5-43de-8ac2-8ec41b279031
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -1703,12 +1759,12 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/9bc4cf98-7951-4b6d-9883-b640b10698ad/$links/members/8745687b-4581-4644-9bd8-1e21380c20fc?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/e4238422-2920-4437-991d-2097edb1ac61/$links/members/0c0d56b6-cc82-4969-8f7b-493c0e151d75?api-version=1.6
   response:
     body:
       string: ''
@@ -1718,25 +1774,27 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 05 Mar 2020 10:18:40 GMT
+      - Wed, 05 Aug 2020 09:36:45 GMT
       duration:
-      - '3409148'
+      - '3362999'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - FzBy1dfPLdnOUgWf0dpSUTgv1fkpsaisLLmIFPDeitU=
+      - OdGMxGQXjcsEi1Ni8TYUlnct7L7Q1SWuomHGX99xfas=
       ocp-aad-session-key:
-      - QK9dDpfjNaLmR4Clpcw6V0XD9wybC31a5wtlPL3hpcVuwzQsMizmqjInWGKNrsSNjNeScRniX8niTlfA9bfutcBouhA9I-4SXZ9_Wa3BA6mfheEVCUaqZQRv1xPNyYEfk65xd6KM5azVz_h8xwLOVyVNf72-wKTh5VqX1_lry5I.kZAtsYILAoLSwYkyb54ksVPpRBJQrFFpL-BPNRMa8Fc
+      - ZWytYvOssDrnD_x4AOAjFkMAYCnJJnQrbUWr6MW7bEUmric6n90Q27KOv7q23ISS9434i_h2oPdu1q6XEkuIX4QOOtXTY6hkDPKQ6ABdQ9TmcwkmFEsslTJEcCPnQQO0_rFppSut6N89LCrUkOU_LyTgU5MgAuWh3pbJL3pmA4w.uETBv5a-uLBazLoUKBvMvgw2JhQXo0r7UggsnN1VfOQ
       pragma:
       - no-cache
       request-id:
-      - 0c37b532-bfb5-41ed-8fe6-640199f29d4d
+      - 634f8748-fe0e-4ae1-af6d-b3f376c8ceb5
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -1756,53 +1814,55 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=displayName%20eq%20%27deleteme_g%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:41 GMT
+      - Wed, 05 Aug 2020 09:36:45 GMT
       duration:
-      - '2260621'
+      - '2429082'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 9WXYjtljUni6R4x3ceMCi6jN8lbj4nyUqEgooMOCvq8=
+      - 9l33+hvZa7+vpwlV9+kred0ApGsxSOS3aTfrwTsjaL0=
       ocp-aad-session-key:
-      - twGAHxR1ZoTLbEoUA0pSP5-KT7Ia5DyHxWyQJkN1PLXwRKUiIl7mt9cG7KODsMijiC10OWiip4YNJ0CpYV9N84lXKV38srDF1XpiDohl1vaeyqgGTjmPYKZ-683Dbwu2b9ZumI11d36nBvuuhwW9Xa0cnafheDeJ3eM5amx62L4.bK6TusRFPaJpS7vWw4JeReyZjjxb9QYJ25op2VjRgOs
+      - KCJxl8x1R6lTjTNVcXAlRH_TYLbI7QtOH_ZYN1vvA_IWwkadqv81K9qUjlVHB1Kmp2DtLaJOAAvz6Z_3KZPYfwnJjFPvuCPMQTcIM0w2OsRFf0uEPNNNuNKlZgt_NeXv1nTN3B3vQullLZz7diBv7NFoP20GtMd10OnrmuPISqU.dEKf3AINcYgq0dp-D3-FPofrgVRn227hCgnBQwhvXeM
       pragma:
       - no-cache
       request-id:
-      - c30f2942-1be3-40ad-ab57-eab1cf299a8d
+      - 4575598d-db4c-47de-b164-2046a6de6965
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"groupId": "9bc4cf98-7951-4b6d-9883-b640b10698ad", "memberId": "8745687b-4581-4644-9bd8-1e21380c20fc"}'
+    body: '{"groupId": "e4238422-2920-4437-991d-2097edb1ac61", "memberId": "0c0d56b6-cc82-4969-8f7b-493c0e151d75"}'
     headers:
       Accept:
       - application/json
@@ -1819,8 +1879,8 @@ interactions:
       ParameterSetName:
       - -g --member-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: POST
@@ -1840,25 +1900,27 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:42 GMT
+      - Wed, 05 Aug 2020 09:36:46 GMT
       duration:
-      - '4424690'
+      - '4863880'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - Ma2LaKb79/2GntcjfamrawcAX6S0AXZp5gioDwbfPXM=
+      - fP4NK2gNaIdDNhBv8pKeGATgIpn16XzVoGGpzH0I8Co=
       ocp-aad-session-key:
-      - 7yqi9sumxOeQ9RfvQA0pinMLGa0W64XWFCglbSZFkTldW0sHzPlv2vVCx9260-wZ6Ly-w7I77xSqadhip0i5FNuKDKJJRaFwXLoBNmbh-pZwuYjtBq_jjJ01TEfi1tykIIWroRj-xUgpM3xnLb3Mj8BqaxFjOSEyYdg2JV8bies.ZMoZkyvZlzd3A6AioIawP_sYtb7bUNG_OT8k52l1FS8
+      - tWQiaQ_vQKtncwetV6v6Lpuro8cW4W6gMED3MqxcSfV1Gw1cS8J2RJjXwoC923VBdfSybwqD-Cz2n7ORCDx_ocQkrM-hyxxUpai4Y0RctMwm27o812ta6oWY6dXHLiEm-gESOjH0D5qNHjsoMHjV2e2LwctSjyUtXca6QAMoXeU.ba6d_n5OoUjkFkDXsaaKYzUU9g1-oi7jownG_J2udBk
       pragma:
       - no-cache
       request-id:
-      - 3d7b88f6-a419-456d-a8f4-723a2dcbab08
+      - 3e341a2e-7433-400c-a0df-c195a9f53c3c
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '4'
       x-powered-by:
       - ASP.NET
     status:
@@ -1878,46 +1940,48 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=displayName%20eq%20%27deleteme_g%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9bc4cf98-7951-4b6d-9883-b640b10698ad","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e4238422-2920-4437-991d-2097edb1ac61","deletionTimestamp":null,"description":"deleteme_g","dirSyncEnabled":null,"displayName":"deleteme_g","lastDirSyncTime":null,"mail":null,"mailNickname":"deleteme_g","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '618'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:43 GMT
+      - Wed, 05 Aug 2020 09:36:46 GMT
       duration:
-      - '2324645'
+      - '2330612'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 2dwL4zmGotV02lDmIuML9wD2xi2nJgoszFrjUl3LYBw=
+      - 1lVR5teXsZbdZmPF11gm59KMWRaNjPR269e9leNdeAg=
       ocp-aad-session-key:
-      - XpCdHfcNEnNMbCZ9THCVKklXnmqVYVcKe9SLylaZmd6ia0GB61H038JTZgRXCIizFCjgfgZWTPgCvefNoindVlMSITRl8LmXobESMohxUkrMWz2Kzfeskqmlkg88ZCl3pXcDEySh7_2Y7rQBH9CtHjxVXjjEUAQTZLn_d67KPh4.RrVGQRz7bTw_a9wmuUovG4N0R9bi2uSuuzF2dc0-t3k
+      - -Rld18XLxaPv-0l6AtW6Xx-8zT9E_vAJxy-ba1q61Y_g29wO3vsFmC0OrinmmvDVq6GNAthagZyoMd-2zdfXzNoGpersslVq3IjS0xr39fNyJaF4mWaRreYY4qeYt-1J1_20VcHB4Ea75mIyaLl9HC86C3yES8LOHbkJ4Qb_vmk.Db79DXXry8gh7vQ5PDIevmlH-4_lkuoh_pwSEfQPMPE
       pragma:
       - no-cache
       request-id:
-      - 40fbdc67-4f49-466f-be00-19415d839fc6
+      - f37baaa8-eaeb-4b77-b60b-f35d0478b25d
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -1939,12 +2003,12 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/9bc4cf98-7951-4b6d-9883-b640b10698ad?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups/e4238422-2920-4437-991d-2097edb1ac61?api-version=1.6
   response:
     body:
       string: ''
@@ -1954,25 +2018,27 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 05 Mar 2020 10:18:44 GMT
+      - Wed, 05 Aug 2020 09:36:47 GMT
       duration:
-      - '3150546'
+      - '3296261'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - UmKZplC7QR9gc5Bj0uCCSHnYW+SyuZTqMuzNl/Z9xsA=
+      - MXtk2KRUe+Pbxfgq6k/d269y526UaR5dGfiehIUvvGs=
       ocp-aad-session-key:
-      - w8Jq49ynKBi9iocqNUByAt9ezP2tEjc9iWPxFSrHw4JjDocHw1rhAPg6xN9zpdgye1u7WNaQIjRXtX-DFZbE7CLd9mRS6LTnNgF2e6irSillx0GMTiBNDDxjC1jzACsea0GUasUiQcsjvIsE4-yDKhyLAcuqdWZSeBM-eZ9FIEE.LE992UL2XHMpSNDJHl0qhq8wXMarKNE1-QFn3EuycAg
+      - BBWOulLTzAIVsIbEkBXA_hl254-Nen-IdTFPqCCENDjdZ2XmIribOVA9fs-CbanOfL5xYI8WxOBLWNO_5WA8Po4pKsCT4OvPrWFDm5IDB8-cN_iEUFS-OmBm4mVnubSGAiuzzlXhcrRoN5umZM1J7P8p5wJBaHSlTIVVFsqzRAA.38RamH8j33TFz_-RH9EnM6PDDxokwHyZbP_CoLK1Vrc
       pragma:
       - no-cache
       request-id:
-      - 70fc977b-886f-4f09-999b-78068b3dbbf8
+      - 111284a6-8307-4f7d-aa7f-a1bf07017534
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -1990,47 +2056,56 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/groups?$filter=&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"5a197067-7d4e-4862-a692-cb5933646da1","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"AAD
-        DC Administrators","lastDirSyncTime":null,"mail":null,"mailNickname":"AADDCAdministrators","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"03dc86f3-86dc-4282-af17-988a0bb03258","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"Group
+        99906158","lastDirSyncTime":null,"mail":null,"mailNickname":"group199906158","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"04dd1e03-f2fb-4063-9964-03529660cca2","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupxhra7s","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"11f6a172-d9e0-400e-98bc-7a6a3c3bbcf5","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"testgroup","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroup","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"12af389a-3835-46c4-abe9-39d62a64c8e4","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"test-group","lastDirSyncTime":null,"mail":null,"mailNickname":"test-group","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"171e4428-4ac0-4594-907c-5533d90c07a3","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"Group
+        68a27503","lastDirSyncTime":null,"mail":null,"mailNickname":"group268a27503","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"1f1b5b3c-130c-4a18-8724-2e4b4efc3483","deletionTimestamp":null,"description":"adfjaskldfjaskl;d  dfasf;","dirSyncEnabled":null,"displayName":"xiaojxu-group-2","lastDirSyncTime":null,"mail":null,"mailNickname":"xiaojxu2","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"1fac6b68-d24f-418a-9e4e-0a8d8d78d1d5","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupry3cqg","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"2cde37aa-6fd0-42ad-849a-33d06c0da145","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"jltestgroup","lastDirSyncTime":null,"mail":null,"mailNickname":"cdf3513b-d","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"3325d5d8-e906-4d86-88df-3e4b2f2288a4","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"groupb7756095e","lastDirSyncTime":null,"mail":null,"mailNickname":"groupb7756095e","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"37727b42-1e63-4fa7-a284-2fc0c924e402","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroup24nwhm","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"38682897-e85b-4ab8-af85-96bc1873040b","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupdcn4oz","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"39633499-b789-45bf-91a2-5de07b47d659","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupmvxlny","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"3bf13c9f-50d6-421f-b0b6-f3ad5e6325cd","deletionTimestamp":null,"description":"This
+        is the default group for everyone in the network","dirSyncEnabled":null,"displayName":"All
+        Company","lastDirSyncTime":null,"mail":"allcompany@AzureSDKTeam.onmicrosoft.com","mailNickname":"allcompany","mailEnabled":true,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":["SPO:SPO_40ce8e27-3250-4920-a3d8-2774e2491374@SPO_54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","SMTP:allcompany@AzureSDKTeam.onmicrosoft.com"],"securityEnabled":false},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"3d534694-6e5c-4908-9b76-1fa1c3cc02ea","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupytuq32","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"43ec8ef5-5d20-4834-8dce-0aadbf5eb4f3","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"qianwengroup123","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"4601c36e-c380-4089-abc0-cd90d767011d","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupcbvq7j","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"47b36d3d-068d-47f7-9f4b-3560c0a97c49","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroup76z2zo","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"58cb07a3-9c8c-4061-9506-404283353c9b","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"Group
+        eb044143","lastDirSyncTime":null,"mail":null,"mailNickname":"group2eb044143","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"5a197067-7d4e-4862-a692-cb5933646da1","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"AAD
+        DC Administrators","lastDirSyncTime":null,"mail":null,"mailNickname":"AADDCAdministrators","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"5a77f1cc-1016-46a7-87b3-144b7ca5ab64","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroup72pdqx","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"61837acc-0176-44ed-9882-0a0c2525e23e","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupfwf526","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"6349a8c5-4d9f-4d2b-99ca-74e52bc1c789","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupl72ohk","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"77924ecf-9a1c-4eff-ad46-2b0e9db9083e","deletionTimestamp":null,"description":"Test
+        for weblogic security","dirSyncEnabled":null,"displayName":"wls-security","lastDirSyncTime":null,"mail":null,"mailNickname":"49eabcd6-5","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"87b65676-35b6-4af1-b064-46bf90d7e7ff","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupkanoev","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"882ae40b-1a7d-453f-bc2b-48e76ac1d014","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupxuaqyh","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"899822d9-0ce3-4d06-be2f-d4e3c690148b","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupmxivwq","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9c13d0bd-2857-40ad-81bd-1b5a84745424","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroup5log7z","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"9c81ad1a-fedf-41f6-a84e-ed901f76ff3f","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"Group
+        98e57286","lastDirSyncTime":null,"mail":null,"mailNickname":"group198e57286","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"a08f6596-50cc-4aeb-baca-2cc3f7f26fc8","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupxsbwfb","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"b671cd6e-9191-488b-80ae-1b710ddd3d1d","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group7b778007d","lastDirSyncTime":null,"mail":null,"mailNickname":"group7b778007d","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"bc487072-e935-4593-9aba-ba2cf839fcdc","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroup4jgprj","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"c1fa0f5e-5ab8-4563-b6e4-cdb0827a4a76","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"xxjtestgroup","lastDirSyncTime":null,"mail":null,"mailNickname":"xxjtestgroup","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"c617af87-3fee-466c-92af-87ee433d294b","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroup3o4gwc","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"c73d203e-725c-4341-b6e9-ad5dc4f30e77","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgrouphvix7n","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"c7659b04-b538-4b02-b088-08e964bbc0d4","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupk3vol7","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"d597c0ce-b84b-4311-adff-db15ec1aced1","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupiwajnh","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"d60449f1-6d9b-42fb-bc14-a2b8e2fc848c","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroup67buch","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"d795f9ea-4595-4bb2-9abb-f4f9606e27b9","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupe2chax","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"de584959-99ef-4a20-b099-9e7882606520","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"groupc4e664492","lastDirSyncTime":null,"mail":null,"mailNickname":"groupc4e664492","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"e661faf9-79de-42cb-9df8-cd8472fc1604","deletionTimestamp":null,"description":"test","dirSyncEnabled":null,"displayName":"xiaojxu-group-1","lastDirSyncTime":null,"mail":null,"mailNickname":"xiaojxu","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"ea3b41e2-b558-4b76-92d2-ef4f24b982c6","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group10914842b","lastDirSyncTime":null,"mail":null,"mailNickname":"group10914842b","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"f0557711-e415-418e-9b24-654af401fb1f","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"cli-grpakxq7xcp","lastDirSyncTime":null,"mail":null,"mailNickname":"cli-grpakxq7xcp","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"f0bec09f-45a4-4c58-ac5b-cf0516d7bc68","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"AzureSDKTeam","lastDirSyncTime":null,"mail":"AzureSDKTeam@AzureSDKTeam.onmicrosoft.com","mailNickname":"AzureSDKTeam","mailEnabled":true,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":["SMTP:AzureSDKTeam@AzureSDKTeam.onmicrosoft.com"],"securityEnabled":false},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"f4468d11-55b1-46b7-857c-ff5a0da635c6","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"test-group-ro","lastDirSyncTime":null,"mail":null,"mailNickname":"test-group-ro","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"f4a9a7a2-2553-42b1-9188-1b18d1f4bf6f","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupyjxqzu","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"f6a96b85-4eba-4fe1-bade-1958538294fb","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupsbivum","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true},{"odata.type":"Microsoft.DirectoryServices.Group","objectType":"Group","objectId":"fea79277-d88a-4262-aa3d-533b142a8351","deletionTimestamp":null,"description":null,"dirSyncEnabled":null,"displayName":"group123","lastDirSyncTime":null,"mail":null,"mailNickname":"testgroupyku24s","mailEnabled":false,"onPremisesDomainName":null,"onPremisesNetBiosName":null,"onPremisesSamAccountName":null,"onPremisesSecurityIdentifier":null,"provisioningErrors":[],"proxyAddresses":[],"securityEnabled":true}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '630'
+      - '23704'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:45 GMT
+      - Wed, 05 Aug 2020 09:36:47 GMT
       duration:
-      - '2688864'
+      - '2416216'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - VGDUYIwMMxxQjRRnndvpoCz/X8I/clG9sX5Ey+KkbZI=
+      - jAY6tweZL71h4Zs/fSXIbbKUblkE4vI7Xhf6+Ag18Ok=
       ocp-aad-session-key:
-      - rvKIgJq5vCqTwGzh4DB7dF5EG8TSrEIo84Q5gdmOJNgrNvbzrbfa7pphtpV7kPSxzO-JVYGwiu-pIVT9oJKF5b18E2jCuExDyt_Bt_ALV6eLwSDAiVdsBQDAIn_DGwAFYK9sIZwFCF53QgkwQqygjJbQe8-XyOomlywcnbsmL4Q.b5blJlOBBmOf23qLNrvsNbKxuxTqc_VGxQiv7QR8l1M
+      - F3UKDdQG3ps_BX1vhUk0naZ7TzKZMVc08pwFCTHWdLfq7zaUWXHpjG6BXEoyf1fJVsYnLpciv-h6aza6xdp1IiUxjFnF7CzVJamH-ucLaXgawqsFehEJgU7-MgLxz-Pa32nWc6hDEEv3a5DYMDiK0cPoU4ycZe4l6AkxlcTdiXQ.e03iXc9VPgfUjf570ouribRZC1zmSZLSD_BMgyEc9b4
       pragma:
       - no-cache
       request-id:
-      - 2793e034-e147-440b-ab43-911ffafd57b7
+      - 6d03c4a2-ea28-47c6-898e-87bf2b1960cf
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -2052,12 +2127,12 @@ interactions:
       ParameterSetName:
       - --upn-or-object-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users/8745687b-4581-4644-9bd8-1e21380c20fc?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users/0c0d56b6-cc82-4969-8f7b-493c0e151d75?api-version=1.6
   response:
     body:
       string: ''
@@ -2067,25 +2142,27 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 05 Mar 2020 10:18:47 GMT
+      - Wed, 05 Aug 2020 09:36:49 GMT
       duration:
-      - '3175123'
+      - '3086169'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - ZtjrL6855/1nWsQgXw4059xGL7CEBjwxyLJieTbtGTs=
+      - xukW/YUz8ZjCN5OuyB75Ot+MQq2Au8EttZedWyKRLIM=
       ocp-aad-session-key:
-      - 7EKa2Ou7dKQZxAqnt77iALgBF_WCQpyLzUF_ckAiIgVmd-5WTNxkPp5Ge8uc9NUT1gG26XC3Q9jd9tzSWyOcZWu_qlBFucKbw9xQbQ5XvqufALfGYjUlMzYfw7RV1IL4Mi_fpXrvX-YjAkCNdoDbJon5KWkMeybpb75USl_o-PI.gGEBTM10B4_-0_pVGJ4Na6c1Ge-7ScNAlpJgsLfB2aM
+      - e4gA6u6N680Addd5oYIx05_uU1UrAvARx9Sg5XVuqq8WfBjy42eacowEH0CEDcpP28LxlgWr4AePAXykMXs6KTqJvE3lAVZDlfo08g7bysJ3uGFTEcTTCJw48NgWEyp-euaFOu0-vw7mT7FmLA2BCeado-AQ_Mh_NdffzvwzJ3w.Ptl19UsOYH6Pj1ckvP7EiEYTFgcIK1OG4G0h3oQ5_rY
       pragma:
       - no-cache
       request-id:
-      - 2eb26736-85ad-47ab-8496-2ec7412dd769
+      - 9b2e3368-a468-4b90-8105-3e39739663c4
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -2107,12 +2184,12 @@ interactions:
       ParameterSetName:
       - --upn-or-object-id
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users/53eb3c12-5fea-44f5-b085-b7e0a161e16f?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users/01c804a4-baa4-48af-8086-f72ae25919d0?api-version=1.6
   response:
     body:
       string: ''
@@ -2122,25 +2199,27 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 05 Mar 2020 10:18:48 GMT
+      - Wed, 05 Aug 2020 09:36:50 GMT
       duration:
-      - '5121739'
+      - '3485122'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - m9WUaBuJWWN8jTTxvaqUkzVAeQ7QyDcmFQANzJzN5CM=
+      - Y82BpKRlUgewplPNRiSw11Z6vGZl7aBO/qroOg5zal8=
       ocp-aad-session-key:
-      - dIAlOdm4V35J5DICcWI2m7uw8_nTeUFZ0hkULGQSGXyu8FxSBCMi6D5QsklbcwtPeaw3mn4EygD7IGRh8_5jDFtpceyMbiy0EApjyWgdNlo6C4m1vNE2TLmP1SfUXCX7P1abfe9QL7SM1Bk7Ogjn4N84hZwYFYZXCEWPnU4q5hY.-3fm5v44nzg5RSD-CGmmQ5JSxll6aMg9aVZE-hhidtU
+      - vrq3jkfALPdF68mVNgrMHTMRIqLWfHc_kXxz_61tzBnvCVzRzqm7L6pO-ay_P9ePhHk5EymsDZaiO3zLLG44i-nqnh7tMwkgxuNLF7-NY3OQF50dBng4Yu99WfHCi5awzWJVY3BvatANTJrWhf8IaMpBtH_nSncW9_shpGHjg_o.4D_5smiQhundKL65ptDc499lFweEBxGABwlm8ZfxzIo
       pragma:
       - no-cache
       request-id:
-      - a9044538-faa7-4041-8483-690f62040565
+      - b31b4d39-3606-4cff-b22e-bfb8a6b3c64b
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -2160,8 +2239,8 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
@@ -2181,25 +2260,27 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:48 GMT
+      - Wed, 05 Aug 2020 09:36:50 GMT
       duration:
-      - '2222680'
+      - '2447904'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - m9WUaBuJWWN8jTTxvaqUkzVAeQ7QyDcmFQANzJzN5CM=
+      - qftXp5zc6ydbQAq8Ev582RPlrRAnvm1DC9BwcgegNJ8=
       ocp-aad-session-key:
-      - KA0M_Jvsgoyfsh_4sEL4c1hrsF8s50XYW5AoyOETWgPWblsC2o26pLpORE2RgOd9aeTdB1Mw_hBz3tUPzb_lR6J8wKphIvpntNVN6PB9UfG1dfw4QxvUTI9N4pjT14ZL766Pb5cKUScJ9Ollw57yAaFEL3n6cakkoCeOX7dnPws.eHcW8BnmStbQ60pKLqsdpl9hJz1eZzxg6zlLNMEkS7M
+      - yBdGRLC8pmqSgD8qfLf_ppgyOF80LnKycKVv6mZodCRY-hwLuQvTP6y0i1W0jBuakTnsk5sPpAviL1vfFSZfeiQu8h5Nfp5D9F6-wIcuugyOeRMMZYYdoSv1BMuZgr7s5frRzURxBfr1VfKxcvXsmUOmhMjdIfeXhXELty7cTgk.WnyJG58HCqI5QsFxO1qJoR_yZX2bn509QGTzu7sLqqA
       pragma:
       - no-cache
       request-id:
-      - bad8ae96-4915-49a8-a79c-313f4230f3aa
+      - f24d136c-4855-4ae6-98d1-ed47e70d1d84
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:
@@ -2219,8 +2300,8 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.8.1 (Windows-10-10.0.18362-SP0) msrest/0.6.11 msrest_azure/0.6.2
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.1.0
+      - python/3.8.5 (macOS-10.15.6-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.9.1
       accept-language:
       - en-US
     method: GET
@@ -2240,25 +2321,27 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 05 Mar 2020 10:18:49 GMT
+      - Wed, 05 Aug 2020 09:36:51 GMT
       duration:
-      - '2261229'
+      - '2882805'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 2dwL4zmGotV02lDmIuML9wD2xi2nJgoszFrjUl3LYBw=
+      - jAY6tweZL71h4Zs/fSXIbbKUblkE4vI7Xhf6+Ag18Ok=
       ocp-aad-session-key:
-      - HpyUDyUiHC1s_FRSp3tr4BZGX1oSQYD8z4z2f-1JfWk8M0QJ3Z_kZcnqzdD1IJkW6XEUBP-Xa_K-08fdJ9O14p4iNSf2wo5VvY0xJUO3W5QmnLtuQ0wYOWeGb8-zFo-PzxA3toyX5hDsltEcUFjmWPOxVbAgbs6PL9Nunx1VgDs.FhJCtt4Z9hpwmtEET0IaTnPMSIOdeR04El_WP2fAhIk
+      - qd6V-NkDwI_VGJiH-ufb1bkmFdC-ZaO08TWKJmh1tah1c_YwhfCbaTcwVEWJY5x1lb6Gm0qATquotWlIYBvJMn6-nYZi8bv4eaPJsfZwkdWoEUszZ3Kzkt9VGlid_IRH9XqpyH56fBa6w2xYIMLTMg0xF6bMShuV9G3awEW9pxY.pkqxDNFdK7CW0Djx5sR2XyFXwuLGnxtDSJBdC82xkNA
       pragma:
       - no-cache
       request-id:
-      - cfbee923-1a92-4aca-bfa7-b3ec9367b3e7
+      - 178d9333-1da9-46a3-b645-3cd7ede7e9cf
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
       - 4.0.30319
       x-ms-dirapi-data-contract-version:
       - '1.6'
+      x-ms-resource-unit:
+      - '1'
       x-powered-by:
       - ASP.NET
     status:

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -339,7 +339,7 @@ class GraphGroupScenarioTest(ScenarioTest):
             user2_result = self.cmd('ad user create --display-name {user2} --password {pass} --user-principal-name {user2}@{domain}').get_output_in_json()
             self.kwargs['user2_id'] = user2_result['objectId']
             # create group
-            group_result = self.cmd('ad group create --display-name {group} --mail-nickname {group}').get_output_in_json()
+            group_result = self.cmd('ad group create --display-name {group} --mail-nickname {group} --description {group}').get_output_in_json()
             self.kwargs['group_id'] = group_result['objectId']
             # add user1 into group
             self.cmd('ad group member add -g {group} --member-id {user1_id}',
@@ -354,7 +354,8 @@ class GraphGroupScenarioTest(ScenarioTest):
             # show group
             self.cmd('ad group show -g {group}', checks=[
                 self.check('objectId', '{group_id}'),
-                self.check('displayName', '{group}')
+                self.check('displayName', '{group}'),
+                self.check('description', '{group}')
             ])
             self.cmd('ad group show -g {group}',
                      checks=self.check('displayName', '{group}'))


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR is to fix #13574 

Previously, the user can't specify description for a group when run `az ad group create`. This PR is to add support for this new parameter.

**Testing Guide**  
`az ad group create --display-name testgroupxxj --mail-nickname testgroupxxj --description "I am a description"`
>{
  "deletionTimestamp": null,
  "description": "I am a description",
  "dirSyncEnabled": null,
  "displayName": "testgroupxxj",
  "lastDirSyncTime": null,
  "mail": null,
  "mailEnabled": false,
  "mailNickname": "testgroupxxj",
  "objectId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
  "objectType": "Group",
  "odata.metadata": "https://graph.windows.net/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/$metadata#directoryObjects/@Element",
  "odata.type": "Microsoft.DirectoryServices.Group",
  "onPremisesDomainName": null,
  "onPremisesNetBiosName": null,
  "onPremisesSamAccountName": null,
  "onPremisesSecurityIdentifier": null,
  "provisioningErrors": [],
  "proxyAddresses": [],
  "securityEnabled": true
}

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
