### PR TITLE
{Extension} Fix extension command mapping

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/extension/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/__init__.py
@@ -40,10 +40,10 @@ class ExtensionCommandsLoader(AzCommandsLoader):
 
         with self.command_group('extension', extension_custom) as g:
             g.command('add', 'add_extension_cmd', confirmation=ext_add_has_confirmed, validator=validate_extension_add)
-            g.command('remove', 'remove_extension')
-            g.command('list', 'list_extensions')
-            g.show_command('show', 'show_extension')
-            g.command('list-available', 'list_available_extensions', table_transformer=transform_extension_list_available)
+            g.command('remove', 'remove_extension_cmd')
+            g.command('list', 'list_extensions_cmd')
+            g.show_command('show', 'show_extension_cmd')
+            g.command('list-available', 'list_available_extensions_cmd', table_transformer=transform_extension_list_available)
             g.command('update', 'update_extension_cmd')
 
         return self.command_table

--- a/src/azure-cli/azure/cli/command_modules/extension/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/custom.py
@@ -14,7 +14,8 @@ logger = get_logger(__name__)
 def add_extension_cmd(cmd, source=None, extension_name=None, index_url=None, yes=None,
                       pip_extra_index_urls=None, pip_proxy=None, system=None, version=None):
     return add_extension(cli_ctx=cmd.cli_ctx, source=source, extension_name=extension_name, index_url=index_url,
-                         yes=yes, pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, system=system, version=version)
+                         yes=yes, pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, system=system,
+                         version=version)
 
 
 def remove_extension_cmd(extension_name):

--- a/src/azure-cli/azure/cli/command_modules/extension/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/custom.py
@@ -12,9 +12,9 @@ logger = get_logger(__name__)
 
 
 def add_extension_cmd(cmd, source=None, extension_name=None, index_url=None, yes=None,
-                      pip_extra_index_urls=None, pip_proxy=None, system=None):
+                      pip_extra_index_urls=None, pip_proxy=None, system=None, version=None):
     return add_extension(cli_ctx=cmd.cli_ctx, source=source, extension_name=extension_name, index_url=index_url,
-                         yes=yes, pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, system=system)
+                         yes=yes, pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, system=system, version=version)
 
 
 def remove_extension_cmd(extension_name):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Previously, the command table of `extension` module uses methods from core, but these methods are meant to be shared in other places as well. Corresponding methods are also defined in `custom.py` but not used. Modification of the core methods could impact the command interface without intention.

We should use the methods in `custom.py` in command mapping and modify these methods when we want to change the command interface.

**Testing Guide**  
<!--Example commands with explanations.-->
Run any existing extension commands and there should be no regression.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
