### PR TITLE
[Network] Support private link for managed disks

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
@@ -31,10 +31,10 @@ def register_providers():
     _register_one_provider('Microsoft.EventGrid/domains', '2020-04-01-preview', True)
     _register_one_provider('Microsoft.SignalRService/signalr', '2020-05-01', False)
     _register_one_provider('Microsoft.Network/applicationGateways', '2020-05-01', True)
-    _register_one_provider('Microsoft.Compute/diskAccesses', '2020-05-01', False, support_manually_approve=False)
+    _register_one_provider('Microsoft.Compute/diskAccesses', '2020-05-01', False, support_connection_operation=False)
 
 
-def _register_one_provider(provider, api_version, support_list_or_not, resource_get_api_version=None, support_manually_approve=True):  # pylint: disable=line-too-long
+def _register_one_provider(provider, api_version, support_list_or_not, resource_get_api_version=None, support_connection_operation=True):  # pylint: disable=line-too-long
     """
     :param provider: namespace + type.
     :param api_version: API version for private link scenarios.
@@ -45,14 +45,16 @@ def _register_one_provider(provider, api_version, support_list_or_not, resource_
         "api_version": api_version,
         "support_list_or_not": support_list_or_not,
         "resource_get_api_version": resource_get_api_version,
-        "support_manually_approve": support_manually_approve
+        "support_connection_operation": support_connection_operation
     }
 
     TYPE_CLIENT_MAPPING[provider] = general_client_settings
 
 
-def _check_manually_approve_support(rp_mapping, resource_provider):
-    if resource_provider in rp_mapping and not rp_mapping[resource_provider]['support_manually_approve']:
+def _check_connection_operation_support(rp_mapping, resource_provider):
+    if resource_provider in rp_mapping \
+       and isinstance(rp_mapping[resource_provider], dict) \
+       and not rp_mapping[resource_provider]['support_connection_operation']:
         raise CLIError("Resource provider {} currently does not support this operation".format(resource_provider))
 
 
@@ -75,7 +77,7 @@ def list_private_link_resource(cmd, resource_group_name, name, resource_provider
 
 def approve_private_endpoint_connection(cmd, resource_group_name, resource_name, resource_provider,
                                         name, approval_description=None):
-    _check_manually_approve_support(TYPE_CLIENT_MAPPING, resource_provider)
+    _check_connection_operation_support(TYPE_CLIENT_MAPPING, resource_provider)
     client = _get_client(TYPE_CLIENT_MAPPING, resource_provider)
     return client.approve_private_endpoint_connection(cmd, resource_group_name,
                                                       resource_name, name,
@@ -84,7 +86,7 @@ def approve_private_endpoint_connection(cmd, resource_group_name, resource_name,
 
 def reject_private_endpoint_connection(cmd, resource_group_name, resource_name, resource_provider,
                                        name, rejection_description=None):
-    _check_manually_approve_support(TYPE_CLIENT_MAPPING, resource_provider)
+    _check_connection_operation_support(TYPE_CLIENT_MAPPING, resource_provider)
     client = _get_client(TYPE_CLIENT_MAPPING, resource_provider)
     return client.reject_private_endpoint_connection(cmd, resource_group_name,
                                                      resource_name, name,
@@ -92,13 +94,13 @@ def reject_private_endpoint_connection(cmd, resource_group_name, resource_name, 
 
 
 def remove_private_endpoint_connection(cmd, resource_group_name, resource_name, resource_provider, name):
-    _check_manually_approve_support(TYPE_CLIENT_MAPPING, resource_provider)
+    _check_connection_operation_support(TYPE_CLIENT_MAPPING, resource_provider)
     client = _get_client(TYPE_CLIENT_MAPPING, resource_provider)
     return client.remove_private_endpoint_connection(cmd, resource_group_name, resource_name, name)
 
 
 def show_private_endpoint_connection(cmd, resource_group_name, resource_name, resource_provider, name):
-    _check_manually_approve_support(TYPE_CLIENT_MAPPING, resource_provider)
+    _check_connection_operation_support(TYPE_CLIENT_MAPPING, resource_provider)
     client = _get_client(TYPE_CLIENT_MAPPING, resource_provider)
     return client.show_private_endpoint_connection(cmd, resource_group_name, resource_name, name)
 

--- a/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
@@ -45,7 +45,7 @@ def _register_one_provider(provider, api_version, support_list_or_not, resource_
         "api_version": api_version,
         "support_list_or_not": support_list_or_not,
         "resource_get_api_version": resource_get_api_version,
-        "support_manually_approve": support_manually_approve,
+        "support_manually_approve": support_manually_approve
     }
 
     TYPE_CLIENT_MAPPING[provider] = general_client_settings

--- a/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
@@ -52,10 +52,7 @@ def _register_one_provider(provider, api_version, support_list_or_not, resource_
 
 
 def _check_manually_approve_support(rp_mapping, resource_provider):
-    if resource_provider not in rp_mapping:
-        raise CLIError("Resource type must be one of {}".format(", ".join(rp_mapping.keys())))
-
-    if not rp_mapping[resource_provider]['support_manually_approve']:
+    if resource_provider in rp_mapping and not rp_mapping[resource_provider]['support_manually_approve']:
         raise CLIError("Resource provider {} currently does not support this operation".format(resource_provider))
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_disk_access_private_endpoint.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_disk_access_private_endpoint.yaml
@@ -1,0 +1,988 @@
+interactions:
+- request:
+    body: '{"location": "centraluseuap"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - disk-access create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '29'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -l -n
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-compute/13.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Compute/diskAccesses/disk_access_name?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"disk_access_name\",\r\n  \"type\": \"Microsoft.Compute/diskAccesses\",\r\n
+        \ \"location\": \"centraluseuap\"\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/centraluseuap/DiskOperations/81cbc2e3-2297-4676-ae9a-85c8c307e270?api-version=2020-05-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '111'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:57:48 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/centraluseuap/DiskOperations/81cbc2e3-2297-4676-ae9a-85c8c307e270?monitor=true&api-version=2020-05-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - disk-access create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -l -n
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-compute/13.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/centraluseuap/DiskOperations/81cbc2e3-2297-4676-ae9a-85c8c307e270?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2020-08-07T06:57:49.4304179+00:00\",\r\n  \"endTime\":
+        \"2020-08-07T06:57:50.9778897+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\"name\":\"disk_access_name\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\"type\":\"Microsoft.Compute/diskAccesses\",\"location\":\"centraluseuap\",\"properties\":{\"provisioningState\":\"Succeeded\",\"timeCreated\":\"2020-08-07T06:57:49.4460223+00:00\"}}\r\n
+        \ },\r\n  \"name\": \"81cbc2e3-2297-4676-ae9a-85c8c307e270\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '624'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperation3Min;49998,Microsoft.Compute/GetOperation30Min;399996
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - disk-access create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -l -n
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-compute/13.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Compute/diskAccesses/disk_access_name?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"disk_access_name\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
+        \ \"type\": \"Microsoft.Compute/diskAccesses\",\r\n  \"location\": \"centraluseuap\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"timeCreated\":
+        \"2020-08-07T06:57:49.4460223+00:00\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '444'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-link-resource list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --type
+      User-Agent:
+      - AZURECLI/2.10.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Compute/diskAccesses/disk_access_name/privateLinkResources?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"disks\",\r\n      \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Compute/diskAccesses/disk_access_name/privateLinkResources/disks\",\r\n
+        \     \"type\": \"Microsoft.Compute/diskAccesses/privateLinkResources\",\r\n
+        \     \"properties\": {\r\n        \"groupId\": \"disks\",\r\n        \"requiredMembers\":
+        [\r\n          \"diskAccess_1\"\r\n        ],\r\n        \"requiredZoneNames\":
+        [\r\n          \"privatelink.blob.core.windows.net\"\r\n        ]\r\n      }\r\n
+        \   }\r\n  ]\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '594'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subnet-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test_disk_access_private_endpoint_000001?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001","name":"test_disk_access_private_endpoint_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-08-07T06:57:40Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/16"]}, "dhcpOptions": {}, "subnets": [{"properties": {"addressPrefix":
+      "10.0.0.0/24"}, "name": "private_endpoint_subnet"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '221'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --subnet-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"private_endpoint_vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet\",\r\n
+        \ \"etag\": \"W/\\\"d264f23a-a05a-4ca4-9c94-d96ece3b28b9\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"e4cfab0d-21ef-428c-9ea3-026c856c90d2\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [\r\n      {\r\n        \"name\": \"private_endpoint_subnet\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\",\r\n
+        \       \"etag\": \"W/\\\"d264f23a-a05a-4ca4-9c94-d96ece3b28b9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\":
+        [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\":
+        \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce380b7b-ffe6-4f74-b3d4-5bc439f919a4?api-version=2020-05-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1517'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - c6c1aacb-b850-4d05-beeb-4a77c55dc5a6
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subnet-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce380b7b-ffe6-4f74-b3d4-5bc439f919a4?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '29'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - b39e09a7-4bda-499b-999c-74db97630f2f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subnet-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"private_endpoint_vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet\",\r\n
+        \ \"etag\": \"W/\\\"0c9aaf71-8d5c-49d1-a4bf-a37fddde1f02\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"e4cfab0d-21ef-428c-9ea3-026c856c90d2\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [\r\n      {\r\n        \"name\": \"private_endpoint_subnet\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\",\r\n
+        \       \"etag\": \"W/\\\"0c9aaf71-8d5c-49d1-a4bf-a37fddde1f02\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\":
+        [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\":
+        \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1519'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:32 GMT
+      etag:
+      - W/"0c9aaf71-8d5c-49d1-a4bf-a37fddde1f02"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 5367d080-2902-4e7f-a289-51cfe319dde7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --disable-private-endpoint-network-policies
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"private_endpoint_subnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\",\r\n
+        \ \"etag\": \"W/\\\"0c9aaf71-8d5c-49d1-a4bf-a37fddde1f02\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+        \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
+        \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '634'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:32 GMT
+      etag:
+      - W/"0c9aaf71-8d5c-49d1-a4bf-a37fddde1f02"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - c6e7e201-d94a-44bb-b242-558d2e1a1ee6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet",
+      "properties": {"addressPrefix": "10.0.0.0/24", "delegations": [], "privateEndpointNetworkPolicies":
+      "Disabled", "privateLinkServiceNetworkPolicies": "Enabled"}, "name": "private_endpoint_subnet"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '446'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --vnet-name --disable-private-endpoint-network-policies
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"private_endpoint_subnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\",\r\n
+        \ \"etag\": \"W/\\\"8d221774-19dd-4482-bc84-0f739512f908\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+        \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Disabled\",\r\n
+        \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f5799e0f-b86c-4a23-adab-02fe025463c6?api-version=2020-05-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '634'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 6cbf9a7f-3b56-4f8a-be83-3455be83ef6c
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --disable-private-endpoint-network-policies
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f5799e0f-b86c-4a23-adab-02fe025463c6?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '29'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - b20bbf09-9d1a-4742-ab8e-0c020a4cce32
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --disable-private-endpoint-network-policies
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"private_endpoint_subnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\",\r\n
+        \ \"etag\": \"W/\\\"dd6ab819-1a10-4763-b08f-1e7a797f8720\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+        \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Disabled\",\r\n
+        \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '635'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:38 GMT
+      etag:
+      - W/"dd6ab819-1a10-4763-b08f-1e7a797f8720"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 48cace3f-2726-4dde-8069-6a6afa3daa45
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --private-connection-resource-id --group-ids --connection-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test_disk_access_private_endpoint_000001?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001","name":"test_disk_access_private_endpoint_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-08-07T06:57:40Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus", "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet"},
+      "privateLinkServiceConnections": [{"properties": {"privateLinkServiceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name",
+      "groupIds": ["disks"]}, "name": "private_connection_name"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '639'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --private-connection-resource-id --group-ids --connection-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"private_endpoint_name\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name\",\r\n
+        \ \"etag\": \"W/\\\"e9dc80b7-2e03-4862-8f53-f168ee6e5047\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/privateEndpoints\",\r\n  \"location\": \"westus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\":
+        \"89b96a5a-78ce-46c0-9297-dbbd2008aaf4\",\r\n    \"privateLinkServiceConnections\":
+        [\r\n      {\r\n        \"name\": \"private_connection_name\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name/privateLinkServiceConnections/private_connection_name\",\r\n
+        \       \"etag\": \"W/\\\"e9dc80b7-2e03-4862-8f53-f168ee6e5047\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateLinkServiceId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
+        \         \"groupIds\": [\r\n            \"disks\"\r\n          ],\r\n          \"privateLinkServiceConnectionState\":
+        {\r\n            \"status\": \"Approved\",\r\n            \"description\":
+        \"\",\r\n            \"actionsRequired\": \"None\"\r\n          }\r\n        },\r\n
+        \       \"type\": \"Microsoft.Network/privateEndpoints/privateLinkServiceConnections\"\r\n
+        \     }\r\n    ],\r\n    \"manualPrivateLinkServiceConnections\": [],\r\n
+        \   \"subnet\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\"\r\n
+        \   },\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/networkInterfaces/private_endpoint_name.nic.e638954c-8e4d-4587-a2a6-0add8ac16270\"\r\n
+        \     }\r\n    ],\r\n    \"customDnsConfigs\": []\r\n  }\r\n}"
+    headers:
+      azure-asyncnotification:
+      - Enabled
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/a4a81392-5334-437e-b483-772c06194f5d?api-version=2020-05-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2285'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - c6ae8414-8af8-4f55-87b7-a4cfa49bbc86
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --private-connection-resource-id --group-ids --connection-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/a4a81392-5334-437e-b483-772c06194f5d?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '29'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - e2098c2a-0a06-4f8e-9fe3-d0774c0c3fff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --vnet-name --subnet --private-connection-resource-id --group-ids --connection-name
+      User-Agent:
+      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
+        Azure-SDK-For-Python AZURECLI/2.10.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"private_endpoint_name\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name\",\r\n
+        \ \"etag\": \"W/\\\"c559581c-25e1-41d0-b7fc-6a6047e20a74\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/privateEndpoints\",\r\n  \"location\": \"westus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"89b96a5a-78ce-46c0-9297-dbbd2008aaf4\",\r\n    \"privateLinkServiceConnections\":
+        [\r\n      {\r\n        \"name\": \"private_connection_name\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name/privateLinkServiceConnections/private_connection_name\",\r\n
+        \       \"etag\": \"W/\\\"c559581c-25e1-41d0-b7fc-6a6047e20a74\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateLinkServiceId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
+        \         \"groupIds\": [\r\n            \"disks\"\r\n          ],\r\n          \"privateLinkServiceConnectionState\":
+        {\r\n            \"status\": \"Approved\",\r\n            \"description\":
+        \"Auto-Approved\",\r\n            \"actionsRequired\": \"None\"\r\n          }\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/privateEndpoints/privateLinkServiceConnections\"\r\n
+        \     }\r\n    ],\r\n    \"manualPrivateLinkServiceConnections\": [],\r\n
+        \   \"subnet\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\"\r\n
+        \   },\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/networkInterfaces/private_endpoint_name.nic.e638954c-8e4d-4587-a2a6-0add8ac16270\"\r\n
+        \     }\r\n    ],\r\n    \"customDnsConfigs\": [\r\n      {\r\n        \"fqdn\":
+        \"md-impexp-fzrf0dglrd1d.z35.blob.storage.azure.net\",\r\n        \"ipAddresses\":
+        [\r\n          \"10.0.0.4\"\r\n        ]\r\n      }\r\n    ]\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2452'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:58 GMT
+      etag:
+      - W/"c559581c-25e1-41d0-b7fc-6a6047e20a74"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - b62fdf4e-ccf1-4bfe-a728-781641474bce
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network private-endpoint-connection list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --type
+      User-Agent:
+      - AZURECLI/2.10.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Compute/diskAccesses/disk_access_name?api-version=2020-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"disk_access_name\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
+        \ \"type\": \"Microsoft.Compute/diskAccesses\",\r\n  \"location\": \"centraluseuap\",\r\n
+        \ \"properties\": {\r\n    \"privateEndpointConnections\": [\r\n      {\r\n
+        \       \"name\": \"disk_access_name.b69b72ad-fd99-42fa-aac2-10e3ca5cdf19\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name/privateEndpointConnections/disk_access_name.b69b72ad-fd99-42fa-aac2-10e3ca5cdf19\",\r\n
+        \       \"type\": \"Microsoft.Compute/diskAccesses/PrivateEndpointConnections\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateEndpoint\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name\"\r\n
+        \         },\r\n          \"privateLinkServiceConnectionState\": {\r\n            \"actionsRequired\":
+        \"None\",\r\n            \"description\": \"Auto-Approved\",\r\n            \"status\":
+        \"Approved\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"timeCreated\": \"2020-08-07T06:57:49.4460223+00:00\"\r\n
+        \ }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1499'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 07 Aug 2020 06:58:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_disk_access_private_endpoint.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_disk_access_private_endpoint.yaml
@@ -29,7 +29,7 @@ interactions:
         \ \"location\": \"centraluseuap\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/centraluseuap/DiskOperations/81cbc2e3-2297-4676-ae9a-85c8c307e270?api-version=2020-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/centraluseuap/DiskOperations/02acc1c5-a055-4e21-9ab5-7df5817b3fc6?api-version=2020-05-01
       cache-control:
       - no-cache
       content-length:
@@ -37,11 +37,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:57:48 GMT
+      - Fri, 07 Aug 2020 07:28:36 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/centraluseuap/DiskOperations/81cbc2e3-2297-4676-ae9a-85c8c307e270?monitor=true&api-version=2020-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/centraluseuap/DiskOperations/02acc1c5-a055-4e21-9ab5-7df5817b3fc6?monitor=true&api-version=2020-05-01
       pragma:
       - no-cache
       server:
@@ -73,22 +73,22 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-compute/13.0.0
         Azure-SDK-For-Python AZURECLI/2.10.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/centraluseuap/DiskOperations/81cbc2e3-2297-4676-ae9a-85c8c307e270?api-version=2020-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/centraluseuap/DiskOperations/02acc1c5-a055-4e21-9ab5-7df5817b3fc6?api-version=2020-05-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2020-08-07T06:57:49.4304179+00:00\",\r\n  \"endTime\":
-        \"2020-08-07T06:57:50.9778897+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\"name\":\"disk_access_name\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\"type\":\"Microsoft.Compute/diskAccesses\",\"location\":\"centraluseuap\",\"properties\":{\"provisioningState\":\"Succeeded\",\"timeCreated\":\"2020-08-07T06:57:49.4460223+00:00\"}}\r\n
-        \ },\r\n  \"name\": \"81cbc2e3-2297-4676-ae9a-85c8c307e270\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2020-08-07T07:28:36.172369+00:00\",\r\n  \"endTime\":
+        \"2020-08-07T07:28:38.5005408+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\"name\":\"disk_access_name\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_7LUIYU2G6XRIDUQSC4L5HI6HJMUVWHCN3W2OCZEJL/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\"type\":\"Microsoft.Compute/diskAccesses\",\"location\":\"centraluseuap\",\"properties\":{\"provisioningState\":\"Succeeded\",\"timeCreated\":\"2020-08-07T07:28:36.172369+00:00\"}}\r\n
+        \ },\r\n  \"name\": \"02acc1c5-a055-4e21-9ab5-7df5817b3fc6\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '624'
+      - '622'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:20 GMT
+      - Fri, 07 Aug 2020 07:29:07 GMT
       expires:
       - '-1'
       pragma:
@@ -105,7 +105,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperation3Min;49998,Microsoft.Compute/GetOperation30Min;399996
+      - Microsoft.Compute/GetOperation3Min;49998,Microsoft.Compute/GetOperation30Min;399995
     status:
       code: 200
       message: OK
@@ -129,19 +129,19 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Compute/diskAccesses/disk_access_name?api-version=2020-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"disk_access_name\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
+      string: "{\r\n  \"name\": \"disk_access_name\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_7LUIYU2G6XRIDUQSC4L5HI6HJMUVWHCN3W2OCZEJL/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
         \ \"type\": \"Microsoft.Compute/diskAccesses\",\r\n  \"location\": \"centraluseuap\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"timeCreated\":
-        \"2020-08-07T06:57:49.4460223+00:00\"\r\n  }\r\n}"
+        \"2020-08-07T07:28:36.172369+00:00\"\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '444'
+      - '443'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:20 GMT
+      - Fri, 07 Aug 2020 07:29:07 GMT
       expires:
       - '-1'
       pragma:
@@ -194,7 +194,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:21 GMT
+      - Fri, 07 Aug 2020 07:29:09 GMT
       expires:
       - '-1'
       pragma:
@@ -235,7 +235,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test_disk_access_private_endpoint_000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001","name":"test_disk_access_private_endpoint_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-08-07T06:57:40Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001","name":"test_disk_access_private_endpoint_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-08-07T07:27:17Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -244,7 +244,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:22 GMT
+      - Fri, 07 Aug 2020 07:29:10 GMT
       expires:
       - '-1'
       pragma:
@@ -287,15 +287,15 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"private_endpoint_vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet\",\r\n
-        \ \"etag\": \"W/\\\"d264f23a-a05a-4ca4-9c94-d96ece3b28b9\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"05761f36-3fc5-47ee-a747-d4bb71bedfc7\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"e4cfab0d-21ef-428c-9ea3-026c856c90d2\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"c9e3fd9c-59f8-44fb-97c1-b3e29536bc89\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"private_endpoint_subnet\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\",\r\n
-        \       \"etag\": \"W/\\\"d264f23a-a05a-4ca4-9c94-d96ece3b28b9\\\"\",\r\n
+        \       \"etag\": \"W/\\\"05761f36-3fc5-47ee-a747-d4bb71bedfc7\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
         \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\":
         [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\":
@@ -306,7 +306,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce380b7b-ffe6-4f74-b3d4-5bc439f919a4?api-version=2020-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/a7ee1f4a-1909-44be-9741-648e1017b678?api-version=2020-05-01
       cache-control:
       - no-cache
       content-length:
@@ -314,7 +314,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:27 GMT
+      - Fri, 07 Aug 2020 07:29:15 GMT
       expires:
       - '-1'
       pragma:
@@ -327,9 +327,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - c6c1aacb-b850-4d05-beeb-4a77c55dc5a6
+      - b1477813-44ea-4b82-8b3e-99fe51d3dd96
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -350,7 +350,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
         Azure-SDK-For-Python AZURECLI/2.10.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/ce380b7b-ffe6-4f74-b3d4-5bc439f919a4?api-version=2020-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/a7ee1f4a-1909-44be-9741-648e1017b678?api-version=2020-05-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -362,7 +362,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:32 GMT
+      - Fri, 07 Aug 2020 07:29:19 GMT
       expires:
       - '-1'
       pragma:
@@ -379,7 +379,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - b39e09a7-4bda-499b-999c-74db97630f2f
+      - 63ac7923-4df2-4386-b8a4-b65d18a7d90f
     status:
       code: 200
       message: OK
@@ -404,15 +404,15 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"private_endpoint_vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet\",\r\n
-        \ \"etag\": \"W/\\\"0c9aaf71-8d5c-49d1-a4bf-a37fddde1f02\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"d2510c96-5dc3-45f6-8743-63702e63eceb\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"e4cfab0d-21ef-428c-9ea3-026c856c90d2\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"c9e3fd9c-59f8-44fb-97c1-b3e29536bc89\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"private_endpoint_subnet\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\",\r\n
-        \       \"etag\": \"W/\\\"0c9aaf71-8d5c-49d1-a4bf-a37fddde1f02\\\"\",\r\n
+        \       \"etag\": \"W/\\\"d2510c96-5dc3-45f6-8743-63702e63eceb\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"delegations\":
         [],\r\n          \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\":
@@ -427,9 +427,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:32 GMT
+      - Fri, 07 Aug 2020 07:29:19 GMT
       etag:
-      - W/"0c9aaf71-8d5c-49d1-a4bf-a37fddde1f02"
+      - W/"d2510c96-5dc3-45f6-8743-63702e63eceb"
       expires:
       - '-1'
       pragma:
@@ -446,7 +446,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 5367d080-2902-4e7f-a289-51cfe319dde7
+      - 19edfc05-ad61-44d7-bde0-9e5c38c3053a
     status:
       code: 200
       message: OK
@@ -473,7 +473,7 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"private_endpoint_subnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\",\r\n
-        \ \"etag\": \"W/\\\"0c9aaf71-8d5c-49d1-a4bf-a37fddde1f02\\\"\",\r\n  \"properties\":
+        \ \"etag\": \"W/\\\"d2510c96-5dc3-45f6-8743-63702e63eceb\\\"\",\r\n  \"properties\":
         {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
         \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
         \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
@@ -486,9 +486,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:32 GMT
+      - Fri, 07 Aug 2020 07:29:21 GMT
       etag:
-      - W/"0c9aaf71-8d5c-49d1-a4bf-a37fddde1f02"
+      - W/"d2510c96-5dc3-45f6-8743-63702e63eceb"
       expires:
       - '-1'
       pragma:
@@ -505,7 +505,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - c6e7e201-d94a-44bb-b242-558d2e1a1ee6
+      - b34347f9-cab9-478b-986b-7d4c4de8a0cf
     status:
       code: 200
       message: OK
@@ -538,14 +538,14 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"private_endpoint_subnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\",\r\n
-        \ \"etag\": \"W/\\\"8d221774-19dd-4482-bc84-0f739512f908\\\"\",\r\n  \"properties\":
+        \ \"etag\": \"W/\\\"c5a5dab4-235e-4d91-8c41-5ccd743cb946\\\"\",\r\n  \"properties\":
         {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
         \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Disabled\",\r\n
         \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f5799e0f-b86c-4a23-adab-02fe025463c6?api-version=2020-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/a1c10fc8-9789-4426-ae56-8f6a15667a25?api-version=2020-05-01
       cache-control:
       - no-cache
       content-length:
@@ -553,7 +553,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:34 GMT
+      - Fri, 07 Aug 2020 07:29:21 GMT
       expires:
       - '-1'
       pragma:
@@ -570,9 +570,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 6cbf9a7f-3b56-4f8a-be83-3455be83ef6c
+      - ccec822b-c9c8-434e-a3e4-770130c176c9
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 200
       message: OK
@@ -593,7 +593,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
         Azure-SDK-For-Python AZURECLI/2.10.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/f5799e0f-b86c-4a23-adab-02fe025463c6?api-version=2020-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/a1c10fc8-9789-4426-ae56-8f6a15667a25?api-version=2020-05-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -605,7 +605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:38 GMT
+      - Fri, 07 Aug 2020 07:29:25 GMT
       expires:
       - '-1'
       pragma:
@@ -622,7 +622,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - b20bbf09-9d1a-4742-ab8e-0c020a4cce32
+      - 5839751b-d2e8-428d-b5e3-57ad95b8a19f
     status:
       code: 200
       message: OK
@@ -647,7 +647,7 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"private_endpoint_subnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\",\r\n
-        \ \"etag\": \"W/\\\"dd6ab819-1a10-4763-b08f-1e7a797f8720\\\"\",\r\n  \"properties\":
+        \ \"etag\": \"W/\\\"749b0fbf-c994-4dc2-bae0-f36f444686b0\\\"\",\r\n  \"properties\":
         {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
         \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Disabled\",\r\n
         \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
@@ -660,9 +660,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:38 GMT
+      - Fri, 07 Aug 2020 07:29:26 GMT
       etag:
-      - W/"dd6ab819-1a10-4763-b08f-1e7a797f8720"
+      - W/"749b0fbf-c994-4dc2-bae0-f36f444686b0"
       expires:
       - '-1'
       pragma:
@@ -679,7 +679,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 48cace3f-2726-4dde-8069-6a6afa3daa45
+      - 7ee4c6c2-4292-4cac-8ac4-fee856a9a472
     status:
       code: 200
       message: OK
@@ -705,7 +705,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test_disk_access_private_endpoint_000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001","name":"test_disk_access_private_endpoint_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-08-07T06:57:40Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001","name":"test_disk_access_private_endpoint_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-08-07T07:27:17Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -714,7 +714,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:40 GMT
+      - Fri, 07 Aug 2020 07:29:26 GMT
       expires:
       - '-1'
       pragma:
@@ -730,7 +730,7 @@ interactions:
       message: OK
 - request:
     body: '{"location": "westus", "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet"},
-      "privateLinkServiceConnections": [{"properties": {"privateLinkServiceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name",
+      "privateLinkServiceConnections": [{"properties": {"privateLinkServiceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_7LUIYU2G6XRIDUQSC4L5HI6HJMUVWHCN3W2OCZEJL/providers/Microsoft.Compute/diskAccesses/disk_access_name",
       "groupIds": ["disks"]}, "name": "private_connection_name"}]}}'
     headers:
       Accept:
@@ -757,28 +757,28 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"private_endpoint_name\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name\",\r\n
-        \ \"etag\": \"W/\\\"e9dc80b7-2e03-4862-8f53-f168ee6e5047\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"7dcc5184-361f-4304-9ed4-8e05086f4366\\\"\",\r\n  \"type\":
         \"Microsoft.Network/privateEndpoints\",\r\n  \"location\": \"westus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\":
-        \"89b96a5a-78ce-46c0-9297-dbbd2008aaf4\",\r\n    \"privateLinkServiceConnections\":
+        \"90d3f438-fec7-45ab-8d48-925988a46a1a\",\r\n    \"privateLinkServiceConnections\":
         [\r\n      {\r\n        \"name\": \"private_connection_name\",\r\n        \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name/privateLinkServiceConnections/private_connection_name\",\r\n
-        \       \"etag\": \"W/\\\"e9dc80b7-2e03-4862-8f53-f168ee6e5047\\\"\",\r\n
+        \       \"etag\": \"W/\\\"7dcc5184-361f-4304-9ed4-8e05086f4366\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateLinkServiceId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
+        \         \"privateLinkServiceId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_7LUIYU2G6XRIDUQSC4L5HI6HJMUVWHCN3W2OCZEJL/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
         \         \"groupIds\": [\r\n            \"disks\"\r\n          ],\r\n          \"privateLinkServiceConnectionState\":
         {\r\n            \"status\": \"Approved\",\r\n            \"description\":
         \"\",\r\n            \"actionsRequired\": \"None\"\r\n          }\r\n        },\r\n
         \       \"type\": \"Microsoft.Network/privateEndpoints/privateLinkServiceConnections\"\r\n
         \     }\r\n    ],\r\n    \"manualPrivateLinkServiceConnections\": [],\r\n
         \   \"subnet\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\"\r\n
-        \   },\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/networkInterfaces/private_endpoint_name.nic.e638954c-8e4d-4587-a2a6-0add8ac16270\"\r\n
+        \   },\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/networkInterfaces/private_endpoint_name.nic.101d2ab4-bdbc-4653-919c-882cd08a5527\"\r\n
         \     }\r\n    ],\r\n    \"customDnsConfigs\": []\r\n  }\r\n}"
     headers:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/a4a81392-5334-437e-b483-772c06194f5d?api-version=2020-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/06544851-59f3-4a29-93f9-30733cf3b0ae?api-version=2020-05-01
       cache-control:
       - no-cache
       content-length:
@@ -786,7 +786,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:46 GMT
+      - Fri, 07 Aug 2020 07:29:33 GMT
       expires:
       - '-1'
       pragma:
@@ -799,9 +799,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - c6ae8414-8af8-4f55-87b7-a4cfa49bbc86
+      - da556a0a-7b90-4bdd-9c04-90c0aad2ef9e
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1196'
     status:
       code: 201
       message: Created
@@ -822,7 +822,7 @@ interactions:
       - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-network/11.0.0
         Azure-SDK-For-Python AZURECLI/2.10.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/a4a81392-5334-437e-b483-772c06194f5d?api-version=2020-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/06544851-59f3-4a29-93f9-30733cf3b0ae?api-version=2020-05-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -834,7 +834,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:57 GMT
+      - Fri, 07 Aug 2020 07:29:43 GMT
       expires:
       - '-1'
       pragma:
@@ -851,7 +851,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e2098c2a-0a06-4f8e-9fe3-d0774c0c3fff
+      - 7eaeecc6-3c5f-4f78-8383-8f90f84e8ffb
     status:
       code: 200
       message: OK
@@ -876,24 +876,24 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"private_endpoint_name\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name\",\r\n
-        \ \"etag\": \"W/\\\"c559581c-25e1-41d0-b7fc-6a6047e20a74\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"75c91ad1-d6fc-4d68-a2b9-84a3a21081fa\\\"\",\r\n  \"type\":
         \"Microsoft.Network/privateEndpoints\",\r\n  \"location\": \"westus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"89b96a5a-78ce-46c0-9297-dbbd2008aaf4\",\r\n    \"privateLinkServiceConnections\":
+        \"90d3f438-fec7-45ab-8d48-925988a46a1a\",\r\n    \"privateLinkServiceConnections\":
         [\r\n      {\r\n        \"name\": \"private_connection_name\",\r\n        \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name/privateLinkServiceConnections/private_connection_name\",\r\n
-        \       \"etag\": \"W/\\\"c559581c-25e1-41d0-b7fc-6a6047e20a74\\\"\",\r\n
+        \       \"etag\": \"W/\\\"75c91ad1-d6fc-4d68-a2b9-84a3a21081fa\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateLinkServiceId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
+        \         \"privateLinkServiceId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_7LUIYU2G6XRIDUQSC4L5HI6HJMUVWHCN3W2OCZEJL/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
         \         \"groupIds\": [\r\n            \"disks\"\r\n          ],\r\n          \"privateLinkServiceConnectionState\":
         {\r\n            \"status\": \"Approved\",\r\n            \"description\":
         \"Auto-Approved\",\r\n            \"actionsRequired\": \"None\"\r\n          }\r\n
         \       },\r\n        \"type\": \"Microsoft.Network/privateEndpoints/privateLinkServiceConnections\"\r\n
         \     }\r\n    ],\r\n    \"manualPrivateLinkServiceConnections\": [],\r\n
         \   \"subnet\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/virtualNetworks/private_endpoint_vnet/subnets/private_endpoint_subnet\"\r\n
-        \   },\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/networkInterfaces/private_endpoint_name.nic.e638954c-8e4d-4587-a2a6-0add8ac16270\"\r\n
+        \   },\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/networkInterfaces/private_endpoint_name.nic.101d2ab4-bdbc-4653-919c-882cd08a5527\"\r\n
         \     }\r\n    ],\r\n    \"customDnsConfigs\": [\r\n      {\r\n        \"fqdn\":
-        \"md-impexp-fzrf0dglrd1d.z35.blob.storage.azure.net\",\r\n        \"ipAddresses\":
+        \"md-impexp-xkrlffrnbnbb.z22.blob.storage.azure.net\",\r\n        \"ipAddresses\":
         [\r\n          \"10.0.0.4\"\r\n        ]\r\n      }\r\n    ]\r\n  }\r\n}"
     headers:
       cache-control:
@@ -903,9 +903,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:58 GMT
+      - Fri, 07 Aug 2020 07:29:43 GMT
       etag:
-      - W/"c559581c-25e1-41d0-b7fc-6a6047e20a74"
+      - W/"75c91ad1-d6fc-4d68-a2b9-84a3a21081fa"
       expires:
       - '-1'
       pragma:
@@ -922,7 +922,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - b62fdf4e-ccf1-4bfe-a728-781641474bce
+      - 5571909b-b84c-4926-9168-0798158bf60f
     status:
       code: 200
       message: OK
@@ -945,28 +945,28 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Compute/diskAccesses/disk_access_name?api-version=2020-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"disk_access_name\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
+      string: "{\r\n  \"name\": \"disk_access_name\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_7LUIYU2G6XRIDUQSC4L5HI6HJMUVWHCN3W2OCZEJL/providers/Microsoft.Compute/diskAccesses/disk_access_name\",\r\n
         \ \"type\": \"Microsoft.Compute/diskAccesses\",\r\n  \"location\": \"centraluseuap\",\r\n
         \ \"properties\": {\r\n    \"privateEndpointConnections\": [\r\n      {\r\n
-        \       \"name\": \"disk_access_name.b69b72ad-fd99-42fa-aac2-10e3ca5cdf19\",\r\n
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_UU4NPUII5UA2BDRI5QKDDEITFYWAETGNOAVTGECAJ/providers/Microsoft.Compute/diskAccesses/disk_access_name/privateEndpointConnections/disk_access_name.b69b72ad-fd99-42fa-aac2-10e3ca5cdf19\",\r\n
+        \       \"name\": \"disk_access_name.e64458df-869b-41f4-9dc5-c02a7180bc7c\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TEST_DISK_ACCESS_PRIVATE_ENDPOINT_7LUIYU2G6XRIDUQSC4L5HI6HJMUVWHCN3W2OCZEJL/providers/Microsoft.Compute/diskAccesses/disk_access_name/privateEndpointConnections/disk_access_name.e64458df-869b-41f4-9dc5-c02a7180bc7c\",\r\n
         \       \"type\": \"Microsoft.Compute/diskAccesses/PrivateEndpointConnections\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateEndpoint\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_disk_access_private_endpoint_000001/providers/Microsoft.Network/privateEndpoints/private_endpoint_name\"\r\n
         \         },\r\n          \"privateLinkServiceConnectionState\": {\r\n            \"actionsRequired\":
         \"None\",\r\n            \"description\": \"Auto-Approved\",\r\n            \"status\":
         \"Approved\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"timeCreated\": \"2020-08-07T06:57:49.4460223+00:00\"\r\n
+        \"Succeeded\",\r\n    \"timeCreated\": \"2020-08-07T07:28:36.172369+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1499'
+      - '1498'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 07 Aug 2020 06:58:59 GMT
+      - Fri, 07 Aug 2020 07:29:45 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
@@ -1383,7 +1383,7 @@ class NetworkPrivateLinkDiskAccessScenarioTest(ScenarioTest):
         })
 
         # Check the auto-approve of the private endpoint connection
-        self.cmd('az network private-endpoint-connection list -g {rg} -n {disk_access} --type Microsoft.Compute/diskAccesses',
+        self.cmd('network private-endpoint-connection list -g {rg} -n {disk_access} --type Microsoft.Compute/diskAccesses',
                  checks=[
                      self.check('length(@)', 1),
                      self.check('@[0].properties.privateEndpoint.id', '{pe_id}'),


### PR DESCRIPTION
**Backgroud** 

Feature Request: CLI Support for private links of managed disks #13917 

This PR is a part of supporting private links for managed disks. Private links for managed disks is a little different from the already supported private links in CLI (e.g, keyvault). It use the disk-access as an intermediate resource rather than connect with the target resource directly. Therefore, to support the private links for managed disks, we have to do the following things. This PR works to support the third step. 

> 1. Support CURD of the new resource disk-access
> 2. Support create/update a disk/snapshot to associate it a disk-access resource
> 3. **Support private links for managed disks**

**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR provides support for:
1. `az network private-link-resource list` for --type Microsoft.Compute/diskAccesses
2. `az network private-endpoint-connection list` for --type Microsoft.Compute/diskAccesses

As service currently does not support for manual approval of the connection, and does not provide the APIs, these commands are not supported.
1. `az network private-endpoint-connection approve`
2. `az network private-endpoint-connection reject`
3. `az network private-endpoint-connection delete`
4. `az network private-endpoint-connection show`

We will raise the following error if users are trying to use these commands.
```
Resource provider Microsoft.Compute/diskAccesses currently does not support this operation
```
**Testing Guide**  
<!--Example commands with explanations.-->
1. Create a disk-access and check private link resource
```
az disk-access create -g {rg} -l {loc} -n {disk_access}

az network private-link-resource list -g {rg} -n {disk_access} --type Microsoft.Compute/diskAccesses
```
2. Prepare and enable VNet
```
az network vnet create -g {rg} -n {pe_vnet} --subnet-name {pe_subnet}

az network vnet subnet update -g {rg} -n {pe_subnet} --vnet-name {pe_vnet}  
   --disable-private-endpoint-network-policies true
```
3. Create a private endpoint connection and check the auto-approval
```
az network private-endpoint create -g {rg} -n {pe_name} --vnet-name {pe_vnet}
  --subnet {pe_subnet} --private-connection-resource-id {disk_access_id}
  --group-ids disks --connection-name {pe_connection}

az network private-endpoint-connection list -g {rg} -n {disk_access} --type Microsoft.Compute/diskAccesses
```
4. Create a disk or snapshot and associate it with the disk-access to test private connection