### PR TITLE
{Cognitive Services} Show additional legal term for certain APIs

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cognitiveservices/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cognitiveservices/custom.py
@@ -85,7 +85,9 @@ def create(
         'Microsoft offers policy controls that may be used to disable new Cognitive'\
         ' Services deployments (https://docs.microsoft.com/azure/cognitive-servic'\
         'es/cognitive-services-apis-create-account).'
-    hint = '\nPlease select'
+    terms_not_police = 'Notice\n' \
+                       'I certify that use of this service is not by or for a police department in the United States.'
+    hint = 'Please select'
     import re
     pattern = re.compile("^[Bb]ing\\..*$")
     if pattern.match(kind):
@@ -96,6 +98,15 @@ def create(
             option = prompt_y_n(hint)
             if not option:
                 raise CLIError('Operation cancelled.')
+    if kind.lower() == 'face':
+        if yes:
+            logger.warning(terms_not_police)
+        else:
+            logger.warning(terms_not_police)
+            option = prompt_y_n(hint)
+            if not option:
+                raise CLIError('Operation cancelled.')
+
     sku = Sku(name=sku_name)
 
     properties = CognitiveServicesAccountProperties()

--- a/src/azure-cli/azure/cli/command_modules/cognitiveservices/tests/latest/test_cognitiveservices_command.py
+++ b/src/azure-cli/azure/cli/command_modules/cognitiveservices/tests/latest/test_cognitiveservices_command.py
@@ -27,7 +27,7 @@ class CognitiveServicesTests(ScenarioTest):
         })
 
         # test to create cognitive services account
-        self.cmd('az cognitiveservices account create -n {sname} -g {rg} --kind {kind} --sku {sku} -l {location}',
+        self.cmd('az cognitiveservices account create -n {sname} -g {rg} --kind {kind} --sku {sku} -l {location} --yes',
                  checks=[self.check('name', '{sname}'),
                          self.check('location', '{location}'),
                          self.check('sku.name', '{sku}'),
@@ -78,7 +78,7 @@ class CognitiveServicesTests(ScenarioTest):
             'location': 'westeurope'
         })
 
-        self.cmd('az cognitiveservices account create -n {name} -g {rg} --kind {kind} --sku {sku} -l {location}',
+        self.cmd('az cognitiveservices account create -n {name} -g {rg} --kind {kind} --sku {sku} -l {location} --yes',
                  checks=[self.check('name', '{name}'),
                          self.check('location', '{location}'),
                          self.check('sku.name', '{sku}'),

--- a/src/azure-cli/azure/cli/command_modules/cognitiveservices/tests/latest/test_custom_domain.py
+++ b/src/azure-cli/azure/cli/command_modules/cognitiveservices/tests/latest/test_custom_domain.py
@@ -23,7 +23,7 @@ class CognitiveServicesCustomDomainTests(ScenarioTest):
         })
 
         # test to create cognitive services account
-        self.cmd('az cognitiveservices account create -n {sname} -g {rg} --kind {kind} --sku {sku} -l {location}'
+        self.cmd('az cognitiveservices account create -n {sname} -g {rg} --kind {kind} --sku {sku} -l {location} --yes'
                  ' --custom-domain {customdomain}',
                  checks=[self.check('name', '{sname}'),
                          self.check('location', '{location}'),
@@ -36,7 +36,7 @@ class CognitiveServicesCustomDomainTests(ScenarioTest):
         self.assertEqual(ret.exit_code, 0)
 
         # test to create cognitive services account
-        self.cmd('az cognitiveservices account create -n {sname} -g {rg} --kind {kind} --sku {sku} -l {location}',
+        self.cmd('az cognitiveservices account create -n {sname} -g {rg} --kind {kind} --sku {sku} -l {location} --yes',
                  checks=[self.check('name', '{sname}'),
                          self.check('location', '{location}'),
                          self.check('sku.name', '{sku}'),

--- a/src/azure-cli/azure/cli/command_modules/cognitiveservices/tests/latest/test_network_rules.py
+++ b/src/azure-cli/azure/cli/command_modules/cognitiveservices/tests/latest/test_network_rules.py
@@ -31,7 +31,7 @@ class CognitiveServicesNetworkRulesTests(ScenarioTest):
                            ' --vnet-name {vnetname} --address-prefixes 10.0.1.0/24').get_output_in_json()
 
         self.cmd('az cognitiveservices account create -n {sname} -g {rg} --kind {kind} --sku {sku} -l {location}'
-                 ' --custom-domain {customdomain}',
+                 ' --custom-domain {customdomain} --yes',
                  checks=[self.check('name', '{sname}'),
                          self.check('location', '{location}'),
                          self.check('sku.name', '{sku}'),


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Show additional legal term for certain APIs

**Testing Guide**  
When creating face api, it should show a special legal term.

**History Notes**  
{Cognitive Services} az cognitiveservices account create: show additional legal term for certain APIs


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
