### PR TITLE
WIP Do not merge: AppService testing environment setup

### DIFF
--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import os
 import time
 import requests
 import adal
@@ -69,6 +70,12 @@ class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-meth
     # This method is exposed for msrest.
     def signed_session(self, session=None):  # pylint: disable=arguments-differ
         session = session or super(AdalAuthentication, self).signed_session()
+
+        private_cert = os.environ.get("AZURE_CLI_CLIENT_CERT_PATH")
+        if private_cert is not None and private_cert != "":
+            session.cert = private_cert
+            session.verify = False
+            return session
 
         scheme, token, _, external_tenant_tokens = self._get_token()
 

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -293,6 +293,13 @@ def _arm_to_cli_mapper(arm_dict):
             acr_login_server_endpoint=get_suffix('acrLoginServer', add_dot=True)))
 
 
+def _get_resource_manager_endpoint(default_resource_manager):
+    private_geo = os.environ.get('AZURE_CLI_PRIVATE_GEO')
+    if private_geo is None or private_geo == '':
+        return default_resource_manager
+    return private_geo
+
+
 class Cloud:  # pylint: disable=too-few-public-methods
     """ Represents an Azure Cloud instance """
 
@@ -323,7 +330,7 @@ AZURE_PUBLIC_CLOUD = Cloud(
     'AzureCloud',
     endpoints=CloudEndpoints(
         management='https://management.core.windows.net/',
-        resource_manager='https://management.azure.com/',
+        resource_manager=_get_resource_manager_endpoint('https://management.azure.com/'),
         sql_management='https://management.core.windows.net:8443/',
         batch_resource_id='https://batch.core.windows.net/',
         gallery='https://gallery.azure.com/',


### PR DESCRIPTION
**Description<!--Mandatory-->**

WIP Do not merge

We would like the convenience to be able to test & work on our AppService/Webapp commands faster, without the need to wait for the deployment of our backend API changes and SDK updates before working on CLI changes. 

In order to do so, we want to check for these two environment variables:
- `AZURE_CLI_PRIVATE_GEO`: The endpoint of our testing environment
- `AZURE_CLI_CLIENT_CERT_PATH`: The path to the certificate used to authenticate to our testing environment

If these two environment variables are set, we want the CLI to make any calls to our testing environment instead of production environment.

We were wondering if this is something we can do?


**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
