### PR TITLE
[Cloud] az cloud register: Fix registering clouds with a config file

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cloud/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/cloud/_help.py
@@ -26,6 +26,24 @@ helps['cloud register'] = """
 type: command
 short-summary: Register a cloud.
 long-summary: When registering a cloud, specify only the resource manager endpoint for the autodetection of other endpoints.
+examples:
+  - name: Register a cloud with a config file
+    text: |
+        az cloud register -n MyCloud --cloud-config @"cloud.json"
+        ("cloud.json" supports all the endpoint and suffix options in camel case or the JSON output format from `az cloud show`. See the example content below.)
+        {
+          "endpointActiveDirectory": "https://login.microsoftonline.us",
+          "suffixAcrLoginServerEndpoint": ".azurecr.us"
+        }
+        or
+        {
+          "endpoint":{
+            "activeDirectory": "https://login.microsoftonline.us"
+          },
+          "suffix":{
+            "acrLoginServerEndpoint": ".azurecr.us"
+          }
+        }
 """
 
 helps['cloud set'] = """

--- a/src/azure-cli/azure/cli/command_modules/cloud/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cloud/custom.py
@@ -36,6 +36,7 @@ def show_cloud(cmd, cloud_name=None):
 
 def _build_cloud(cli_ctx, cloud_name, cloud_config=None, cloud_args=None):
     from msrestazure.azure_cloud import _populate_from_metadata_endpoint, MetadataEndpointError
+    from azure.cli.core.cloud import CloudEndpointNotSetException
 
     if cloud_config:
         # Using JSON format so convert the keys to snake case
@@ -44,12 +45,29 @@ def _build_cloud(cli_ctx, cloud_name, cloud_config=None, cloud_args=None):
         cloud_args = cloud_config
     c = Cloud(cloud_name)
     c.profile = cloud_args.get('profile', None)
+    try:
+        endpoints = cloud_args['endpoints']
+        for arg in endpoints:
+            setattr(c.endpoints, to_snake_case(arg), endpoints[arg])
+    except KeyError:
+        pass
+    try:
+        suffixes = cloud_args['suffixes']
+        for arg in suffixes:
+            setattr(c.suffixes, to_snake_case(arg), suffixes[arg])
+    except KeyError:
+        pass
+
     for arg in cloud_args:
         if arg.startswith('endpoint_') and cloud_args[arg] is not None:
             setattr(c.endpoints, arg.replace('endpoint_', ''), cloud_args[arg])
         elif arg.startswith('suffix_') and cloud_args[arg] is not None:
             setattr(c.suffixes, arg.replace('suffix_', ''), cloud_args[arg])
-    arm_endpoint = cloud_args.get('endpoint_resource_manager', None)
+
+    try:
+        arm_endpoint = c.endpoints.resource_manager
+    except CloudEndpointNotSetException:
+        arm_endpoint = None
     try:
         _populate_from_metadata_endpoint(c, arm_endpoint)
     except MetadataEndpointError as err:

--- a/src/azure-cli/azure/cli/command_modules/cloud/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cloud/custom.py
@@ -37,12 +37,9 @@ def show_cloud(cmd, cloud_name=None):
 def _build_cloud(cli_ctx, cloud_name, cloud_config=None, cloud_args=None):
     from msrestazure.azure_cloud import _populate_from_metadata_endpoint, MetadataEndpointError
     from azure.cli.core.cloud import CloudEndpointNotSetException
-
     if cloud_config:
         # Using JSON format so convert the keys to snake case
-        for key in cloud_config:
-            cloud_config[to_snake_case(key)] = cloud_config.pop(key)
-        cloud_args = cloud_config
+        cloud_args = {to_snake_case(k): v for k, v in cloud_config.items()}
     c = Cloud(cloud_name)
     c.profile = cloud_args.get('profile', None)
     try:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Resolve #14653
Support registering clouds using the output format of `az cloud show`.
Fix the for loop that modifies the dict. 

**Testing Guide**  
<!--Example commands with explanations.-->
Run command `az cloud register -n test --cloud-config @"cloud.json"`
With this PR, it should work with the following 2 formats for `cloud.json`:
```
{
  "endpointResourceManager": "https://management.usgovcloudapi.net/",
  "endpointActiveDirectory": "https://login.microsoftonline.us",
  "suffixAcrLoginServerEndpoint": ".azurecr.us",
  "suffixKeyvaultDns": ".vault.usgovcloudapi.net"
}
```

```
{
  "endpoint":{
    "resourceManager": "https://management.usgovcloudapi.net/",
    "activeDirectory": "https://login.microsoftonline.us"
  },
  "suffix":{
    "acrLoginServerEndpoint": ".azurecr.us",
    "keyvaultDns": ".vault.usgovcloudapi.net"
  }
}
```
Or you can create the file with `az cloud show -n AzureUSGovernment -o json > cloud.json`.
**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
