### PR TITLE
Add special CLI name.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -829,7 +829,7 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
             raise ValueError("The operation '{}' is invalid.".format(operation))
 
 
-def get_default_cli():
+def get_default_cli(cli_name='az'):
     from azure.cli.core.azlogging import AzCliLogging
     from azure.cli.core.commands import AzCliCommandInvoker
     from azure.cli.core.parser import AzCliCommandParser
@@ -837,7 +837,7 @@ def get_default_cli():
     from azure.cli.core._help import AzCliHelp
     from azure.cli.core._output import AzOutputProducer
 
-    return AzCli(cli_name='az',
+    return AzCli(cli_name=cli_name,
                  config_dir=GLOBAL_CONFIG_DIR,
                  config_env_var_prefix=ENV_VAR_PREFIX,
                  commands_loader_cls=MainCommandsLoader,


### PR DESCRIPTION
**Description**  
In order to use azure-cli-core in 3rd-party CLIs, the CLI name has to be configured. Getting an `AzCLI` object with default settings, however, is a great Azure CLI Core feature. Therefore, we recommend this backward compatible change to accept `cli_name` with `az` default value in `get_default_cli(...)` function.

