### PR TITLE
{Storage} `az storage container`: Fix language in logging.warning call

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -176,12 +176,12 @@ def validate_client_parameters(cmd, namespace):
 
     # if account name is specified but no key, attempt to query
     if n.account_name and not n.account_key and not n.sas_token:
-        logger.warning('There is no credential provided in your command and environment, we will query account key '
-                       'for your storage account. \nPlease provide --connection-string, --account-key or --sas-token '
-                       'as credential, or use `--auth-mode login` if you have required RBAC roles in your command. '
+        logger.warning('There are no credentials provided in your command and environment, we will query for the account key '
+                       'inside your storage account. \nPlease provide --connection-string, --account-key or --sas-token '
+                       'as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
                        'For more information about RBAC roles in storage, you can see '
                        'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
-                       'Setting corresponding environment variable can avoid inputting credential in your command. '
+                       'Setting the corresponding environment variables can avoid inputting credentials in your command. '
                        'Please use --help to get more information.')
         n.account_key = _query_account_key(cmd.cli_ctx, n.account_name)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -177,9 +177,10 @@ def validate_client_parameters(cmd, namespace):
     # if account name is specified but no key, attempt to query
     if n.account_name and not n.account_key and not n.sas_token:
         logger.warning('There are no credentials provided in your command and environment, we will query for the '
-                       'account key inside your storage account. \nPlease provide --connection-string, --account-key or '
-                       '--sas-token as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
-                       'For more information about RBAC roles in storage, visit '
+                       'account key inside your storage account. \nPlease provide --connection-string, '
+                       '--account-key or --sas-token as credentials, or use `--auth-mode login` if you '
+                       'have required RBAC roles in your command. For more information about RBAC roles '
+                       'in storage, visit '
                        'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
                        'Setting the corresponding environment variables can avoid inputting credentials in '
                        'your command. Please use --help to get more information.')

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -176,13 +176,13 @@ def validate_client_parameters(cmd, namespace):
 
     # if account name is specified but no key, attempt to query
     if n.account_name and not n.account_key and not n.sas_token:
-        logger.warning('There are no credentials provided in your command and environment, we will query for the account key '
-                       'inside your storage account. \nPlease provide --connection-string, --account-key or --sas-token '
-                       'as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
-                       'For more information about RBAC roles in storage, you can see '
-                       'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
-                       'Setting the corresponding environment variables can avoid inputting credentials in your command. '
-                       'Please use --help to get more information.')
+        logger.warning('There are no credentials provided in your command and environment, we will query for the '
+            'account key inside your storage account. \nPlease provide --connection-string, --account-key or '
+            '--sas-token as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
+            'For more information about RBAC roles in storage, visit '
+            'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
+            'Setting the corresponding environment variables can avoid inputting credentials in '
+            'your command. Please use --help to get more information.')
         n.account_key = _query_account_key(cmd.cli_ctx, n.account_name)
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -177,12 +177,12 @@ def validate_client_parameters(cmd, namespace):
     # if account name is specified but no key, attempt to query
     if n.account_name and not n.account_key and not n.sas_token:
         logger.warning('There are no credentials provided in your command and environment, we will query for the '
-            'account key inside your storage account. \nPlease provide --connection-string, --account-key or '
-            '--sas-token as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
-            'For more information about RBAC roles in storage, visit '
-            'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
-            'Setting the corresponding environment variables can avoid inputting credentials in '
-            'your command. Please use --help to get more information.')
+                       'account key inside your storage account. \nPlease provide --connection-string, --account-key or '
+                       '--sas-token as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
+                       'For more information about RBAC roles in storage, visit '
+                       'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
+                       'Setting the corresponding environment variables can avoid inputting credentials in '
+                       'your command. Please use --help to get more information.')
         n.account_key = _query_account_key(cmd.cli_ctx, n.account_name)
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
@@ -171,12 +171,12 @@ def validate_client_parameters(cmd, namespace):
     # if account name is specified but no key, attempt to query
     if n.account_name and not n.account_key and not n.sas_token:
         logger.warning('There are no credentials provided in your command and environment, we will query for the '
-            'account key inside your storage account. \nPlease provide --connection-string, --account-key or '
-            '--sas-token as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
-            'For more information about RBAC roles in storage, visit '
-            'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
-            'Setting the corresponding environment variables can avoid inputting credentials in '
-            'your command. Please use --help to get more information.')
+                       'account key inside your storage account. \nPlease provide --connection-string, --account-key or '
+                       '--sas-token as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
+                       'For more information about RBAC roles in storage, visit '
+                       'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
+                       'Setting the corresponding environment variables can avoid inputting credentials in '
+                       'your command. Please use --help to get more information.')
         n.account_key = _query_account_key(cmd.cli_ctx, n.account_name)
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
@@ -170,12 +170,12 @@ def validate_client_parameters(cmd, namespace):
 
     # if account name is specified but no key, attempt to query
     if n.account_name and not n.account_key and not n.sas_token:
-        logger.warning('There is no credential provided in your command and environment, we will query account key '
+        logger.warning('There are no credentials provided in your command and environment, we will query account key '
                        'for your storage account. \nPlease provide --connection-string, --account-key or --sas-token '
-                       'as credential, or use `--auth-mode login` if you have required RBAC roles in your command. '
+                       'as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
                        'For more information about RBAC roles in storage, you can see '
                        'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
-                       'Setting corresponding environment variable can avoid inputting credential in your command. '
+                       'Setting the corresponding environment variables can avoid inputting credentials in your command. '
                        'Please use --help to get more information.')
         n.account_key = _query_account_key(cmd.cli_ctx, n.account_name)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
@@ -171,9 +171,10 @@ def validate_client_parameters(cmd, namespace):
     # if account name is specified but no key, attempt to query
     if n.account_name and not n.account_key and not n.sas_token:
         logger.warning('There are no credentials provided in your command and environment, we will query for the '
-                       'account key inside your storage account. \nPlease provide --connection-string, --account-key or '
-                       '--sas-token as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
-                       'For more information about RBAC roles in storage, visit '
+                       'account key inside your storage account. \nPlease provide --connection-string, '
+                       '--account-key or --sas-token as credentials, or use `--auth-mode login` if you '
+                       'have required RBAC roles in your command. For more information about RBAC roles '
+                       'in storage, visit '
                        'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
                        'Setting the corresponding environment variables can avoid inputting credentials in '
                        'your command. Please use --help to get more information.')

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
@@ -170,13 +170,13 @@ def validate_client_parameters(cmd, namespace):
 
     # if account name is specified but no key, attempt to query
     if n.account_name and not n.account_key and not n.sas_token:
-        logger.warning('There are no credentials provided in your command and environment, we will query account key '
-                       'for your storage account. \nPlease provide --connection-string, --account-key or --sas-token '
-                       'as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
-                       'For more information about RBAC roles in storage, you can see '
-                       'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
-                       'Setting the corresponding environment variables can avoid inputting credentials in your command. '
-                       'Please use --help to get more information.')
+        logger.warning('There are no credentials provided in your command and environment, we will query for the '
+            'account key inside your storage account. \nPlease provide --connection-string, --account-key or '
+            '--sas-token as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. '
+            'For more information about RBAC roles in storage, visit '
+            'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
+            'Setting the corresponding environment variables can avoid inputting credentials in '
+            'your command. Please use --help to get more information.')
         n.account_key = _query_account_key(cmd.cli_ctx, n.account_name)
 
 


### PR DESCRIPTION

**Description<!--Mandatory-->**  
Noticed a typo when running `az storage container create --account-name {} -n {}`

**Testing Guide**  
I"m not sure about what triggers both validators, but one can be tested by running `az storage container list --account-name 'STORAGE_ACCOUNT_NAME'` without any environment variables that are listed in `az storage container list --help` to get the warning

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] az storage container: Fix language in logging.warning call

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
