### PR TITLE
{CI} Fix yum package test failure caused by gcc not found

### DIFF
--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -7,7 +7,7 @@ export USERNAME=azureuser
 
 yum --nogpgcheck localinstall /mnt/yum/$YUM_NAME -y
 
-yum install git -y
+yum install git gcc python3-devel -y
 
 ln -s /usr/bin/python3 /usr/bin/python
 ln -s /usr/bin/pip3 /usr/bin/pip


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The yum package test in `centos8` docker failed because of `gcc` not found, probably caused by a recent update of the image. This PR installs `gcc` during test setup.

**Testing Guide**  
<!--Example commands with explanations.-->
Tested in the `build_test` branch: https://github.com/Azure/azure-cli/runs/992224152

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
