### PR TITLE
{RBAC} az ad user create: refine --force-change-password-next-login help message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -526,7 +526,7 @@ type: command
 short-summary: Create an Azure Active Directory user.
 parameters:
   - name: --force-change-password-next-login
-    short-summary: Marks this user as needing to update their password the next time they authenticate.
+    short-summary: Marks this user as needing to update their password the next time they authenticate. If omitted, false will be used.
   - name: --password
     short-summary: The password that should be assigned to the user for authentication.
 """


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This bug is to fix #13970 .

This is a simple PR, just add a message to indicate what is the default value for `--force-change-password-next-login`.

**Testing Guide**  
`az ad user create -h`

>--force-change-password-next-login :
Marks this user as needing to update their password the next time they authenticate. **If omitted, false will be used.**  Allowed values: false, true.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
