### PR TITLE
[Container] Fix #6235 update help text for ports parameter in container create

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/container/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/container/_params.py
@@ -68,7 +68,7 @@ def load_arguments(self, _):
         c.argument('memory', type=float, help='The required memory of the containers in GB, accurate to one decimal place')
         c.argument('os_type', arg_type=get_enum_type(OperatingSystemTypes), help='The OS type of the containers')
         c.argument('ip_address', arg_type=get_enum_type(IP_ADDRESS_TYPES), help='The IP address type of the container group')
-        c.argument('ports', type=int, nargs='+', default=[80], help='The ports to open')
+        c.argument('ports', type=int, nargs='+', default=[80], help='A list of ports to open. Space-separated list of ports')
         c.argument('protocol', arg_type=get_enum_type(ContainerNetworkProtocol), help='The network protocol to use')
         c.argument('dns_name_label', help='The dns name label for container group with public IP')
         c.argument('restart_policy', arg_type=get_enum_type(ContainerGroupRestartPolicy), help='Restart policy for all containers within the container group')


### PR DESCRIPTION
**Description**  
This PR updates the help text for `ports` parameter users can specify when using `az container create` 

**Testing Guide**  
`az container create -h`

**History Notes**  

--

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
