### PR TITLE
[AppService] functionapp: Removed ability to create 2.x Functions in regions that don't support it

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
@@ -49,7 +49,6 @@ class FUNCTIONS_STACKS_API_KEYS():
         self.SITE_CONFIG_DICT = 'siteConfigPropertiesDictionary'
         self.APP_SETTINGS_DICT = 'appSettingsDictionary'
         self.LINUX_FX_VERSION = 'linuxFxVersion'
-        self.FUNCTIONS_WORKER_RUNTIME = "FUNCTIONS_WORKER_RUNTIME"
         self.APPLICATION_INSIGHTS = 'applicationInsights'
         self.SUPPORTED_EXTENSION_VERSIONS = 'supportedFunctionsExtensionVersions'
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
@@ -26,6 +26,12 @@ FUNCTIONS_STACKS_API_JSON_PATHS = {
 }
 FUNCTIONS_LINUX_RUNTIME_VERSION_REGEX = r"^.*\|(.*)$"
 FUNCTIONS_WINDOWS_RUNTIME_VERSION_REGEX = r"^~(.*)$"
+FUNCTIONS_NO_V2_REGIONS = {
+    "USNat West",
+    "USNat East",
+    "USSec West",
+    "USSec East"
+}
 
 
 class FUNCTIONS_STACKS_API_KEYS():
@@ -43,6 +49,7 @@ class FUNCTIONS_STACKS_API_KEYS():
         self.SITE_CONFIG_DICT = 'siteConfigPropertiesDictionary'
         self.APP_SETTINGS_DICT = 'appSettingsDictionary'
         self.LINUX_FX_VERSION = 'linuxFxVersion'
+        self.FUNCTIONS_WORKER_RUNTIME = "FUNCTIONS_WORKER_RUNTIME"
         self.APPLICATION_INSIGHTS = 'applicationInsights'
         self.SUPPORTED_EXTENSION_VERSIONS = 'supportedFunctionsExtensionVersions'
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -60,7 +60,7 @@ from ._create_util import (zip_contents_from_dir, get_runtime_version_details, c
                            detect_os_form_src)
 from ._constants import (FUNCTIONS_STACKS_API_JSON_PATHS, FUNCTIONS_STACKS_API_KEYS,
                          FUNCTIONS_LINUX_RUNTIME_VERSION_REGEX, FUNCTIONS_WINDOWS_RUNTIME_VERSION_REGEX,
-                         NODE_VERSION_DEFAULT, RUNTIME_STACKS)
+                         NODE_VERSION_DEFAULT, RUNTIME_STACKS, FUNCTIONS_NO_V2_REGIONS)
 
 logger = get_logger(__name__)
 
@@ -2737,6 +2737,10 @@ def create_function(cmd, resource_group_name, name, storage_account, plan=None,
         is_linux = plan_info.reserved
         functionapp_def.server_farm_id = plan
         functionapp_def.location = location
+
+    if functions_version == '2' and functionapp_def.location in FUNCTIONS_NO_V2_REGIONS:
+        raise CLIError("2.x functions are not supported in this region. To create a 3.x function, "
+                       "pass in the flag '--functions-version 3'")
 
     if is_linux and not runtime and (consumption_plan_location or not deployment_container_image_name):
         raise CLIError(


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR removed the ability to create V2 function apps in specific regions because those regions don't support it. This is an important requirement

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AppService] functionapp create: Removed ability to create 2.x Functions in regions that don't support it

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
