### PR TITLE
[Network] `az network application-gateway auth-cert show`: Add example to demonstrate certificate format

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -106,6 +106,10 @@ short-summary: Show an authorization certificate.
 examples:
   - name: Show an authorization certificate.
     text: az network application-gateway auth-cert show -g MyResourceGroup --gateway-name MyAppGateway -n MyAuthCert
+  - name: View expiry date of an authorization certificate. It is in Base-64 encoded X.509(.CER) format.
+    text: |
+        az network application-gateway auth-cert show -g MyResourceGroup --gateway-name MyAppGateway \\
+            -n MyAuthCert --query data -o tsv | base64 -d | openssl x509 -enddate -noout
 """
 
 helps['network application-gateway auth-cert update'] = """


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR is to add an example to clarify the backend authentication certificate format returned by the `az network application-gateway auth-cert show` command. The certificate is in Base-64 encoded X.509(.CER) format. The current documentation or help does not mention this anywhere. This is needed for scenarios where we need to retrieve details from the certificate like expiry date etc. Without this information, we have to try different options with the raw data which is returned to get the correct format. 

Adding this example should help clarify the certificate format.

**Testing Guide**  
Details with example are in https://github.com/Azure/azure-cli/issues/14522

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
