### PR TITLE
{History} Fix history notes in PR description and optimize component name

### DIFF
--- a/scripts/release/generate_history_notes.py
+++ b/scripts/release/generate_history_notes.py
@@ -26,8 +26,38 @@ commit_pr_url = '{}/commits/commit_id/pulls'.format(base_url)
 history_line_breaker = '==============='
 history_notes = {}
 
+# key is lower case and removed spaces of a component
+# value is the recommended format of a component
+customized_dict = {
+    "privatedns": "Private DNS",
+    "appconfig": "App Config",
+}
+
+# This dict will be filled with all historical compenents.
+# key is lower case and removed spaces of a component
+# value is the recommended format of a component, when there're multiple formats,
+# the one with spaces will be picked, i.e. pick 'Key Vault' over 'KeyVault'.
+# If the key also exists in customized_dict, the value will be overwritten with customized_dict[key].
+component_dict = {}
+
+def get_component_dict():
+    with open('src/azure-cli/HISTORY.rst', 'r', encoding="utf-8") as history_file:
+        for line in history_file:
+            result = re.search(r'^\*\*(.*)\*\*$', line)
+            if result is not None:
+                comp = result.group(1)
+                key = comp.lower().replace(' ', '')
+                if key in customized_dict:
+                    component_dict[key] = customized_dict[key]
+                elif key in component_dict:
+                    if ' ' not in component_dict[key] and ' ' in comp:
+                        component_dict[key] = comp
+                else:
+                    component_dict[key] = comp
+    print(component_dict)
 
 def generate_history_notes():
+    get_component_dict()
     dev_commits = get_commits()
     print("Get PRs for {} commits.".format(len(dev_commits)))
     for commit in dev_commits:
@@ -132,6 +162,7 @@ def get_prs_for_commit(commit: str):
 def process_pr(pr):
     lines = [pr['title']]
     body = pr['body']
+    content = ''
     search_result = re.search(r'\*\*History Notes:\*\*(.*)---',
                               body,
                               flags=re.DOTALL)
@@ -140,10 +171,11 @@ def process_pr(pr):
                                   body,
                                   flags=re.DOTALL)
         if search_result is not None:
-            body = search_result.group(1)
+            content = search_result.group(1)
     else:
-        body = search_result.group(1)
-    lines.extend(body.splitlines())
+        content = search_result.group(1)
+    if content:
+        lines.extend(content.splitlines())
     process_lines(lines, pr['number'])
 
 
@@ -161,13 +193,25 @@ def process_lines(lines: [str], pr_num: str = None):
         component, note = parse_message(desc, pr_num)
         if component is not None:
             note_in_desc = True
+            component = process_component(component)
             history_notes.setdefault(component, []).append(note)
     # if description has no history notes, parse PR title/commit message
     # otherwise should skip PR title/commit message
     if not note_in_desc:
         component, note = parse_message(lines[0], pr_num)
         if component is not None:
+            component = process_component(component)
             history_notes.setdefault(component, []).append(note)
+
+
+def process_component(component):
+    key = component.lower().replace(' ', '')
+    if key in component_dict:
+        if ' ' not in component_dict[key] and ' ' in component:
+            component_dict[key] = component
+        else:
+            component = component_dict[key]
+    return component
 
 
 def parse_message(message: str, pr_num: str = None) -> (str, str):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The script now only checks the content below **History Notes** in PR description for history notes.

It tries to make future component names consistent and more human-readable by comparing historical component names and using customized settings.


**Testing Guide**  
<!--Example commands with explanations.-->
To test locally:
`PRE_VERSION=${PRE_VERSION} PAT_TOKEN=${PAT_TOKEN} python scripts/release/generate_history_notes.py`
`PRE_VERSION` is the last version of Azure CLI in the source code. `PAT_TOKEN` is a Github PAT token.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
