### PR TITLE
[IoT Hub] Deprecated 'show-connection-string' command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/commands.py
@@ -8,7 +8,7 @@ from ._client_factory import iot_hub_service_factory
 from ._client_factory import iot_service_provisioning_factory
 from ._client_factory import iot_central_service_factory
 
-JOB_DEPRECATION_INFO = 'IoT Extension (azure-cli-iot-ext) Job commands'
+CS_DEPRECATION_INFO = 'IoT Extension (azure-iot) connection-string command (az iot hub connection-string show)'
 
 
 class PolicyUpdateResultTransform(LongRunningOperation):  # pylint: disable=too-few-public-methods
@@ -99,7 +99,8 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
     with self.command_group('iot hub', client_factory=iot_hub_service_factory) as g:
         g.custom_command('create', 'iot_hub_create')
         g.custom_command('list', 'iot_hub_list')
-        g.custom_command('show-connection-string', 'iot_hub_show_connection_string')
+        g.custom_command('show-connection-string', 'iot_hub_show_connection_string',
+                         deprecate_info=self.deprecate(redirect=CS_DEPRECATION_INFO))
         g.custom_show_command('show', 'iot_hub_get')
         g.generic_update_command('update', getter_name='iot_hub_get', setter_name='iot_hub_update',
                                  command_type=update_custom_util, custom_func_name='update_iot_hub_custom')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Deprecating command **az iot hub show-connection-string**
![image](https://user-images.githubusercontent.com/31940305/91090851-9578ba00-e60a-11ea-8e49-14dad0687c32.png)

Now, we have another command group for connection-string from IoT-Extension that can use instead
![image](https://user-images.githubusercontent.com/31940305/90945017-151e4300-e3d7-11ea-9b3e-03bc5812fdab.png)


**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
