### PR TITLE
{Package} extend homebrew package test timeout value

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -574,7 +574,7 @@ jobs:
 
 - job: TestHomebrewPackage
   displayName: Test Homebrew Package
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   dependsOn: BuildHomebrewFormula
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
   pool:

--- a/scripts/release/homebrew/test_homebrew_package.py
+++ b/scripts/release/homebrew/test_homebrew_package.py
@@ -21,7 +21,7 @@ pytest_base_cmd = 'PYTHONPATH={}/lib/{}/site-packages python -m pytest -x -v --b
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
 
 for mod_name in mod_list:
-    if mod_name in ['botservice', 'network', 'configure']:
+    if mod_name in ['botservice', 'network', 'configure', 'monitor']:
         exit_code = subprocess.call(['{} --junit-xml ./azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(pytest_base_cmd, mod_name, mod_name)], shell=True)
     else:
         exit_code = subprocess.call(['{} --junit-xml ./azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(pytest_parallel_cmd, mod_name, mod_name)], shell=True)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Sometimes, when ADO resources are limit in the evening, homebrew package test may fail because of timeout. Extend this value to 3 hours.

Also remove monitor module from parallel running list.

**Testing Guide**  
ADO tasks should be passed.

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
