### PR TITLE
{VM} Fix #14897: display all requirements for vm admin password when it's invalid

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -1034,20 +1034,23 @@ def _validate_admin_password(password, os_type):
     is_linux = (os_type.lower() == 'linux')
     max_length = 72 if is_linux else 123
     min_length = 12
-    error_msg = ("Rule 1: The password length must be between {} and {}\n"
-                 "Rule 2: Password must have the 3 of the following: 1 lower case character, "
-                 "1 upper case character, 1 number and 1 special character").format(min_length, max_length)
-    if len(password) not in range(min_length, max_length + 1):
-        raise CLIError("Your password is invalid for it violates Rule 1\n{}".format(error_msg))
+
     contains_lower = re.findall('[a-z]+', password)
     contains_upper = re.findall('[A-Z]+', password)
     contains_digit = re.findall('[0-9]+', password)
     contains_special_char = re.findall(r'[ `~!@#$%^&*()=+_\[\]{}\|;:.\/\'\",<>?]+', password)
     count = len([x for x in [contains_lower, contains_upper,
                              contains_digit, contains_special_char] if x])
+
     # pylint: disable=line-too-long
+    length_error = "The password length must be between {} and {}.".format(min_length, max_length)
+    complexity_error = "Password must have the 3 of the following: 1 lower case character, 1 upper case character, 1 number and 1 special character."
+    if len(password) not in range(min_length, max_length + 1) and count < 3:
+        raise CLIError("{} {}".format(length_error, complexity_error))
+    if len(password) not in range(min_length, max_length + 1):
+        raise CLIError(length_error)
     if count < 3:
-        raise CLIError("Your password is invalid for it violates Rule 2\n{}".format(error_msg))
+        raise CLIError(complexity_error)
 
 
 def validate_ssh_key(namespace):

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -1043,14 +1043,10 @@ def _validate_admin_password(password, os_type):
                              contains_digit, contains_special_char] if x])
 
     # pylint: disable=line-too-long
-    length_error = "The password length must be between {} and {}.".format(min_length, max_length)
-    complexity_error = "Password must have the 3 of the following: 1 lower case character, 1 upper case character, 1 number and 1 special character."
-    if len(password) not in range(min_length, max_length + 1) and count < 3:
-        raise CLIError("{} {}".format(length_error, complexity_error))
-    if len(password) not in range(min_length, max_length + 1):
-        raise CLIError(length_error)
-    if count < 3:
-        raise CLIError(complexity_error)
+    error_msg = ("The password length must be between {} and {}. And the password must have the 3 of the following: "
+                 "1 lower case character, 1 upper case character, 1 number and 1 special character.").format(min_length, max_length)
+    if len(password) not in range(min_length, max_length + 1) or count < 3:
+        raise CLIError(error_msg)
 
 
 def validate_ssh_key(namespace):

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -1034,7 +1034,7 @@ def _validate_admin_password(password, os_type):
     is_linux = (os_type.lower() == 'linux')
     max_length = 72 if is_linux else 123
     min_length = 12
-    error_msg = ("Rule 1: The password length must be betwween {} and {}\n"
+    error_msg = ("Rule 1: The password length must be between {} and {}\n"
                  "Rule 2: Password must have the 3 of the following: 1 lower case character, "
                  "1 upper case character, 1 number and 1 special character").format(min_length, max_length)
     if len(password) not in range(min_length, max_length + 1):

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -1043,7 +1043,7 @@ def _validate_admin_password(password, os_type):
                              contains_digit, contains_special_char] if x])
 
     # pylint: disable=line-too-long
-    error_msg = ("The password length must be between {} and {}. And the password must have the 3 of the following: "
+    error_msg = ("The password length must be between {} and {}. Password must have the 3 of the following: "
                  "1 lower case character, 1 upper case character, 1 number and 1 special character.").format(min_length, max_length)
     if len(password) not in range(min_length, max_length + 1) or count < 3:
         raise CLIError(error_msg)

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -1034,9 +1034,11 @@ def _validate_admin_password(password, os_type):
     is_linux = (os_type.lower() == 'linux')
     max_length = 72 if is_linux else 123
     min_length = 12
+    error_msg = ("Rule 1: The password length must be betwween {} and {}\n"
+                 "Rule 2: Password must have the 3 of the following: 1 lower case character, "
+                 "1 upper case character, 1 number and 1 special character").format(min_length, max_length)
     if len(password) not in range(min_length, max_length + 1):
-        raise CLIError('The password length must be between {} and {}'.format(min_length,
-                                                                              max_length))
+        raise CLIError("Your password is invalid for it violates Rule 1\n{}".format(error_msg))
     contains_lower = re.findall('[a-z]+', password)
     contains_upper = re.findall('[A-Z]+', password)
     contains_digit = re.findall('[0-9]+', password)
@@ -1045,7 +1047,7 @@ def _validate_admin_password(password, os_type):
                              contains_digit, contains_special_char] if x])
     # pylint: disable=line-too-long
     if count < 3:
-        raise CLIError('Password must have the 3 of the following: 1 lower case character, 1 upper case character, 1 number and 1 special character')
+        raise CLIError("Your password is invalid for it violates Rule 2\n{}".format(error_msg))
 
 
 def validate_ssh_key(namespace):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR fix issue #14897. 

**Before**
When creating a vm with an invalid admin password, the message shows only the current rule the password violates. When user changes the password and try it again, another error may happen showing that the user violates anthoer rule.

**After**
This PR improves the behavior by displaying all the requirements once we found the password is invalid. 
 

**Testing Guide**  
<!--Example commands with explanations.-->
**Before**
```
Admin Password:
Confirm Admin Password:
The password length must be between 12 and 123

Admin Password:
Confirm Admin Password:
Password must have the 3 of the following: 1 lower case character, 1 upper case character, 1 number and 1 special character
```
**After**
```
Your password is invalid for it violates Rule 1
Rule 1: The password length must be betwween 12 and 123
Rule 2: Password must have the 3 of the following: 1 lower case character, 1 upper case character, 1 number and 1 special character
```
