### PR TITLE
{CI} Example of bypassing show-command linter rule

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -14,7 +14,7 @@ steps:
       chmod +x env/bin/activate
       . env/bin/activate
 
-      pip install -q azdev==0.1.26
+      pip install -q azdev==0.1.28
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then

--- a/pylintrc
+++ b/pylintrc
@@ -14,7 +14,8 @@ disable=
     cyclic-import,
     too-many-arguments,
     invalid-name,
-    duplicate-code
+    duplicate-code,
+    bad-option-value
 
 [FORMAT]
 max-line-length=120

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -355,7 +355,7 @@ def load_command_table(self, _):
         g.custom_command('delete', 'delete_host_key')
 
     with self.command_group('functionapp function') as g:
-        g.custom_command('show', 'show_function')
+        g.custom_command('show', 'show_function')  # pylint: disable=show-command
         g.custom_command('delete', 'delete_function')
 
     with self.command_group('functionapp function keys') as g:

--- a/src/azure-cli/azure/cli/command_modules/configure/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/commands.py
@@ -16,12 +16,12 @@ def load_command_table(self, _):
 
     with self.command_group('cache', configure_custom, is_preview=True) as g:
         g.command('list', 'list_cache_contents')
-        g.command('show', 'show_cache_contents')
+        g.command('show', 'show_cache_contents')  # pylint: disable=show-command
         g.command('delete', 'delete_cache_contents')
         g.command('purge', 'purge_cache_contents')
 
     with self.command_group('local-context', configure_custom, is_experimental=True) as g:
         g.command('on', 'turn_local_context_on')
         g.command('off', 'turn_local_context_off')
-        g.command('show', 'show_local_context', validator=validate_local_context)
+        g.command('show', 'show_local_context', validator=validate_local_context)  # pylint: disable=show-command
         g.command('delete', 'delete_local_context', validator=validate_local_context_for_delete)

--- a/src/azure-cli/azure/cli/command_modules/hdinsight/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/hdinsight/commands.py
@@ -109,7 +109,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
     with self.command_group('hdinsight autoscale', hdinsight_clusters_sdk, client_factory=cf_hdinsight_clusters) as g:
         g.custom_command('create', 'create_autoscale', supports_no_wait=True)
         g.custom_command('update', 'update_autoscale', supports_no_wait=True)
-        g.custom_command('show', 'show_autoscale')
+        g.custom_show_command('show', 'show_autoscale')
         g.custom_command('delete', 'delete_autoscale', supports_no_wait=True, confirmation=True)
         g.custom_command('list-timezones', 'list_timezones')
         g.wait_command('wait')

--- a/src/azure-cli/azure/cli/command_modules/vm/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/commands.py
@@ -488,7 +488,7 @@ def load_command_table(self, _):
         g.command('delete', 'delete')
 
     with self.command_group('vm monitor log', client_factory=cf_log_analytics_data_plane) as g:
-        g.custom_command('show', 'execute_query_for_vm', transform=transform_log_analytics_query_output)
+        g.custom_command('show', 'execute_query_for_vm', transform=transform_log_analytics_query_output)  # pylint: disable=show-command
 
     with self.command_group('vm monitor metrics', custom_command_type=monitor_custom, command_type=metric_definitions_sdk, resource_type=ResourceType.MGMT_MONITOR, operation_group='metric_definitions', min_api='2018-01-01', is_preview=True) as g:
         from azure.cli.command_modules.monitor.transformers import metrics_table, metrics_definitions_table


### PR DESCRIPTION
`az configure show`, `az cache show` or `az vm monitor show` is not a real show command.
`az functionapp function show` has its own error handler logic


