### PR TITLE
[acr] Fix #14811 Add support for dockerignore override

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
@@ -69,8 +69,7 @@ def upload_source_code(cmd, client,
 def _pack_source_code(source_location, tar_file_path, docker_file_path, docker_file_in_tar):
     logger.warning("Packing source code into tar to upload...")
 
-    # NOTE: os.path.basename is unable to parse "\" in the file path
-    original_docker_file_name = os.path.basename(docker_file_path.replace("\\", "/"))
+    original_docker_file_name = os.path.basename(docker_file_path.replace("\\", os.sep))
     ignore_list, ignore_list_size = _load_dockerignore_file(source_location, original_docker_file_name)
     common_vcs_ignore_list = {'.git', '.gitignore', '.bzr', 'bzrignore', '.hg', '.hgignore', '.svn'}
 


### PR DESCRIPTION
**Description**  

There is currently no way to specify (or override) the .dockerignore file in the acr build command. This prevents multiple Dockerfile(s) to share the same context effectively.

This change allows different Dockerfiles to define different subsets of the context files with different ignore rules.
In case the docker file is not named Dockerfile, the frontend (i.e. acr build) first checks for <path/to/docker_file_name>.dockerignore and if it is found it will be used instead of the root .dockerignore.

This is consistent with the docker behaviour implemented in:
moby/buildkit#901

For more information see the related issue #14811 

**Testing Guide**  
No command changes. This PR affects the `acr build` command, when the `-f <docker_file_name>` option is used. 

**History Notes**  

[acr] Add support for dockerignore override

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
