### PR TITLE
[AKS] fix: aks cluster create issue

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1748,7 +1748,7 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
                kubernetes_version='',
                node_vm_size="Standard_DS2_v2",
                node_osdisk_size=0,
-               node_osdisk_diskencryptionset_id='',
+               node_osdisk_diskencryptionset_id=None,
                node_count=3,
                nodepool_name="nodepool1",
                nodepool_tags=None,


### PR DESCRIPTION
**Description<!--Mandatory-->**  
fix: aks cluster create issue mentioned here: https://github.com/Azure/azure-cli/pull/14688#discussion_r476665073
```
`>az aks create -g vsoto-aks-aad-test-rg -n vsoto-aks-aad-test --enable-aad --aad-admin-group-object-id <>
Finished service principal creation[##################################] 100.0000%Property id '' at path 'properties.diskEncryptionSetID' is invalid. Expect fully qualified resource Id that start with '/subscriptions/{subscriptionId}' or '/providers/{resourceProviderNamespace}/'.

az --version
azure-cli 2.11.0

core 2.11.0
telemetry 1.0.5

Extensions:
azure-devops 0.11.0`
```
**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

cc @vinisoto @MyronFanQiu