### PR TITLE
[Config] Use core as the default section

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/config/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/config/_help.py
@@ -18,38 +18,42 @@ long-summary: |
     For available configuration options, see https://docs.microsoft.com/en-us/cli/azure/azure-cli-configuration.
     By default without specifying --local, the configuration will be saved to `~/.azure/config`.
 examples:
-  - name: Disable color with `core.no_color`.
-    text: az config set core.no_color=true
-  - name: Hide warnings and only show errors with `core.only_show_errors`.
-    text: az config set core.only_show_errors=true
-  - name: Turn on client-side telemetry.
-    text: az config set core.collect_telemetry=true
-  - name: Turn on file logging and set its location.
-    text: |-
-        az config set logging.enable_log_file=true
-        az config set logging.log_dir=~/az-logs
+  - name: Disable color.
+    text: az config set no_color=true
+  - name: Hide warnings and only show errors.
+    text: az config set only_show_errors=true
   - name: Set the default location to `westus2` and default resource group to `myRG`.
     text: az config set defaults.location=westus2 defaults.group=MyResourceGroup
   - name: Set the default resource group to `myRG` on a local scope.
     text: az config set defaults.group=myRG --local
+  - name: Turn on client-side telemetry.
+    text: az config set collect_telemetry=true
+  - name: Turn on file logging and set its location.
+    text: az config set logging.enable_log_file=true logging.log_dir=~/az-logs
 """
 
 helps['config get'] = """
 type: command
 short-summary: Get a configuration.
 examples:
-  - name: Get all configurations.
+  - name: Get all configured options.
     text: az config get
-  - name: Get configurations in `core` section.
-    text: az config get core
-  - name: Get the configuration of key `core.no_color`.
-    text: az config get core.no_color
+  - name: Get the configured value of option `no_color`.
+    text: az config get no_color
+  - name: Get options in `core` section. Note that `core` is followed by a dot (.).
+    text: az config get core.
+  - name: Get configured defaults. Note that `defaults` is followed by a dot (.).
+    text: az config get defaults.
+  - name: Get the configured default resource group.
+    text: az config get defaults.group
 """
 
 helps['config unset'] = """
 type: command
 short-summary: Unset a configuration.
 examples:
-  - name: Unset the configuration of key `core.no_color`.
-    text: az config unset core.no_color
+  - name: Unset `no_color`.
+    text: az config unset no_color
+  - name: Unset the configured default resource group.
+    text: az config unset defaults.group
 """

--- a/src/azure-cli/azure/cli/command_modules/config/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/config/_params.py
@@ -11,20 +11,27 @@ def load_arguments(self, _):
         c.ignore('_subscription')  # ignore the global subscription param
 
     with self.argument_context('config set') as c:
-        c.positional('key_value', nargs='+', help="Space-separated configurations in the form of <section>.<key>=<value>.")
+        c.positional('key_value_pairs', nargs='+',
+                     help="Set options in the form of <section>.<name>=<value>. "
+                          "If `<section>` is omitted, `core` will be used. "
+                          "To set multiple options, separate each key value pair with spaces.")
         c.argument('local', action='store_true', help='Set as a local configuration in the working directory.')
 
     with self.argument_context('config get') as c:
-        c.positional('key', nargs='?', help='The configuration to get. '
-                                            'If not provided, all sections and configurations will be listed. '
-                                            'If `section` is provided, all configurations under the specified section will be listed. '
-                                            'If `<section>.<key>` is provided, only the corresponding configuration is shown.')
+        c.positional('key', nargs='?',
+                     help='The configuration to get. '
+                          'To list all options under all sections, leave it unspecified. '
+                          'To list all options under a section, use `<section>.`. '
+                          'To list one option, use `<section>.<name>`. If `<section>` is omitted, `core` will be used. ')
         c.argument('local', action='store_true',
                    help='Include local configuration. Scan from the working directory up to the root drive, then the global configuration '
                         'and return the first occurrence.')
 
     with self.argument_context('config unset') as c:
-        c.positional('key', nargs='+', help='The configuration to unset, in the form of <section>.<key>.')
+        c.positional('keys', nargs='+',
+                     help='The configuration to unset, in the form of `<section>.<name>`. '
+                          'If `<section>` is omitted, `core` will be used. '
+                          'To unset multiple options, separate each key with spaces.')
         c.argument('local', action='store_true',
                    help='Include local configuration. Scan from the working directory up to the root drive, then the global configuration '
                         'and unset the first occurrence.')

--- a/src/azure-cli/azure/cli/command_modules/config/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/config/custom.py
@@ -17,25 +17,38 @@ def _normalize_config_value(value):
     return value
 
 
-def config_set(cmd, key_value=None, local=False):
-    if key_value:
-        with ScopedConfig(cmd.cli_ctx.config, local):
-            for kv in key_value:
-                # core.no_color=true
-                parts = kv.split('=', 1)
-                if len(parts) == 1:
-                    raise CLIError('usage error: [section].[name]=[value] ...')
-                key = parts[0]
-                value = parts[1]
+def _parse_key(key):
+    """Parse the key to section and option name. There can be 2 case:
+        1. If no section is provided, like `no_color`, section will default to `core`
+        2. If section is provided, like `core.no_color`, use the specified section.
+    """
+    if not key:
+        raise ValueError
+    parts = key.split('.', 1)
+    if len(parts) == 1:
+        # Section is not provided, default to `core`
+        return 'core', key
+    elif len(parts) == 2:
+        # Section is provided, like `core.no_color`, use the specified section.
+        return parts[0], parts[1]
 
-                # core.no_color
-                parts = key.split('.', 1)
-                if len(parts) == 1:
-                    raise CLIError('usage error: [section].[name]=[value] ...')
-                section = parts[0]
-                name = parts[1]
 
-                cmd.cli_ctx.config.set_value(section, name, _normalize_config_value(value))
+def config_set(cmd, key_value_pairs=None, local=False):
+    with ScopedConfig(cmd.cli_ctx.config, local):
+        for kv in key_value_pairs:
+            # core.no_color=true
+            parts = kv.split('=', 1)
+            if len(parts) == 1:
+                raise CLIError('usage error: [section].[name]=[value] ...')
+            key = parts[0]
+            value = parts[1]
+
+            try:
+                section, name = _parse_key(key)
+            except ValueError:
+                raise CLIError('usage error: [section].[name]=[value] ...')
+
+            cmd.cli_ctx.config.set_value(section, name, _normalize_config_value(value))
 
 
 def config_get(cmd, key=None, local=False):
@@ -49,15 +62,7 @@ def config_get(cmd, key=None, local=False):
                 result[section] = items
             return result
 
-    parts = key.split('.', 1)
-    if len(parts) == 1:
-        # Only section is provided
-        section = key
-        name = None
-    else:
-        # section.name
-        section = parts[0]
-        name = parts[1]
+    section, name = _parse_key(key)
 
     with ScopedConfig(cmd.cli_ctx.config, local):
         items = cmd.cli_ctx.config.items(section)
@@ -70,19 +75,16 @@ def config_get(cmd, key=None, local=False):
     try:
         return next(x for x in items if x['name'] == name)
     except StopIteration:
-        raise CLIError("Configuration '{}' is not set.".format(key))
+        raise CLIError("Configuration '{}.{}' is not set.".format(section, name))
 
 
-def config_unset(cmd, key=None, local=False):
-    for k in key:
+def config_unset(cmd, keys=None, local=False):
+    for key in keys:
         # section.name
-        parts = k.split('.', 1)
-
-        if len(parts) == 1:
+        try:
+            section, name = _parse_key(key)
+        except ValueError:
             raise CLIError("usage error: [section].[name]")
-
-        section = parts[0]
-        name = parts[1]
 
         with ScopedConfig(cmd.cli_ctx.config, local):
             cmd.cli_ctx.config.remove_option(section, name)

--- a/src/azure-cli/azure/cli/command_modules/config/tests/latest/test_config.py
+++ b/src/azure-cli/azure/cli/command_modules/config/tests/latest/test_config.py
@@ -15,6 +15,10 @@ class ConfigTest(ScenarioTest):
 
     def test_config(self):
 
+        # [core]
+        # core_option1 = core_value1
+        # core_option2 = core_value2
+        #
         # [test_section1]
         # test_option1 = test_value1
         #
@@ -32,6 +36,8 @@ class ConfigTest(ScenarioTest):
         local_test_args = {"source": os.path.join(tempdir, '.azure', 'config'), "flag": " --local"}
 
         for args in (global_test_args, local_test_args):
+            core_option1_expected = {'name': 'core_option1', 'source': args["source"], 'value': 'core_value1'}
+            core_option2_expected = {'name': 'core_option2', 'source': args["source"], 'value': 'core_value2'}
             test_option1_expected = {'name': 'test_option1', 'source': args["source"], 'value': 'test_value1'}
             test_option21_expected = {'name': 'test_option21', 'source': args["source"], 'value': 'test_value21'}
             test_option22_expected = {'name': 'test_option22', 'source': args["source"], 'value': 'test_value22'}
@@ -40,24 +46,34 @@ class ConfigTest(ScenarioTest):
             test_section2_expected = [test_option21_expected, test_option22_expected]
 
             # 1. set
-            # Test setting one option
+            # Set `core` section without explicitly specifying `core`
+            self.cmd('config set core_option1=core_value1' + args['flag'])
+            # Set `core` section by explicitly specifying `core`
+            self.cmd('config set core.core_option2=core_value2' + args['flag'])
+            # Set one option
             self.cmd('config set test_section1.test_option1=test_value1' + args['flag'])
-            # Test setting multiple options
+            # Set multiple options
             self.cmd('config set test_section2.test_option21=test_value21 test_section2.test_option22=test_value22' + args['flag'])
 
             # 2. get
-            # 2.1 Test get all sections
+            # 2.1 Get all sections
             output = self.cmd('config get' + args['flag']).get_output_in_json()
+            self.assertIn(core_option1_expected, output['core'])
+            self.assertIn(core_option2_expected, output['core'])
             self.assertListEqual(output['test_section1'], test_section1_expected)
             self.assertListEqual(output['test_section2'], test_section2_expected)
 
-            # 2.2 Test get one section
-            output = self.cmd('config get test_section1' + args['flag']).get_output_in_json()
+            # 2.2 Get one section
+            output = self.cmd('config get test_section1.' + args['flag']).get_output_in_json()
             self.assertListEqual(output, test_section1_expected)
-            output = self.cmd('config get test_section2' + args['flag']).get_output_in_json()
+            output = self.cmd('config get test_section2.' + args['flag']).get_output_in_json()
             self.assertListEqual(output, test_section2_expected)
 
-            # 2.3 Test get one item
+            # 2.3 Get one item
+            output = self.cmd('config get core_option1' + args['flag']).get_output_in_json()
+            self.assertDictEqual(output, core_option1_expected)
+            output = self.cmd('config get core.core_option2' + args['flag']).get_output_in_json()
+            self.assertDictEqual(output, core_option2_expected)
             output = self.cmd('config get test_section1.test_option1' + args['flag']).get_output_in_json()
             self.assertDictEqual(output, test_option1_expected)
             output = self.cmd('config get test_section2.test_option21' + args['flag']).get_output_in_json()
@@ -66,15 +82,44 @@ class ConfigTest(ScenarioTest):
             self.assertDictEqual(output, test_option22_expected)
 
             with self.assertRaises(CLIError):
-                self.cmd('config get test_section1.test_option22' + args['flag'])
+                self.cmd('config get test_section1.non_exist' + args['flag'])
 
             # 3. unset
-            # Test unsetting one option
+            # Set `core` section without explicitly specifying `core`
+            self.cmd('config unset core_option1' + args['flag'])
+            with self.assertRaises(CLIError):
+                self.cmd('config get core_option1' + args['flag'])
+
+            # Unset `core` section by explicitly specifying `core`
+            self.cmd('config unset core.core_option2' + args['flag'])
+            with self.assertRaises(CLIError):
+                self.cmd('config get core.core_option2' + args['flag'])
+
+            # Unset one option
             self.cmd('config unset test_section1.test_option1' + args['flag'])
-            # Test unsetting multiple options
+            with self.assertRaises(CLIError):
+                self.cmd('config get test_section1.test_option1' + args['flag'])
+
+            # Unset multiple options
             self.cmd('config unset test_section2.test_option21 test_section2.test_option22' + args['flag'])
+            with self.assertRaises(CLIError):
+                self.cmd('config get test_section2.test_option21' + args['flag'])
+            with self.assertRaises(CLIError):
+                self.cmd('config get test_section2.test_option22' + args['flag'])
 
         os.chdir(original_path)
+
+    def test_parse_key(self):
+        from azure.cli.command_modules.config.custom import _parse_key
+        # Test section defaults to core
+        self.assertEqual(_parse_key("test_option"), ('core', 'test_option'))
+        # Test explicitly specifying section as core
+        self.assertEqual(_parse_key("core.test_option"), ('core', 'test_option'))
+        # Test specifying only section for get operation
+        self.assertEqual(_parse_key("core."), ('core', ''))
+        # Test empty key raises a ValueError
+        with self.assertRaises(ValueError):
+            _parse_key("")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Use `core` as the default section for `set`/`get`/`unset`.

## Testing Guide

```sh
# Omit `core.`
az config set no_color=true
az config get no_color
az config unset no_color

# Explicitly specify `core.`
az config set core.no_color=true
az config get core.no_color
az config unset core.no_color
```

Note there is a breaking change for `az config get`: If `<name>` is specified, it is treated as `core.<name>` instead of the section name. To get all options under a section, use `<section>.`:

```sh
az config get core.
```

**History Notes**  

[Config] az config set/get: If `section` is unspecified, use `core` as the default section.
[Config] BREAKING CHANGE: az config get: If `<name>` is specified, it is treated as `core.<name>` instead of the section name. To get all options under a section, use `<section>.`.
