### PR TITLE
[ARM] az deployment group/sub/mg/tenant what-if: Show "Ignore" resource changes last

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -48,8 +48,8 @@ _change_type_to_weight = {
     ChangeType.create: 1,
     ChangeType.deploy: 2,
     ChangeType.modify: 3,
-    ChangeType.ignore: 4,
-    ChangeType.no_change: 5,
+    ChangeType.no_change: 4,
+    ChangeType.ignore: 5,
 }
 
 _property_change_type_to_weight = {

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
@@ -273,9 +273,9 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
   - p6/foo
   - p7/foo{Color.RESET}{Color.GREEN}
   + p2/foo{Color.RESET}{Color.BLUE}
-  ! p4/foo{Color.RESET}{Color.GRAY}
-  * p1/foo{Color.RESET}{Color.RESET}
-  = p3/foo
+  ! p4/foo{Color.RESET}{Color.RESET}
+  = p3/foo{Color.RESET}{Color.GRAY}
+  * p1/foo
 {Color.RESET}"""
         result = format_what_if_operation_result(WhatIfOperationResult(changes=changes))
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The PR contains a minor tweak for the `az deployment group/sub/mg/tenant what-if` commands to let them show "Ignore" resource changes last in outputs (addresses https://github.com/Azure/arm-template-whatif/issues/115).

Before the change:
![before](https://user-images.githubusercontent.com/16367959/91782733-d2b4ed00-ebb2-11ea-94c3-f2ec2b4db797.png)

After the change:
![after](https://user-images.githubusercontent.com/16367959/91782748-dd6f8200-ebb2-11ea-941d-811f91055854.png)


**Testing Guide**  
```
az deployment group/sub/mg/tenant what-if -m <mg_id> -f <path_to_deployment_file> -l <location>
az deployment group/sub/mg/tenant create -m <mg_id> -f <path_to_deployment_file> -l <location> -c
```

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
