### PR TITLE
{Packaging} Remove upper bound on cryptography

### DIFF
--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -126,7 +126,7 @@ DEPENDENCIES = [
     'azure-storage-common~=1.4',
     'azure-synapse-accesscontrol~=0.2.0',
     'azure-synapse-spark~=0.2.0',
-    'cryptography>=2.3.1,<3.0.0',
+    'cryptography>=2.3.1',
     'fabric~=2.4',
     'jsmin~=2.2.2',
     'pytz==2019.1',


### PR DESCRIPTION
As major version bumps have no semantic meaning in cryptography's versioning scheme (2.9 → 3.0 is the same as 2.8 → 2.9), this bound makes no sense afaict.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
