### PR TITLE
{Test} Fix cloud tests

### DIFF
--- a/scripts/release/debian/test_deb_package.py
+++ b/scripts/release/debian/test_deb_package.py
@@ -14,7 +14,7 @@ pytest_base_cmd = '/opt/az/bin/python3 -m pytest -x -v --boxed -p no:warnings --
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
 
 for mod_name in mod_list:
-    if mod_name in ['botservice', 'network']:
+    if mod_name in ['botservice', 'network', 'cloud']:
         exit_code = subprocess.call(['{} --junit-xml /azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(pytest_base_cmd, mod_name, mod_name)], shell=True)
     else:
         exit_code = subprocess.call(['{} --junit-xml /azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(pytest_parallel_cmd, mod_name, mod_name)], shell=True)

--- a/scripts/release/homebrew/test_homebrew_package.py
+++ b/scripts/release/homebrew/test_homebrew_package.py
@@ -21,7 +21,7 @@ pytest_base_cmd = 'PYTHONPATH={}/lib/{}/site-packages python -m pytest -x -v --b
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
 
 for mod_name in mod_list:
-    if mod_name in ['botservice', 'network', 'configure', 'monitor']:
+    if mod_name in ['botservice', 'network', 'configure', 'monitor', 'cloud']:
         exit_code = subprocess.call(['{} --junit-xml ./azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(pytest_base_cmd, mod_name, mod_name)], shell=True)
     else:
         exit_code = subprocess.call(['{} --junit-xml ./azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(pytest_parallel_cmd, mod_name, mod_name)], shell=True)

--- a/scripts/release/rpm/test_rpm_package.py
+++ b/scripts/release/rpm/test_rpm_package.py
@@ -14,7 +14,7 @@ pytest_base_cmd = 'PYTHONPATH=/usr/lib64/az/lib/python3.6/site-packages python3 
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
 
 for mod_name in mod_list:
-    if mod_name in ['botservice', 'network']:
+    if mod_name in ['botservice', 'network', 'cloud']:
         exit_code = subprocess.call(['{} --junit-xml /azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(pytest_base_cmd, mod_name, mod_name)], shell=True)
     else:
         exit_code = subprocess.call(['{} --junit-xml /azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(pytest_parallel_cmd, mod_name, mod_name)], shell=True)

--- a/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
+++ b/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 from azure.cli.testsdk import ScenarioTest
-
+from azure.cli.testsdk.decorators import serial_test
 
 class CloudTests(ScenarioTest):
     def setUp(self):
@@ -17,23 +17,48 @@ class CloudTests(ScenarioTest):
         self.cli_ctx.cloud.name = ''
         self.cmd('az cloud set -n ' + self.cloudname)
 
-    def test_cloud_set(self):
+    @serial_test()
+    def test_cloud_set_AzureCloud(self):
         self.cmd('az cloud set -n AzureCloud')
         self.cmd('az cloud show -n AzureCloud', checks=[self.check('isActive', True)])
+
+    @serial_test()
+    def test_cloud_set_AzureChinaCloud(self):
         self.cmd('az cloud set -n AzureChinaCloud')
         self.cmd('az cloud show -n AzureChinaCloud', checks=[self.check('isActive', True)])
+
+    @serial_test()
+    def test_cloud_set_AzureUSGovernment(self):
         self.cmd('az cloud set -n AzureUSGovernment')
         self.cmd('az cloud show -n AzureUSGovernment', checks=[self.check('isActive', True)])
+
+    @serial_test()
+    def test_cloud_set_AzureGermanCloud(self):
         self.cmd('az cloud set -n AzureGermanCloud')
         self.cmd('az cloud show -n AzureGermanCloud', checks=[self.check('isActive', True)])
+
+    @serial_test()
+    def test_cloud_set_azurecloud(self):
         self.cmd('az cloud set -n azurecloud')
         self.cmd('az cloud show -n AzureCloud', checks=[self.check('isActive', True)])
+
+    @serial_test()
+    def test_cloud_set_azurechinacloud(self):
         self.cmd('az cloud set -n azurechinacloud')
         self.cmd('az cloud show -n AzureChinaCloud', checks=[self.check('isActive', True)])
+
+    @serial_test()
+    def test_cloud_set_azureusgovernment(self):
         self.cmd('az cloud set -n azureusgovernment')
         self.cmd('az cloud show -n AzureUSGovernment', checks=[self.check('isActive', True)])
+
+    @serial_test()
+    def test_cloud_set_azuregermancloud(self):
         self.cmd('az cloud set -n azuregermancloud')
         self.cmd('az cloud show -n AzureGermanCloud', checks=[self.check('isActive', True)])
+
+    @serial_test()
+    def test_cloud_set_unregistered_cloud_name(self):
         self.cmd('az cloud set -n azCloud', expect_failure=True)
 
 

--- a/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
+++ b/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
@@ -2,8 +2,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+# When tested locally, please use 'azdev test cloud -a "-n 1" to run in serial'
+
 from azure.cli.testsdk import ScenarioTest
 from azure.cli.testsdk.decorators import serial_test
+
 
 class CloudTests(ScenarioTest):
     def setUp(self):

--- a/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
+++ b/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
@@ -17,31 +17,23 @@ class CloudTests(ScenarioTest):
         self.cli_ctx.cloud.name = ''
         self.cmd('az cloud set -n ' + self.cloudname)
 
-    def test_cloud_set_AzureCloud(self):
+    def test_cloud_set(self):
         self.cmd('az cloud set -n AzureCloud')
-
-    def test_cloud_set_AzureChinaCloud(self):
+        self.cmd('az cloud show -n AzureCloud', checks=[self.check('isActive', True)])
         self.cmd('az cloud set -n AzureChinaCloud')
-
-    def test_cloud_set_AzureUSGovernment(self):
+        self.cmd('az cloud show -n AzureChinaCloud', checks=[self.check('isActive', True)])
         self.cmd('az cloud set -n AzureUSGovernment')
-
-    def test_cloud_set_AzureGermanCloud(self):
+        self.cmd('az cloud show -n AzureUSGovernment', checks=[self.check('isActive', True)])
         self.cmd('az cloud set -n AzureGermanCloud')
-
-    def test_cloud_set_azurecloud(self):
+        self.cmd('az cloud show -n AzureGermanCloud', checks=[self.check('isActive', True)])
         self.cmd('az cloud set -n azurecloud')
-
-    def test_cloud_set_azurechinacloud(self):
+        self.cmd('az cloud show -n AzureCloud', checks=[self.check('isActive', True)])
         self.cmd('az cloud set -n azurechinacloud')
-
-    def test_cloud_set_azureusgovernment(self):
+        self.cmd('az cloud show -n AzureChinaCloud', checks=[self.check('isActive', True)])
         self.cmd('az cloud set -n azureusgovernment')
-
-    def test_cloud_set_azuregermancloud(self):
+        self.cmd('az cloud show -n AzureUSGovernment', checks=[self.check('isActive', True)])
         self.cmd('az cloud set -n azuregermancloud')
-
-    def test_cloud_set_unregistered_cloud_name(self):
+        self.cmd('az cloud show -n AzureGermanCloud', checks=[self.check('isActive', True)])
         self.cmd('az cloud set -n azCloud', expect_failure=True)
 
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When running cloud tests in parallel, it may fail to revert to the original cloud settings. The tests relies on `setup()` to get the original active cloud and `tearDown()` to set back to the original cloud. But when running in parallel, if the original cloud is A, it is possible that process 1 runs a test to set to cloud B, then process 2 begins and treats cloud B as the original cloud in enviroment. Process 1 finishes and set the cloud back to A, process 2 finishes and set the cloud back to B. Now the cloud of the environemnt changes from cloud A to cloud B. This will cause issues with other tests running afterwards.

This PR modifies package tests to run cloud tests in serial and add `serial_test` mark to run in serial in live test pipeline.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
