### PR TITLE
{Core} Print error details if fail to get msal token

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_msal.py
+++ b/src/azure-cli-core/azure/cli/core/_msal.py
@@ -30,5 +30,5 @@ class AdalRefreshTokenBasedClientApplication(ClientApplication):
             kwargs.pop('correlation_id')
         response = client.obtain_token_by_refresh_token(refresh_token, scope=scopes, **kwargs)
         if "error" in response:
-            raise CLIError(response["error"])
+            raise CLIError("Get token failed. {error}: {error_description}".format(**response))
         return response


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Currently if the `get_msal_token` function fails, it will only print an error "invalid_grant", which is not enough to guide user to do further actions. This PR is to print the error details of it.

**Testing Guide**  
Need to test via vmssh extension.
1. install vmssh extension
2. setup vmssh feature in portal
3. configure condition access for a particular VM
4. connect to the VM

current behavior: 
>invalid_grant

expected behavior: 
>Get token failed. invalid_grant: AADSTS50076: Due to a configuration change made by your administrator, or because you moved to a new location, you must use multi-factor authentication to access 'ce6ff14a-7fdc-4685-bbe0-f6afdfcfa8e0'.
Trace ID: 0afea3cd-00af-406b-bbd0-959d217f0b00
Correlation ID: ff9bb588-aee5-4f22-9b02-005d98dbe197
Timestamp: 2020-09-01 06:15:16Z

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
