### PR TITLE
[AKS] Fixed case sensitive issue for AKS addon and addon config

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1609,7 +1609,7 @@ def aks_browse(cmd, client, resource_group_name, name, disable_browser=False,
 
     # verify the kube-dashboard addon was not disabled
     instance = client.get(resource_group_name, name)
-    addon_profiles = {k.lower():v for k, v in (instance.addon_profiles or {}).items()}
+    addon_profiles = {k.lower(): v for k, v in (instance.addon_profiles or {}).items()}
     addon_profile = addon_profiles.get("kubedashboard", ManagedClusterAddonProfile(enabled=True))
     if not addon_profile.enabled:
         raise CLIError('The kube-dashboard addon was disabled for this managed cluster.\n'
@@ -1719,7 +1719,7 @@ def _add_monitoring_role_assignment(result, cluster_resource_id, cmd):
         service_principal_msi_id = result.service_principal_profile.client_id
         is_service_principal = True
     elif hasattr(result, 'addon_profiles'):
-        addon_profiles = {k.lower():v for k, v in (result.addon_profiles or {}).items()}
+        addon_profiles = {k.lower(): v for k, v in (result.addon_profiles or {}).items()}
         if (
                 ('omsagent' in addon_profiles) and
                 hasattr(addon_profiles['omsagent'], 'identity') and
@@ -2157,6 +2157,7 @@ def aks_get_credentials(cmd, client, resource_group_name, name, admin=False,
     except (IndexError, ValueError):
         raise CLIError("Fail to find kubeconfig file.")
 
+
 # To be consistent, values of ADDONS dict should all be lower case
 ADDONS = {
     'http_application_routing': 'httpapplicationrouting',
@@ -2521,7 +2522,7 @@ def _update_addons(cmd, instance, subscription_id, resource_group_name, addons, 
     # parse the comma-separated addons argument
     addon_args = addons.split(',')
 
-    addon_profiles = {k.lower():v for k, v in (instance.addon_profiles or {}).items()}
+    addon_profiles = {k.lower(): v for k, v in (instance.addon_profiles or {}).items()}
 
     # To be consistent, os_type is lower case
     os_type = 'linux'
@@ -2599,7 +2600,7 @@ def _get_azext_module(extension_name, module_name):
 
 def _handle_addons_args(cmd, addons_str, subscription_id, resource_group_name, addon_profiles=None,
                         workspace_resource_id=None):
-    addon_profiles = {k.lower():v for k, v in (addon_profiles or {}).items()}
+    addon_profiles = {k.lower(): v for k, v in (addon_profiles or {}).items()}
     addons = addons_str.split(',') if addons_str else []
     if 'http_application_routing' in addons:
         addon_profiles['httpapplicationrouting'] = ManagedClusterAddonProfile(enabled=True)
@@ -2832,7 +2833,7 @@ def _ensure_default_log_analytics_workspace_for_monitoring(cmd, subscription_id,
 
 def _ensure_container_insights_for_monitoring(cmd, addon):
     # lower case the keys of the addon config
-    addon.config = {k.lower():v for k, v in (addon.config or {}).items()}
+    addon.config = {k.lower(): v for k, v in (addon.config or {}).items()}
 
     workspace_resource_id = addon.config['loganalyticsworkspaceresourceid']
 

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1718,15 +1718,16 @@ def _add_monitoring_role_assignment(result, cluster_resource_id, cmd):
         logger.info('valid service principal exists, using it')
         service_principal_msi_id = result.service_principal_profile.client_id
         is_service_principal = True
-    elif (
-            (hasattr(result, 'addon_profiles')) and
-            ('omsagent' in result.addon_profiles) and
-            (hasattr(result.addon_profiles['omsagent'], 'identity')) and
-            (hasattr(result.addon_profiles['omsagent'].identity, 'object_id'))
-    ):
-        logger.info('omsagent MSI exists, using it')
-        service_principal_msi_id = result.addon_profiles['omsagent'].identity.object_id
-        is_service_principal = False
+    elif hasattr(result, 'addon_profiles'):
+        addon_profiles = {k.lower():v for k, v in (result.addon_profiles or {}).items()}
+        if (
+                ('omsagent' in addon_profiles) and
+                hasattr(addon_profiles['omsagent'], 'identity') and
+                hasattr(addon_profiles['omsagent'].identity, 'object_id')
+        ):
+            logger.info('omsagent MSI exists, using it')
+            service_principal_msi_id = addon_profiles['omsagent'].identity.object_id
+            is_service_principal = False
 
     if service_principal_msi_id is not None:
         if not _add_role_assignment(cmd.cli_ctx, 'Monitoring Metrics Publisher',

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -587,14 +587,14 @@ class AcsCustomCommandTest(unittest.TestCase):
         cmd = mock.MagicMock()
         instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
                                   'clitest000001', 'http_application_routing', enable=True)
-        self.assertIn('httpApplicationRouting', instance.addon_profiles)
-        addon_profile = instance.addon_profiles['httpApplicationRouting']
+        self.assertIn('httpapplicationrouting', instance.addon_profiles)
+        addon_profile = instance.addon_profiles['httpapplicationrouting']
         self.assertTrue(addon_profile.enabled)
 
         # http_application_routing enabled
         instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
                                   'clitest000001', 'http_application_routing', enable=False)
-        addon_profile = instance.addon_profiles['httpApplicationRouting']
+        addon_profile = instance.addon_profiles['httpapplicationrouting']
         self.assertFalse(addon_profile.enabled)
 
         # monitoring added
@@ -602,7 +602,7 @@ class AcsCustomCommandTest(unittest.TestCase):
                                   'clitest000001', 'monitoring', enable=True)
         monitoring_addon_profile = instance.addon_profiles['omsagent']
         self.assertTrue(monitoring_addon_profile.enabled)
-        routing_addon_profile = instance.addon_profiles['httpApplicationRouting']
+        routing_addon_profile = instance.addon_profiles['httpapplicationrouting']
         self.assertFalse(routing_addon_profile.enabled)
 
         # monitoring disabled, routing enabled
@@ -612,9 +612,9 @@ class AcsCustomCommandTest(unittest.TestCase):
                                   'http_application_routing', enable=True)
         monitoring_addon_profile = instance.addon_profiles['omsagent']
         self.assertFalse(monitoring_addon_profile.enabled)
-        routing_addon_profile = instance.addon_profiles['httpApplicationRouting']
+        routing_addon_profile = instance.addon_profiles['httpapplicationrouting']
         self.assertTrue(routing_addon_profile.enabled)
-        self.assertEqual(sorted(list(instance.addon_profiles)), ['httpApplicationRouting', 'omsagent'])
+        self.assertEqual(sorted(list(instance.addon_profiles)), ['httpapplicationrouting', 'omsagent'])
 
         # monitoring enabled and then enabled again should error
         instance = mock.Mock()


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
'az aks' has some case sensitive issues for addon profile names and addon profile configs. Two addon profiles for the same actual addon will be sent in the request if case is different. We have received customer report that kube-dashboard addon cannot be disable, due to this bug.
This PR is to make sure all the keys are lower cased before comparing, which is consistent with the AKS server side.

**Testing Guide**  
<!--Example commands with explanations.-->
az aks disable-addons --addons kube-dashboard -g eastus -n testCluster

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AKS] Fixed case sensitive issue for AKS addon and addon config

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
