### PR TITLE
{Core} Add SessionId for telemetry

### DIFF
--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -409,9 +409,7 @@ def _get_installation_id():
 
 @decorators.suppress_all_exceptions(fallback_return="")
 def _get_session_id():
-    # This function works as a workaround to get the terminal info: when the difference
-    # of create time between current process and its parent process is larger than a given
-    # threshold, the parent process will be viewed as a terminal process.
+    # As a workaround to get the terminal info as SessionId, this function may not be accurate.
 
     def get_hash_result(content):
         import hashlib
@@ -420,10 +418,12 @@ def _get_session_id():
         hasher.update(content.encode('utf-8'))
         return hasher.hexdigest()
 
-    # Usually, more than one layer of sub-process will be called when excuting a CLI command. While, the create time
-    # of these processes will be very close, usually in several milliseconds. We use 1 second as the threshold here.
-    time_threshold = 1
+    # Usually, more than one layer of sub-process will be started when excuting a CLI command. While, the create time
+    # of these sub-processes will be very close, usually in several milliseconds. We use 1 second as the threshold here.
+    # When the difference of create time between current process and its parent process is larger than the threshold, 
+    # the parent process will be viewed as the terminal process.
     import psutil
+    time_threshold = 1
     process = psutil.Process()
     while process and process.ppid() and process.pid != process.ppid():
         parent_process = process.parent()

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -420,7 +420,7 @@ def _get_session_id():
 
     # Usually, more than one layer of sub-process will be started when excuting a CLI command. While, the create time
     # of these sub-processes will be very close, usually in several milliseconds. We use 1 second as the threshold here.
-    # When the difference of create time between current process and its parent process is larger than the threshold, 
+    # When the difference of create time between current process and its parent process is larger than the threshold,
     # the parent process will be viewed as the terminal process.
     import psutil
     time_threshold = 1

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -108,6 +108,7 @@ oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==1.4.0
+psutil==5.7.2
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -108,6 +108,7 @@ oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==1.4.0
+psutil==5.7.2
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -106,6 +106,7 @@ oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==1.2.1
+psutil==5.7.2
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -139,6 +139,10 @@ DEPENDENCIES = [
     'jsondiff==1.2.0'
 ]
 
+# dependencies for specific OSes
+if not sys.platform.startswith('cygwin'):
+    DEPENDENCIES.append('psutil~=5.7')
+
 TESTS_REQUIRE = [
     'mock~=4.0'
 ]


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
SessionId is used to help us identify whether the users are running their CLI commands in the same terminal. It can help us analysis the user behavior, by which we may be able to cluster the commands and improve CLI error rate measurement. It may also help us separate interactive users from automation scripts.

This PR 
- adds session id  for telemetry
- adds package psutil as azure-cli dependency (except for cygwin)

**Note**

The package **psutil** was remove from CLI dependencies in #11665 because of cygwin incompatibility. In this PR, we reintroduce the package and provide a workaround to avoid installing it in cygwin.

**Known Issue**

For automation script, the sessionIDs of the commands in script will be the same except for the first command. It only occurs on None-windwos OSes and only in automation scripts.

