### PR TITLE
[Extension] az extension add: Add --upgrade option to update the extension if already installed

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -64,7 +64,9 @@ def resolve_from_index(extension_name, cur_version=None, index_url=None, target_
     if not candidates:
         raise NoExtensionCandidatesError("No extension found with name '{}'".format(extension_name))
 
-    filters = [_is_not_platform_specific, _is_compatible_with_cli_version, _is_greater_than_cur_version(cur_version)]
+    filters = [_is_not_platform_specific, _is_compatible_with_cli_version]
+    if not target_version:
+        filters.append(_is_greater_than_cur_version(cur_version))
 
     for f in filters:
         logger.debug("Candidates %s", [c['filename'] for c in candidates])

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -206,9 +206,17 @@ def check_version_compatibility(azext_metadata):
         raise CLIError(min_max_msg_fmt)
 
 
-def add_extension(cmd=None, source=None, extension_name=None, index_url=None, yes=None,  # pylint: disable=unused-argument
+def add_extension(cmd=None, source=None, extension_name=None, index_url=None, yes=None,  # pylint: disable=unused-argument, too-many-statements
                   pip_extra_index_urls=None, pip_proxy=None, system=None,
                   version=None, cli_ctx=None):
+    from knack.prompting import prompt_y_n, NoTTYException
+    if source:
+        try:
+            if not prompt_y_n('Are you sure you want to install this extension?'):
+                raise CLIError('Operation cancelled.')
+        except NoTTYException:
+            raise CLIError(
+                'Unable to prompt for confirmation as no tty available. Use --yes.')
     ext_sha256 = None
 
     version = None if version == 'latest' else version
@@ -222,7 +230,21 @@ def add_extension(cmd=None, source=None, extension_name=None, index_url=None, ye
             pass
         if ext:
             if isinstance(ext, WheelExtension):
-                logger.warning("Extension '%s' is already installed.", extension_name)
+                logger.warning("Extension '%s' %s is already installed.", extension_name, ext.get_version())
+                if version and version == ext.get_version():
+                    return
+                prompt_msg = "Do you want to override it with version {}?".format(version) if version \
+                    else "Do you want to update it?"
+
+                try:
+                    go_on = True if yes else prompt_y_n(prompt_msg, default='y')
+                    if not go_on:
+                        return
+                except NoTTYException:
+                    raise CLIError("Unable to prompt for confirmation as no tty available. Please run with --yes.")
+                if yes:
+                    logger.warning("It will be overriden with version %s.", version)
+                update_extension(cmd=cmd, extension_name=extension_name, index_url=index_url, pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, cli_ctx=cli_ctx, version=version)
                 return
             logger.warning("Overriding development version of '%s' with production version.", extension_name)
         try:
@@ -289,16 +311,16 @@ def show_extension(extension_name):
         raise CLIError(e)
 
 
-def update_extension(cmd=None, extension_name=None, index_url=None, pip_extra_index_urls=None, pip_proxy=None, cli_ctx=None):
+def update_extension(cmd=None, extension_name=None, index_url=None, pip_extra_index_urls=None, pip_proxy=None, cli_ctx=None, version=None):
     try:
         cmd_cli_ctx = cli_ctx or cmd.cli_ctx
         ext = get_extension(extension_name, ext_type=WheelExtension)
         cur_version = ext.get_version()
         try:
-            download_url, ext_sha256 = resolve_from_index(extension_name, cur_version=cur_version, index_url=index_url)
+            download_url, ext_sha256 = resolve_from_index(extension_name, cur_version=cur_version, index_url=index_url, target_version=version)
         except NoExtensionCandidatesError as err:
             logger.debug(err)
-            msg = "No updates available for '{}'. Use --debug for more information.".format(extension_name)
+            msg = "Extension {} with version {} not found.".format(extension_name, version) if version else "No updates available for '{}'. Use --debug for more information.".format(extension_name)
             logger.warning(msg)
             return
         # Copy current version of extension to tmp directory in case we need to restore it after a failed install.

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -243,7 +243,8 @@ def add_extension(cmd=None, source=None, extension_name=None, index_url=None, ye
                 except NoTTYException:
                     raise CLIError("Unable to prompt for confirmation as no tty available. Please run with --yes.")
                 if yes:
-                    logger.warning("It will be overriden with version %s.", version)
+                    logger.warning("It will be overriden with version {}.".format(version) if version else "It will be updated if available.")
+
                 update_extension(cmd=cmd, extension_name=extension_name, index_url=index_url, pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, cli_ctx=cli_ctx, version=version)
                 return
             logger.warning("Overriding development version of '%s' with production version.", extension_name)

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -395,7 +395,7 @@ class AzCliCommandParser(CLICommandParser):
                                 go_on = False
                         if go_on:
                             from azure.cli.core.extension.operations import add_extension
-                            add_extension(cli_ctx=cli_ctx, extension_name=ext_name)
+                            add_extension(cli_ctx=cli_ctx, extension_name=ext_name, upgrade=True)
                             if run_after_extension_installed:
                                 import subprocess
                                 import platform
@@ -406,8 +406,8 @@ class AzCliCommandParser(CLICommandParser):
                             else:
                                 error_msg = 'Extension {} installed. Please rerun your command.'.format(ext_name)
                         else:
-                            error_msg = "The command requires the extension {ext_name}. " \
-                                "To install, run 'az extension add -n {ext_name}'.".format(ext_name=ext_name)
+                            error_msg = "The command requires the latest version of extension {ext_name}. " \
+                                "To install, run 'az extension add --upgrade -n {ext_name}'.".format(ext_name=ext_name)
                 if not error_msg:
                     # parser has no `command_source`, value is part of command itself
                     error_msg = "{prog}: '{value}' is not in the '{prog}' command group. See '{prog} --help'." \

--- a/src/azure-cli/azure/cli/command_modules/extension/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/__init__.py
@@ -6,7 +6,6 @@
 import argparse
 from collections import OrderedDict
 
-from knack.prompting import prompt_y_n
 from knack.util import CLIError
 
 from azure.cli.core import AzCommandsLoader
@@ -23,9 +22,6 @@ class ExtensionCommandsLoader(AzCommandsLoader):
 
     def load_command_table(self, args):
 
-        def ext_add_has_confirmed(command_args):
-            return bool(not command_args.get('source') or prompt_y_n('Are you sure you want to install this extension?'))
-
         def transform_extension_list_available(results):
             if isinstance(results, dict):
                 # For --show-details, transform the table
@@ -39,7 +35,7 @@ class ExtensionCommandsLoader(AzCommandsLoader):
         extension_custom = CliCommandType(operations_tmpl='azure.cli.command_modules.extension.custom#{}')
 
         with self.command_group('extension', extension_custom) as g:
-            g.command('add', 'add_extension_cmd', confirmation=ext_add_has_confirmed, validator=validate_extension_add)
+            g.command('add', 'add_extension_cmd', validator=validate_extension_add)
             g.command('remove', 'remove_extension_cmd')
             g.command('list', 'list_extensions_cmd')
             g.show_command('show', 'show_extension_cmd')

--- a/src/azure-cli/azure/cli/command_modules/extension/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/_help.py
@@ -31,6 +31,10 @@ examples:
     text: az extension add --source ~/anextension-0.0.1-py2.py3-none-any.whl --pip-proxy https://user:pass@proxy.server:8080
   - name: Add extension to system directory
     text: az extension add --name anextension --system
+  - name: Add a specific version of extension
+    text: az extension add --name anextension --version 1.0.0
+  - name: Upgrade the extension if already installed
+    text: az extension add --upgrade --name anextension
 """
 
 helps['extension list'] = """

--- a/src/azure-cli/azure/cli/command_modules/extension/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/extension/custom.py
@@ -12,10 +12,10 @@ logger = get_logger(__name__)
 
 
 def add_extension_cmd(cmd, source=None, extension_name=None, index_url=None, yes=None,
-                      pip_extra_index_urls=None, pip_proxy=None, system=None, version=None):
+                      pip_extra_index_urls=None, pip_proxy=None, system=None, version=None, upgrade=None):
     return add_extension(cli_ctx=cmd.cli_ctx, source=source, extension_name=extension_name, index_url=index_url,
                          yes=yes, pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, system=system,
-                         version=version)
+                         version=version, upgrade=upgrade)
 
 
 def remove_extension_cmd(extension_name):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Resolve #13930

This PR makes it possible to use `az extension add --upgrade` to install or update an extension. The behavior of `az extension add`(without `--upgrade`) will not change.

**When the extension is not installed**:(the behavior is the same as not providing `--upgrade` option)
`az extension add --upgrade -n anext` will install the latest version of `anext`.
`az extension add --upgrade -n anext --version aversion` will install the specific version of `anext`.

**If the extension is already installed**:
`az extension add --upgrade -n anext` will try to update the extension to the latest version if available.
`az extension add --upgrade -n anext --version aversion` will override the existing version if the specified version is different from it. Otherwise, it prints a warning message: `Extension 'anext' x.x.x is already installed`.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Extension] `az extension add`: Add `--upgrade` option to update the extension if already installed

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
