### PR TITLE
[AKS] Support azure policy addon in azure-cli

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -298,6 +298,7 @@ parameters:
             monitoring - turn on Log Analytics monitoring. Uses the Log Analytics Default Workspace if it exists, else creates one.
                          Specify "--workspace-resource-id" to use an existing workspace.
                          If monitoring addon is enabled --no-wait argument will have no effect
+            azure-policy - enable Azure policy.
   - name: --disable-rbac
     type: bool
     short-summary: Disable Kubernetes Role-Based Access Control.
@@ -507,6 +508,7 @@ long-summary: |-
         monitoring - turn on Log Analytics monitoring. Requires "--workspace-resource-id".
                      If monitoring addon is enabled --no-wait argument will have no effect
         virtual-node - enable AKS Virtual Node. Requires --subnet-name to provide the name of an existing subnet for the Virtual Node to use.
+        azure-policy - enable Azure policy.
 parameters:
   - name: --addons -a
     type: string

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -298,7 +298,8 @@ parameters:
             monitoring - turn on Log Analytics monitoring. Uses the Log Analytics Default Workspace if it exists, else creates one.
                          Specify "--workspace-resource-id" to use an existing workspace.
                          If monitoring addon is enabled --no-wait argument will have no effect
-            azure-policy - enable Azure policy.
+            azure-policy - enable Azure policy. The Azure Policy add-on for AKS enables at-scale enforcements and safeguards on your clusters in a centralized, consistent manner.
+                         Learn more at aka.ms/aks/policy.
   - name: --disable-rbac
     type: bool
     short-summary: Disable Kubernetes Role-Based Access Control.
@@ -508,7 +509,8 @@ long-summary: |-
         monitoring - turn on Log Analytics monitoring. Requires "--workspace-resource-id".
                      If monitoring addon is enabled --no-wait argument will have no effect
         virtual-node - enable AKS Virtual Node. Requires --subnet-name to provide the name of an existing subnet for the Virtual Node to use.
-        azure-policy - enable Azure policy.
+        azure-policy - enable Azure policy. The Azure Policy add-on for AKS enables at-scale enforcements and safeguards on your clusters in a centralized, consistent manner.
+                     Learn more at aka.ms/aks/policy.
 parameters:
   - name: --addons -a
     type: string

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2159,7 +2159,8 @@ ADDONS = {
     'http_application_routing': 'httpApplicationRouting',
     'monitoring': 'omsagent',
     'virtual-node': 'aciConnector',
-    'kube-dashboard': 'kubeDashboard'
+    'kube-dashboard': 'kubeDashboard',
+    'azure-policy': 'azurepolicy'
 }
 
 
@@ -2619,6 +2620,9 @@ def _handle_addons_args(cmd, addons_str, subscription_id, resource_group_name, a
     # error out if '--enable-addons=monitoring' isn't set but workspace_resource_id is
     elif workspace_resource_id:
         raise CLIError('"--workspace-resource-id" requires "--enable-addons monitoring".')
+    if 'azure-policy' in addons:
+        addon_profiles['azurepolicy'] = ManagedClusterAddonProfile(enabled=True)
+        addons.remove('azure-policy')
     # error out if any (unrecognized) addons remain
     if addons:
         raise CLIError('"{}" {} not recognized by the --enable-addons argument.'.format(

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -591,7 +591,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         addon_profile = instance.addon_profiles['httpApplicationRouting']
         self.assertTrue(addon_profile.enabled)
 
-        # http_application_routing enabled
+        # http_application_routing disabled
         instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
                                   'clitest000001', 'http_application_routing', enable=False)
         addon_profile = instance.addon_profiles['httpApplicationRouting']
@@ -615,6 +615,29 @@ class AcsCustomCommandTest(unittest.TestCase):
         routing_addon_profile = instance.addon_profiles['httpApplicationRouting']
         self.assertTrue(routing_addon_profile.enabled)
         self.assertEqual(sorted(list(instance.addon_profiles)), ['httpApplicationRouting', 'omsagent'])
+
+        # azurepolicy added
+        instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
+                                  'clitest000001', 'azure-policy', enable=True)
+        azurepolicy_addon_profile = instance.addon_profiles['azurepolicy']
+        self.assertTrue(azurepolicy_addon_profile.enabled)
+        routing_addon_profile = instance.addon_profiles['httpApplicationRouting']
+        self.assertTrue(routing_addon_profile.enabled)
+        monitoring_addon_profile = instance.addon_profiles['omsagent']
+        self.assertFalse(monitoring_addon_profile.enabled)
+
+        # azurepolicy disabled, routing enabled
+        instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
+                                  'clitest000001', 'azurepolicy', enable=False)
+        instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000', 'clitest000001',
+                                  'http_application_routing', enable=True)
+        azurepolicy_addon_profile = instance.addon_profiles['azurepolicy']
+        self.assertTrue(azurepolicy_addon_profile.enabled)
+        monitoring_addon_profile = instance.addon_profiles['omsagent']
+        self.assertFalse(monitoring_addon_profile.enabled)
+        routing_addon_profile = instance.addon_profiles['httpApplicationRouting']
+        self.assertTrue(routing_addon_profile.enabled)
+        self.assertEqual(sorted(list(instance.addon_profiles)), ['azurepolicy','httpApplicationRouting', 'omsagent'])
 
         # monitoring enabled and then enabled again should error
         instance = mock.Mock()

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -628,11 +628,11 @@ class AcsCustomCommandTest(unittest.TestCase):
 
         # azurepolicy disabled, routing enabled
         instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
-                                  'clitest000001', 'azurepolicy', enable=False)
+                                  'clitest000001', 'azure-policy', enable=False)
         instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000', 'clitest000001',
                                   'http_application_routing', enable=True)
         azurepolicy_addon_profile = instance.addon_profiles['azurepolicy']
-        self.assertTrue(azurepolicy_addon_profile.enabled)
+        self.assertFalse(azurepolicy_addon_profile.enabled)
         monitoring_addon_profile = instance.addon_profiles['omsagent']
         self.assertFalse(monitoring_addon_profile.enabled)
         routing_addon_profile = instance.addon_profiles['httpApplicationRouting']

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -637,7 +637,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         self.assertFalse(monitoring_addon_profile.enabled)
         routing_addon_profile = instance.addon_profiles['httpApplicationRouting']
         self.assertTrue(routing_addon_profile.enabled)
-        self.assertEqual(sorted(list(instance.addon_profiles)), ['azurepolicy','httpApplicationRouting', 'omsagent'])
+        self.assertEqual(sorted(list(instance.addon_profiles)), ['azurepolicy', 'httpApplicationRouting', 'omsagent'])
 
         # monitoring enabled and then enabled again should error
         instance = mock.Mock()


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Azurepolicy addon was supported in AKS through extensions as of now. Since this addon is planned for GA, adding to azure-cli official repo.

**Testing Guide**  
<!--Example commands with explanations.-->
az aks create -g <rg> -n <rn> -a azure-policy 
az aks enable-addons -g <rg> -n <rn> -a azure-policy

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

azure cli extensions PR - https://github.com/Azure/azure-cli-extensions/pull/651/files

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
