### PR TITLE
{Role} az role definition create/update -h: fix the examples text

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -682,7 +682,7 @@ examples:
         az role definition update --role-definition '{ 
             "roleName": "Contoso On-call", 
             "Description": "Perform VM actions and read storage and network information.", 
-            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.Authorization/roleDefinitions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", \\
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.Authorization/roleDefinitions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", 
             "roleType": "CustomRole", 
             "type": "Microsoft.Authorization/roleDefinitions", 
             "Actions": [ 

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -625,7 +625,7 @@ parameters:
     type: string
     short-summary: Description of a role as JSON, or a path to a file containing a JSON description.
 examples:
-  - name: Create a role with read-only access to storage and network resources, and the ability to start or restart VMs.
+  - name: Create a role with read-only access to storage and network resources, and the ability to start or restart VMs. (Bash)
     text: |
         az role definition create --role-definition '{
             "Name": "Contoso On-call",
@@ -677,7 +677,7 @@ parameters:
     type: string
     short-summary: Description of an existing role as JSON, or a path to a file containing a JSON description.
 examples:
-  - name: Update a role using the output of "az role definition list"
+  - name: Update a role using the output of "az role definition list". (Bash)
     text: |
         az role definition update --role-definition '{
             "roleName": "Contoso On-call",

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -627,28 +627,28 @@ parameters:
 examples:
   - name: Create a role with read-only access to storage and network resources, and the ability to start or restart VMs.
     text: |
-        az role definition create --role-definition '{ 
-            "Name": "Contoso On-call", 
-            "Description": "Perform VM actions and read storage and network information.", 
-            "Actions": [ 
-                "Microsoft.Compute/*/read", 
-                "Microsoft.Compute/virtualMachines/start/action", 
-                "Microsoft.Compute/virtualMachines/restart/action", 
-                "Microsoft.Network/*/read", 
-                "Microsoft.Storage/*/read", 
-                "Microsoft.Authorization/*/read", 
-                "Microsoft.Resources/subscriptions/resourceGroups/read", 
-                "Microsoft.Resources/subscriptions/resourceGroups/resources/read", 
-                "Microsoft.Insights/alertRules/*", 
-                "Microsoft.Support/*" 
-            ], 
-            "DataActions": [ 
-                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*" 
-            ], 
-            "NotDataActions": [ 
-                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write" 
-            ], 
-            "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"] 
+        az role definition create --role-definition '{
+            "Name": "Contoso On-call",
+            "Description": "Perform VM actions and read storage and network information.",
+            "Actions": [
+                "Microsoft.Compute/*/read",
+                "Microsoft.Compute/virtualMachines/start/action",
+                "Microsoft.Compute/virtualMachines/restart/action",
+                "Microsoft.Network/*/read",
+                "Microsoft.Storage/*/read",
+                "Microsoft.Authorization/*/read",
+                "Microsoft.Resources/subscriptions/resourceGroups/read",
+                "Microsoft.Resources/subscriptions/resourceGroups/resources/read",
+                "Microsoft.Insights/alertRules/*",
+                "Microsoft.Support/*"
+            ],
+            "DataActions": [
+                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*"
+            ],
+            "NotDataActions": [
+                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write"
+            ],
+            "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
         }'
   - name: Create a role from a file containing a JSON description.
     text: >
@@ -679,29 +679,29 @@ parameters:
 examples:
   - name: Update a role using the output of "az role definition list"
     text: |
-        az role definition update --role-definition '{ 
-            "roleName": "Contoso On-call", 
-            "Description": "Perform VM actions and read storage and network information.", 
-            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.Authorization/roleDefinitions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", 
-            "roleType": "CustomRole", 
-            "type": "Microsoft.Authorization/roleDefinitions", 
-            "Actions": [ 
-                "Microsoft.Compute/*/read", 
-                "Microsoft.Compute/virtualMachines/start/action", 
-                "Microsoft.Compute/virtualMachines/restart/action", 
-                "Microsoft.Network/*/read", 
-                "Microsoft.Storage/*/read", 
-                "Microsoft.Authorization/*/read", 
-                "Microsoft.Resources/subscriptions/resourceGroups/read", 
-                "Microsoft.Resources/subscriptions/resourceGroups/resources/read", 
-                "Microsoft.Support/*" 
-            ], 
-            "DataActions": [ 
-                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*" 
-            ], 
-            "NotDataActions": [ 
-                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write" 
-            ], 
-            "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"] 
+        az role definition update --role-definition '{
+            "roleName": "Contoso On-call",
+            "Description": "Perform VM actions and read storage and network information.",
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.Authorization/roleDefinitions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            "roleType": "CustomRole",
+            "type": "Microsoft.Authorization/roleDefinitions",
+            "Actions": [
+                "Microsoft.Compute/*/read",
+                "Microsoft.Compute/virtualMachines/start/action",
+                "Microsoft.Compute/virtualMachines/restart/action",
+                "Microsoft.Network/*/read",
+                "Microsoft.Storage/*/read",
+                "Microsoft.Authorization/*/read",
+                "Microsoft.Resources/subscriptions/resourceGroups/read",
+                "Microsoft.Resources/subscriptions/resourceGroups/resources/read",
+                "Microsoft.Support/*"
+            ],
+            "DataActions": [
+                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*"
+            ],
+            "NotDataActions": [
+                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write"
+            ],
+            "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
         }'
 """

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -679,29 +679,29 @@ parameters:
 examples:
   - name: Update a role using the output of "az role definition list"
     text: |
-        az role definition update --role-definition '{ \\
-            "roleName": "Contoso On-call", \\
-            "Description": "Perform VM actions and read storage and network information.", \\
+        az role definition update --role-definition '{ 
+            "roleName": "Contoso On-call", 
+            "Description": "Perform VM actions and read storage and network information.", 
             "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.Authorization/roleDefinitions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", \\
-            "roleType": "CustomRole", \\
-            "type": "Microsoft.Authorization/roleDefinitions", \\
-            "Actions": [ \\
-                "Microsoft.Compute/*/read", \\
-                "Microsoft.Compute/virtualMachines/start/action", \\
-                "Microsoft.Compute/virtualMachines/restart/action", \\
-                "Microsoft.Network/*/read", \\
-                "Microsoft.Storage/*/read", \\
-                "Microsoft.Authorization/*/read", \\
-                "Microsoft.Resources/subscriptions/resourceGroups/read", \\
-                "Microsoft.Resources/subscriptions/resourceGroups/resources/read", \\
-                "Microsoft.Support/*" \\
-            ], \\
-            "DataActions": [ \\
-                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*" \\
-            ], \\
-            "NotDataActions": [ \\
-                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write" \\
-            ], \\
-            "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"] \\
+            "roleType": "CustomRole", 
+            "type": "Microsoft.Authorization/roleDefinitions", 
+            "Actions": [ 
+                "Microsoft.Compute/*/read", 
+                "Microsoft.Compute/virtualMachines/start/action", 
+                "Microsoft.Compute/virtualMachines/restart/action", 
+                "Microsoft.Network/*/read", 
+                "Microsoft.Storage/*/read", 
+                "Microsoft.Authorization/*/read", 
+                "Microsoft.Resources/subscriptions/resourceGroups/read", 
+                "Microsoft.Resources/subscriptions/resourceGroups/resources/read", 
+                "Microsoft.Support/*" 
+            ], 
+            "DataActions": [ 
+                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*" 
+            ], 
+            "NotDataActions": [ 
+                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write" 
+            ], 
+            "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"] 
         }'
 """

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -627,28 +627,28 @@ parameters:
 examples:
   - name: Create a role with read-only access to storage and network resources, and the ability to start or restart VMs.
     text: |
-        az role definition create --role-definition '{ \\
-            "Name": "Contoso On-call", \\
-            "Description": "Perform VM actions and read storage and network information.", \\
-            "Actions": [ \\
-                "Microsoft.Compute/*/read", \\
-                "Microsoft.Compute/virtualMachines/start/action", \\
-                "Microsoft.Compute/virtualMachines/restart/action", \\
-                "Microsoft.Network/*/read", \\
-                "Microsoft.Storage/*/read", \\
-                "Microsoft.Authorization/*/read", \\
-                "Microsoft.Resources/subscriptions/resourceGroups/read", \\
-                "Microsoft.Resources/subscriptions/resourceGroups/resources/read", \\
-                "Microsoft.Insights/alertRules/*", \\
-                "Microsoft.Support/*" \\
-            ], \\
-            "DataActions": [ \\
-                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*" \\
-            ], \\
-            "NotDataActions": [ \\
-                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write" \\
-            ], \\
-            "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"] \\
+        az role definition create --role-definition '{ 
+            "Name": "Contoso On-call", 
+            "Description": "Perform VM actions and read storage and network information.", 
+            "Actions": [ 
+                "Microsoft.Compute/*/read", 
+                "Microsoft.Compute/virtualMachines/start/action", 
+                "Microsoft.Compute/virtualMachines/restart/action", 
+                "Microsoft.Network/*/read", 
+                "Microsoft.Storage/*/read", 
+                "Microsoft.Authorization/*/read", 
+                "Microsoft.Resources/subscriptions/resourceGroups/read", 
+                "Microsoft.Resources/subscriptions/resourceGroups/resources/read", 
+                "Microsoft.Insights/alertRules/*", 
+                "Microsoft.Support/*" 
+            ], 
+            "DataActions": [ 
+                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*" 
+            ], 
+            "NotDataActions": [ 
+                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write" 
+            ], 
+            "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"] 
         }'
   - name: Create a role from a file containing a JSON description.
     text: >


### PR DESCRIPTION
**Description**  
This PR fix the examples text of `az role definition create` and `az role definition update`. We provide one example using a big JSON string as the value of role-definition argument. As the backslash in a JSON will cause a failure when the JSON is quoted by single quotes. So the backslashes are removed.

**Testing Guide**  
examples text before:
```sh
az role definition create -h                                                                   
Command
    az role definition create : Create a custom role definition.

Arguments
    --role-definition [Required] : Description of a role as JSON, or a path to a file containing a
                                   JSON description.

Global Arguments
    --debug                      : Increase logging verbosity to show all debug logs.
    --help -h                    : Show this help message and exit.
    --only-show-errors           : Only show errors, suppressing warnings.
    --output -o                  : Output format.  Allowed values: json, jsonc, none, table, tsv,
                                   yaml, yamlc.  Default: json.
    --query                      : JMESPath query string. See http://jmespath.org/ for more
                                   information and examples.
    --subscription               : Name or ID of subscription. You can configure the default
                                   subscription using `az account set -s NAME_OR_ID`.
    --verbose                    : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Create a role with read-only access to storage and network resources, and the ability to start
    or restart VMs.
        az role definition create --role-definition '{ \
            "Name": "Contoso On-call", \
            "Description": "Perform VM actions and read storage and network information.", \
            "Actions": [ \
                "Microsoft.Compute/*/read", \
                "Microsoft.Compute/virtualMachines/start/action", \
                "Microsoft.Compute/virtualMachines/restart/action", \
                "Microsoft.Network/*/read", \
                "Microsoft.Storage/*/read", \
                "Microsoft.Authorization/*/read", \
                "Microsoft.Resources/subscriptions/resourceGroups/read", \
                "Microsoft.Resources/subscriptions/resourceGroups/resources/read", \
                "Microsoft.Insights/alertRules/*", \
                "Microsoft.Support/*" \
            ], \
            "DataActions": [ \
                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*" \
            ], \
            "NotDataActions": [ \
                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write" \
            ], \
            "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"] \
        }'


    Create a role from a file containing a JSON description.
        az role definition create --role-definition @ad-role.json


For more specific examples, use: az find "az role definition create"
```
examples text after:
```sh
az role definition create -h                                                                   
Command
    az role definition create : Create a custom role definition.

Arguments
    --role-definition [Required] : Description of a role as JSON, or a path to a file containing a
                                   JSON description.

Global Arguments
    --debug                      : Increase logging verbosity to show all debug logs.
    --help -h                    : Show this help message and exit.
    --only-show-errors           : Only show errors, suppressing warnings.
    --output -o                  : Output format.  Allowed values: json, jsonc, none, table, tsv,
                                   yaml, yamlc.  Default: json.
    --query                      : JMESPath query string. See http://jmespath.org/ for more
                                   information and examples.
    --subscription               : Name or ID of subscription. You can configure the default
                                   subscription using `az account set -s NAME_OR_ID`.
    --verbose                    : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Create a role with read-only access to storage and network resources, and the ability to start
    or restart VMs.
        az role definition create --role-definition '{
            "Name": "Contoso On-call",
            "Description": "Perform VM actions and read storage and network information.",
            "Actions": [
                "Microsoft.Compute/*/read",
                "Microsoft.Compute/virtualMachines/start/action",
                "Microsoft.Compute/virtualMachines/restart/action",
                "Microsoft.Network/*/read",
                "Microsoft.Storage/*/read",
                "Microsoft.Authorization/*/read",
                "Microsoft.Resources/subscriptions/resourceGroups/read",
                "Microsoft.Resources/subscriptions/resourceGroups/resources/read",
                "Microsoft.Insights/alertRules/*",
                "Microsoft.Support/*"
            ],
            "DataActions": [
                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/*"
            ],
            "NotDataActions": [
                "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write"
            ],
            "AssignableScopes": ["/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
        }'


    Create a role from a file containing a JSON description.
        az role definition create --role-definition @ad-role.json


For more specific examples, use: az find "az role definition create"
```