### PR TITLE
[Core] Fix issue 15051 for msi login issue in azure.core

### DIFF
--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -90,6 +90,6 @@ class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-meth
 
 class MSIAuthenticationWrapper(MSIAuthentication):
     # This method is exposed for Azure Core.
-    def get_token(self):
+    def get_token(self, *scopes, **kwargs):
         self.set_token()
         return AccessToken(self.token['access_token'], int(self.token['expires_on']))

--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -89,7 +89,7 @@ class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-meth
 
 
 class MSIAuthenticationWrapper(MSIAuthentication):
-    # This method is exposed for Azure Core.
-    def get_token(self, *scopes, **kwargs):
+    # This method is exposed for Azure Core. Add *scopes, **kwargs to fit azure.core requirement
+    def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
         self.set_token()
         return AccessToken(self.token['access_token'], int(self.token['expires_on']))


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix issue #15051 

With azure.core, all get_token method will need two addition arguments: *scope and **kwargs.
Here is a fix for msi login.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
