### PR TITLE
[AKS] Fixed case sensitive issue for AKS dashboard addon

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -639,6 +639,37 @@ class AcsCustomCommandTest(unittest.TestCase):
         self.assertTrue(routing_addon_profile.enabled)
         self.assertEqual(sorted(list(instance.addon_profiles)), ['azurepolicy', 'httpApplicationRouting', 'omsagent'])
 
+        # kube-dashboard disabled, no existing dashboard addon profile
+        instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
+                                  'clitest000001', 'kube-dashboard', enable=False)
+        dashboard_addon_profile = instance.addon_profiles['kubeDashboard']
+        self.assertFalse(dashboard_addon_profile.enabled)
+
+        # kube-dashboard enabled, no existing dashboard addon profile
+        instance.addon_profiles.pop('kubeDashboard', None)
+        instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
+                                  'clitest000001', 'kube-dashboard', enable=True)
+        dashboard_addon_profile = instance.addon_profiles['kubeDashboard']
+        self.assertTrue(dashboard_addon_profile.enabled)
+
+        # kube-dashboard disabled, there's existing dashboard addon profile
+        instance.addon_profiles.pop('kubeDashboard', None)
+        # test lower cased key name
+        instance.addon_profiles['kubedashboard'] = ManagedClusterAddonProfile(enabled=True)
+        instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
+                                  'clitest000001', 'kube-dashboard', enable=False)
+        dashboard_addon_profile = instance.addon_profiles['kubedashboard']
+        self.assertFalse(dashboard_addon_profile.enabled)
+
+        # kube-dashboard enabled, there's existing dashboard addon profile
+        instance.addon_profiles.pop('kubedashboard', None)
+        # test lower cased key name
+        instance.addon_profiles['kubedashboard'] = ManagedClusterAddonProfile(enabled=False)
+        instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
+                                  'clitest000001', 'kube-dashboard', enable=True)
+        dashboard_addon_profile = instance.addon_profiles['kubedashboard']
+        self.assertTrue(dashboard_addon_profile.enabled)
+
         # monitoring enabled and then enabled again should error
         instance = mock.Mock()
         instance.addon_profiles = None

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -25,6 +25,7 @@ from azure.cli.command_modules.acs.custom import (merge_kubernetes_configuration
 from azure.mgmt.containerservice.models import (ContainerServiceOrchestratorTypes,
                                                 ContainerService,
                                                 ContainerServiceOrchestratorProfile)
+from azure.mgmt.containerservice.v2020_03_01.models import ManagedClusterAddonProfile
 from azure.cli.core.util import CLIError
 
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Customer reported dashboard addon can't be disabled. The root cause is in L2359 the select from dict is not case insensitive, so that 2 addon profiles of dashboard with different keys will be added to the addon_profiles and sent in the request.

**Testing Guide**  
<!--Example commands with explanations.-->
az aks disable-addons --addons kube-dashboard -g eastus -n testCluster

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
[AKS] Fixed case sensitive issue for AKS dashboard addon

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
