### PR TITLE
{Profile} Fix: test_get_raw_token fails on non-UTC machine

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -78,10 +78,8 @@ def get_access_token(cmd, subscription=None, resource=None, resource_type=None, 
     # MSIAuthentication's token entry has `expires_on`, while ADAL's token entry has `expiresOn`
     # Unify to ISO `expiresOn`, like "2020-06-30 06:14:41"
     if 'expires_on' in token_entry:
-        from datetime import datetime
-        from pytz import utc
         # https://docs.python.org/3.8/library/datetime.html#strftime-and-strptime-format-codes
-        token_entry['expiresOn'] = datetime.fromtimestamp(int(token_entry['expires_on']), utc)\
+        token_entry['expiresOn'] = _fromtimestamp(int(token_entry['expires_on']))\
             .strftime("%Y-%m-%d %H:%M:%S.%f")
 
     result = {
@@ -231,3 +229,13 @@ def check_cli(cmd):
         print('CLI self-test completed: OK')
     else:
         raise CLIError(exceptions)
+
+
+def _fromtimestamp(t):
+    # datetime.datetime can't be patched:
+    #   TypeError: can't set attributes of built-in/extension type 'datetime.datetime'
+    # So we wrap datetime.datetime.fromtimestamp with this function.
+    # https://docs.python.org/3/library/unittest.mock-examples.html#partial-mocking
+    # https://williambert.online/2011/07/how-to-unit-testing-in-django-with-mocking-and-patching/
+    from datetime import datetime
+    return datetime.fromtimestamp(t)

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -79,8 +79,9 @@ def get_access_token(cmd, subscription=None, resource=None, resource_type=None, 
     # Unify to ISO `expiresOn`, like "2020-06-30 06:14:41"
     if 'expires_on' in token_entry:
         from datetime import datetime
+        from pytz import utc
         # https://docs.python.org/3.8/library/datetime.html#strftime-and-strptime-format-codes
-        token_entry['expiresOn'] = datetime.fromtimestamp(int(token_entry['expires_on']))\
+        token_entry['expiresOn'] = datetime.fromtimestamp(int(token_entry['expires_on']), utc)\
             .strftime("%Y-%m-%d %H:%M:%S.%f")
 
     result = {


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Inspired by https://github.com/Azure/azure-cli/pull/14718. Fix: `test_get_raw_token` fails on non-UTC machine.

The test `test_get_raw_token` was introduced in #14128.

When using `az account get-access-token` for managed identity, `expiresOn` will be converted from POSIX to datetime in **local timezone**. For example, `1593497681` is converted to 

- `2020-06-30 06:14:41.000000` on a UTC machine
- `2020-06-30 14:14:41.000000` on a UTC+8 machine

The test `test_get_raw_token fails` is written for a UTC machine on DevOps and this test will fail on a non-UTC machine (such as UTC+8).

This PR patches `fromtimestamp` with `utcfromtimestamp` to force `expiresOn` to be converted to UTC to make the test pass on any machine.
