### PR TITLE
[ARM] Fixed the returned data when tagging multiple resources

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1644,9 +1644,9 @@ def tag_resource(cmd, tags, resource_ids=None, resource_group_name=None, resourc
                                                                               resource_type,
                                                                               resource_name)]
 
-    return _single_or_collection(
-        [_get_rsrc_util_from_parsed_id(cmd.cli_ctx, id_dict, api_version, latest_include_preview).tag(
-            tags, is_incremental) for id_dict in parsed_ids])
+    return _single_or_collection([LongRunningOperation(cmd.cli_ctx)(
+        _get_rsrc_util_from_parsed_id(cmd.cli_ctx, id_dict, api_version, latest_include_preview).tag(
+            tags, is_incremental)) for id_dict in parsed_ids])
 
 
 # pylint: unused-argument

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_tag_update_by_patch.yaml
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_tag_update_by_patch.yaml
@@ -13,8 +13,8 @@ interactions:
       ParameterSetName:
       - -g -n --resource-type --is-full-object -p
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
@@ -28,7 +28,7 @@ interactions:
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-07-10-preview","2018-07-10","2018-01-10","2017-09-01","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
@@ -37,107 +37,107 @@ interactions:
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '12409'
+      - '12934'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:10 GMT
+      - Mon, 14 Sep 2020 02:57:23 GMT
       expires:
       - '-1'
       pragma:
@@ -169,15 +169,15 @@ interactions:
       ParameterSetName:
       - -g -n --resource-type --is-full-object -p
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
   response:
     body:
-      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-07-29T01%3A02%3A13.0040374Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-09-14T02%3A57%3A33.0282124Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -186,7 +186,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 29 Jul 2020 01:02:12 GMT
+      - Mon, 14 Sep 2020 02:57:33 GMT
       expires:
       - '-1'
       pragma:
@@ -198,7 +198,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '204'
+      - '203'
     status:
       code: 201
       message: Created
@@ -216,8 +216,8 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
@@ -231,7 +231,7 @@ interactions:
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-07-10-preview","2018-07-10","2018-01-10","2017-09-01","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
@@ -240,107 +240,107 @@ interactions:
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '12409'
+      - '12934'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:12 GMT
+      - Mon, 14 Sep 2020 02:57:34 GMT
       expires:
       - '-1'
       pragma:
@@ -368,15 +368,15 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
   response:
     body:
-      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-07-29T01%3A02%3A13.0040374Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-09-14T02%3A57%3A33.0282124Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -385,7 +385,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 29 Jul 2020 01:02:13 GMT
+      - Mon, 14 Sep 2020 02:57:35 GMT
       expires:
       - '-1'
       pragma:
@@ -421,15 +421,15 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
   response:
     body:
-      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-07-29T01%3A02%3A15.0259592Z''\"","tags":{"cli-test":"test"},"properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-09-14T02%3A57%3A38.5394871Z''\"","tags":{"cli-test":"test"},"properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -438,7 +438,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 29 Jul 2020 01:02:14 GMT
+      - Mon, 14 Sep 2020 02:57:41 GMT
       expires:
       - '-1'
       pragma:
@@ -454,7 +454,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '203'
+      - '204'
     status:
       code: 200
       message: OK
@@ -472,8 +472,8 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
@@ -487,7 +487,7 @@ interactions:
         India","West India","Canada Central","Canada East","West Central US","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-07-10-preview","2018-07-10","2018-01-10","2017-09-01","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
@@ -496,107 +496,107 @@ interactions:
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West India","West Central US","Canada Central","Canada East","West
         US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
         Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '12409'
+      - '12934'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:15 GMT
+      - Mon, 14 Sep 2020 02:57:41 GMT
       expires:
       - '-1'
       pragma:
@@ -624,15 +624,15 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
   response:
     body:
-      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-07-29T01%3A02%3A15.0259592Z''\"","tags":{"cli-test":"test"},"properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-09-14T02%3A57%3A38.5394871Z''\"","tags":{"cli-test":"test"},"properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -641,7 +641,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 29 Jul 2020 01:02:16 GMT
+      - Mon, 14 Sep 2020 02:57:43 GMT
       expires:
       - '-1'
       pragma:
@@ -677,15 +677,15 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
   response:
     body:
-      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-07-29T01%3A02%3A17.6424506Z''\"","tags":{},"properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-09-14T02%3A57%3A45.4711226Z''\"","tags":{},"properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -694,7 +694,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 29 Jul 2020 01:02:18 GMT
+      - Mon, 14 Sep 2020 02:57:47 GMT
       expires:
       - '-1'
       pragma:
@@ -722,218 +722,21 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - resource delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --id
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices?api-version=2020-06-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorizations":[{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},{"applicationId":"3b2fa68d-a091-48c9-95be-88d572e08fb7","roleDefinitionId":"47d68fae-99c7-4c10-b9db-2316116a061e"},{"applicationId":"9bdab391-7bbe-42e8-8132-e4491dc29cc0","roleDefinitionId":"0383f7f5-023d-4379-b2c7-9ef786459969"}],"resourceTypes":[{"resourceType":"vaults","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-07-10-preview","2018-07-10","2018-01-10","2017-09-01","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
-        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
-        Asia","North Central US","South Central US","Japan East","Japan West","Australia
-        East","Australia Southeast","Central US","East US 2","Central India","South
-        India","West India","West Central US","Canada Central","Canada East","West
-        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
-        Central","South Africa North","UAE North","Switzerland North","Germany West
-        Central","Norway East"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12409'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 29 Jul 2020 01:02:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - resource delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - --id
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 29 Jul 2020 01:02:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '199'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
       - resource tag
       Connection:
       - keep-alive
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001","name":"cli_test_tag_update_by_patch000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-07-29T01:02:09Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001","name":"cli_test_tag_update_by_patch000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-09-14T02:57:14Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -942,7 +745,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:20 GMT
+      - Mon, 14 Sep 2020 02:57:48 GMT
       expires:
       - '-1'
       pragma:
@@ -974,8 +777,8 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PATCH
@@ -991,7 +794,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:20 GMT
+      - Mon, 14 Sep 2020 02:57:50 GMT
       expires:
       - '-1'
       pragma:
@@ -1005,7 +808,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 200
       message: OK
@@ -1028,24 +831,24 @@ interactions:
       ParameterSetName:
       - -n -g -l --sku
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-containerregistry/3.0.0rc14
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-containerregistry/3.0.0rc14 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003?api-version=2019-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard","tier":"Standard"},"type":"Microsoft.ContainerRegistry/registries","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003","name":"clireg000003","location":"westus","tags":{},"properties":{"loginServer":"clireg000003.azurecr.io","creationDate":"2020-07-29T01:02:22.7437222Z","provisioningState":"Succeeded","adminUserEnabled":false,"policies":{"quarantinePolicy":{"status":"disabled"},"trustPolicy":{"type":"Notary","status":"disabled"},"retentionPolicy":{"days":7,"lastUpdatedTime":"2020-07-29T01:02:24.2720588+00:00","status":"disabled"}},"encryption":{"status":"disabled"},"dataEndpointEnabled":false,"dataEndpointHostNames":[],"privateEndpointConnections":[],"publicNetworkAccess":"Enabled"}}'
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"type":"Microsoft.ContainerRegistry/registries","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003","name":"clireg000003","location":"westus","tags":{},"systemData":{"createdBy":"zhoxing@microsoft.com","createdByType":"User","createdAt":"2020-09-14T02:57:55.7077933+00:00","lastModifiedBy":"zhoxing@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2020-09-14T02:57:55.7077933+00:00"},"properties":{"loginServer":"clireg000003.azurecr.io","creationDate":"2020-09-14T02:57:55.7077933Z","provisioningState":"Succeeded","adminUserEnabled":false,"policies":{"quarantinePolicy":{"status":"disabled"},"trustPolicy":{"type":"Notary","status":"disabled"},"retentionPolicy":{"days":7,"lastUpdatedTime":"2020-09-14T02:57:57.7019975+00:00","status":"disabled"}},"encryption":{"status":"disabled"},"dataEndpointEnabled":false,"dataEndpointHostNames":[],"privateEndpointConnections":[],"publicNetworkAccess":"Enabled"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '902'
+      - '1146'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:24 GMT
+      - Mon, 14 Sep 2020 02:57:58 GMT
       expires:
       - '-1'
       pragma:
@@ -1061,7 +864,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1194'
     status:
       code: 200
       message: OK
@@ -1079,24 +882,24 @@ interactions:
       ParameterSetName:
       - -n -r --uri --actions
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceType%20eq%20%27Microsoft.ContainerRegistry%2Fregistries%27&api-version=2020-06-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003","name":"clireg000003","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Standard","tier":"Standard"},"location":"westus","tags":{}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003","name":"clireg000003","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Standard","tier":"Standard"},"location":"westus","tags":{},"systemData":{"createdBy":"zhoxing@microsoft.com","createdByType":"User","createdAt":"2020-09-14T02:57:55.7077933Z","lastModifiedBy":"zhoxing@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2020-09-14T02:57:55.7077933Z"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/feng-cli-rg/providers/Microsoft.ContainerRegistry/registries/fengacr","name":"fengacr","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Premium","tier":"Premium"},"location":"centralus","tags":{}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qianwens/providers/Microsoft.ContainerRegistry/registries/qianwen","name":"qianwen","type":"Microsoft.ContainerRegistry/registries","sku":{"name":"Standard","tier":"Standard"},"location":"eastus","tags":{}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '385'
+      - '1185'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:24 GMT
+      - Mon, 14 Sep 2020 02:57:58 GMT
       expires:
       - '-1'
       pragma:
@@ -1124,24 +927,24 @@ interactions:
       ParameterSetName:
       - -n -r --uri --actions
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-containerregistry/3.0.0rc14
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-containerregistry/3.0.0rc14 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003?api-version=2019-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard","tier":"Standard"},"type":"Microsoft.ContainerRegistry/registries","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003","name":"clireg000003","location":"westus","tags":{},"properties":{"loginServer":"clireg000003.azurecr.io","creationDate":"2020-07-29T01:02:22.7437222Z","provisioningState":"Succeeded","adminUserEnabled":false,"policies":{"quarantinePolicy":{"status":"disabled"},"trustPolicy":{"type":"Notary","status":"disabled"},"retentionPolicy":{"days":7,"lastUpdatedTime":"2020-07-29T01:02:24.2720588+00:00","status":"disabled"}},"encryption":{"status":"disabled"},"dataEndpointEnabled":false,"dataEndpointHostNames":[],"privateEndpointConnections":[],"publicNetworkAccess":"Enabled"}}'
+      string: '{"sku":{"name":"Standard","tier":"Standard"},"type":"Microsoft.ContainerRegistry/registries","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003","name":"clireg000003","location":"westus","tags":{},"systemData":{"createdBy":"zhoxing@microsoft.com","createdByType":"User","createdAt":"2020-09-14T02:57:55.7077933+00:00","lastModifiedBy":"zhoxing@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2020-09-14T02:57:55.7077933+00:00"},"properties":{"loginServer":"clireg000003.azurecr.io","creationDate":"2020-09-14T02:57:55.7077933Z","provisioningState":"Succeeded","adminUserEnabled":false,"policies":{"quarantinePolicy":{"status":"disabled"},"trustPolicy":{"type":"Notary","status":"disabled"},"retentionPolicy":{"days":7,"lastUpdatedTime":"2020-09-14T02:57:57.7019975+00:00","status":"disabled"}},"encryption":{"status":"disabled"},"dataEndpointEnabled":false,"dataEndpointHostNames":[],"privateEndpointConnections":[],"publicNetworkAccess":"Enabled"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '902'
+      - '1146'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:25 GMT
+      - Mon, 14 Sep 2020 02:58:00 GMT
       expires:
       - '-1'
       pragma:
@@ -1178,24 +981,24 @@ interactions:
       ParameterSetName:
       - -n -r --uri --actions
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-containerregistry/3.0.0rc14
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-containerregistry/3.0.0rc14 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook?api-version=2019-12-01-preview
   response:
     body:
-      string: '{"type":"Microsoft.ContainerRegistry/registries/webhooks","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook","name":"cliregwebhook","location":"westus","tags":{},"properties":{"status":"enabled","scope":"","actions":["push"],"provisioningState":"Succeeded"}}'
+      string: '{"type":"Microsoft.ContainerRegistry/registries/webhooks","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook","name":"cliregwebhook","location":"westus","tags":{},"systemData":{"createdBy":"zhoxing@microsoft.com","createdByType":"User","createdAt":"2020-09-14T02:58:06.2318312+00:00","lastModifiedBy":"zhoxing@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2020-09-14T02:58:06.2318312+00:00"},"properties":{"status":"enabled","scope":"","actions":["push"],"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '450'
+      - '694'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:26 GMT
+      - Mon, 14 Sep 2020 02:58:08 GMT
       expires:
       - '-1'
       pragma:
@@ -1229,8 +1032,8 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
@@ -1243,7 +1046,8 @@ interactions:
         Central","South Africa North","UAE North","East Asia","Japan East","Japan
         West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"CrossResourceGroupResourceMove,
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"registries/scopeMaps","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
@@ -1251,118 +1055,137 @@ interactions:
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
         US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/tokens","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/tokens","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
         US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/generateCredentials","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/generateCredentials","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
         US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnections","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnections","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies","locations":["West
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies/validate","locations":["West
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies/validate","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateLinkResources","locations":["West
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateLinkResources","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/importImage","locations":["South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/importImage","locations":["South
         Central US","West Central US","East US","West Europe","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","France Central","South
         Africa North","UAE North","Central US","Canada East","Canada Central","UK
         South","UK West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/exportPipelines","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/exportPipelines","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/importPipelines","locations":["West
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/importPipelines","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/pipelineRuns","locations":["West
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/pipelineRuns","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/listBuildSourceUploadUrl","locations":["East
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/listBuildSourceUploadUrl","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/scheduleRun","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/scheduleRun","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/taskRuns","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/taskRuns","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"None"},{"resourceType":"registries/taskRuns/listDetails","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"None"},{"resourceType":"registries/taskRuns/listDetails","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/agentPools","locations":["East
-        US","West US 2","South Central US","East US 2"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/agentPools","locations":["East
+        US","West US 2","South Central US","Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/agentPools/listQueueStatus","locations":["East
-        US","West US 2","South Central US","East US 2"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/runs/listLogSasUrl","locations":["East
+        US","West US 2","South Central US","Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/runs/listLogSasUrl","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs/cancel","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs/cancel","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/tasks","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/tasks","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"defaultApiVersion":"2019-04-01","capabilities":"CrossResourceGroupResourceMove,
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"defaultApiVersion":"2019-04-01","capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"registries/tasks/listDetails","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
@@ -1370,180 +1193,213 @@ interactions:
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/getBuildSourceUploadUrl","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/getBuildSourceUploadUrl","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/queueBuild","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/queueBuild","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/getLogLink","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/getLogLink","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/cancel","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/cancel","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/buildTasks/listSourceRepositoryProperties","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps/listBuildArguments","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps/listBuildArguments","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/replications","locations":["South
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/replications","locations":["South
         Central US","West Central US","East US","West Europe","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks/ping","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/listEvents","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/setupAuth","locations":["East
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/setupAuth","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/authorize","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/authorize","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["West
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","France Central","Central
         US","South Africa North","UAE North","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/GetCredentials","locations":["West
-        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/listCredentials","locations":["South
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","Korea Central","South
         Africa North","UAE North","France Central","East Asia","Japan East","Japan
         West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","Korea Central","South
         Africa North","UAE North","France Central","East Asia","Japan East","Japan
         West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/listUsages","locations":["West
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/listUsages","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/listPolicies","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/listPolicies","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","Korea Central","South
         Africa North","UAE North","France Central","East Asia","Japan East","Japan
         West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/updatePolicies","locations":["West
+        US 2","Switzerland North","Switzerland West","UAE Central","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/updatePolicies","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","Korea Central","South
         Africa North","UAE North","France Central","East Asia","Japan East","Japan
         West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredentials","locations":["West
-        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/eventGridFilters","locations":["South
+        US 2","Switzerland North","Switzerland West","UAE Central","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/eventGridFilters","locations":["South
         Central US","West Central US","East US","West Europe","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["South
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
-        Central","France Central","South Africa North","UAE North","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["South
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
-        Central","France Central","South Africa North","UAE North","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01"],"capabilities":"None"},{"resourceType":"locations","locations":["South
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01"],"capabilities":"None"},{"resourceType":"locations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
-        Central","France Central","South Africa North","UAE North","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01","2017-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01","2017-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '28968'
+      - '34018'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:27 GMT
+      - Mon, 14 Sep 2020 02:58:08 GMT
       expires:
       - '-1'
       pragma:
@@ -1571,8 +1427,8 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
@@ -1588,7 +1444,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:28 GMT
+      - Mon, 14 Sep 2020 02:58:09 GMT
       expires:
       - '-1'
       pragma:
@@ -1624,8 +1480,8 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PATCH
@@ -1641,7 +1497,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:29 GMT
+      - Mon, 14 Sep 2020 02:58:11 GMT
       expires:
       - '-1'
       pragma:
@@ -1657,7 +1513,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1193'
     status:
       code: 200
       message: OK
@@ -1675,8 +1531,8 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
@@ -1689,7 +1545,8 @@ interactions:
         Central","South Africa North","UAE North","East Asia","Japan East","Japan
         West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"CrossResourceGroupResourceMove,
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"registries/scopeMaps","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
@@ -1697,118 +1554,137 @@ interactions:
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
         US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/tokens","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/tokens","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
         US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/generateCredentials","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/generateCredentials","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
         US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnections","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnections","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies","locations":["West
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies/validate","locations":["West
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies/validate","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateLinkResources","locations":["West
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateLinkResources","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/importImage","locations":["South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/importImage","locations":["South
         Central US","West Central US","East US","West Europe","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","France Central","South
         Africa North","UAE North","Central US","Canada East","Canada Central","UK
         South","UK West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/exportPipelines","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/exportPipelines","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/importPipelines","locations":["West
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/importPipelines","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/pipelineRuns","locations":["West
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/pipelineRuns","locations":["West
         US","East US","South Central US","West Europe","Switzerland North","North
         Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
         South","Canada East","Canada Central","Central US","East US 2","North Central
         US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/listBuildSourceUploadUrl","locations":["East
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/listBuildSourceUploadUrl","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/scheduleRun","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/scheduleRun","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/taskRuns","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/taskRuns","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"None"},{"resourceType":"registries/taskRuns/listDetails","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"None"},{"resourceType":"registries/taskRuns/listDetails","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/agentPools","locations":["East
-        US","West US 2","South Central US","East US 2"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/agentPools","locations":["East
+        US","West US 2","South Central US","Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/agentPools/listQueueStatus","locations":["East
-        US","West US 2","South Central US","East US 2"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/runs/listLogSasUrl","locations":["East
+        US","West US 2","South Central US","Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/runs/listLogSasUrl","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs/cancel","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs/cancel","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/tasks","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/tasks","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"defaultApiVersion":"2019-04-01","capabilities":"CrossResourceGroupResourceMove,
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"defaultApiVersion":"2019-04-01","capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"registries/tasks/listDetails","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
@@ -1816,180 +1692,213 @@ interactions:
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/getBuildSourceUploadUrl","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/getBuildSourceUploadUrl","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/queueBuild","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/queueBuild","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/getLogLink","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/getLogLink","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/cancel","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/cancel","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/buildTasks/listSourceRepositoryProperties","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps/listBuildArguments","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps/listBuildArguments","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/replications","locations":["South
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/replications","locations":["South
         Central US","West Central US","East US","West Europe","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks/ping","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/listEvents","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/setupAuth","locations":["East
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/setupAuth","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/authorize","locations":["East
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/authorize","locations":["East
         US","West Europe","West US 2","South Central US","Australia East","Australia
         Southeast","Brazil South","Canada Central","Canada East","Central India","Central
         US","East Asia","East US 2","Japan East","Japan West","North Central US","North
         Europe","Southeast Asia","South India","UK South","UK West","West US","West
         Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["West
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","France Central","Central
         US","South Africa North","UAE North","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/GetCredentials","locations":["West
-        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/listCredentials","locations":["South
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","Korea Central","South
         Africa North","UAE North","France Central","East Asia","Japan East","Japan
         West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","Korea Central","South
         Africa North","UAE North","France Central","East Asia","Japan East","Japan
         West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/listUsages","locations":["West
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/listUsages","locations":["West
         Central US","East US","West Europe","South Central US","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/listPolicies","locations":["West
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/listPolicies","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","Korea Central","South
         Africa North","UAE North","France Central","East Asia","Japan East","Japan
         West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/updatePolicies","locations":["West
+        US 2","Switzerland North","Switzerland West","UAE Central","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/updatePolicies","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","Korea Central","South
         Africa North","UAE North","France Central","East Asia","Japan East","Japan
         West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredentials","locations":["West
-        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/eventGridFilters","locations":["South
+        US 2","Switzerland North","Switzerland West","UAE Central","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/eventGridFilters","locations":["South
         Central US","West Central US","East US","West Europe","West US","Japan East","North
         Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
         South","Australia East","Central India","Korea Central","South Africa North","UAE
         North","France Central","Central US","Canada East","Canada Central","UK South","UK
         West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["South
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
-        Central","France Central","South Africa North","UAE North","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["South
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
-        Central","France Central","South Africa North","UAE North","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01"],"capabilities":"None"},{"resourceType":"locations","locations":["South
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01"],"capabilities":"None"},{"resourceType":"locations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
         India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
-        Central","France Central","South Africa North","UAE North","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01","2017-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01","2017-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '28968'
+      - '34018'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:29 GMT
+      - Mon, 14 Sep 2020 02:58:11 GMT
       expires:
       - '-1'
       pragma:
@@ -2017,8 +1926,8 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
@@ -2034,7 +1943,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:29 GMT
+      - Mon, 14 Sep 2020 02:58:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2070,8 +1979,8 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PATCH
@@ -2087,7 +1996,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:30 GMT
+      - Mon, 14 Sep 2020 02:58:16 GMT
       expires:
       - '-1'
       pragma:
@@ -2103,396 +2012,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - resource delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --id
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry?api-version=2020-06-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorizations":[{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},{"applicationId":"737d58c1-397a-46e7-9d12-7d8c830883c2","roleDefinitionId":"716bb53a-0390-4428-bf41-b1bedde7d751"},{"applicationId":"918d0db8-4a38-4938-93c1-9313bdfe0272","roleDefinitionId":"dcd2d2c9-3f80-4d72-95a8-2593111b4b12"},{"applicationId":"d2fa1650-4805-4a83-bcb9-cf41fe63539c","roleDefinitionId":"c15f8dab-b103-4f8d-9afb-fbe4b8e98de2"},{"applicationId":"a4c95b9e-3994-40cc-8953-5dc66d48348d","roleDefinitionId":"dc88c655-90fa-48d9-8d51-003cc8738508"},{"applicationId":"62c559cd-db0c-4da0-bab2-972528c65d42","roleDefinitionId":"437b639a-6d74-491d-959f-d172e8c5c1fc"}],"resourceTypes":[{"resourceType":"registries","locations":["West
-        US","East US","South Central US","West Europe","North Europe","UK South","UK
-        West","Australia East","Australia Southeast","Central India","Korea Central","France
-        Central","South Africa North","UAE North","East Asia","Japan East","Japan
-        West","Southeast Asia","South India","Brazil South","Canada East","Canada
-        Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"registries/scopeMaps","locations":["West
-        US","East US","South Central US","West Europe","North Europe","UK South","UK
-        West","Australia East","Australia Southeast","Central India","East Asia","Japan
-        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
-        Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/tokens","locations":["West
-        US","East US","South Central US","West Europe","North Europe","UK South","UK
-        West","Australia East","Australia Southeast","Central India","East Asia","Japan
-        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
-        Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/generateCredentials","locations":["West
-        US","East US","South Central US","West Europe","North Europe","UK South","UK
-        West","Australia East","Australia Southeast","Central India","East Asia","Japan
-        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
-        Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnections","locations":["West
-        US","East US","South Central US","West Europe","Switzerland North","North
-        Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
-        South","Canada East","Canada Central","Central US","East US 2","North Central
-        US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies","locations":["West
-        US","East US","South Central US","West Europe","Switzerland North","North
-        Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
-        South","Canada East","Canada Central","Central US","East US 2","North Central
-        US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies/validate","locations":["West
-        US","East US","South Central US","West Europe","Switzerland North","North
-        Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
-        South","Canada East","Canada Central","Central US","East US 2","North Central
-        US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateLinkResources","locations":["West
-        US","East US","South Central US","West Europe","Switzerland North","North
-        Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
-        South","Canada East","Canada Central","Central US","East US 2","North Central
-        US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/importImage","locations":["South
-        Central US","West Central US","East US","West Europe","West US","Japan East","North
-        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
-        South","Australia East","Central India","Korea Central","France Central","South
-        Africa North","UAE North","Central US","Canada East","Canada Central","UK
-        South","UK West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/exportPipelines","locations":["West
-        US","East US","South Central US","West Europe","Switzerland North","North
-        Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
-        South","Canada East","Canada Central","Central US","East US 2","North Central
-        US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/importPipelines","locations":["West
-        US","East US","South Central US","West Europe","Switzerland North","North
-        Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
-        South","Canada East","Canada Central","Central US","East US 2","North Central
-        US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/pipelineRuns","locations":["West
-        US","East US","South Central US","West Europe","Switzerland North","North
-        Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
-        South","Canada East","Canada Central","Central US","East US 2","North Central
-        US","West Central US","West US 2","Korea Central","France Central","South
-        Africa North","UAE North"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/listBuildSourceUploadUrl","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/scheduleRun","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/taskRuns","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"None"},{"resourceType":"registries/taskRuns/listDetails","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/agentPools","locations":["East
-        US","West US 2","South Central US","East US 2"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/agentPools/listQueueStatus","locations":["East
-        US","West US 2","South Central US","East US 2"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/runs/listLogSasUrl","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs/cancel","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/tasks","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"defaultApiVersion":"2019-04-01","capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
-        SupportsLocation"},{"resourceType":"registries/tasks/listDetails","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/getBuildSourceUploadUrl","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/queueBuild","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/getLogLink","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/cancel","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/buildTasks/listSourceRepositoryProperties","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps/listBuildArguments","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/replications","locations":["South
-        Central US","West Central US","East US","West Europe","West US","Japan East","North
-        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
-        South","Australia East","Central India","Korea Central","South Africa North","UAE
-        North","France Central","Central US","Canada East","Canada Central","UK South","UK
-        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe","South Central US","West US","Japan East","North
-        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
-        South","Australia East","Central India","Korea Central","South Africa North","UAE
-        North","France Central","Central US","Canada East","Canada Central","UK South","UK
-        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe","South Central US","West US","Japan East","North
-        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
-        South","Australia East","Central India","Korea Central","South Africa North","UAE
-        North","France Central","Central US","Canada East","Canada Central","UK South","UK
-        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe","South Central US","West US","Japan East","North
-        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
-        South","Australia East","Central India","Korea Central","South Africa North","UAE
-        North","France Central","Central US","Canada East","Canada Central","UK South","UK
-        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe","South Central US","West US","Japan East","North
-        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
-        South","Australia East","Central India","Korea Central","South Africa North","UAE
-        North","France Central","Central US","Canada East","Canada Central","UK South","UK
-        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/setupAuth","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/authorize","locations":["East
-        US","West Europe","West US 2","South Central US","Australia East","Australia
-        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
-        Europe","Southeast Asia","South India","UK South","UK West","West US","West
-        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
-        North"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe","South Central US","West US","Japan East","North
-        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
-        South","Australia East","Central India","Korea Central","France Central","Central
-        US","South Africa North","UAE North","Canada East","Canada Central","UK South","UK
-        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["West
-        Central US","East US","West Europe","South Central US","West US","Japan East","North
-        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
-        South","Australia East","Central India","Korea Central","South Africa North","UAE
-        North","France Central","Central US","Canada East","Canada Central","UK South","UK
-        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/GetCredentials","locations":["West
-        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/listCredentials","locations":["South
-        Central US","East US","West US","West Europe","North Europe","UK South","UK
-        West","Australia East","Australia Southeast","Central India","Korea Central","South
-        Africa North","UAE North","France Central","East Asia","Japan East","Japan
-        West","Southeast Asia","South India","Brazil South","Canada East","Canada
-        Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredential","locations":["South
-        Central US","West US","East US","West Europe","North Europe","UK South","UK
-        West","Australia East","Australia Southeast","Central India","Korea Central","South
-        Africa North","UAE North","France Central","East Asia","Japan East","Japan
-        West","Southeast Asia","South India","Brazil South","Canada East","Canada
-        Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe","South Central US","West US","Japan East","North
-        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
-        South","Australia East","Central India","Korea Central","South Africa North","UAE
-        North","France Central","Central US","Canada East","Canada Central","UK South","UK
-        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/listPolicies","locations":["West
-        US","East US","South Central US","West Europe","North Europe","UK South","UK
-        West","Australia East","Australia Southeast","Central India","Korea Central","South
-        Africa North","UAE North","France Central","East Asia","Japan East","Japan
-        West","Southeast Asia","South India","Brazil South","Canada East","Canada
-        Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/updatePolicies","locations":["West
-        US","East US","South Central US","West Europe","North Europe","UK South","UK
-        West","Australia East","Australia Southeast","Central India","Korea Central","South
-        Africa North","UAE North","France Central","East Asia","Japan East","Japan
-        West","Southeast Asia","South India","Brazil South","Canada East","Canada
-        Central","Central US","East US 2","North Central US","West Central US","West
-        US 2","Switzerland North"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredentials","locations":["West
-        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/eventGridFilters","locations":["South
-        Central US","West Central US","East US","West Europe","West US","Japan East","North
-        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
-        South","Australia East","Central India","Korea Central","South Africa North","UAE
-        North","France Central","Central US","Canada East","Canada Central","UK South","UK
-        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
-        North"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
-        Central","France Central","South Africa North","UAE North","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
-        Central","France Central","South Africa North","UAE North","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01"],"capabilities":"None"},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
-        Central","France Central","South Africa North","UAE North","Switzerland North"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01","2017-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '28968'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 29 Jul 2020 01:02:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - resource delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - --id
-      User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook?api-version=2019-05-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Wed, 29 Jul 2020 01:02:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
+      - '1195'
     status:
       code: 200
       message: OK
@@ -2510,8 +2030,8 @@ interactions:
       ParameterSetName:
       - -g -n --image
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
@@ -2527,7 +2047,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:32 GMT
+      - Mon, 14 Sep 2020 02:58:17 GMT
       expires:
       - '-1'
       pragma:
@@ -2561,8 +2081,8 @@ interactions:
       ParameterSetName:
       - -g -n --image
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-containerinstance/1.5.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-containerinstance/1.5.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PUT
@@ -2572,7 +2092,7 @@ interactions:
       string: '{"properties":{"provisioningState":"Pending","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"resources":{"requests":{"memoryInGB":1.5,"cpu":1.0}}}}],"restartPolicy":"Always","osType":"Linux","instanceView":{"events":[],"state":"Pending"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004","name":"clicontainer000004","type":"Microsoft.ContainerInstance/containerGroups","location":"westus","tags":{}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/e7e5840d-00eb-47cb-b912-e9633dd87c2a?api-version=2018-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/ccd7ef5a-7e5d-4762-9c15-24d591a59df7?api-version=2018-06-01
       cache-control:
       - no-cache
       content-length:
@@ -2580,7 +2100,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:02:36 GMT
+      - Mon, 14 Sep 2020 02:58:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2612,16 +2132,16 @@ interactions:
       ParameterSetName:
       - -g -n --image
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-containerinstance/1.5.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-containerinstance/1.5.0 Azure-SDK-For-Python AZURECLI/2.11.1
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/e7e5840d-00eb-47cb-b912-e9633dd87c2a?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/ccd7ef5a-7e5d-4762-9c15-24d591a59df7?api-version=2018-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004","status":"Succeeded","startTime":"2020-07-29T01:02:36.8380314Z","properties":{"events":[{"count":1,"firstTimestamp":"2020-07-29T01:02:41Z","lastTimestamp":"2020-07-29T01:02:41Z","name":"Pulling","message":"pulling
-        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:50Z","lastTimestamp":"2020-07-29T01:02:50Z","name":"Pulled","message":"Successfully
-        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Created","message":"Created
-        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Started","message":"Started
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004","status":"Succeeded","startTime":"2020-09-14T02:58:23.4857113Z","properties":{"events":[{"count":1,"firstTimestamp":"2020-09-14T02:58:28Z","lastTimestamp":"2020-09-14T02:58:28Z","name":"Pulling","message":"pulling
+        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:36Z","lastTimestamp":"2020-09-14T02:58:36Z","name":"Pulled","message":"Successfully
+        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Created","message":"Created
+        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Started","message":"Started
         container","type":"Normal"}]}}'
     headers:
       cache-control:
@@ -2631,7 +2151,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:03:07 GMT
+      - Mon, 14 Sep 2020 02:58:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2661,16 +2181,16 @@ interactions:
       ParameterSetName:
       - -g -n --image
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-containerinstance/1.5.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-containerinstance/1.5.0 Azure-SDK-For-Python AZURECLI/2.11.1
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004?api-version=2018-10-01
   response:
     body:
-      string: '{"properties":{"provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-07-29T01:02:57Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-07-29T01:02:41Z","lastTimestamp":"2020-07-29T01:02:41Z","name":"Pulling","message":"pulling
-        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:50Z","lastTimestamp":"2020-07-29T01:02:50Z","name":"Pulled","message":"Successfully
-        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Created","message":"Created
-        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Started","message":"Started
+      string: '{"properties":{"provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-09-14T02:58:43Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-09-14T02:58:28Z","lastTimestamp":"2020-09-14T02:58:28Z","name":"Pulling","message":"pulling
+        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:36Z","lastTimestamp":"2020-09-14T02:58:36Z","name":"Pulled","message":"Successfully
+        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Created","message":"Created
+        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Started","message":"Started
         container","type":"Normal"}]},"resources":{"requests":{"memoryInGB":1.5,"cpu":1.0}}}}],"restartPolicy":"Always","osType":"Linux","instanceView":{"events":[],"state":"Running"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004","name":"clicontainer000004","type":"Microsoft.ContainerInstance/containerGroups","location":"westus","tags":{}}'
     headers:
       cache-control:
@@ -2680,7 +2200,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:03:08 GMT
+      - Mon, 14 Sep 2020 02:58:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2710,8 +2230,8 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
@@ -2760,7 +2280,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:03:09 GMT
+      - Mon, 14 Sep 2020 02:58:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2788,18 +2308,18 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004?api-version=2019-12-01
   response:
     body:
-      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-07-29T01:02:57Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-07-29T01:02:41Z","lastTimestamp":"2020-07-29T01:02:41Z","name":"Pulling","message":"pulling
-        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:50Z","lastTimestamp":"2020-07-29T01:02:50Z","name":"Pulled","message":"Successfully
-        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Created","message":"Created
-        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Started","message":"Started
+      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-09-14T02:58:43Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-09-14T02:58:28Z","lastTimestamp":"2020-09-14T02:58:28Z","name":"Pulling","message":"pulling
+        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:36Z","lastTimestamp":"2020-09-14T02:58:36Z","name":"Pulled","message":"Successfully
+        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Created","message":"Created
+        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Started","message":"Started
         container","type":"Normal"}]},"resources":{"requests":{"memoryInGB":1.5,"cpu":1.0}}}}],"initContainers":[],"restartPolicy":"Always","osType":"Linux","instanceView":{"events":[],"state":"Running"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004","name":"clicontainer000004","type":"Microsoft.ContainerInstance/containerGroups","location":"westus","tags":{}}'
     headers:
       cache-control:
@@ -2809,7 +2329,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:03:10 GMT
+      - Mon, 14 Sep 2020 02:58:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2843,18 +2363,18 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004?api-version=2019-12-01
   response:
     body:
-      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-07-29T01:02:57Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-07-29T01:02:41Z","lastTimestamp":"2020-07-29T01:02:41Z","name":"Pulling","message":"pulling
-        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:50Z","lastTimestamp":"2020-07-29T01:02:50Z","name":"Pulled","message":"Successfully
-        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Created","message":"Created
-        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Started","message":"Started
+      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-09-14T02:58:43Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-09-14T02:58:28Z","lastTimestamp":"2020-09-14T02:58:28Z","name":"Pulling","message":"pulling
+        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:36Z","lastTimestamp":"2020-09-14T02:58:36Z","name":"Pulled","message":"Successfully
+        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Created","message":"Created
+        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Started","message":"Started
         container","type":"Normal"}]},"resources":{"requests":{"memoryInGB":1.5,"cpu":1.0}}}}],"initContainers":[],"restartPolicy":"Always","osType":"Linux","instanceView":{"events":[],"state":"Running"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004","name":"clicontainer000004","type":"Microsoft.ContainerInstance/containerGroups","location":"westus","tags":{"cli-test":"test"}}'
     headers:
       cache-control:
@@ -2864,7 +2384,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:03:11 GMT
+      - Mon, 14 Sep 2020 02:59:01 GMT
       expires:
       - '-1'
       pragma:
@@ -2896,8 +2416,8 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
@@ -2946,7 +2466,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:03:10 GMT
+      - Mon, 14 Sep 2020 02:59:02 GMT
       expires:
       - '-1'
       pragma:
@@ -2974,18 +2494,18 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004?api-version=2019-12-01
   response:
     body:
-      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-07-29T01:02:57Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-07-29T01:02:41Z","lastTimestamp":"2020-07-29T01:02:41Z","name":"Pulling","message":"pulling
-        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:50Z","lastTimestamp":"2020-07-29T01:02:50Z","name":"Pulled","message":"Successfully
-        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Created","message":"Created
-        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Started","message":"Started
+      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-09-14T02:58:43Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-09-14T02:58:28Z","lastTimestamp":"2020-09-14T02:58:28Z","name":"Pulling","message":"pulling
+        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:36Z","lastTimestamp":"2020-09-14T02:58:36Z","name":"Pulled","message":"Successfully
+        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Created","message":"Created
+        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Started","message":"Started
         container","type":"Normal"}]},"resources":{"requests":{"memoryInGB":1.5,"cpu":1.0}}}}],"initContainers":[],"restartPolicy":"Always","osType":"Linux","instanceView":{"events":[],"state":"Running"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004","name":"clicontainer000004","type":"Microsoft.ContainerInstance/containerGroups","location":"westus","tags":{"cli-test":"test"}}'
     headers:
       cache-control:
@@ -2995,7 +2515,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:03:11 GMT
+      - Mon, 14 Sep 2020 02:59:04 GMT
       expires:
       - '-1'
       pragma:
@@ -3029,18 +2549,18 @@ interactions:
       ParameterSetName:
       - --ids --tags
       User-Agent:
-      - python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.9 msrest_azure/0.6.3 azure-mgmt-resource/10.1.0
-        Azure-SDK-For-Python AZURECLI/2.9.1
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
       accept-language:
       - en-US
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004?api-version=2019-12-01
   response:
     body:
-      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-07-29T01:02:57Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-07-29T01:02:41Z","lastTimestamp":"2020-07-29T01:02:41Z","name":"Pulling","message":"pulling
-        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:50Z","lastTimestamp":"2020-07-29T01:02:50Z","name":"Pulled","message":"Successfully
-        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Created","message":"Created
-        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-07-29T01:02:57Z","lastTimestamp":"2020-07-29T01:02:57Z","name":"Started","message":"Started
+      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-09-14T02:58:43Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-09-14T02:58:28Z","lastTimestamp":"2020-09-14T02:58:28Z","name":"Pulling","message":"pulling
+        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:36Z","lastTimestamp":"2020-09-14T02:58:36Z","name":"Pulled","message":"Successfully
+        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Created","message":"Created
+        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Started","message":"Started
         container","type":"Normal"}]},"resources":{"requests":{"memoryInGB":1.5,"cpu":1.0}}}}],"initContainers":[],"restartPolicy":"Always","osType":"Linux","instanceView":{"events":[],"state":"Running"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004","name":"clicontainer000004","type":"Microsoft.ContainerInstance/containerGroups","location":"westus","tags":{}}'
     headers:
       cache-control:
@@ -3050,7 +2570,948 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 29 Jul 2020 01:03:12 GMT
+      - Mon, 14 Sep 2020 02:59:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorizations":[{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},{"applicationId":"3b2fa68d-a091-48c9-95be-88d572e08fb7","roleDefinitionId":"47d68fae-99c7-4c10-b9db-2316116a061e"},{"applicationId":"9bdab391-7bbe-42e8-8132-e4491dc29cc0","roleDefinitionId":"0383f7f5-023d-4379-b2c7-9ef786459969"}],"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-07-10-preview","2018-07-10","2018-01-10","2017-09-01","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12934'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 14 Sep 2020 02:59:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
+  response:
+    body:
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-09-14T02%3A57%3A45.4711226Z''\"","tags":{},"properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '554'
+      content-type:
+      - application/json
+      date:
+      - Mon, 14 Sep 2020 02:59:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"tags": {"cli-test": "test"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
+  response:
+    body:
+      string: '{"location":"westus","name":"vault-000002","etag":"W/\"datetime''2020-09-14T02%3A59%3A12.3232826Z''\"","tags":{"cli-test":"test"},"properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '571'
+      content-type:
+      - application/json
+      date:
+      - Mon, 14 Sep 2020 02:59:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '204'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorizations":[{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},{"applicationId":"737d58c1-397a-46e7-9d12-7d8c830883c2","roleDefinitionId":"716bb53a-0390-4428-bf41-b1bedde7d751"},{"applicationId":"918d0db8-4a38-4938-93c1-9313bdfe0272","roleDefinitionId":"dcd2d2c9-3f80-4d72-95a8-2593111b4b12"},{"applicationId":"d2fa1650-4805-4a83-bcb9-cf41fe63539c","roleDefinitionId":"c15f8dab-b103-4f8d-9afb-fbe4b8e98de2"},{"applicationId":"a4c95b9e-3994-40cc-8953-5dc66d48348d","roleDefinitionId":"dc88c655-90fa-48d9-8d51-003cc8738508"},{"applicationId":"62c559cd-db0c-4da0-bab2-972528c65d42","roleDefinitionId":"437b639a-6d74-491d-959f-d172e8c5c1fc"}],"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","France
+        Central","South Africa North","UAE North","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"registries/scopeMaps","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/tokens","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/generateCredentials","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnections","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies/validate","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateLinkResources","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/importImage","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","France Central","South
+        Africa North","UAE North","Central US","Canada East","Canada Central","UK
+        South","UK West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/exportPipelines","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/importPipelines","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/pipelineRuns","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/listBuildSourceUploadUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/scheduleRun","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/taskRuns","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"None"},{"resourceType":"registries/taskRuns/listDetails","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/agentPools","locations":["East
+        US","West US 2","South Central US","Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/agentPools/listQueueStatus","locations":["East
+        US","West US 2","South Central US","Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/runs/listLogSasUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs/cancel","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/tasks","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"defaultApiVersion":"2019-04-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"registries/tasks/listDetails","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/getBuildSourceUploadUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/queueBuild","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/getLogLink","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/cancel","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/buildTasks/listSourceRepositoryProperties","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps/listBuildArguments","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/setupAuth","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/authorize","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","France Central","Central
+        US","South Africa North","UAE North","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/listPolicies","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","Switzerland West","UAE Central","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/updatePolicies","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","Switzerland West","UAE Central","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/eventGridFilters","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01"],"capabilities":"None"},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01","2017-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '34018'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 14 Sep 2020 02:59:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook?api-version=2019-05-01
+  response:
+    body:
+      string: '{"type":"Microsoft.ContainerRegistry/registries/webhooks","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook","name":"cliregwebhook","location":"westus","tags":{},"properties":{"status":"enabled","scope":"","actions":["push"],"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '450'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 14 Sep 2020 02:59:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"tags": {"cli-test": "test"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook?api-version=2019-05-01
+  response:
+    body:
+      string: '{"type":"Microsoft.ContainerRegistry/registries/webhooks","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook","name":"cliregwebhook","location":"westus","tags":{"cli-test":"test"},"properties":{"status":"enabled","scope":"","actions":["push"],"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '467'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 14 Sep 2020 02:59:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","authorizations":[{"applicationId":"6bb8e274-af5d-4df2-98a3-4fd78b4cafd9","roleDefinitionId":"3c60422b-a83a-428d-9830-22609c77aa6c"}],"resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        Central US","West US","East US","West Europe","West US 2","North Europe","Southeast
+        Asia","East US 2","Central US","Australia East","UK South","South Central
+        US","Central India","Brazil South","South India","North Central US","East
+        Asia","Canada Central","Japan East","Korea Central","France Central"],"apiVersions":["2019-12-01","2018-10-01","2018-09-01","2018-07-01","2018-06-01","2018-04-01","2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"],"capabilities":"SystemAssignedResourceIdentity,
+        SupportsTags, SupportsLocation"},{"resourceType":"serviceAssociationLinks","locations":["West
+        Central US","West US","East US","West Europe","West US 2","North Europe","Southeast
+        Asia","East US 2","Central US","Australia East","UK South","South Central
+        US","Central India","Brazil South","South India","North Central US","East
+        Asia","Canada Central","Japan East","Korea Central","France Central"],"apiVersions":["2019-12-01","2018-10-01","2018-09-01","2018-07-01","2018-06-01","2018-04-01","2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"],"capabilities":"SupportsExtension"},{"resourceType":"locations","locations":[],"apiVersions":["2019-12-01","2018-10-01","2018-09-01","2018-07-01","2018-06-01","2018-04-01","2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"],"capabilities":"None"},{"resourceType":"locations/capabilities","locations":["West
+        Central US","West US","East US","West Europe","West US 2","North Europe","Southeast
+        Asia","East US 2","Central US","Australia East","UK South","South Central
+        US","Central India","Brazil South","South India","North Central US","East
+        Asia","Canada Central","Japan East","Korea Central","France Central"],"apiVersions":["2019-12-01","2018-10-01","2018-09-01","2018-07-01","2018-06-01","2018-04-01","2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"],"capabilities":"None"},{"resourceType":"locations/usages","locations":["West
+        Central US","West US","East US","West Europe","West US 2","North Europe","Southeast
+        Asia","East US 2","Central US","Australia East","UK South","South Central
+        US","Central India","Brazil South","South India","North Central US","East
+        Asia","Canada Central","Japan East","Korea Central","France Central"],"apiVersions":["2019-12-01","2018-10-01","2018-09-01","2018-07-01","2018-06-01","2018-04-01","2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"],"capabilities":"None"},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","North Europe","Southeast Asia","East
+        US 2","Central US","Australia East","UK South","South Central US","Central
+        India","West Central US","Brazil South","South India","North Central US","East
+        Asia","Canada Central","Japan East","Korea Central","France Central"],"apiVersions":["2019-12-01","2018-10-01","2018-09-01","2018-07-01","2018-06-01","2018-04-01","2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"],"capabilities":"None"},{"resourceType":"locations/operationresults","locations":["West
+        US","East US","West Europe","West US 2","North Europe","Southeast Asia","East
+        US 2","Central US","Australia East","UK South","South Central US","Central
+        India","West Central US","Brazil South","South India","North Central US","East
+        Asia","Canada Central","Japan East","Korea Central","France Central"],"apiVersions":["2019-12-01","2018-10-01","2018-09-01","2018-07-01","2018-06-01","2018-04-01","2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":[],"apiVersions":["2019-12-01","2018-10-01","2018-09-01","2018-07-01","2018-06-01","2018-04-01","2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"],"capabilities":"None"},{"resourceType":"locations/cachedImages","locations":["West
+        Central US","West US","East US","West Europe","West US 2","North Europe","Southeast
+        Asia","East US 2","Central US","Australia East","UK South","South Central
+        US","Central India","Brazil South","South India","North Central US","East
+        Asia","Canada Central","Japan East","Korea Central","France Central"],"apiVersions":["2019-12-01","2018-10-01"],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["West
+        Central US","West US","East US","West Europe","West US 2","North Europe","Southeast
+        Asia","East US 2","Central US","Australia East","UK South","South Central
+        US","Central India","Brazil South","South India","North Central US","East
+        Asia","Canada Central","Japan East","Korea Central","France Central"],"apiVersions":["2019-12-01","2018-10-01","2018-09-01","2018-07-01","2018-06-01","2018-04-01","2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 14 Sep 2020 02:59:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004?api-version=2019-12-01
+  response:
+    body:
+      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-09-14T02:58:43Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-09-14T02:58:28Z","lastTimestamp":"2020-09-14T02:58:28Z","name":"Pulling","message":"pulling
+        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:36Z","lastTimestamp":"2020-09-14T02:58:36Z","name":"Pulled","message":"Successfully
+        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Created","message":"Created
+        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Started","message":"Started
+        container","type":"Normal"}]},"resources":{"requests":{"memoryInGB":1.5,"cpu":1.0}}}}],"initContainers":[],"restartPolicy":"Always","osType":"Linux","instanceView":{"events":[],"state":"Running"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004","name":"clicontainer000004","type":"Microsoft.ContainerInstance/containerGroups","location":"westus","tags":{}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1462'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 14 Sep 2020 02:59:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"tags": {"cli-test": "test"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource tag
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --ids --tags
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004?api-version=2019-12-01
+  response:
+    body:
+      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000004","properties":{"image":"nginx:latest","ports":[],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2020-09-14T02:58:43Z","detailStatus":""},"events":[{"count":1,"firstTimestamp":"2020-09-14T02:58:28Z","lastTimestamp":"2020-09-14T02:58:28Z","name":"Pulling","message":"pulling
+        image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:36Z","lastTimestamp":"2020-09-14T02:58:36Z","name":"Pulled","message":"Successfully
+        pulled image \"nginx:latest\"","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Created","message":"Created
+        container","type":"Normal"},{"count":1,"firstTimestamp":"2020-09-14T02:58:43Z","lastTimestamp":"2020-09-14T02:58:43Z","name":"Started","message":"Started
+        container","type":"Normal"}]},"resources":{"requests":{"memoryInGB":1.5,"cpu":1.0}}}}],"initContainers":[],"restartPolicy":"Always","osType":"Linux","instanceView":{"events":[],"state":"Running"}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000004","name":"clicontainer000004","type":"Microsoft.ContainerInstance/containerGroups","location":"westus","tags":{"cli-test":"test"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1479'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 14 Sep 2020 02:59:25 GMT
       expires:
       - '-1'
       pragma:
@@ -3065,6 +3526,645 @@ interactions:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1198'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorizations":[{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},{"applicationId":"3b2fa68d-a091-48c9-95be-88d572e08fb7","roleDefinitionId":"47d68fae-99c7-4c10-b9db-2316116a061e"},{"applicationId":"9bdab391-7bbe-42e8-8132-e4491dc29cc0","roleDefinitionId":"0383f7f5-023d-4379-b2c7-9ef786459969"}],"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-12-20-preview","2018-07-10-preview","2018-07-10","2018-01-10","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-02-02-preview","2020-02-02","2019-06-15","2019-05-13-preview","2019-05-13","2018-07-10-preview","2018-07-10","2018-01-10","2017-09-01","2017-07-01-preview","2017-07-01","2016-12-01","2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-08-10"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01","2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-01-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-01-10"}],"capabilities":"None"},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2016-06-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2016-06-01"}],"capabilities":"None"},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJobs","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrJob","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupAadProperties","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrossRegionRestore","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationResults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"locations/backupCrrOperationsStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-12-20-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-12-20-preview"}],"capabilities":"None"},{"resourceType":"backupProtectedItems","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2017-07-01-preview"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2017-07-01-preview"}],"capabilities":"SupportsExtension"},{"resourceType":"replicationEligibilityResults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West India","West Central US","Canada Central","Canada East","West
+        US 2","UK South","UK West","Korea Central","Korea South","France Central","Australia
+        Central","South Africa North","UAE North","Switzerland North","Germany West
+        Central","Norway East","Central US EUAP","East US 2 EUAP"],"apiVersions":["2018-07-10"],"apiProfiles":[{"profileVersion":"2018-06-01-profile","apiVersion":"2018-07-10"}],"capabilities":"SupportsExtension"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12934'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 14 Sep 2020 02:59:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.RecoveryServices/vaults/vault-000002?api-version=2020-02-02
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 14 Sep 2020 02:59:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorizations":[{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},{"applicationId":"737d58c1-397a-46e7-9d12-7d8c830883c2","roleDefinitionId":"716bb53a-0390-4428-bf41-b1bedde7d751"},{"applicationId":"918d0db8-4a38-4938-93c1-9313bdfe0272","roleDefinitionId":"dcd2d2c9-3f80-4d72-95a8-2593111b4b12"},{"applicationId":"d2fa1650-4805-4a83-bcb9-cf41fe63539c","roleDefinitionId":"c15f8dab-b103-4f8d-9afb-fbe4b8e98de2"},{"applicationId":"a4c95b9e-3994-40cc-8953-5dc66d48348d","roleDefinitionId":"dc88c655-90fa-48d9-8d51-003cc8738508"},{"applicationId":"62c559cd-db0c-4da0-bab2-972528c65d42","roleDefinitionId":"437b639a-6d74-491d-959f-d172e8c5c1fc"}],"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","France
+        Central","South Africa North","UAE North","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"registries/scopeMaps","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/tokens","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/generateCredentials","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Korea Central","France Central","South Africa North","UAE North","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnections","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateEndpointConnectionProxies/validate","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/privateLinkResources","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/importImage","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","France Central","South
+        Africa North","UAE North","Central US","Canada East","Canada Central","UK
+        South","UK West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/exportPipelines","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/importPipelines","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"SystemAssignedResourceIdentity"},{"resourceType":"registries/pipelineRuns","locations":["West
+        US","East US","South Central US","West Europe","Switzerland North","North
+        Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Brazil
+        South","Canada East","Canada Central","Central US","East US 2","North Central
+        US","West Central US","West US 2","Korea Central","France Central","South
+        Africa North","UAE North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview"],"capabilities":"None"},{"resourceType":"registries/listBuildSourceUploadUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/scheduleRun","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/taskRuns","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"None"},{"resourceType":"registries/taskRuns/listDetails","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/agentPools","locations":["East
+        US","West US 2","South Central US","Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"defaultApiVersion":"2019-06-01-preview","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/agentPools/listQueueStatus","locations":["East
+        US","West US 2","South Central US","Central US","East US 2","East US 2 EUAP"],"apiVersions":["2019-06-01-preview"],"capabilities":"None"},{"resourceType":"registries/runs/listLogSasUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/runs/cancel","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/tasks","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"defaultApiVersion":"2019-04-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"registries/tasks/listDetails","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2019-06-01-preview","2019-04-01","2018-09-01"],"capabilities":"None"},{"resourceType":"registries/getBuildSourceUploadUrl","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/queueBuild","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/getLogLink","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/builds/cancel","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/buildTasks/listSourceRepositoryProperties","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/buildTasks/steps/listBuildArguments","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/setupAuth","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/authorize","locations":["East
+        US","West Europe","West US 2","South Central US","Australia East","Australia
+        Southeast","Brazil South","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US 2","Japan East","Japan West","North Central US","North
+        Europe","Southeast Asia","South India","UK South","UK West","West US","West
+        Central US","France Central","Korea Central","South Africa North","UAE North","Switzerland
+        North","Switzerland West","UAE Central","Brazil Southeast","Germany West Central","East
+        US 2 EUAP"],"apiVersions":["2018-02-01-preview"],"capabilities":"None"},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","France Central","Central
+        US","South Africa North","UAE North","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","UAE Central","Switzerland West","Germany West Central","Brazil
+        Southeast","Central US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-03-01"],"capabilities":"None"},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"registries/listPolicies","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","Switzerland West","UAE Central","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/updatePolicies","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","Korea Central","South
+        Africa North","UAE North","France Central","East Asia","Japan East","Japan
+        West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2","Switzerland North","Switzerland West","UAE Central","Germany West Central","Brazil
+        Southeast","East US 2 EUAP","Central US EUAP"],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe","East US 2 EUAP","Central US
+        EUAP"],"apiVersions":["2016-06-27-preview"],"capabilities":"None"},{"resourceType":"registries/eventGridFilters","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Korea Central","South Africa North","UAE
+        North","France Central","Central US","Canada East","Canada Central","UK South","UK
+        West","Australia Southeast","East Asia","Japan West","South India","Switzerland
+        North","UAE Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-05-01","2017-10-01"],"capabilities":"None"},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01","2017-10-01","2017-06-01-preview","2017-03-01"],"capabilities":"None"},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India","Korea
+        Central","France Central","South Africa North","UAE North","Switzerland North","UAE
+        Central","Switzerland West","Germany West Central","Brazil Southeast","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2019-12-01-preview","2019-05-01-preview","2019-05-01","2017-10-01","2017-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '34018'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 14 Sep 2020 02:59:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - resource delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_tag_update_by_patch000001/providers/Microsoft.ContainerRegistry/registries/clireg000003/webhooks/cliregwebhook?api-version=2019-05-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 14 Sep 2020 02:59:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -350,8 +350,6 @@ class TagScenarioTest(ScenarioTest):
         self.cmd('resource tag --ids {vault_id} --tags {tag}', checks=self.check('tags', {'cli-test': 'test'}))
         self.cmd('resource tag --ids {vault_id} --tags', checks=self.check('tags', {}))
 
-        self.cmd('resource delete --id {vault_id}', checks=self.is_empty())
-
         # Test Microsoft.Resources/resourceGroups
         self.cmd('resource tag --ids {resource_group_id} --tags {tag}',
                  checks=self.check('tags', {'cli-test': 'test'}))
@@ -374,8 +372,6 @@ class TagScenarioTest(ScenarioTest):
         self.cmd('resource tag --ids {webhook_id} --tags {tag}', checks=self.check('tags', {'cli-test': 'test'}))
         self.cmd('resource tag --ids {webhook_id} --tags', checks=self.check('tags', {}))
 
-        self.cmd('resource delete --id {webhook_id}', checks=self.is_empty())
-
         # Test Microsoft.ContainerInstance/containerGroups
         self.kwargs.update({
             'container_group_name': self.create_random_name('clicontainer', 16),
@@ -387,6 +383,14 @@ class TagScenarioTest(ScenarioTest):
         self.kwargs['container_id'] = container['id']
         self.cmd('resource tag --ids {container_id} --tags {tag}', checks=self.check('tags', {'cli-test': 'test'}))
         self.cmd('resource tag --ids {container_id} --tags', checks=self.check('tags', {}))
+
+        self.cmd('resource tag --ids {vault_id} {webhook_id} {container_id} --tags {tag}', checks=[
+            self.check('length(@)', 3),
+            self.check('[0].tags', {'cli-test': 'test'})
+        ])
+
+        self.cmd('resource delete --id {vault_id}', checks=self.is_empty())
+        self.cmd('resource delete --id {webhook_id}', checks=self.is_empty())
 
     @ResourceGroupPreparer(name_prefix='cli_test_tag_incrementally', location='westus')
     def test_tag_incrementally(self, resource_group, resource_group_location):


### PR DESCRIPTION
Fix the returned data when tagging multiple resources for [15106](https://github.com/Azure/azure-cli/issues/15106)
Another problem is that it's not easy to fix it in a short time, so just fix this one for the time being.

**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The data returned after the resource is tagged is `LROPoller`, which needs to be wrapped by `LongRunningOperation` to get the actual result.
When only one resource is tagged, it is handled here [link](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/azure/cli/core/commands/__init__.py#L698).
However, the process of parsing the results will be omitted when multiple resources are tagged, so add the logic of processing.

**Testing Guide**  
<!--Example commands with explanations.-->
Run `az resource tag --tags key=value --ids resource-id1 resource-id2`
Before:
```
[
  {},
  {}
]
```
After:
```
[
  {
     "id":"xxx",
      ....
   },
   {
     "id":"xxx",
      ....
   },
]
```

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
