### PR TITLE
{Profile} Update comment to be more accurate

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -268,7 +268,7 @@ class Profile:
                 _TENANT_ID: s.tenant_id,
                 _ENVIRONMENT_NAME: self.cli_ctx.cloud.name
             }
-            # for Subscriptions - List REST API 2019-06-01's subscription account
+            # For subscription account from Subscriptions - List 2019-06-01 and later.
             if subscription_dict[_SUBSCRIPTION_NAME] != _TENANT_LEVEL_ACCOUNT_NAME:
                 if hasattr(s, 'home_tenant_id'):
                     subscription_dict[_HOME_TENANT_ID] = s.home_tenant_id


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Update comment to be more accurate, as requested by ARM service team: `home_tenant_id` and `managed_by_tenants` are properties _in_ and _after_ `2019-06-01`, not only limited to `2019-06-01`.