### PR TITLE
{Version} Only show az upgrade instruction when update for azure-cli is available

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -105,9 +105,9 @@ class AzCli(CLI):
         from azure.cli.core.commands.constants import (SURVEY_PROMPT, SURVEY_PROMPT_COLOR,
                                                        UX_SURVEY_PROMPT, UX_SURVEY_PROMPT_COLOR)
 
-        ver_string, updates_available = get_az_version_string()
+        ver_string, updates_available_components = get_az_version_string()
         print(ver_string)
-        show_updates(updates_available)
+        show_updates(updates_available_components)
 
         show_link = self.config.getboolean('output', 'show_survey_link', True)
         if show_link:

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -156,35 +156,6 @@ def get_installed_cli_distributions():
     ]
 
 
-def _update_latest_from_pypi(versions):
-    from subprocess import check_output, STDOUT, CalledProcessError
-
-    success = False
-
-    if not check_connectivity(max_retries=0):
-        return versions, success
-
-    try:
-        cmd = [sys.executable] + \
-            '-m pip search azure-cli -vv --disable-pip-version-check --no-cache-dir --retries 0'.split()
-        logger.debug('Running: %s', cmd)
-        log_output = check_output(cmd, stderr=STDOUT, universal_newlines=True)
-        success = True
-        for line in log_output.splitlines():
-            if not line.startswith(CLI_PACKAGE_NAME):
-                continue
-            comps = line.split()
-            mod = comps[0].replace(COMPONENT_PREFIX, '') or CLI_PACKAGE_NAME
-            version = comps[1].replace('(', '').replace(')', '')
-            try:
-                versions[mod]['pypi'] = version
-            except KeyError:
-                pass
-    except CalledProcessError:
-        pass
-    return versions, success
-
-
 def get_latest_from_github(package_path='azure-cli'):
     try:
         import requests
@@ -262,8 +233,8 @@ def get_az_version_string(use_cache=False):  # pylint: disable=too-many-statemen
     versions = _get_local_versions()
 
     # get the versions from pypi
-    versions, success = get_cached_latest_versions(versions) if use_cache else _update_latest_from_pypi(versions)
-    updates_available = 0
+    versions, success = get_cached_latest_versions(versions) if use_cache else _update_latest_from_github(versions)
+    updates_available_components = []
 
     def _print(val=''):
         print(val, file=output)
@@ -278,13 +249,13 @@ def get_az_version_string(use_cache=False):  # pylint: disable=too-many-statemen
 
     ver_string = _get_version_string(CLI_PACKAGE_NAME, versions.pop(CLI_PACKAGE_NAME))
     if '*' in ver_string:
-        updates_available += 1
+        updates_available_components.append(CLI_PACKAGE_NAME)
     _print(ver_string)
     _print()
     for name in sorted(versions.keys()):
         ver_string = _get_version_string(name, versions.pop(name))
         if '*' in ver_string:
-            updates_available += 1
+            updates_available_components.append(name)
         _print(ver_string)
     _print()
     extensions = get_extensions()
@@ -315,8 +286,8 @@ def get_az_version_string(use_cache=False):  # pylint: disable=too-many-statemen
     # if unable to query PyPI, use sentinel value to flag that
     # we couldn't check for updates
     if not success:
-        updates_available = -1
-    return version_string, updates_available
+        updates_available_components = None
+    return version_string, updates_available_components
 
 
 def get_az_version_json():
@@ -341,25 +312,27 @@ def show_updates_available(new_line_before=False, new_line_after=False):
         if datetime.datetime.now() < version_check_time + datetime.timedelta(days=7):
             return
 
-    _, updates_available = get_az_version_string(use_cache=True)
-    if updates_available > 0:
+    _, updates_available_components = get_az_version_string(use_cache=True)
+    if updates_available_components:
         if new_line_before:
             logger.warning("")
-        show_updates(updates_available)
+        show_updates(updates_available_components)
         if new_line_after:
             logger.warning("")
     VERSIONS[_VERSION_CHECK_TIME] = str(datetime.datetime.now())
 
 
-def show_updates(updates_available):
-    if updates_available == -1:
+def show_updates(updates_available_components):
+    if updates_available_components is None:
         logger.warning('Unable to check if your CLI is up-to-date. Check your internet connection.')
-    elif updates_available:  # pylint: disable=too-many-nested-blocks
+    elif updates_available_components:  # pylint: disable=too-many-nested-blocks
         if in_cloud_console():
             warning_msg = 'You have %i updates available. They will be updated with the next build of Cloud Shell.'
         else:
-            warning_msg = "You have %i updates available. Consider updating your CLI installation with 'az upgrade'"
-        logger.warning(warning_msg, updates_available)
+            warning_msg = "You have %i updates available."
+            if CLI_PACKAGE_NAME in updates_available_components:
+                warning_msg = "{} Consider updating your CLI installation with 'az upgrade'".format(warning_msg)
+        logger.warning(warning_msg, len(updates_available_components))
     else:
         print('Your CLI is up-to-date.')
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Make the instruction of using `az upgrade` only displayed when there is update for `azure-cli` package to prevent issues like #15133.

This PR also deprecates the `_update_latest_from_pypi` method which uses fuzzy match in package name and package description to search for `azure-cli` in pypi. Lots of packages that contain `azure-cli` in name or in description are returned. So this method is slow. This PR replaces it with `_update_latest_from_github` which searches for the latest versions on Github master branch. Legacy module packages installed before such as `azure-cli-vm` will no longer be listed in `az --version`.

Comparison of `azdev perf benchmark "az --version" --runs 10`:
Before:
```
[
  {
    "Avg": 3.8947,
    "Command": "az --version",
    "Max": 4.4901,
    "Media": 4.3117,
    "Min": 2.0803,
    "Runs": 10,
    "Std": 0.9021
  }
]
```
After:
```
[
  {
    "Avg": 3.4807,
    "Command": "az --version",
    "Max": 3.9086,
    "Media": 3.8219,
    "Min": 2.0002,
    "Runs": 10,
    "Std": 0.7321
  }
]
```
**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
