### PR TITLE
[Network] `az network application-gateway ssl-cert show`: Add example to demonstrate certificate format and fetch information

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -911,6 +911,10 @@ short-summary: Get the details of an SSL certificate.
 examples:
   - name: Get the details of an SSL certificate.
     text: az network application-gateway ssl-cert show -g MyResourceGroup --gateway-name MyAppGateway -n MySslCert
+  - name: Display the expiry date of SSL certificate. The certificate is returned in PKCS7 format from which the expiration date needs to be retrieved.
+    text: |
+        publiccert=`az network application-gateway ssl-cert show -g MyResourceGroup --gateway-name MyAppGateway --name mywebsite.com --query publicCertData -o tsv`
+        echo -e "-----BEGIN CERTIFICATE-----\n$publiccert\n-----END CERTIFICATE-----" | fold -w 64 | openssl pkcs7 -print_certs | openssl x509 -noout -enddate
 """
 
 helps['network application-gateway ssl-cert update'] = """

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -914,7 +914,8 @@ examples:
   - name: Display the expiry date of SSL certificate. The certificate is returned in PKCS7 format from which the expiration date needs to be retrieved.
     text: |
         publiccert=`az network application-gateway ssl-cert show -g MyResourceGroup --gateway-name MyAppGateway --name mywebsite.com --query publicCertData -o tsv`
-        echo -e "-----BEGIN CERTIFICATE-----\n$publiccert\n-----END CERTIFICATE-----" | fold -w 64 | openssl pkcs7 -print_certs | openssl x509 -noout -enddate
+        echo "-----BEGIN CERTIFICATE-----" >> public.cert; echo "${publiccert}" >> public.cert; echo "-----END CERTIFICATE-----" >> public.cert
+        cat public.cert | fold -w 64 | openssl pkcs7 -print_certs | openssl x509 -noout -enddate
 """
 
 helps['network application-gateway ssl-cert update'] = """


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/14132

`az network application-gateway ssl-cert show` is used to display the SSL certificates of an application gateway. There is no information or examples provided in the help or documentation which mentions the format of the certificate returned or ways to extract information from the certificate like expiry date etc. This PR is add an example to demonstrate the certificate format and fetch the expiry date of the certificate.

The details of the PR and tests/confirmation of the example being added have been discussed in https://github.com/Azure/azure-cli/issues/14132. The certificate information returned is in `PKCS7` format which needs to be converted appropriately and information retrieved from it.