### PR TITLE
[HDInsight] Add deprecation info to old private link's arguments

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/hdinsight/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/hdinsight/_params.py
@@ -184,10 +184,12 @@ def load_arguments(self, _):
 
         # Private Link Network Settings
         c.argument('public_network_access_type', arg_group='Private Link Network Settings',
-                   arg_type=get_enum_type(PublicNetworkAccess), help='The public network access type.')
+                   arg_type=get_enum_type(PublicNetworkAccess), help='The public network access type.',
+                   deprecate_info=c.deprecate(expiration='2.12.2'))
         c.argument('outbound_public_network_access_type', arg_group='Private Link Network Settings',
                    arg_type=get_enum_type(OutboundOnlyPublicNetworkAccessType),
-                   help='The outbound only public network access type.')
+                   help='The outbound only public network access type.',
+                   deprecate_info=c.deprecate(expiration='2.12.2'))
 
         # Encryption In Transit
         c.argument('encryption_in_transit', arg_group='Encryption In Transit', arg_type=get_three_state_flag(),

--- a/src/azure-cli/azure/cli/command_modules/hdinsight/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/hdinsight/_params.py
@@ -185,11 +185,11 @@ def load_arguments(self, _):
         # Private Link Network Settings
         c.argument('public_network_access_type', arg_group='Private Link Network Settings',
                    arg_type=get_enum_type(PublicNetworkAccess), help='The public network access type.',
-                   deprecate_info=c.deprecate(expiration='2.12.2'))
+                   deprecate_info=c.deprecate(expiration='2.14.0'))
         c.argument('outbound_public_network_access_type', arg_group='Private Link Network Settings',
                    arg_type=get_enum_type(OutboundOnlyPublicNetworkAccessType),
                    help='The outbound only public network access type.',
-                   deprecate_info=c.deprecate(expiration='2.12.2'))
+                   deprecate_info=c.deprecate(expiration='2.14.0'))
 
         # Encryption In Transit
         c.argument('encryption_in_transit', arg_group='Encryption In Transit', arg_type=get_three_state_flag(),


### PR DESCRIPTION
Add deprecation info for argument public_networrk_access_type and outbound_only_public_network_access_type

**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[HDInsight] : az hdinsight create: add deprecate information for argument --public-networrk-access-type and --outbound-public-network-access-type

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
