### PR TITLE
{Core} Fix query-examples bug: extra dot when parsing a JSON with an array in a dict.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/query_examples.py
+++ b/src/azure-cli-core/azure/cli/core/commands/query_examples.py
@@ -145,7 +145,10 @@ class QueryTreeNode:
         """
         if self._is_array:
             if self._parent:
-                outer_trace = '{}.{}'.format(self._parent.get_trace_to_root(), self._name)
+                if self._parent.is_dummy and not self._parent._is_array:  # pylint: disable=protected-access
+                    outer_trace = self._name
+                else:
+                    outer_trace = '{}.{}'.format(self._parent.get_trace_to_root(), self._name)
             else:
                 outer_trace = self._name
             return outer_trace, inner_trace

--- a/src/azure-cli-core/azure/cli/core/tests/test_query_examples.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_query_examples.py
@@ -172,6 +172,32 @@ class TestQueryExamplesQueryTreeBuilder(unittest.TestCase):
         self.assertIn('[].friends[].Name', examples)
         self.assertIn("[].friends[?Name=='Bob']", examples)
 
+        input_json = '''
+        {
+            "name": {
+                "firstName": "Ann"
+            },
+            "age": "20",
+            "friends": [
+                {
+                    "Name": "Bob"
+                }
+            ]
+        }
+        '''
+        json_obj = json.loads(input_json)
+        builder = QueryTreeBuilder(mock_config)
+        builder.build(json_obj)
+        examples_list = builder.generate_examples(keyword_list, output_format)
+        examples = self.examples_to_dict(examples_list)
+        self.assertIn('name', examples)
+        self.assertIn('name.firstName', examples)
+        self.assertIn('age', examples)
+        self.assertIn('friends[]', examples)
+        self.assertIn('friends[].Name', examples)
+        self.assertIn("friends[?Name=='Bob']", examples)
+        self.assertIn("friends[?contains(@.Name, 'something')==\\`true\\`].Name", examples)
+
     def test_dict_recommend_with_keywords(self):
         mock_config = MockConfig()
         keyword_list = ['name']


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR fix the bug when parsing a JSON with an array in a dict, there is an extra dot in the examples.

For examples, given the JSON as following
```json
{
  "list": [
    { "name": "item1" },
    { "name": "item2" },
  ]
}
```
We may generate the wrong examples such as `.list[?name='item1']`. This PR fix the wrong dot. And this PR will generate the correct examples such as `list[?name='item1']`.

This PR also provide an extra unit test to test this situation.

**Testing Guide**  
<!--Example commands with explanations.-->
* Scenario Test
Most `show` commands returns a JSON dict which can be used for test.
```bash
$ az account show --query-examples
Query string                                                             Help
-----------------------------------------------------------------------  ---------------------------------------------------
managedByTenants[].tenantId                                              Show the value of tenantId field.
managedByTenants[?tenantId=='2f4axxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx']      Show the resources that satisfy the condition.
managedByTenants[?contains(@.tenantId, 'something')==\`true\`].tenantId  Show the tenantId field that contains given string.
tenantId                                                                 Show the value of tenantId field.
managedByTenants[]                                                       Show the value of managedByTenants field.
environmentName                                                          Show the value of environmentName field.
name                                                                     Show the value of name field.
user.name                                                                Show the value of name field.
id                                                                       Show the value of id field.
isDefault                                                                Show the value of isDefault field.
```


**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
