### PR TITLE
{KeyVault} Mark HSM related tests as `record_only`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_commands.py
@@ -188,6 +188,7 @@ class KeyVaultPrivateEndpointConnectionScenarioTest(ScenarioTest):
 
 
 class KeyVaultHSMMgmtScenarioTest(ScenarioTest):
+    @record_only()
     def test_keyvault_hsm_mgmt(self):
         self.kwargs.update({
             'hsm_name': ACTIVE_HSM_NAME,
@@ -409,7 +410,7 @@ class KeyVaultHSMSecurityDomainScenarioTest(ScenarioTest):
 
 
 class KeyVaultHSMFullBackupRestoreScenarioTest(ScenarioTest):
-    @pytest.mark.serial()
+    @record_only()
     @ResourceGroupPreparer(name_prefix='cli_test_keyvault_hsm_full_backup')
     @AllowLargeResponse()
     def test_keyvault_hsm_full_backup_restore(self):
@@ -462,7 +463,7 @@ class KeyVaultHSMFullBackupRestoreScenarioTest(ScenarioTest):
 
 
 class KeyVaultHSMRoleScenarioTest(ScenarioTest):
-    @pytest.mark.serial()
+    @record_only()
     def test_keyvault_hsm_role(self):
         self.kwargs.update({
             'hsm_url': ACTIVE_HSM_URL,
@@ -793,7 +794,7 @@ class KeyVaultKeyScenarioTest(ScenarioTest):
 
 
 class KeyVaultHSMKeyUsingHSMNameScenarioTest(ScenarioTest):
-    @pytest.mark.serial()
+    @record_only()
     def test_keyvault_hsm_key_using_hsm_name(self):
         self.kwargs.update({
             'hsm_name': ACTIVE_HSM_NAME,
@@ -919,7 +920,7 @@ class KeyVaultHSMKeyUsingHSMNameScenarioTest(ScenarioTest):
 
 
 class KeyVaultHSMKeyUsingHSMURLScenarioTest(ScenarioTest):
-    @pytest.mark.serial()
+    @record_only()
     def test_keyvault_hsm_key_using_hsm_url(self):
         self.kwargs.update({
             'hsm_name': ACTIVE_HSM_NAME,
@@ -1142,6 +1143,7 @@ class KeyVaultKeyDownloadScenarioTest(ScenarioTest):
 
 
 class KeyVaultHSMKeyDownloadScenarioTest(ScenarioTest):
+    @record_only()
     def test_keyvault_hsm_key_download(self):
         self.kwargs.update({
             'hsm_url': ACTIVE_HSM_URL,


### PR DESCRIPTION
Temporarily mark HSM related tests as `record_only` to improve the live test pass rate, because these tests are based on a hardcoded HSM instance, which can be only accessed via my personal account.
Currently, only one HSM instance can be created within a subscription, if one day there is no more quota limitation, I will remove these `record_only` decorators.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
