### PR TITLE
{KeyVault} Use absolute references instead of relative references

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/__init__.py
@@ -12,8 +12,8 @@ class KeyVaultCommandsLoader(AzCommandsLoader):
 
     def __init__(self, cli_ctx=None):
         from azure.cli.core.commands import CliCommandType
-        from ._client_factory import keyvault_mgmt_client_factory
-        from ._command_type import KeyVaultCommandGroup, KeyVaultArgumentContext
+        from azure.cli.command_modules.keyvault._client_factory import keyvault_mgmt_client_factory
+        from azure.cli.command_modules.keyvault._command_type import KeyVaultCommandGroup, KeyVaultArgumentContext
         from azure.cli.core import ModExtensionSuppress
         keyvault_custom = CliCommandType(
             operations_tmpl='azure.cli.command_modules.keyvault.custom#{}',
@@ -33,12 +33,12 @@ class KeyVaultCommandsLoader(AzCommandsLoader):
                                                     recommend_remove=True))
 
     def load_command_table(self, args):
-        from .commands import load_command_table
+        from azure.cli.command_modules.keyvault.commands import load_command_table
         load_command_table(self, args)
         return self.command_table
 
     def load_arguments(self, command):
-        from ._params import load_arguments
+        from azure.cli.command_modules.keyvault._params import load_arguments
         load_arguments(self, command)
 
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
@@ -159,7 +159,8 @@ def keyvault_data_plane_factory(cli_ctx, _):
 
 
 def keyvault_private_data_plane_factory_v7_2_preview(cli_ctx, _):
-    from .vendored_sdks.azure_keyvault_t1 import KeyVaultAuthentication, KeyVaultClient
+    from azure.cli.command_modules.keyvault.vendored_sdks.azure_keyvault_t1 import (
+        KeyVaultAuthentication, KeyVaultClient)
     from azure.cli.core.util import should_disable_connection_verify
 
     version = str(get_api_version(cli_ctx, ResourceType.DATA_PRIVATE_KEYVAULT))

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_command_type.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_command_type.py
@@ -54,7 +54,7 @@ def keyvault_exception_handler(cmd, ex):
 class KeyVaultCommandGroup(AzCommandGroup):
 
     def __init__(self, command_loader, group_name, **kwargs):
-        from ._client_factory import keyvault_data_plane_factory
+        from azure.cli.command_modules.keyvault._client_factory import keyvault_data_plane_factory
         # all regular and custom commands should use the keyvault data plane client
         merged_kwargs = self._merge_kwargs(kwargs, base_kwargs=command_loader.module_kwargs)
         merged_kwargs['custom_command_type'].settings['client_factory'] = keyvault_data_plane_factory
@@ -160,7 +160,7 @@ class KeyVaultCommandGroup(AzCommandGroup):
 class KeyVaultArgumentContext(AzArgumentContext):
 
     def attributes_argument(self, name, attr_class, create=False, ignore=None):
-        from ._validators import get_attribute_validator, datetime_type
+        from azure.cli.command_modules.keyvault._validators import get_attribute_validator, datetime_type
         from azure.cli.core.commands.parameters import get_three_state_flag
 
         from knack.arguments import ignore_type

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -16,9 +16,9 @@ from azure.cli.core.commands.parameters import (
 from azure.cli.core.util import get_json_object
 from azure.cli.core.profiles import ResourceType
 
-from ._completers import (
+from azure.cli.command_modules.keyvault._completers import (
     get_keyvault_name_completion_list, get_keyvault_version_completion_list)
-from ._validators import (
+from azure.cli.command_modules.keyvault._validators import (
     datetime_type, certificate_type,
     get_vault_base_url_type, get_hsm_base_url_type,
     process_storage_uri, validate_key_import_source, validate_key_type, validate_policy_permissions, validate_principal,

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 from collections.abc import Iterable
-from ._validators import KeyEncryptionDataType
+from azure.cli.command_modules.keyvault._validators import KeyEncryptionDataType
 
 
 def multi_transformers(*transformers):

--- a/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
@@ -8,13 +8,14 @@ from collections import OrderedDict
 from azure.cli.core.commands import CliCommandType
 from azure.cli.core.profiles import get_api_version, ResourceType
 
-from ._client_factory import get_client, get_client_factory, Clients, is_azure_stack_profile
+from azure.cli.command_modules.keyvault._client_factory import (
+    get_client, get_client_factory, Clients, is_azure_stack_profile)
 
-from ._transformers import (
+from azure.cli.command_modules.keyvault._transformers import (
     extract_subresource_name, filter_out_managed_resources,
     multi_transformers, transform_key_decryption_output, keep_max_results)
 
-from ._validators import (
+from azure.cli.command_modules.keyvault._validators import (
     process_secret_set_namespace, process_certificate_cancel_namespace,
     validate_private_endpoint_connection_id)
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -14,23 +14,6 @@ import struct
 import time
 import uuid
 
-from knack.log import get_logger
-from knack.util import CLIError
-
-from OpenSSL import crypto
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import rsa, ec
-from cryptography.hazmat.primitives.serialization import load_pem_private_key, Encoding, PublicFormat
-from cryptography.exceptions import UnsupportedAlgorithm
-from cryptography.x509 import load_pem_x509_certificate
-
-from azure.cli.core import telemetry
-from azure.cli.core.profiles import ResourceType, AZURE_API_PROFILES, SDKProfile
-from azure.cli.core.util import sdk_no_wait
-from azure.graphrbac.models import GraphErrorException
-
-from msrestazure.azure_exceptions import CloudError
-
 from azure.cli.command_modules.keyvault._client_factory import get_client_factory, Clients, is_azure_stack_profile
 from azure.cli.command_modules.keyvault._validators import _construct_vnet, secret_text_encoding_values
 from azure.cli.command_modules.keyvault.security_domain.jwe import JWE
@@ -38,6 +21,24 @@ from azure.cli.command_modules.keyvault.security_domain.security_domain import D
 from azure.cli.command_modules.keyvault.security_domain.shared_secret import SharedSecret
 from azure.cli.command_modules.keyvault.security_domain.sp800_108 import KDF
 from azure.cli.command_modules.keyvault.security_domain.utils import Utils
+from azure.cli.core import telemetry
+from azure.cli.core.profiles import ResourceType, AZURE_API_PROFILES, SDKProfile
+from azure.cli.core.util import sdk_no_wait
+from azure.graphrbac.models import GraphErrorException
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa, ec
+from cryptography.hazmat.primitives.serialization import load_pem_private_key, Encoding, PublicFormat
+from cryptography.exceptions import UnsupportedAlgorithm
+from cryptography.x509 import load_pem_x509_certificate
+
+from msrestazure.azure_exceptions import CloudError
+
+from knack.log import get_logger
+from knack.util import CLIError
+
+from OpenSSL import crypto
+
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -31,13 +31,13 @@ from azure.graphrbac.models import GraphErrorException
 
 from msrestazure.azure_exceptions import CloudError
 
-from ._client_factory import get_client_factory, Clients, is_azure_stack_profile
-from ._validators import _construct_vnet, secret_text_encoding_values
-from .security_domain.jwe import JWE
-from .security_domain.security_domain import Datum, SecurityDomainRestoreData
-from .security_domain.shared_secret import SharedSecret
-from .security_domain.sp800_108 import KDF
-from .security_domain.utils import Utils
+from azure.cli.command_modules.keyvault._client_factory import get_client_factory, Clients, is_azure_stack_profile
+from azure.cli.command_modules.keyvault._validators import _construct_vnet, secret_text_encoding_values
+from azure.cli.command_modules.keyvault.security_domain.jwe import JWE
+from azure.cli.command_modules.keyvault.security_domain.security_domain import Datum, SecurityDomainRestoreData
+from azure.cli.command_modules.keyvault.security_domain.shared_secret import SharedSecret
+from azure.cli.command_modules.keyvault.security_domain.sp800_108 import KDF
+from azure.cli.command_modules.keyvault.security_domain.utils import Utils
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/security_domain/byte_shares.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/security_domain/byte_shares.py
@@ -5,7 +5,7 @@
 
 import array
 
-from .mod_math import ModMath
+from azure.cli.command_modules.keyvault.security_domain.mod_math import ModMath
 
 
 class Share:

--- a/src/azure-cli/azure/cli/command_modules/keyvault/security_domain/jwe.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/security_domain/jwe.py
@@ -15,8 +15,8 @@ from cryptography.hazmat.primitives.asymmetric import padding as asymmetric_padd
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from knack.util import CLIError
 
-from .sp800_108 import KDF
-from .utils import Utils
+from azure.cli.command_modules.keyvault.security_domain.sp800_108 import KDF
+from azure.cli.command_modules.keyvault.security_domain.utils import Utils
 
 
 class JWEHeader:  # pylint: disable=too-many-instance-attributes

--- a/src/azure-cli/azure/cli/command_modules/keyvault/security_domain/shared_secret.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/security_domain/shared_secret.py
@@ -6,7 +6,7 @@
 import array
 
 from knack.util import CLIError
-from .byte_shares import ByteShares
+from azure.cli.command_modules.keyvault.security_domain.byte_shares import ByteShares
 
 
 class SharedSecret:


### PR DESCRIPTION
Fix: #15144 

Using absolute references would benefit our packaging and debugging work.

FYI, PEP 8 states:
> Absolute imports are recommended, as they are usually more readable and tend to be better behaved (or at least give better error messages) if the import system is incorrectly configured (such as when a directory inside a package ends up on sys.path)


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
