### PR TITLE
[AppService] Bugfix: Better error messages for webapp commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
@@ -9,6 +9,7 @@ from knack.util import CLIError
 from knack.log import get_logger
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.mgmt.web.models import SkuDescription
+from colorama import Fore, Style
 
 from ._constants import (NETCORE_VERSION_DEFAULT, NETCORE_VERSIONS, NODE_VERSION_DEFAULT,
                          NODE_VERSIONS, NETCORE_RUNTIME_NAME, NODE_RUNTIME_NAME, DOTNET_RUNTIME_NAME,
@@ -34,29 +35,35 @@ def zip_contents_from_dir(dirPath, lang):
     file_val = os.path.split(path_and_file)[1]
     zip_file_path = relroot + os.path.sep + file_val + ".zip"
     abs_src = os.path.abspath(dirPath)
-    with zipfile.ZipFile("{}".format(zip_file_path), "w", zipfile.ZIP_DEFLATED) as zf:
-        for dirname, subdirs, files in os.walk(dirPath):
-            # skip node_modules folder for Node apps,
-            # since zip_deployment will perform the build operation
-            if lang.lower() == NODE_RUNTIME_NAME:
-                subdirs[:] = [d for d in subdirs if 'node_modules' not in d]
-            elif lang.lower() == NETCORE_RUNTIME_NAME:
-                subdirs[:] = [d for d in subdirs if d not in ['obj', 'bin']]
-            elif lang.lower() == PYTHON_RUNTIME_NAME:
-                subdirs[:] = [d for d in subdirs if 'env' not in d]  # Ignores dir that contain env
+    try:
+        with zipfile.ZipFile("{}".format(zip_file_path), "w", zipfile.ZIP_DEFLATED) as zf:
+            for dirname, subdirs, files in os.walk(dirPath):
+                # skip node_modules folder for Node apps,
+                # since zip_deployment will perform the build operation
+                if lang.lower() == NODE_RUNTIME_NAME:
+                    subdirs[:] = [d for d in subdirs if 'node_modules' not in d]
+                elif lang.lower() == NETCORE_RUNTIME_NAME:
+                    subdirs[:] = [d for d in subdirs if d not in ['obj', 'bin']]
+                elif lang.lower() == PYTHON_RUNTIME_NAME:
+                    subdirs[:] = [d for d in subdirs if 'env' not in d]  # Ignores dir that contain env
 
-                filtered_files = []
+                    filtered_files = []
+                    for filename in files:
+                        if filename == '.env':
+                            logger.info("Skipping file: %s/%s", dirname, filename)
+                        else:
+                            filtered_files.append(filename)
+                    files[:] = filtered_files
+
                 for filename in files:
-                    if filename == '.env':
-                        logger.info("Skipping file: %s/%s", dirname, filename)
-                    else:
-                        filtered_files.append(filename)
-                files[:] = filtered_files
+                    absname = os.path.abspath(os.path.join(dirname, filename))
+                    arcname = absname[len(abs_src) + 1:]
+                    zf.write(absname, arcname)
+    except IOError as e:
+        if e.errno == 13:
+            raise CLIError('Insufficient permissions to create a zip in current directory. Please re-run the command with administrator privileges')
+        raise CLIError(e)
 
-            for filename in files:
-                absname = os.path.abspath(os.path.join(dirname, filename))
-                arcname = absname[len(abs_src) + 1:]
-                zf.write(absname, arcname)
     return zip_file_path
 
 
@@ -165,8 +172,11 @@ def get_lang_from_content(src_path, html=False):
         runtime_details_dict['file_loc'] = package_netcore_file
         runtime_details_dict['default_sku'] = 'F1'
     else:  # TODO: Update the doc when the detection logic gets updated
-        raise CLIError("Could not auto-detect the runtime stack of your app, "
-                       "see 'https://go.microsoft.com/fwlink/?linkid=2109470' for more information")
+        raise CLIError("Could not auto-detect the runtime stack of your app.\n"
+                       "HINT: Are you in the right folder?\n"
+                        "For more information, see "
+                        + Fore.BLUE + Style.BRIGHT + "'https://go.microsoft.com/fwlink/?linkid=2109470'"
+                        + Style.RESET_ALL)
     return runtime_details_dict
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
@@ -9,7 +9,6 @@ from knack.util import CLIError
 from knack.log import get_logger
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.mgmt.web.models import SkuDescription
-from colorama import Fore, Style
 
 from ._constants import (NETCORE_VERSION_DEFAULT, NETCORE_VERSIONS, NODE_VERSION_DEFAULT,
                          NODE_VERSIONS, NETCORE_RUNTIME_NAME, NODE_RUNTIME_NAME, DOTNET_RUNTIME_NAME,
@@ -61,7 +60,8 @@ def zip_contents_from_dir(dirPath, lang):
                     zf.write(absname, arcname)
     except IOError as e:
         if e.errno == 13:
-            raise CLIError('Insufficient permissions to create a zip in current directory. Please re-run the command with administrator privileges')
+            raise CLIError('Insufficient permissions to create a zip in current directory. '
+                           'Please re-run the command with administrator privileges')
         raise CLIError(e)
 
     return zip_file_path
@@ -174,9 +174,7 @@ def get_lang_from_content(src_path, html=False):
     else:  # TODO: Update the doc when the detection logic gets updated
         raise CLIError("Could not auto-detect the runtime stack of your app.\n"
                        "HINT: Are you in the right folder?\n"
-                        "For more information, see "
-                        + Fore.BLUE + Style.BRIGHT + "'https://go.microsoft.com/fwlink/?linkid=2109470'"
-                        + Style.RESET_ALL)
+                       "For more information, see 'https://go.microsoft.com/fwlink/?linkid=2109470'")
     return runtime_details_dict
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3588,8 +3588,8 @@ def webapp_up(cmd, name, resource_group_name=None, plan=None, location=None, sku
         # Raise error if current OS of the app is different from the current one
         if current_os.lower() != os_name.lower():
             raise CLIError("The webapp '{}' is a {} app. The code detected at '{}' will default to "
-                           "'{}'. "
-                           "Please create a new app to continue this operation.".format(name, current_os, src_dir, os_name))
+                           "'{}'. Please create a new app"
+                           "to continue this operation.".format(name, current_os, src_dir, os_name))
         _is_linux = plan_info.reserved
         # for an existing app check if the runtime version needs to be updated
         # Get site config to check the runtime version

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3589,7 +3589,7 @@ def webapp_up(cmd, name, resource_group_name=None, plan=None, location=None, sku
         if current_os.lower() != os_name.lower():
             raise CLIError("The webapp '{}' is a {} app. The code detected at '{}' will default to "
                            "'{}'. "
-                           "Please create a new app to continue this operation.".format(name, current_os, src_dir, os))
+                           "Please create a new app to continue this operation.".format(name, current_os, src_dir, os_name))
         _is_linux = plan_info.reserved
         # for an existing app check if the runtime version needs to be updated
         # Get site config to check the runtime version


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Fixes #15202 

**Testing Guide**  
Better error messages around the AppService commands

- run `az webapp up -n webappName` in a directory that isn't source code
Better error msg:
![image](https://user-images.githubusercontent.com/14339314/93807676-cf37e300-fbff-11ea-9224-c0b20524ab85.png)

- run `az webapp up -n webappName` without administrator privileges in a directory in C:
Better error msg:
![image](https://user-images.githubusercontent.com/14339314/93541181-8aaffd00-f90a-11ea-8a71-bc30a74b1d14.png)


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
