### PR TITLE
{KeyVault} Hotfix: Lock the SDK version

### DIFF
--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -90,7 +90,7 @@ DEPENDENCIES = [
     'azure-mgmt-iotcentral~=3.0.0',
     'azure-mgmt-iothub~=0.12.0',
     'azure-mgmt-iothubprovisioningservices~=0.2.0',
-    'azure-mgmt-keyvault~=7.0.0b3',
+    'azure-mgmt-keyvault==7.0.0b3',
     'azure-mgmt-kusto~=0.3.0',
     'azure-mgmt-loganalytics~=0.7.0',
     'azure-mgmt-managedservices~=1.0',


### PR DESCRIPTION
azure-mgmt-keyvault 7.0.0 has a breaking change due to codegen change, this breaks our CLI:

`TypeError: __init__() missing 1 required keyword-only argument: 'family'`

![image](https://user-images.githubusercontent.com/3250203/93845426-56a25680-fcd3-11ea-893a-6e89b2f6eacc.png)

Lock the version in `setup.py` to avoid the effect.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
