### PR TITLE
{Network} application-gateway waf-config: Remove deprecation info

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/commands.py
@@ -524,9 +524,7 @@ def load_command_table(self, _):
         g.custom_command('create', 'create_ag_url_path_map_rule', supports_no_wait=True, validator=process_ag_url_path_map_rule_create_namespace)
         g.custom_command('delete', 'delete_ag_url_path_map_rule', supports_no_wait=True)
 
-    waf_config_deprecate_info = self.deprecate(redirect='network application-gateway waf-policy', hide=False)
-    with self.command_group('network application-gateway waf-config',
-                            deprecate_info=waf_config_deprecate_info) as g:
+    with self.command_group('network application-gateway waf-config') as g:
         g.custom_command('set', 'set_ag_waf_config_2017_03_01', min_api='2017-03-01', supports_no_wait=True)
         g.custom_command('set', 'set_ag_waf_config_2016_09_01', max_api='2016-09-01', supports_no_wait=True)
         g.custom_show_command('show', 'show_ag_waf_config')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

As email indicates, the waf-config is not deprecated.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
