### PR TITLE
{Package} Rollback homebrew build method to update_existing

### DIFF
--- a/scripts/release/homebrew/docker/run.sh
+++ b/scripts/release/homebrew/docker/run.sh
@@ -10,4 +10,4 @@ pip install -r /mnt/src/azure-cli/requirements.py3.Darwin.txt
 
 pip list
 
-python $root/formula_generate.py -b use_template
+python $root/formula_generate.py


### PR DESCRIPTION
**Description<!--Mandatory-->**  
We update the build method to template when doing PEP420. Now it's time to rollback to original `update_existing`.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
