### PR TITLE
[AppService] az webapp config ssl import: Add functionality to import App Service Certificate to a web app, changing parameter names

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -329,12 +329,15 @@ helps['functionapp config ssl import'] = """
 type: command
 short-summary: Import a certificate to a functionapp. The certificate can be from Key Vault, or an App Service Certificate.
 examples:
-  - name: Import an SSL certificate to a function app from Key Vault. Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
-    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault MyKeyVault --certificate-name MyCertificateName
-  - name: Import an SSL certificate to a function app from Key Vault using resource id (typically if Key Vault is in another subscription). Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
-    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
+  - name: Import an SSL certificate to a function app from Key Vault. Option '--key-vault-certificate-name' has been deprecated, use '--certificate' instead
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault MyKeyVault --certificate MyCertificateName
+  - name: Import an SSL certificate to a function app from Key Vault using resource id (typically if Key Vault is in another subscription). Option '--key-vault-certificate-name' has been deprecated, use '--certificate' instead
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate MyCertificateName
   - name: Import an App Service Certificate to a function app
-    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --certificate-name MyCertificateName
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --certificate MyCertificateName
+  - name: Import an App Service Certificate to a function app using the certificate resource id (if the certificate is in a different subscription)
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --certificate '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.Web/certificates/[certificate name]'
+
 
 """
 
@@ -1303,12 +1306,14 @@ helps['webapp config ssl import'] = """
 type: command
 short-summary: Import a certificate to a web app. The certificate can be from Key Vault, or an App Service Certificate.
 examples:
-  - name: Import an SSL certificate to a web app from Key Vault. Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
-    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --certificate-name MyCertificateName
-  - name: Import an SSL certificate to a web app from Key Vault using resource id (typically if Key Vault is in another subscription). Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
-    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
+  - name: Import an SSL certificate to a web app from Key Vault. Option '--key-vault-certificate-name' has been deprecated, use '--certificate' instead
+    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --certificate MyCertificateName
+  - name: Import an SSL certificate to a web app from Key Vault using resource id (typically if Key Vault is in another subscription). Option '--key-vault-certificate-name' has been deprecated, use '--certificate' instead
+    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate MyCertificateName
   - name: Import an App Service Certificate to a web app
-    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --certificate-name MyCertificateName
+    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --certificate MyCertificateName
+  - name: Import an App Service Certificate to a web app using the certificate resource id (if the certificate is in a different subscription)
+    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --certificate '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.Web/certificates/[certificate name]'
 
 """
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -1310,7 +1310,7 @@ examples:
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
   - name: Import an SSL certificate to a web app from Key Vault using resource id (typically if Key Vault is in another subscription).
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
-    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName  
+    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName
   - name: Import an App Service Certificate to a web app
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --certificate-name MyCertificateName
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -1305,10 +1305,8 @@ short-summary: Import a certificate to a web app. The certificate can be from Ke
 examples:
   - name: Import an SSL certificate to a web app from Key Vault. Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --certificate-name MyCertificateName
-    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
   - name: Import an SSL certificate to a web app from Key Vault using resource id (typically if Key Vault is in another subscription). Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
-    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName
   - name: Import an App Service Certificate to a web app
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --certificate-name MyCertificateName
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -330,11 +330,13 @@ type: command
 short-summary: Import a certificate to a functionapp. The certificate can be from Key Vault, or an App Service Certificate.
 examples:
   - name: Import an SSL certificate to a function app from Key Vault.
-    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionapp --key-vault MyKeyVault --certificate-name MyCertificateName
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault MyKeyVault --certificate-name MyCertificateName
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
   - name: Import an SSL certificate to a function app from Key Vault using resource id (typically if Key Vault is in another subscription).
-    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName
   - name: Import an App Service Certificate to a function app
-    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionapp --certificate-name MyCertificateName
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --certificate-name MyCertificateName
 
 """
 
@@ -1305,8 +1307,10 @@ short-summary: Import a certificate to a web app. The certificate can be from Ke
 examples:
   - name: Import an SSL certificate to a web app from Key Vault.
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --certificate-name MyCertificateName
+    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
   - name: Import an SSL certificate to a web app from Key Vault using resource id (typically if Key Vault is in another subscription).
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
+    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName  
   - name: Import an App Service Certificate to a web app
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --certificate-name MyCertificateName
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -329,10 +329,10 @@ helps['functionapp config ssl import'] = """
 type: command
 short-summary: Import a certificate to a functionapp. The certificate can be from Key Vault, or an App Service Certificate.
 examples:
-  - name: Import an SSL certificate to a function app from Key Vault.
+  - name: Import an SSL certificate to a function app from Key Vault. Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
     text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault MyKeyVault --certificate-name MyCertificateName
     text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
-  - name: Import an SSL certificate to a function app from Key Vault using resource id (typically if Key Vault is in another subscription).
+  - name: Import an SSL certificate to a function app from Key Vault using resource id (typically if Key Vault is in another subscription). Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
     text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
     text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName
   - name: Import an App Service Certificate to a function app
@@ -1305,10 +1305,10 @@ helps['webapp config ssl import'] = """
 type: command
 short-summary: Import a certificate to a web app. The certificate can be from Key Vault, or an App Service Certificate.
 examples:
-  - name: Import an SSL certificate to a web app from Key Vault.
+  - name: Import an SSL certificate to a web app from Key Vault. Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --certificate-name MyCertificateName
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
-  - name: Import an SSL certificate to a web app from Key Vault using resource id (typically if Key Vault is in another subscription).
+  - name: Import an SSL certificate to a web app from Key Vault using resource id (typically if Key Vault is in another subscription). Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName
   - name: Import an App Service Certificate to a web app

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -331,10 +331,8 @@ short-summary: Import a certificate to a functionapp. The certificate can be fro
 examples:
   - name: Import an SSL certificate to a function app from Key Vault. Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
     text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault MyKeyVault --certificate-name MyCertificateName
-    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
   - name: Import an SSL certificate to a function app from Key Vault using resource id (typically if Key Vault is in another subscription). Option '--key-vault-certificate-name' has been deprecated, use '--certificate-name' instead
     text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
-    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName
   - name: Import an App Service Certificate to a function app
     text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --certificate-name MyCertificateName
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -327,12 +327,15 @@ examples:
 
 helps['functionapp config ssl import'] = """
 type: command
-short-summary: Import an SSL certificate to a function app from Key Vault.
+short-summary: Import a certificate to a functionapp. The certificate can be from Key Vault, or an App Service Certificate.
 examples:
   - name: Import an SSL certificate to a function app from Key Vault.
-    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionapp --key-vault MyKeyVault --certificate-name MyCertificateName
   - name: Import an SSL certificate to a function app from Key Vault using resource id (typically if Key Vault is in another subscription).
-    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionApp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
+  - name: Import an App Service Certificate to a function app
+    text: az functionapp config ssl import --resource-group MyResourceGroup --name MyFunctionapp --certificate-name MyCertificateName
+
 """
 
 helps['functionapp config ssl create'] = """
@@ -1298,12 +1301,15 @@ examples:
 
 helps['webapp config ssl import'] = """
 type: command
-short-summary: Import an SSL certificate to a web app from Key Vault.
+short-summary: Import a certificate to a web app. The certificate can be from Key Vault, or an App Service Certificate.
 examples:
   - name: Import an SSL certificate to a web app from Key Vault.
-    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
+    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --certificate-name MyCertificateName
   - name: Import an SSL certificate to a web app from Key Vault using resource id (typically if Key Vault is in another subscription).
-    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName
+    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --certificate-name MyCertificateName
+  - name: Import an App Service Certificate to a web app
+    text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --certificate-name MyCertificateName
+
 """
 
 helps['webapp config ssl create'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -228,7 +228,7 @@ def load_arguments(self, _):
             c.argument('setting_names', nargs='+', help="space-separated app setting names")
         with self.argument_context(scope + ' config ssl import') as c:
             c.argument('certificate_name', help='The name of the certificate to be imported')
-            c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault', deprecate_info=c.deprecate(expiration='2.15.0', target='--key-vault-certificate-name', redirect='--certificate-name'))
+            c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault', deprecate_info=c.deprecate(expiration='2.18.0', target='--key-vault-certificate-name', redirect='--certificate-name'))
             c.argument('key_vault', help='The name or resource ID of the Key Vault')
         with self.argument_context(scope + ' config ssl create') as c:
             c.argument('hostname', help='The custom domain name')

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -228,7 +228,7 @@ def load_arguments(self, _):
             c.argument('setting_names', nargs='+', help="space-separated app setting names")
         with self.argument_context(scope + ' config ssl import') as c:
             c.argument('certificate_name', help='The name of the certificate to be imported')
-            c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault', deprecate_info=c.deprecate(expiration='2.15.0'))
+            c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault', deprecate_info=c.deprecate(expiration='2.15.0', target='--key-vault-certificate-name', redirect='--certificate-name'))
             c.argument('key_vault', help='The name or resource ID of the Key Vault')
         with self.argument_context(scope + ' config ssl create') as c:
             c.argument('hostname', help='The custom domain name')

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -228,7 +228,7 @@ def load_arguments(self, _):
             c.argument('setting_names', nargs='+', help="space-separated app setting names")
         with self.argument_context(scope + ' config ssl import') as c:
             c.argument('certificate_name', help='The name of the certificate to be imported')
-            c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault', deprecate_info=c.deprecate(expiration='2.13.2'))
+            c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault', deprecate_info=c.deprecate(expiration='2.15.0'))
             c.argument('key_vault', help='The name or resource ID of the Key Vault')
         with self.argument_context(scope + ' config ssl create') as c:
             c.argument('hostname', help='The custom domain name')

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -227,7 +227,7 @@ def load_arguments(self, _):
             c.argument('settings', nargs='+', help="space-separated app settings in a format of `<name>=<value>`")
             c.argument('setting_names', nargs='+', help="space-separated app setting names")
         with self.argument_context(scope + ' config ssl import') as c:
-            c.argument('certificate_name', help='The name of the certificate to be imported')
+            c.argument('certificate', help='The name or resource ID of the certificate to be imported')
             c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault', deprecate_info=c.deprecate(expiration='2.18.0', target='--key-vault-certificate-name', redirect='--certificate-name'))
             c.argument('key_vault', help='The name or resource ID of the Key Vault')
         with self.argument_context(scope + ' config ssl create') as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -228,7 +228,8 @@ def load_arguments(self, _):
             c.argument('setting_names', nargs='+', help="space-separated app setting names")
         with self.argument_context(scope + ' config ssl import') as c:
             c.argument('certificate_name', help='The name of the certificate to be imported')
-            c.argument('key_vault', help='the keyvault id')
+            c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault', deprecate_info=c.deprecate(expiration='5.1.0'))
+            c.argument('key_vault', help='The name or resource ID of the Key Vault')
         with self.argument_context(scope + ' config ssl create') as c:
             c.argument('hostname', help='The custom domain name')
         with self.argument_context(scope + ' config hostname') as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -227,8 +227,8 @@ def load_arguments(self, _):
             c.argument('settings', nargs='+', help="space-separated app settings in a format of `<name>=<value>`")
             c.argument('setting_names', nargs='+', help="space-separated app setting names")
         with self.argument_context(scope + ' config ssl import') as c:
-            c.argument('key_vault', help='The name or resource ID of the Key Vault')
-            c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault')
+            c.argument('certificate_name', help='The name of the certificate to be imported')
+            c.argument('key_vault', help='the keyvault id')
         with self.argument_context(scope + ' config ssl create') as c:
             c.argument('hostname', help='The custom domain name')
         with self.argument_context(scope + ' config hostname') as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -228,7 +228,7 @@ def load_arguments(self, _):
             c.argument('setting_names', nargs='+', help="space-separated app setting names")
         with self.argument_context(scope + ' config ssl import') as c:
             c.argument('certificate_name', help='The name of the certificate to be imported')
-            c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault', deprecate_info=c.deprecate(expiration='5.1.0'))
+            c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault', deprecate_info=c.deprecate(expiration='2.13.2'))
             c.argument('key_vault', help='The name or resource ID of the Key Vault')
         with self.argument_context(scope + ' config ssl create') as c:
             c.argument('hostname', help='The custom domain name')

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2395,7 +2395,7 @@ def import_ssl_cert(cmd, resource_group_name, name, certificate_name=None, key_v
     if certificate_name and key_vault_certificate_name:
         no_two_certs = "Provide only one certificate name, use \'--certificate-name\'."
         logger.warning(no_two_certs)
-        return 
+        return
     if certificate_name:
         cert = certificate_name
     elif key_vault_certificate_name:

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2392,11 +2392,14 @@ def import_ssl_cert(cmd, resource_group_name, name, certificate_name=None, key_v
     server_farm_id = webapp.server_farm_id
     location = webapp.location
 
-    if key_vault_certificate_name:
-        return
-
+    if certificate_name and key_vault_certificate_name:
+        no_two_certs = "Provide only one certificate name, use \'--certificate-name\'."
+        logger.warning(no_two_certs)
+        return 
     if certificate_name:
         cert = certificate_name
+    elif key_vault_certificate_name:
+        cert = key_vault_certificate_name
     else:
         no_cert_msg = 'You must provide a certificate name, use \'--certificate-name\'.'
         logger.warning(no_cert_msg)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2391,26 +2391,18 @@ def import_ssl_cert(cmd, resource_group_name, name, certificate_name=None, key_v
     server_farm_id = webapp.server_farm_id
     location = webapp.location
 
-    if not key_vault_certificate_name and not certificate_name:
-        name_needed_msg = 'You must provide a certificate name, use either: ' \
-                          'certificate-name or key-vault-certificate-name.'
-        logger.warning(name_needed_msg)
+    if key_vault_certificate_name:
+        deprecated_msg = 'Option \'--key-vault-certificate-name\' has been deprecated, and will be removed' \
+                         'in version \'2.15.0\'. Use \'--certificate-name\' instead'
+        logger.warning(deprecated_msg)
         return
 
-    if key_vault_certificate_name:
-        if certificate_name:
-            diff_name_msg = 'Only one certificate name can be provided,' \
-                            'use certificate-name or key-vault-certificate-name.'
-            logger.warning(diff_name_msg)
-            return
-        if not key_vault:
-            no_key_vault_msg = 'if you are trying to import a keyvault certificate,' \
-                               ' you must provide a Key Vault, use --key-vault.'
-            logger.warning(no_key_vault_msg)
-            return
-        cert = key_vault_certificate_name
     if certificate_name:
         cert = certificate_name
+    else:
+        no_cert_msg = 'You must provide a certificate name, use \'--certificate-name\'.'
+        logger.warning(no_cert_msg)
+        return
 
     (kv_id, kv_secret_name, error) = get_import_kv_details(cmd, client, cert, key_vault)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2387,7 +2387,8 @@ def import_ssl_cert(cmd, resource_group_name, name, certificate_name=None, key_v
     client = web_client_factory(cmd.cli_ctx)
     webapp = client.web_apps.get(resource_group_name, name)
     if not webapp:
-        raise CLIError("'{}' app doesn't exist in resource group {}".format(name, resource_group_name))
+        err_msg = "'{}' app doesn't exist in resource group {}".format(name, resource_group_name))
+        raise ResourceNotFoundError(err_msg)
     server_farm_id = webapp.server_farm_id
     location = webapp.location
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -41,6 +41,7 @@ from azure.mgmt.web.models import KeyInfo, DefaultErrorResponseException
 from azure.cli.command_modules.relay._client_factory import hycos_mgmt_client_factory, namespaces_mgmt_client_factory
 from azure.cli.command_modules.network._client_factory import network_client_factory
 
+from azure.cli.core.azclierror import ResourceNotFoundError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.util import in_cloud_console, shell_safe_json_parse, open_page_in_browser, get_json_object, \
@@ -2387,7 +2388,7 @@ def import_ssl_cert(cmd, resource_group_name, name, certificate_name=None, key_v
     client = web_client_factory(cmd.cli_ctx)
     webapp = client.web_apps.get(resource_group_name, name)
     if not webapp:
-        err_msg = "'{}' app doesn't exist in resource group {}".format(name, resource_group_name))
+        err_msg = "'{}' app doesn't exist in resource group {}".format(name, resource_group_name)
         raise ResourceNotFoundError(err_msg)
     server_farm_id = webapp.server_farm_id
     location = webapp.location

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2392,9 +2392,6 @@ def import_ssl_cert(cmd, resource_group_name, name, certificate_name=None, key_v
     location = webapp.location
 
     if key_vault_certificate_name:
-        deprecated_msg = 'Option \'--key-vault-certificate-name\' has been deprecated, and will be removed' \
-                         'in version \'2.15.0\'. Use \'--certificate-name\' instead'
-        logger.warning(deprecated_msg)
         return
 
     if certificate_name:

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -41,7 +41,6 @@ from azure.mgmt.web.models import KeyInfo, DefaultErrorResponseException
 from azure.cli.command_modules.relay._client_factory import hycos_mgmt_client_factory, namespaces_mgmt_client_factory
 from azure.cli.command_modules.network._client_factory import network_client_factory
 
-from azure.cli.core.azclierror import ResourceNotFoundError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.util import in_cloud_console, shell_safe_json_parse, open_page_in_browser, get_json_object, \

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2437,13 +2437,13 @@ def get_import_kv_details(cmd, client, certificate_name, key_vault):
                 break
 
         if not cert:
-            no_cert_msg = 'This app service certificate does not exist'
+            no_cert_msg = 'An App Service Certificate with this name does not exist in this subscription.'
             logger.warning(no_cert_msg)
             return
 
         kv_id = cert.key_vault_id
         if kv_id is None:
-            no_kv_msg = 'this cert is not associated with a KV'
+            no_kv_msg = 'This App Service Certificate has not been added to a KeyVault, and cannot be imported.'
             logger.warning(no_kv_msg)
             return
         kv_secret_name = cert.key_vault_secret_name

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -16,6 +16,7 @@ from binascii import hexlify
 from os import urandom
 import datetime
 import json
+import random
 import ssl
 import sys
 import uuid
@@ -2388,41 +2389,8 @@ def import_ssl_cert(cmd, resource_group_name, name, certificate_name, key_vault=
         raise CLIError("'{}' app doesn't exist in resource group {}".format(name, resource_group_name))
     server_farm_id = webapp.server_farm_id
     location = webapp.location
-    kv_id = None
-    kv_secret_name = certificate_name
 
-    # if key_vault is not populated, we are attempting to import an App Service Certificate
-    if not key_vault: 
-        certs = client.app_service_certificate_orders.list()
-        cert = None
-        for c in certs:
-            rg = parse_resource_id(c.id)['resource_group']
-            if c.name == certificate_name:
-                cert = c.certificates[certificate_name]
-                break
-
-        if not cert:
-            no_cert_msg = 'This app service certificate does not exist'
-            logger.warning(no_cert_msg)
-            return
-        
-        kv_id = cert.key_vault_id
-        if kv_id is None: 
-            no_kv_msg = 'this cert is not associated with a KV'
-            logger.warning(no_kv_msg)
-            return
-        kv_secret_name = cert.key_vault_secret_name
-
-    else:
-        if not is_valid_resource_id(key_vault):
-            kv_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_KEYVAULT)
-            key_vaults = kv_client.vaults.list_by_subscription()
-            for kv in key_vaults:
-                if key_vault == kv.name:
-                    kv_id = kv.id
-                    break
-        else:
-            kv_id = key_vault
+    (kv_id, kv_secret_name) = get_import_kv_details(cmd, client, certificate_name, key_vault)
 
     if kv_id is None:
         kv_msg = 'The Key Vault {0} was not found in the subscription in context. ' \
@@ -2438,7 +2406,8 @@ def import_ssl_cert(cmd, resource_group_name, name, certificate_name, key_vault=
     kv_resource_group_name = kv_id_parts['resource_group']
     kv_subscription = kv_id_parts['subscription']
     if not key_vault:
-        cert_name = '{}-{}-{}'.format(certificate_name, resource_group_name, certificate_name)
+        r = random.randrange(0, 99999)
+        cert_name = '{}-{}-{}'.format(certificate_name, resource_group_name, r)
     else:
         cert_name = '{}-{}-{}'.format(resource_group_name, kv_name, certificate_name)
     lnk = 'https://azure.github.io/AppService/2016/05/24/Deploying-Azure-Web-App-Certificate-through-Key-Vault.html'
@@ -2453,6 +2422,43 @@ def import_ssl_cert(cmd, resource_group_name, name, certificate_name, key_vault=
 
     return client.certificates.create_or_update(name=cert_name, resource_group_name=resource_group_name,
                                                 certificate_envelope=kv_cert_def)
+
+
+def get_import_kv_details(cmd, client, certificate_name, key_vault):
+    kv_id = None
+    kv_secret_name = certificate_name
+    # if key_vault is not populated, we are attempting to import an App Service Certificate
+    if not key_vault:
+        certs = client.app_service_certificate_orders.list()
+        cert = None
+        for c in certs:
+            if c.name == certificate_name:
+                cert = c.certificates[certificate_name]
+                break
+
+        if not cert:
+            no_cert_msg = 'This app service certificate does not exist'
+            logger.warning(no_cert_msg)
+            return
+
+        kv_id = cert.key_vault_id
+        if kv_id is None:
+            no_kv_msg = 'this cert is not associated with a KV'
+            logger.warning(no_kv_msg)
+            return
+        kv_secret_name = cert.key_vault_secret_name
+
+    else:
+        if not is_valid_resource_id(key_vault):
+            kv_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_KEYVAULT)
+            key_vaults = kv_client.vaults.list_by_subscription()
+            for kv in key_vaults:
+                if key_vault == kv.name:
+                    kv_id = kv.id
+                    break
+        else:
+            kv_id = key_vault
+    return (kv_id, kv_secret_name)
 
 
 def create_managed_ssl_cert(cmd, resource_group_name, name, hostname, slot=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -1345,7 +1345,7 @@ class WebappSSLImportCertTest(ScenarioTest):
         self.cmd('keyvault certificate import --name {} --vault-name {} --file "{}" --password {}'.format(
             cert_name, kv_name, pfx_file, cert_password))
 
-        self.cmd('webapp config ssl import --resource-group {} --name {}  --key-vault {} --key-vault-certificate-name {}'.format(resource_group, webapp_name, kv_name, cert_name), checks=[
+        self.cmd('webapp config ssl import --resource-group {} --name {}  --key-vault {} --certificate-name {}'.format(resource_group, webapp_name, kv_name, cert_name), checks=[
             JMESPathCheck('thumbprint', cert_thumbprint)
         ])
 
@@ -1379,7 +1379,7 @@ class WebappSSLImportCertTest(ScenarioTest):
         self.cmd('keyvault certificate import --name {} --vault-name {} --file "{}" --password {}'.format(
             cert_name, kv_name, pfx_file, cert_password))
 
-        self.cmd('webapp config ssl import --resource-group {} --name {}  --key-vault {} --key-vault-certificate-name {}'.format(resource_group, webapp_name, kv_id, cert_name), checks=[
+        self.cmd('webapp config ssl import --resource-group {} --name {}  --key-vault {} --certificate-name {}'.format(resource_group, webapp_name, kv_id, cert_name), checks=[
             JMESPathCheck('thumbprint', cert_thumbprint)
         ])
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
I am enabling az webapp config ssl import to also import an app service certificate to a webapp. At the moment, it just allows importing a KeyVault cert. With this change, it can be used for both of these. The breaking change here is changing the parameters, making key_vault optional, and changing the name from key_vault_certificate_name to certificate_name
Fixes #12427, #13907

**Testing Guide**  
existing functionality is changed to:
az webapp config ssl import --resource-group rg --name webapp --certificate-name kvCertName --key-vault kvName
added functionality is: 
az webapp config ssl import --resource-group rg --name webapp --certificate-name appServiceCertificate


**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
