### PR TITLE
[Role] Fix #15278: az role assignment list/delete: Forbid empty string arguments

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -556,8 +556,6 @@ def _build_role_scope(resource_group_name, scope, subscription_id):
         from azure.mgmt.core.tools import is_valid_resource_id
         if scope.startswith('/subscriptions/') and not is_valid_resource_id(scope):
             raise CLIError('Invalid scope. Please use --help to view the valid format.')
-    elif scope == '':
-        raise CLIError('Invalid scope. Please use --help to view the valid format.')
     elif resource_group_name:
         scope = subscription_scope + '/resourceGroups/' + resource_group_name
     else:

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -491,6 +491,17 @@ class RoleAssignmentScenarioTest(RoleScenarioTest):
                 os.chdir(base_dir)
                 self.cmd('ad user delete --upn-or-object-id {upn}')
 
+    def test_role_assignment_delete_empty_args(self):
+        expected_msg = "{} can't be an empty string"
+        with self.assertRaisesRegex(CLIError, expected_msg.format("--assignee")):
+            self.cmd('role assignment delete --assignee ""')
+        with self.assertRaisesRegex(CLIError, expected_msg.format("--scope")):
+            self.cmd('role assignment delete --scope ""')
+        with self.assertRaisesRegex(CLIError, expected_msg.format("--role")):
+            self.cmd('role assignment delete --role ""')
+        with self.assertRaisesRegex(CLIError, expected_msg.format("--resource-group")):
+            self.cmd('role assignment delete --resource-group ""')
+
     @unittest.skip("Known service random 403 issue")
     @ResourceGroupPreparer(name_prefix='cli_role_assign')
     @AllowLargeResponse()

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -486,7 +486,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTest):
                 os.chdir(base_dir)
                 self.cmd('ad user delete --upn-or-object-id {upn}')
 
-    def test_role_assignment_delete_empty_args(self):
+    def test_role_assignment_empty_args(self):
         expected_msg = "{} can't be an empty string"
         with self.assertRaisesRegex(CLIError, expected_msg.format("--assignee")):
             self.cmd('role assignment delete --assignee ""')

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -344,11 +344,6 @@ class RoleAssignmentScenarioTest(RoleScenarioTest):
                 self.cmd('role assignment delete --assignee {upn} --role reader')
 
                 # test role assignment on empty scope
-                with self.assertRaisesRegexp(CLIError, 'Invalid scope. Please use --help to view the valid format.'):
-                    self.cmd('role assignment create --assignee {upn} --scope "" --role reader')
-                    self.cmd('role assignment delete --assignee {upn} --scope "" --role reader')
-
-                # test role assignment on empty scope
                 with self.assertRaisesRegexp(CLIError, "Cannot find user or service principal in graph database for 'fake'."):
                     self.cmd('role assignment create --assignee fake --role contributor')
             finally:

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -486,7 +486,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTest):
                 os.chdir(base_dir)
                 self.cmd('ad user delete --upn-or-object-id {upn}')
 
-    def test_role_assignment_empty_args(self):
+    def test_role_assignment_empty_string_args(self):
         expected_msg = "{} can't be an empty string"
         with self.assertRaisesRegex(CLIError, expected_msg.format("--assignee")):
             self.cmd('role assignment delete --assignee ""')


### PR DESCRIPTION
**Description<!--Mandatory-->**  

Fix #15278: `az role assignment delete` will delete all assignments when `--assignee` is empty string

In `az role assignment list/delete`, when `--assignee`, `--scope`, `--role`, `--resource-group` are accidentally provided as an empty string `""` (especially when in a script), they won't take effect when filtering the role assignments, causing all matched role assignments to be listed/deleted. For example,

```
az role assignment delete --assignee ""
```

removes all role assignments under the subscription.

This PR checks whether these arguments are empty strings and throws `CLIError` accordingly.

**Testing Guide**  
```
az role assignment list --assignee ""
az role assignment list --scope ""
az role assignment list --role ""
az role assignment list --resource-group ""

az role assignment delete --assignee ""
az role assignment delete --scope ""
az role assignment delete --role ""
az role assignment delete --resource-group ""
```

(Use `'""'` for empty string in PowerShell.)