### PR TITLE
[SQL] Adding AAD-only Support for SQL Managed Instances and Servers

### DIFF
--- a/azure-cli2017.pyproj
+++ b/azure-cli2017.pyproj
@@ -1466,6 +1466,15 @@
     <Content Include="azure-cli\setup.cfg" />
   </ItemGroup>
   <ItemGroup>
+    <Interpreter Include="..\..\env2\">
+      <Id>env2</Id>
+      <Version>2.7</Version>
+      <Description>env2 (Python 2.7 (64-bit))</Description>
+      <InterpreterPath>Scripts\python.exe</InterpreterPath>
+      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
+      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
+      <Architecture>X64</Architecture>
+    </Interpreter>
     <Interpreter Include="..\..\env\">
       <Id>env</Id>
       <Version>3.7</Version>

--- a/azure-cli2017.pyproj
+++ b/azure-cli2017.pyproj
@@ -1466,15 +1466,6 @@
     <Content Include="azure-cli\setup.cfg" />
   </ItemGroup>
   <ItemGroup>
-    <Interpreter Include="..\..\env2\">
-      <Id>env2</Id>
-      <Version>2.7</Version>
-      <Description>env2 (Python 2.7 (64-bit))</Description>
-      <InterpreterPath>Scripts\python.exe</InterpreterPath>
-      <WindowsInterpreterPath>Scripts\pythonw.exe</WindowsInterpreterPath>
-      <PathEnvironmentVariable>PYTHONPATH</PathEnvironmentVariable>
-      <Architecture>X64</Architecture>
-    </Interpreter>
     <Interpreter Include="..\..\env\">
       <Id>env</Id>
       <Version>3.7</Version>

--- a/src/azure-cli/azure/cli/command_modules/sql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_help.py
@@ -638,16 +638,25 @@ short-summary: Manage a Managed Instance's Azure Active Directly only settings.
 helps['sql mi ad-only-auth enable'] = """
 type: command
 short-summary: Enable Azure Active Directly only Authentication for this Managed Instance.
+examples:
+  - name: Enable Active Directory only authentication for a managed instance
+    text: az sql mi ad-only-auth enable --resource-group mygroup --name myMI
 """
 
 helps['sql mi ad-only-auth disable'] = """
 type: command
 short-summary: Disable Azure Active Directly only Authentication for this Managed Instance.
+examples:
+  - name: Disable Active Directory only authentication for a managed instance
+    text: az sql mi ad-only-auth disable --resource-group mygroup --name myMI
 """
 
 helps['sql mi ad-only-auth get'] = """
 type: command
 short-summary: Get a specific Azure Active Directly only Authentication property.
+examples:
+  - name: Get Active Directory only authentication status for a managed instance
+    text: az sql mi ad-only-auth get --resource-group mygroup --name myMI
 """
 
 helps['sql mi create'] = """
@@ -937,27 +946,31 @@ short-summary: Update an existing server Active Directory administrator.
 
 helps['sql server ad-only-auth'] = """
 type: group
-short-summary: Manage a Server's Azure Active Directly only settings.
-"""
-
-helps['sql server ad-only-auth enable'] = """
-type: command
 short-summary: Manage Azure Active Directly only Authentication settings for this Server.
 """
 
 helps['sql server ad-only-auth enable'] = """
 type: command
 short-summary: Enable Azure Active Directly only Authentication for this Server.
+examples:
+  - name: Enable Active Directory only authentication for a sql server
+    text: az sql server ad-only-auth enable --resource-group mygroup --name myServer
 """
 
 helps['sql server ad-only-auth disable'] = """
 type: command
 short-summary: Disable Azure Active Directly only Authentication for this Server.
+examples:
+  - name: Disable Active Directory only authentication for a sql server
+    text: az sql server ad-only-auth disable --resource-group mygroup --name myServer
 """
 
 helps['sql server ad-only-auth get'] = """
 type: command
 short-summary: Get a specific Azure Active Directly only Authentication property.
+examples:
+  - name: Get Active Directory only authentication status for a sql server
+    text: az sql server ad-only-auth get --resource-group mygroup --name myServer
 """
 
 helps['sql server audit-policy'] = """

--- a/src/azure-cli/azure/cli/command_modules/sql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_help.py
@@ -605,13 +605,6 @@ type: group
 short-summary: Manage SQL managed instances.
 """
 
-#####*****####
-helps['sql mi aad-only'] = """
-type: group
-short-summary: Manage a managed instanec's Azure Active Directly only settings.
-"""
-#####*****####
-
 helps['sql mi ad-admin'] = """
 type: group
 short-summary: Manage a managed instance's Active Directory administrator.
@@ -635,6 +628,26 @@ short-summary: Returns a list of managed instance Active Directory Administrator
 helps['sql mi ad-admin update'] = """
 type: command
 short-summary: Updates an existing managed instance Active Directory administrator.
+"""
+
+helps['sql mi ad-only-auth'] = """
+type: group
+short-summary: Manage a Managed Instance's Azure Active Directly only settings.
+"""
+
+helps['sql mi ad-only-auth enable'] = """
+type: group
+short-summary: Enable Azure Active Directly only Authentication for this Managed Instance.
+"""
+
+helps['sql mi ad-only-auth disable'] = """
+type: group
+short-summary: Disable Azure Active Directly only Authentication for this Managed Instance.
+"""
+
+ps['sql mi ad-only-auth get'] = """
+type: group
+short-summary: Get a specific Azure Active Directly only Authentication property.
 """
 
 helps['sql mi create'] = """
@@ -920,6 +933,26 @@ short-summary: Create a new server Active Directory administrator.
 helps['sql server ad-admin update'] = """
 type: command
 short-summary: Update an existing server Active Directory administrator.
+"""
+
+helps['sql server ad-only-auth enable'] = """
+type: command
+short-summary: Manage Azure Active Directly only Authentication settings for this Server.
+"""
+
+helps['sql server ad-only-auth enable'] = """
+type: command
+short-summary: Enable Azure Active Directly only Authentication for this Server.
+"""
+
+helps['sql server ad-only-auth disable'] = """
+type: command
+short-summary: Disable Azure Active Directly only Authentication for this Server.
+"""
+
+helps['sql server ad-only-auth get'] = """
+type: command
+short-summary: Get a specific Azure Active Directly only Authentication property.
 """
 
 helps['sql server audit-policy'] = """

--- a/src/azure-cli/azure/cli/command_modules/sql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_help.py
@@ -645,7 +645,7 @@ type: group
 short-summary: Disable Azure Active Directly only Authentication for this Managed Instance.
 """
 
-ps['sql mi ad-only-auth get'] = """
+helps['sql mi ad-only-auth get'] = """
 type: group
 short-summary: Get a specific Azure Active Directly only Authentication property.
 """

--- a/src/azure-cli/azure/cli/command_modules/sql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_help.py
@@ -636,17 +636,17 @@ short-summary: Manage a Managed Instance's Azure Active Directly only settings.
 """
 
 helps['sql mi ad-only-auth enable'] = """
-type: group
+type: command
 short-summary: Enable Azure Active Directly only Authentication for this Managed Instance.
 """
 
 helps['sql mi ad-only-auth disable'] = """
-type: group
+type: command
 short-summary: Disable Azure Active Directly only Authentication for this Managed Instance.
 """
 
 helps['sql mi ad-only-auth get'] = """
-type: group
+type: command
 short-summary: Get a specific Azure Active Directly only Authentication property.
 """
 
@@ -933,6 +933,11 @@ short-summary: Create a new server Active Directory administrator.
 helps['sql server ad-admin update'] = """
 type: command
 short-summary: Update an existing server Active Directory administrator.
+"""
+
+helps['sql server ad-only-auth'] = """
+type: group
+short-summary: Manage a Server's Azure Active Directly only settings.
 """
 
 helps['sql server ad-only-auth enable'] = """

--- a/src/azure-cli/azure/cli/command_modules/sql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_help.py
@@ -605,6 +605,13 @@ type: group
 short-summary: Manage SQL managed instances.
 """
 
+#####*****####
+helps['sql mi aad-only'] = """
+type: group
+short-summary: Manage a managed instanec's Azure Active Directly only settings.
+"""
+#####*****####
+
 helps['sql mi ad-admin'] = """
 type: group
 short-summary: Manage a managed instance's Active Directory administrator.

--- a/src/azure-cli/azure/cli/command_modules/sql/_util.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_util.py
@@ -143,6 +143,9 @@ def get_sql_server_usages_operations(cli_ctx, _):
 def get_sql_subscription_usages_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).subscription_usages
 
+def get_sql_server_azure_ad_only_operations(cli_ctx, _):
+    return get_sql_management_client(cli_ctx).server_azure_ad_only_authentications
+
 
 def get_sql_virtual_network_rules_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).virtual_network_rules
@@ -159,10 +162,8 @@ def get_sql_managed_instances_operations(cli_ctx, _):
 def get_sql_managed_instance_azure_ad_administrators_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).managed_instance_administrators
 
-#####*****####
 def get_sql_managed_instance_azure_ad_only_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).managed_instance_azure_ad_only_authentications
-#####*****####
 
 def get_sql_managed_databases_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).managed_databases

--- a/src/azure-cli/azure/cli/command_modules/sql/_util.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_util.py
@@ -159,6 +159,10 @@ def get_sql_managed_instances_operations(cli_ctx, _):
 def get_sql_managed_instance_azure_ad_administrators_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).managed_instance_administrators
 
+#####*****####
+def get_sql_managed_instance_azure_ad_only_operations(cli_ctx, _):
+    return get_sql_management_client(cli_ctx).managed_instance_azure_ad_only_authentications
+#####*****####
 
 def get_sql_managed_databases_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).managed_databases

--- a/src/azure-cli/azure/cli/command_modules/sql/_util.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_util.py
@@ -143,6 +143,7 @@ def get_sql_server_usages_operations(cli_ctx, _):
 def get_sql_subscription_usages_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).subscription_usages
 
+
 def get_sql_server_azure_ad_only_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).server_azure_ad_only_authentications
 
@@ -162,8 +163,10 @@ def get_sql_managed_instances_operations(cli_ctx, _):
 def get_sql_managed_instance_azure_ad_administrators_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).managed_instance_administrators
 
+
 def get_sql_managed_instance_azure_ad_only_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).managed_instance_azure_ad_only_authentications
+
 
 def get_sql_managed_databases_operations(cli_ctx, _):
     return get_sql_management_client(cli_ctx).managed_databases

--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -582,7 +582,7 @@ def load_command_table(self, _):
 
         g.custom_command('disable', 'server_aad_only_disable')
         g.custom_command('enable', 'server_aad_only_enable')
-        g.command('get', 'get')
+        g.show_command('get', 'get')
 
     ###############################################
     #                sql managed instance         #
@@ -660,7 +660,7 @@ def load_command_table(self, _):
 
         g.custom_command('disable', 'mi_aad_only_disable')
         g.custom_command('enable', 'mi_aad_only_enable')
-        g.command('get', 'get')
+        g.show_command('get', 'get')
 
     ###############################################
     #                sql managed db               #

--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -577,7 +577,7 @@ def load_command_table(self, _):
         operations_tmpl='azure.mgmt.sql.operations#ServerAzureADOnlyAuthenticationsOperations.{}',
         client_factory=get_sql_server_azure_ad_only_operations)
 
-    with self.command_group ('sql server ad-only-auth',
+    with self.command_group('sql server ad-only-auth',
                              server_aadonly_operations,
                              client_factory=get_sql_server_azure_ad_only_operations) as g:
         
@@ -655,7 +655,7 @@ def load_command_table(self, _):
         operations_tmpl='azure.mgmt.sql.operations#ManagedInstanceAzureADOnlyAuthenticationsOperations.{}',
         client_factory=get_sql_managed_instance_azure_ad_only_operations)
 
-    with self.command_group ('sql mi ad-only-auth',
+    with self.command_group('sql mi ad-only-auth',
                              managed_instance_aadonly_operations,
                              client_factory=get_sql_managed_instance_azure_ad_only_operations) as g:
         

--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -46,6 +46,7 @@ from ._util import (
     get_sql_managed_database_long_term_retention_policies_operations,
     get_sql_managed_database_long_term_retention_backups_operations,
     get_sql_managed_instance_azure_ad_administrators_operations,
+    get_sql_managed_instance_azure_ad_only_operations,
     get_sql_managed_instance_encryption_protectors_operations,
     get_sql_managed_instance_keys_operations,
     get_sql_managed_instance_operations_operations,
@@ -53,6 +54,7 @@ from ._util import (
     get_sql_replication_links_operations,
     get_sql_restorable_dropped_databases_operations,
     get_sql_restorable_dropped_managed_databases_operations,
+    get_sql_server_azure_ad_only_operations,
     get_sql_server_connection_policies_operations,
     get_sql_server_dns_aliases_operations,
     get_sql_server_keys_operations,
@@ -63,6 +65,7 @@ from ._util import (
     get_sql_virtual_network_rules_operations,
     get_sql_instance_failover_groups_operations,
     get_sql_import_export_operations
+    
 )
 
 from ._validators import (
@@ -570,20 +573,17 @@ def load_command_table(self, _):
         c.command('delete', 'delete')
         c.custom_command('set', 'server_dns_alias_set')
 
-    #####*****#####
     server_aadonly_operations = CliCommandType(
         operations_tmpl='azure.mgmt.sql.operations#ServerAzureADOnlyAuthentications.{}',
         client_factory=get_sql_server_azure_ad_only_operations)
 
-    with self.command_group ('sql server aad-only',
+    with self.command_group ('sql server ad-only-auth',
                              server_aadonly_operations,
                              client_factory=get_sql_server_azure_ad_only_operations) as g:
         
-        g.custom_command('disable', 'server_aad_only_delete')
-        g.custom_command('enable', 'server_aad_only_create')
-        g.command('list', 'list_by_instance')
+        g.custom_command('disable', 'server_aad_only_disable')
+        g.custom_command('enable', 'server_aad_only_enable')
         g.command('get', 'get')
-    #####*****#####
 
     ###############################################
     #                sql managed instance         #
@@ -655,13 +655,12 @@ def load_command_table(self, _):
         operations_tmpl='azure.mgmt.sql.operations#ManagedInstanceAzureADOnlyAuthenticationsOperations.{}',
         client_factory=get_sql_managed_instance_azure_ad_only_operations)
 
-    with self.command_group ('sql mi aad-only',
-                             maanged_instance_aadonly_operations,
+    with self.command_group ('sql mi ad-only-auth',
+                             managed_instance_aadonly_operations,
                              client_factory=get_sql_managed_instance_azure_ad_only_operations) as g:
         
-        g.custom_command('disable', 'mi_aad_only_delete')
-        g.custom_command('enable', 'mi_aad_only_create')
-        g.command('list', 'list_by_instance')
+        g.custom_command('disable', 'mi_aad_only_disable')
+        g.custom_command('enable', 'mi_aad_only_enable')
         g.command('get', 'get')
 
     ###############################################

--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -570,6 +570,21 @@ def load_command_table(self, _):
         c.command('delete', 'delete')
         c.custom_command('set', 'server_dns_alias_set')
 
+    #####*****#####
+    server_aadonly_operations = CliCommandType(
+        operations_tmpl='azure.mgmt.sql.operations#ServerAzureADOnlyAuthentications.{}',
+        client_factory=get_sql_server_azure_ad_only_operations)
+
+    with self.command_group ('sql server aad-only',
+                             server_aadonly_operations,
+                             client_factory=get_sql_server_azure_ad_only_operations) as g:
+        
+        g.custom_command('disable', 'server_aad_only_delete')
+        g.custom_command('enable', 'server_aad_only_create')
+        g.command('list', 'list_by_instance')
+        g.command('get', 'get')
+    #####*****#####
+
     ###############################################
     #                sql managed instance         #
     ###############################################
@@ -636,7 +651,6 @@ def load_command_table(self, _):
         g.custom_command('delete', 'mi_ad_admin_delete')
         g.custom_command('update', 'mi_ad_admin_set')
 
-    #####*****####
     managed_instance_aadonly_operations = CliCommandType(
         operations_tmpl='azure.mgmt.sql.operations#ManagedInstanceAzureADOnlyAuthenticationsOperations.{}',
         client_factory=get_sql_managed_instance_azure_ad_only_operations)
@@ -648,7 +662,7 @@ def load_command_table(self, _):
         g.custom_command('disable', 'mi_aad_only_delete')
         g.custom_command('enable', 'mi_aad_only_create')
         g.command('list', 'list_by_instance')
-    #####*****####
+        g.command('get', 'get')
 
     ###############################################
     #                sql managed db               #

--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -65,7 +65,6 @@ from ._util import (
     get_sql_virtual_network_rules_operations,
     get_sql_instance_failover_groups_operations,
     get_sql_import_export_operations
-    
 )
 
 from ._validators import (
@@ -578,8 +577,8 @@ def load_command_table(self, _):
         client_factory=get_sql_server_azure_ad_only_operations)
 
     with self.command_group('sql server ad-only-auth',
-                             server_aadonly_operations,
-                             client_factory=get_sql_server_azure_ad_only_operations) as g:
+                            server_aadonly_operations,
+                            client_factory=get_sql_server_azure_ad_only_operations) as g:
         
         g.custom_command('disable', 'server_aad_only_disable')
         g.custom_command('enable', 'server_aad_only_enable')

--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -574,7 +574,7 @@ def load_command_table(self, _):
         c.custom_command('set', 'server_dns_alias_set')
 
     server_aadonly_operations = CliCommandType(
-        operations_tmpl='azure.mgmt.sql.operations#ServerAzureADOnlyAuthentications.{}',
+        operations_tmpl='azure.mgmt.sql.operations#ServerAzureADOnlyAuthenticationsOperations.{}',
         client_factory=get_sql_server_azure_ad_only_operations)
 
     with self.command_group ('sql server ad-only-auth',

--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -579,7 +579,7 @@ def load_command_table(self, _):
     with self.command_group('sql server ad-only-auth',
                             server_aadonly_operations,
                             client_factory=get_sql_server_azure_ad_only_operations) as g:
-        
+
         g.custom_command('disable', 'server_aad_only_disable')
         g.custom_command('enable', 'server_aad_only_enable')
         g.command('get', 'get')
@@ -655,9 +655,9 @@ def load_command_table(self, _):
         client_factory=get_sql_managed_instance_azure_ad_only_operations)
 
     with self.command_group('sql mi ad-only-auth',
-                             managed_instance_aadonly_operations,
-                             client_factory=get_sql_managed_instance_azure_ad_only_operations) as g:
-        
+                            managed_instance_aadonly_operations,
+                            client_factory=get_sql_managed_instance_azure_ad_only_operations) as g:
+
         g.custom_command('disable', 'mi_aad_only_disable')
         g.custom_command('enable', 'mi_aad_only_enable')
         g.command('get', 'get')

--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -636,6 +636,20 @@ def load_command_table(self, _):
         g.custom_command('delete', 'mi_ad_admin_delete')
         g.custom_command('update', 'mi_ad_admin_set')
 
+    #####*****####
+    managed_instance_aadonly_operations = CliCommandType(
+        operations_tmpl='azure.mgmt.sql.operations#ManagedInstanceAzureADOnlyAuthenticationsOperations.{}',
+        client_factory=get_sql_managed_instance_azure_ad_only_operations)
+
+    with self.command_group ('sql mi aad-only',
+                             maanged_instance_aadonly_operations,
+                             client_factory=get_sql_managed_instance_azure_ad_only_operations) as g:
+        
+        g.custom_command('disable', 'mi_aad_only_delete')
+        g.custom_command('enable', 'mi_aad_only_create')
+        g.command('list', 'list_by_instance')
+    #####*****####
+
     ###############################################
     #                sql managed db               #
     ###############################################

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -2970,7 +2970,6 @@ def mi_aad_only_disable(
         resource_group_name=resource_group_name,
         managed_instance_name=managed_instance_name,
         azure_ad_only_authentication=False
-        #parameters=kwargs
     )
 
 

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -2916,6 +2916,39 @@ def mi_ad_admin_delete(
         managed_instance_name=managed_instance_name
     )
 
+
+#####
+#           sql managed instance aad-only
+#####
+
+def mi_aad_only_delete(
+    client,
+    resource_group_name,
+    managed_instance_name):
+    '''
+    Disables the managed instance AAD-only setting
+    '''
+    return client.delete(
+        resource_group_name=resource_group_name,
+        managed_instance_name=managed_instance_name
+        )
+
+def mi_aad_only_create(
+    client,
+    resource_group_name,
+    managed_instance_name,
+    **kwargs):
+    '''
+    Enables the AAD-only setting
+    '''
+    kwargs['tenant_id'] = _get_tenant_id()
+
+    return client.create_or_update(
+        resource_group_name=resource_group_name,
+        managed_instance_name=managed_instance_name,
+        parameters=kwargs
+        )
+
 ###############################################
 #                sql managed db               #
 ###############################################

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -2635,6 +2635,37 @@ def encryption_protector_update(
         server_key_name=key_name
     )
 
+#####
+#           sql server aad-only
+#####
+
+def server_aad_only_delete(
+    client,
+    resource_group_name,
+    server_name):
+    '''
+    Disables a servers aad-only setting
+    '''
+    return client.delete(
+        resource_group_name=resource_group_name,
+        server_name=server_name
+    )
+
+def server_aad_only_create(
+    client,
+    resource_group_name,
+    server_name,
+    **kwargs):
+    '''
+    Enables a servers aad-only setting
+    '''
+    kwargs['tenant_id'] = _get_tenant_id()
+    return client.create_or_update(
+        resource_group_name=resource_group_name,
+        server_name=server_name
+        parameters=kwargs
+    )
+
 ###############################################
 #                sql managed instance         #
 ###############################################
@@ -2931,7 +2962,7 @@ def mi_aad_only_delete(
     return client.delete(
         resource_group_name=resource_group_name,
         managed_instance_name=managed_instance_name
-        )
+    )
 
 def mi_aad_only_create(
     client,
@@ -2947,7 +2978,7 @@ def mi_aad_only_create(
         resource_group_name=resource_group_name,
         managed_instance_name=managed_instance_name,
         parameters=kwargs
-        )
+    )
 
 ###############################################
 #                sql managed db               #

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -2655,8 +2655,7 @@ def server_aad_only_disable(
 def server_aad_only_enable(
     client,
     resource_group_name,
-    server_name,
-    **kwargs):
+    server_name):
     '''
     Enables a servers aad-only setting
     '''
@@ -2968,18 +2967,15 @@ def mi_aad_only_disable(
 def mi_aad_only_enable(
     client,
     resource_group_name,
-    managed_instance_name,
-    **kwargs):
+    managed_instance_name):
     '''
     Enables the AAD-only setting
     '''
-    #kwargs['tenant_id'] = _get_tenant_id()
 
     return client.create_or_update(
         resource_group_name=resource_group_name,
         managed_instance_name=managed_instance_name,
-        azure_ad_only_authentication=True,
-        parameters=kwargs
+        azure_ad_only_authentication=True
     )
 
 ###############################################

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -2662,7 +2662,7 @@ def server_aad_only_create(
     kwargs['tenant_id'] = _get_tenant_id()
     return client.create_or_update(
         resource_group_name=resource_group_name,
-        server_name=server_name
+        server_name=server_name,
         parameters=kwargs
     )
 

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -2639,19 +2639,20 @@ def encryption_protector_update(
 #           sql server aad-only
 #####
 
-def server_aad_only_delete(
+def server_aad_only_disable(
     client,
     resource_group_name,
     server_name):
     '''
     Disables a servers aad-only setting
     '''
-    return client.delete(
+    return client.create_or_update(
         resource_group_name=resource_group_name,
-        server_name=server_name
+        server_name=server_name,
+        azure_ad_only_authentication=False
     )
 
-def server_aad_only_create(
+def server_aad_only_enable(
     client,
     resource_group_name,
     server_name,
@@ -2659,11 +2660,10 @@ def server_aad_only_create(
     '''
     Enables a servers aad-only setting
     '''
-    kwargs['tenant_id'] = _get_tenant_id()
     return client.create_or_update(
         resource_group_name=resource_group_name,
         server_name=server_name,
-        parameters=kwargs
+        azure_ad_only_authentication=True
     )
 
 ###############################################
@@ -2952,19 +2952,20 @@ def mi_ad_admin_delete(
 #           sql managed instance aad-only
 #####
 
-def mi_aad_only_delete(
+def mi_aad_only_disable(
     client,
     resource_group_name,
     managed_instance_name):
     '''
     Disables the managed instance AAD-only setting
     '''
-    return client.delete(
+    return client.create_or_update(
         resource_group_name=resource_group_name,
-        managed_instance_name=managed_instance_name
+        managed_instance_name=managed_instance_name,
+        azure_ad_only_authentication=False
+        #parameters=kwargs
     )
-
-def mi_aad_only_create(
+def mi_aad_only_enable(
     client,
     resource_group_name,
     managed_instance_name,
@@ -2972,11 +2973,12 @@ def mi_aad_only_create(
     '''
     Enables the AAD-only setting
     '''
-    kwargs['tenant_id'] = _get_tenant_id()
+    #kwargs['tenant_id'] = _get_tenant_id()
 
     return client.create_or_update(
         resource_group_name=resource_group_name,
         managed_instance_name=managed_instance_name,
+        azure_ad_only_authentication=True,
         parameters=kwargs
     )
 

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -2639,31 +2639,36 @@ def encryption_protector_update(
 #           sql server aad-only
 #####
 
+
 def server_aad_only_disable(
-    client,
-    resource_group_name,
-    server_name):
+        client,
+        resource_group_name,
+        server_name):
     '''
     Disables a servers aad-only setting
     '''
+
     return client.create_or_update(
         resource_group_name=resource_group_name,
         server_name=server_name,
         azure_ad_only_authentication=False
     )
 
+
 def server_aad_only_enable(
-    client,
-    resource_group_name,
-    server_name):
+        client,
+        resource_group_name,
+        server_name):
     '''
     Enables a servers aad-only setting
     '''
+
     return client.create_or_update(
         resource_group_name=resource_group_name,
         server_name=server_name,
         azure_ad_only_authentication=True
     )
+
 
 ###############################################
 #                sql managed instance         #
@@ -2941,6 +2946,7 @@ def mi_ad_admin_delete(
     '''
     Deletes a managed instance active directory administrator.
     '''
+
     return client.delete(
         resource_group_name=resource_group_name,
         managed_instance_name=managed_instance_name
@@ -2951,23 +2957,27 @@ def mi_ad_admin_delete(
 #           sql managed instance aad-only
 #####
 
+
 def mi_aad_only_disable(
-    client,
-    resource_group_name,
-    managed_instance_name):
+        client,
+        resource_group_name,
+        managed_instance_name):
     '''
     Disables the managed instance AAD-only setting
     '''
+
     return client.create_or_update(
         resource_group_name=resource_group_name,
         managed_instance_name=managed_instance_name,
         azure_ad_only_authentication=False
         #parameters=kwargs
     )
+
+
 def mi_aad_only_enable(
-    client,
-    resource_group_name,
-    managed_instance_name):
+        client,
+        resource_group_name,
+        managed_instance_name):
     '''
     Enables the AAD-only setting
     '''
@@ -2977,6 +2987,7 @@ def mi_aad_only_enable(
         managed_instance_name=managed_instance_name,
         azure_ad_only_authentication=True
     )
+
 
 ###############################################
 #                sql managed db               #

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_aadonly.yaml
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_aadonly.yaml
@@ -1,0 +1,931 @@
+interactions:
+- request:
+    body: '{"location": "westeurope", "properties": {"administratorLogin": "admin123",
+      "administratorLoginPassword": "SecretPassword123"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"operation":"UpsertLogicalServer","startTime":"2020-10-20T17:05:17.767Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/8e874c4a-c26b-4440-8936-3013525947e1?api-version=2019-06-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '74'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:05:17 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/8e874c4a-c26b-4440-8936-3013525947e1?api-version=2019-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/8e874c4a-c26b-4440-8936-3013525947e1?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"name":"8e874c4a-c26b-4440-8936-3013525947e1","status":"InProgress","startTime":"2020-10-20T17:05:17.767Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:05:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/8e874c4a-c26b-4440-8936-3013525947e1?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"name":"8e874c4a-c26b-4440-8936-3013525947e1","status":"InProgress","startTime":"2020-10-20T17:05:17.767Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:05:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/8e874c4a-c26b-4440-8936-3013525947e1?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"name":"8e874c4a-c26b-4440-8936-3013525947e1","status":"InProgress","startTime":"2020-10-20T17:05:17.767Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:05:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/8e874c4a-c26b-4440-8936-3013525947e1?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"name":"8e874c4a-c26b-4440-8936-3013525947e1","status":"InProgress","startTime":"2020-10-20T17:05:17.767Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:05:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/8e874c4a-c26b-4440-8936-3013525947e1?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"name":"8e874c4a-c26b-4440-8936-3013525947e1","status":"InProgress","startTime":"2020-10-20T17:05:17.767Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:05:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/8e874c4a-c26b-4440-8936-3013525947e1?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"name":"8e874c4a-c26b-4440-8936-3013525947e1","status":"InProgress","startTime":"2020-10-20T17:05:17.767Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:06:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/8e874c4a-c26b-4440-8936-3013525947e1?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"name":"8e874c4a-c26b-4440-8936-3013525947e1","status":"Succeeded","startTime":"2020-10-20T17:05:17.767Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:06:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000002.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002","name":"clitestserver000002","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '645'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:06:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"administratorType": "ActiveDirectory", "login": "jareddwelsh",
+      "sid": "7b36067c-fb68-441c-9254-843933fd18c1", "tenantId": "0e50c24f-dec1-48ae-a4b5-4beba7a9a4b1"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server ad-admin create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '179'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -s -g -u -i
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/administrators/ActiveDirectory?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"operation":"CreateActiveDirectoryAdministrator","startTime":"2020-10-20T17:06:24.87Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAdministratorAzureAsyncOperation/93c561f7-bc59-42a9-b740-ad1381c36e5c?api-version=2019-06-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '88'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:06:24 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAdministratorOperationResults/93c561f7-bc59-42a9-b740-ad1381c36e5c?api-version=2019-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server ad-admin create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -s -g -u -i
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAdministratorAzureAsyncOperation/93c561f7-bc59-42a9-b740-ad1381c36e5c?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"name":"93c561f7-bc59-42a9-b740-ad1381c36e5c","status":"Succeeded","startTime":"2020-10-20T17:06:24.87Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:06:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server ad-admin create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -s -g -u -i
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/administrators/ActiveDirectory?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"properties":{"administratorType":"ActiveDirectory","login":"jareddwelsh","sid":"7b36067c-fb68-441c-9254-843933fd18c1","tenantId":"0e50c24f-dec1-48ae-a4b5-4beba7a9a4b1"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/administrators/ActiveDirectory","name":"ActiveDirectory","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '503'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:06:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"azureADOnlyAuthentication": true}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server ad-only-auth enable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/azureADOnlyAuthentications/Default?api-version=2020-02-02-preview
+  response:
+    body:
+      string: '{"operation":"UpdateActiveDirectoryAdministrator","startTime":"2020-10-20T17:06:41.48Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAdministratorAzureAsyncOperation/d4353cfe-6384-4570-a9d8-bd40173b2aa1?api-version=2020-02-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '88'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:06:40 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAdministratorOperationResults/d4353cfe-6384-4570-a9d8-bd40173b2aa1?api-version=2020-02-02-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server ad-only-auth enable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAdministratorAzureAsyncOperation/d4353cfe-6384-4570-a9d8-bd40173b2aa1?api-version=2020-02-02-preview
+  response:
+    body:
+      string: '{"name":"d4353cfe-6384-4570-a9d8-bd40173b2aa1","status":"Succeeded","startTime":"2020-10-20T17:06:41.48Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:06:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server ad-only-auth enable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/azureADOnlyAuthentications/Default?api-version=2020-02-02-preview
+  response:
+    body:
+      string: '{"properties":{"azureADOnlyAuthentication":true},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/azureADOnlyAuthentications/Default","name":"Default","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:06:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"azureADOnlyAuthentication": false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server ad-only-auth disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '52'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/azureADOnlyAuthentications/Default?api-version=2020-02-02-preview
+  response:
+    body:
+      string: '{"operation":"UpdateActiveDirectoryAdministrator","startTime":"2020-10-20T17:06:58.33Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAdministratorAzureAsyncOperation/3cc57f20-a378-4e6b-95f4-a6350f964e89?api-version=2020-02-02-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '88'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:06:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAdministratorOperationResults/3cc57f20-a378-4e6b-95f4-a6350f964e89?api-version=2020-02-02-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server ad-only-auth disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAdministratorAzureAsyncOperation/3cc57f20-a378-4e6b-95f4-a6350f964e89?api-version=2020-02-02-preview
+  response:
+    body:
+      string: '{"name":"3cc57f20-a378-4e6b-95f4-a6350f964e89","status":"Succeeded","startTime":"2020-10-20T17:06:58.33Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:07:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server ad-only-auth disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/azureADOnlyAuthentications/Default?api-version=2020-02-02-preview
+  response:
+    body:
+      string: '{"properties":{"azureADOnlyAuthentication":false},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/azureADOnlyAuthentications/Default","name":"Default","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:07:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server ad-only-auth get
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-sql/0.21.0 Azure-SDK-For-Python AZURECLI/2.12.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/azureADOnlyAuthentications/Default?api-version=2020-02-02-preview
+  response:
+    body:
+      string: '{"properties":{"azureADOnlyAuthentication":false},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/azureADOnlyAuthentications/Default","name":"Default","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 20 Oct 2020 17:07:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -984,7 +984,7 @@ class SqlServerADOnlyAuthScenarioTest(ScenarioTest):
 
         self.cmd('sql server ad-admin create -s {} -g {} -u {} -i {}'.format(server, resource_group, user, oid), checks=[])
         
-        self.cmd('sql server ad-only-auth enable -n {} -g {}'.format(server, resource_group),checks=[])
+        self.cmd('sql server ad-only-auth enable -n {} -g {}'.format(server, resource_group), checks=[])
         self.cmd('sql server ad-only-auth disable -n {} -g {}'.format(server, resource_group), checks=[])
         self.cmd('sql server ad-only-auth get -n {} -g {}'.format(server, resource_group), checks=[])
 
@@ -1065,9 +1065,9 @@ class SqlManagedInstanceAzureActiveDirectoryAdministratorScenarioTest(ScenarioTe
                      self.check('login', '{user}'),
                      self.check('sid', '{oid}')])
 
-        self.cmd ('sql mi ad-only-auth enable -n {managed_instance_name} -g {rg}', checks=[])
-        self.cmd ('sql mi ad-only-auth disable -n {managed_instance_name} -g {rg}', checks=[])
-        self.cmd ('sql mi ad-only-auth get -n {managed_instance_name} -g {rg}', checks=[])
+        self.cmd('sql mi ad-only-auth enable -n {managed_instance_name} -g {rg}', checks=[])
+        self.cmd('sql mi ad-only-auth disable -n {managed_instance_name} -g {rg}', checks=[])
+        self.cmd('sql mi ad-only-auth get -n {managed_instance_name} -g {rg}', checks=[])
 
 
 class SqlServerDbCopyScenarioTest(ScenarioTest):

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -983,7 +983,7 @@ class SqlServerADOnlyAuthScenarioTest(ScenarioTest):
         oid = '5e90ef3b-9b42-4777-819b-25c36961ea4d'
 
         self.cmd('sql server ad-admin create -s {} -g {} -u {} -i {}'.format(server, resource_group, user, oid), checks=[])
-        
+
         self.cmd('sql server ad-only-auth enable -n {} -g {}'.format(server, resource_group), checks=[])
         self.cmd('sql server ad-only-auth disable -n {} -g {}'.format(server, resource_group), checks=[])
         self.cmd('sql server ad-only-auth get -n {} -g {}'.format(server, resource_group), checks=[])

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -991,8 +991,6 @@ class SqlServerADOnlyAuthScenarioTest(ScenarioTest):
 
 class SqlManagedInstanceAzureActiveDirectoryAdministratorScenarioTest(ScenarioTest):
 
-    # Remove when issue #9393 is fixed.
-    @live_only()
     def test_sql_mi_aad_admin(self):
 
         print('Test is started...\n')


### PR DESCRIPTION
Adding support for a new feature to az cli. Azure Active Directory only allows for only AD users to be admins not traditional username/password combinations. This feature has been added to Azure Python SDK and is now being supported in az cli

Using either a managed instance or server with a ad admin run:

az sql server ad-only-auth enable
az sql server ad-only-auth disable
az sql server ad-only-auth get

az sql mi ad-only-auth enable
az sql mi ad-only-auth disable
az sql mi ad-only-auth get

to enable, disable and show AAD only authentication.