### PR TITLE
[ACR] Fix helm url with non-regional aka.ms link

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/commands.py
@@ -279,7 +279,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         msg = "This {} has been deprecated and will be removed in future release.".format(self.object_type)
         msg += " Use '{}' instead.".format(self.redirect)
         msg += " For more information go to"
-        msg += " https://docs.microsoft.com/en-us/azure/container-registry/container-registry-helm-repos"
+        msg += " https://aka.ms/acr/helm"
         return msg
 
     with self.command_group('acr helm', acr_helm_util,


### PR DESCRIPTION
**Description**  
Update region url to use non-regional aka.ms links 

**Testing Guide**  
Before : 

```
az acr helm --help

Group
    az acr helm : Manage helm charts for Azure Container Registries.
        This command group has been deprecated and will be removed in future release. Use 'helm
        v3' instead. For more information go to https://docs.microsoft.com/en-us/azure/container-
        registry/container-registry-helm-repos
```

After: 

```
az acr helm --help

Group
    az acr helm : Manage helm charts for Azure Container Registries.
        This command group has been deprecated and will be removed in future release. Use 'helm
        v3' instead. For more information go to https://aka.ms/acr/helm
```
**History Notes**  

[ACR] NON-BREAKING: az acr helm - deprecation url upate

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
