### PR TITLE
{Core} Allow exception_handler to mute exception

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -706,8 +706,7 @@ class AzCliCommandInvoker(CommandInvoker):
             return event_data['result']
         except Exception as ex:  # pylint: disable=broad-except
             if cmd_copy.exception_handler:
-                cmd_copy.exception_handler(ex)
-                return CommandResultItem(None, exit_code=1, error=ex)
+                return cmd_copy.exception_handler(ex)
             six.reraise(*sys.exc_info())
 
     def _run_jobs_serially(self, jobs, ids):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Allow `exception_handler` to mute exception.

In the current code, 

https://github.com/Azure/azure-cli/blob/2cd62de349e30b7774f116118a62246b88225091/src/azure-cli-core/azure/cli/core/commands/__init__.py#L707-L710

if `cmd_copy.exception_handler(ex)` doesn't throw an exception, `CommandResultItem` will be returned and wrapped again later in another `CommandResultItem`:

https://github.com/Azure/azure-cli/blob/8824e41608cc4fc18d41ed3b37f652ef109c5410/src/azure-cli-core/azure/cli/core/commands/__init__.py#L674-L677

This causes Knack to fail at https://github.com/microsoft/knack/blob/0d0308bc567f2d25654bb39201c02ab262d7ce0a/knack/cli.py#L221

```py
self.output.out(cmd_result, formatter=formatter, out_file=out_file)
```

This PRs returns the result of `exception_handler`, instead of wrapping the exception in a `CommandResultItem`.

**Testing Guide**  
In `src/azure-cli/azure/cli/command_modules/resource/commands.py`:

```py
def my_handler(ex):
    return str(ex)

g.custom_command('list', 'list_resource_groups', exception_handler=my_handler)
```

In `src/azure-cli/azure/cli/command_modules/resource/custom.py`

```py
def list_resource_groups(cmd, tag=None):
    raise Exception("temp exception")
```

Then call the command:

```
az group list
"temp exception"
```

If `exception_handler` does not mute the exception, it should use

```py
def my_handler(ex):
    raise ex
```