### PR TITLE
{Storage} Fix #15052: show warning according to command arguments

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -65,8 +65,30 @@ def _create_token_credential(cli_ctx):
 
     def _cancel_timer_event_handler(_, **__):
         updater.cancel()
+
     cli_ctx.register_event(EVENT_CLI_POST_EXECUTE, _cancel_timer_event_handler)
     return token_credential
+
+
+def _show_no_credentials_warning(namespace, auth_mode_attr=None):
+    credentials_choices = [ca for ca in ['--connection-string', '--account-key', '--sas-token']
+                           if hasattr(namespace, ca[2:].replace('-', '_'))]
+    logger.warning('There are no credentials provided in your command and environment, we will query for the '
+                   'account key inside your storage account. ')
+    if credentials_choices:
+        credentials_choices_str = ' or '.join(credentials_choices)
+        auth_mode_log = '.'
+        if auth_mode_attr:
+            auth_mode_log = ', or use `--auth-mode login` if you have required RBAC roles in your command. ' \
+                            'For more information about RBAC roles in storage, visit ' \
+                            'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli.'
+        logger.warning("Please provide %s as credentials%s ", credentials_choices_str, auth_mode_log)
+    elif auth_mode_attr:
+        logger.warning('Try `--auth-mode login` if you have required RBAC roles in your command. '
+                       'For more information about RBAC roles in storage, visit '
+                       'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. ')
+    logger.warning('Setting the corresponding environment variables can avoid inputting credentials in '
+                   'your command. Please use --help to get more information.')
 
 
 # region PARAMETER VALIDATORS
@@ -116,8 +138,10 @@ def validate_client_parameters(cmd, namespace):
     """ Retrieves storage connection parameters from environment variables and parses out connection string into
     account name and key """
     n = namespace
+    auth_mode_attr = False
 
     if hasattr(n, 'auth_mode'):
+        auth_mode_attr = True
         auth_mode = n.auth_mode or get_config_value(cmd, 'storage', 'auth_mode', None)
         del n.auth_mode
         if not n.account_name:
@@ -176,14 +200,7 @@ def validate_client_parameters(cmd, namespace):
 
     # if account name is specified but no key, attempt to query
     if n.account_name and not n.account_key and not n.sas_token:
-        logger.warning('There are no credentials provided in your command and environment, we will query for the '
-                       'account key inside your storage account. \nPlease provide --connection-string, '
-                       '--account-key or --sas-token as credentials, or use `--auth-mode login` if you '
-                       'have required RBAC roles in your command. For more information about RBAC roles '
-                       'in storage, visit '
-                       'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
-                       'Setting the corresponding environment variables can avoid inputting credentials in '
-                       'your command. Please use --help to get more information.')
+        _show_no_credentials_warning(namespace, auth_mode_attr)
         n.account_key = _query_account_key(cmd.cli_ctx, n.account_name)
 
 
@@ -1305,7 +1322,7 @@ def validate_client_auth_parameter(cmd, ns):
             ns.resource_group_name = _query_account_rg(cmd.cli_ctx, account_name=ns.account_name)[0]
         pop_data_client_auth(ns)
     elif (ns.default_encryption_scope and ns.prevent_encryption_scope_override is None) or \
-         (not ns.default_encryption_scope and ns.prevent_encryption_scope_override is not None):
+            (not ns.default_encryption_scope and ns.prevent_encryption_scope_override is not None):
         raise CLIError("usage error: You need to specify both --default-encryption-scope and "
                        "--prevent-encryption-scope-override to set encryption scope information "
                        "when creating container.")


### PR DESCRIPTION
## Description
Fix #15052 : `az storage table create` doesn't have an `--auth-mode` parameter, but mentions it in a warning
This PR customize warning message according to the arguments each command includes

## Testing Guide
`az storage table list --account-name $ACCOUNT`
 
warning before:
```sh
> az storage table list --account-name xxxx
There are no credentials provided in your command and environment, we will query for the account key inside your storage account.
Please provide --connection-string, --account-key or --sas-token as credentials, or use `--auth-mode login` if you have required RBAC roles in your command. For more information about RBAC roles in storage, visit https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli.
Setting the corresponding environment variables can avoid inputting credentials in your command. Please use --help to get more information.
[]
```
warning after:
```sh
> az storage table list --account-name yssa
There are no credentials provided in your command and environment, we will query for the account key inside your storage account.
Please provide --connection-string or --account-key or --sas-token as credentials.
Setting the corresponding environment variables can avoid inputting credentials in your command. Please use --help to get more information.
[]
```
