### PR TITLE
{Storage} add oauth_cmd in test scenarios

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_oauth.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_oauth.py
@@ -12,9 +12,6 @@ from ..storage_test_util import StorageScenarioMixin
 
 @api_version_constraint(ResourceType.DATA_STORAGE, min_api='2017-11-09')
 class StorageOauthTests(StorageScenarioMixin, ScenarioTest):
-    def oauth_cmd(self, cmd, *args, **kwargs):
-        return self.cmd(cmd + ' --auth-mode login', *args, **kwargs)
-
     @AllowLargeResponse()
     @ResourceGroupPreparer(name_prefix='cli_test_storage_oauth')
     @StorageAccountPreparer()

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_oauth_track2.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_oauth_track2.py
@@ -10,9 +10,6 @@ from ..storage_test_util import StorageScenarioMixin
 
 
 class StorageOauthTests(StorageScenarioMixin, ScenarioTest):
-    def oauth_cmd(self, cmd, *args, **kwargs):
-        return self.cmd(cmd + ' --auth-mode login', *args, **kwargs)
-
     @api_version_constraint(ResourceType.DATA_STORAGE_FILEDATALAKE, min_api='2018-11-09')
     @ResourceGroupPreparer(name_prefix='cli_test_storage_oauth')
     @StorageAccountPreparer(kind="StorageV2", hns=True)

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/storage_test_util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/storage_test_util.py
@@ -30,6 +30,9 @@ class StorageScenarioMixin:
         """Returns the storage account name and key in a tuple"""
         return name, self.get_account_key(group, name)
 
+    def oauth_cmd(self, cmd, *args, **kwargs):
+        return self.cmd(cmd + ' --auth-mode login', *args, **kwargs)
+
     def storage_cmd(self, cmd, account_info, *args):
         cmd = cmd.format(*args)
         cmd = '{} --account-name {} --account-key {}'.format(cmd, *account_info)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
oauth_cmd is widely used in storage test scenarios. Here is removing it in StorageTestMixin class for ease of use.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
