### PR TITLE
{KeyVault} Hotfix: Fix CloudSuffixNotSetException while using `az keyvault` in Azure Stack and Air-Gaped Cloud

### DIFF
--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -309,6 +309,7 @@ def _arm_to_cli_mapper(arm_dict):
             storage_endpoint=get_suffix('storage'),
             storage_sync_endpoint=get_suffix('storageSyncEndpointSuffix', fallback_value=_get_storage_sync_endpoint(arm_dict['name'])),
             keyvault_dns=get_suffix('keyVaultDns', add_dot=True),
+            mhsm_dns=get_suffix('mhsmDns', add_dot=True),
             sql_server_hostname=sql_server_hostname,
             mysql_server_endpoint=get_suffix('mysqlServerEndpoint', add_dot=True, fallback_value=get_db_server_endpoint('.mysql')),
             postgresql_server_endpoint=get_suffix('postgresqlServerEndpoint', add_dot=True, fallback_value=get_db_server_endpoint('.postgres')),

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -191,8 +191,8 @@ def _get_storage_sync_endpoint(cloud_name):
 
 def _get_synapse_analytics_endpoint(cloud_name):
     synapse_analytics_endpoint_mapper = {
-        'AzureCloud': 'dev.azuresynapse.net',
-        'AzureChinaCloud': 'dev.azuresynapse.azure.cn'
+        'AzureCloud': '.dev.azuresynapse.net',
+        'AzureChinaCloud': '.dev.azuresynapse.azure.cn'
     }
     return synapse_analytics_endpoint_mapper.get(cloud_name, None)
 
@@ -256,6 +256,11 @@ def _get_attestation_endpoint(cloud_name):
     return attestation_endpoint_mapper.get(cloud_name, None)
 
 
+def _get_mhsm_dns_suffix(cloud_name):
+    mhsm_dns_suffix_mapper = {c.name: c.suffixes.mhsm_dns for c in HARD_CODED_CLOUD_LIST}
+    return mhsm_dns_suffix_mapper.get(cloud_name, None)
+
+
 def _convert_arm_to_cli(arm_cloud_metadata_dict):
     cli_cloud_metadata_dict = {}
     for cloud in arm_cloud_metadata_dict:
@@ -309,7 +314,7 @@ def _arm_to_cli_mapper(arm_dict):
             storage_endpoint=get_suffix('storage'),
             storage_sync_endpoint=get_suffix('storageSyncEndpointSuffix', fallback_value=_get_storage_sync_endpoint(arm_dict['name'])),
             keyvault_dns=get_suffix('keyVaultDns', add_dot=True),
-            mhsm_dns=get_suffix('mhsmDns', add_dot=True),
+            mhsm_dns=get_suffix('mhsmDns', add_dot=True, fallback_value=_get_mhsm_dns_suffix(arm_dict['name'])),
             sql_server_hostname=sql_server_hostname,
             mysql_server_endpoint=get_suffix('mysqlServerEndpoint', add_dot=True, fallback_value=get_db_server_endpoint('.mysql')),
             postgresql_server_endpoint=get_suffix('postgresqlServerEndpoint', add_dot=True, fallback_value=get_db_server_endpoint('.postgres')),
@@ -475,6 +480,8 @@ AZURE_GERMAN_CLOUD = Cloud(
         postgresql_server_endpoint='.postgres.database.cloudapi.de',
         mariadb_server_endpoint='.mariadb.database.cloudapi.de'))
 
+HARD_CODED_CLOUD_LIST = [AZURE_PUBLIC_CLOUD, AZURE_CHINA_CLOUD, AZURE_US_GOV_CLOUD, AZURE_GERMAN_CLOUD]
+
 
 def get_known_clouds(refresh=False):
     if 'ARM_CLOUD_METADATA_URL' in os.environ:
@@ -507,7 +514,7 @@ def get_known_clouds(refresh=False):
         if not clouds:
             raise CLIError("No clouds available. Please ensure ARM_CLOUD_METADATA_URL is valid.")
         return clouds
-    return [AZURE_PUBLIC_CLOUD, AZURE_CHINA_CLOUD, AZURE_US_GOV_CLOUD, AZURE_GERMAN_CLOUD]
+    return HARD_CODED_CLOUD_LIST
 
 
 KNOWN_CLOUDS = get_known_clouds()

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -387,7 +387,11 @@ def _get_base_url_type(cli_ctx, service):
     if service == 'vault':
         suffix = cli_ctx.cloud.suffixes.keyvault_dns
     elif service == 'hsm':
-        suffix = cli_ctx.cloud.suffixes.mhsm_dns
+        from azure.cli.core.cloud import CloudSuffixNotSetException
+        try:
+            suffix = cli_ctx.cloud.suffixes.mhsm_dns
+        except CloudSuffixNotSetException:  # For Azure Stack and Air-Gaped Cloud
+            suffix = ''
 
     def base_url_type(name):
         return 'https://{}{}'.format(name, suffix)


### PR DESCRIPTION
Pick up the changes in #15298 for hotfix release.

**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
