### PR TITLE
{Core} Extract error message from AdalError

### DIFF
--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -36,7 +36,7 @@ class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-meth
             if in_cloud_console():
                 AdalAuthentication._log_hostname()
 
-            err = (getattr(err, 'error_response', None) or {}).get('error_description') or ''
+            err = (getattr(err, 'error_response', None) or {}).get('error_description') or str(err)
             if 'AADSTS70008' in err:  # all errors starting with 70008 should be creds expiration related
                 raise CLIError("Credentials have expired due to inactivity. {}".format(
                     "Please run 'az login'" if not in_cloud_console() else ''))


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Reported in https://github.com/Azure/azure-cli/issues/15320

If `AdalError` is created directly with

```py
raise AdalError('More than one token matches the criteria. The result is ambiguous.')
```

The original code fails to extract the error message and returns an empty string `''`. Thus, the original error is lost. 
