### PR TITLE
{Core} Replace naive datetime with aware datetime for Telemetry

### DIFF
--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -246,7 +246,7 @@ def _user_agrees_to_telemetry(func):
 def start(mode=None):
     if mode:
         _session.mode = mode
-    _session.start_time = datetime.datetime.utcnow()
+    _session.start_time = datetime.datetime.now(datetime.timezone.utc)
 
 
 @decorators.suppress_all_exceptions()
@@ -266,7 +266,7 @@ def flush():
     from azure.cli.telemetry import save
 
     # flush out current information
-    _session.end_time = datetime.datetime.utcnow()
+    _session.end_time = datetime.datetime.now(datetime.timezone.utc)
     save(get_config_dir(), _session.generate_payload())
 
     # reset session fields, retaining correlation id and application
@@ -279,7 +279,7 @@ def conclude():
     from azure.cli.core._environment import get_config_dir
     from azure.cli.telemetry import save
 
-    _session.end_time = datetime.datetime.utcnow()
+    _session.end_time = datetime.datetime.now(datetime.timezone.utc)
     save(get_config_dir(), _session.generate_payload())
 
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #15336
This pr replaces the orignal naive datetime with aware datetime for Telemetry StartTime and EndTime.

Before
```
"Context.Default.AzureCLI.StartTime":"2020-09-29 03:04:15.523825"
```

After
```
"Context.Default.AzureCLI.StartTime":"2020-09-29 03:25:53.873073+00:00"
```

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
