### PR TITLE
{Config} Change local context on/off error to warning

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/config/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/config/custom.py
@@ -93,7 +93,7 @@ def turn_param_persist_on(cmd):
         cmd.cli_ctx.local_context.turn_on()
         logger.warning('Parameter persistence is turned on, you can run `az config param-persist off` to turn it off.')
     else:
-        raise CLIError('Parameter persistence is on already.')
+        logger.warning('Parameter persistence is on already.')
 
 
 def turn_param_persist_off(cmd):
@@ -101,7 +101,7 @@ def turn_param_persist_off(cmd):
         cmd.cli_ctx.local_context.turn_off()
         logger.warning('Parameter persistence is turned off, you can run `az config param-persist on` to turn it on.')
     else:
-        raise CLIError('Parameter persistence is off already.')
+        logger.warning('Parameter persistence is off already.')
 
 
 def show_param_persist(cmd, name=None):

--- a/src/azure-cli/azure/cli/command_modules/configure/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/custom.py
@@ -254,7 +254,7 @@ def turn_local_context_on(cmd):
         cmd.cli_ctx.local_context.turn_on()
         logger.warning('Local context is turned on, you can run `az local-context off` to turn it off.')
     else:
-        raise CLIError('Local context is on already.')
+        logger.warning('Local context is on already.')
 
 
 def turn_local_context_off(cmd):
@@ -262,7 +262,7 @@ def turn_local_context_off(cmd):
         cmd.cli_ctx.local_context.turn_off()
         logger.warning('Local context is turned off, you can run `az local-context on` to turn it on.')
     else:
-        raise CLIError('Local context is off already.')
+        logger.warning('Local context is off already.')
 
 
 def show_local_context(cmd, name=None):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Previously when param persist is already on/off, it will raise an CLIError, which does not make sense. Update it to a warning message.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
