### PR TITLE
{Upgrade} Run powershell cmd with noprofile

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -126,7 +126,7 @@ def upgrade_version(cmd, update_all=None, yes=None):  # pylint: disable=too-many
                            "or run 'pip install --upgrade azure-cli' in this container")
         elif installer == 'MSI':
             logger.debug("Update azure cli with MSI from https://aka.ms/installazurecliwindows")
-            exit_code = subprocess.call(['powershell.exe', "Start-Process msiexec.exe -Wait -ArgumentList '/i https://aka.ms/installazurecliwindows'"])  # pylint: disable=line-too-long
+            exit_code = subprocess.call(['powershell.exe', '-No-Profile', "Start-Process msiexec.exe -Wait -ArgumentList '/i https://aka.ms/installazurecliwindows'"])  # pylint: disable=line-too-long
         else:
             logger.warning(UPGRADE_MSG)
     if exit_code:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #15313

When windows users have a `Microsoft.Powershell_profile.ps1` file in their environment, `powershell.exe` will start by loading it and with the default `Restricted` execution policy, an error will be thrown:
```
File C:\Users\***\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1 cannot be loaded because running scripts is disabled on this system. 
For more information, see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170.
```


This PR adds `-NoProfile` the Powershell command for `az upgrade` to skip loading the profile script.
 

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
