### PR TITLE
[AKS] Honor addon names defined in Azure CLI

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2429,8 +2429,12 @@ def _update_addons(cmd, instance, subscription_id, resource_group_name, addons, 
         if addon == 'aciConnector':
             # only linux is supported for now, in the future this will be a user flag
             addon += os_type
-        # addon name is case insensitive
-        addon = next((x for x in addon_profiles.keys() if x.lower() == addon.lower()), addon)
+
+        # honor addon names defined in Azure CLI
+        for key in list(addon_profiles):
+            if key.lower() == addon.lower() and key != addon:
+                addon_profiles[addon] = addon_profiles.pop(key)
+
         if enable:
             # add new addons or update existing ones and enable them
             addon_profile = addon_profiles.get(addon, ManagedClusterAddonProfile(enabled=False))
@@ -2740,8 +2744,9 @@ def _ensure_default_log_analytics_workspace_for_monitoring(cmd, subscription_id,
 
 def _ensure_container_insights_for_monitoring(cmd, addon):
     # Workaround for this addon key which has been seen lowercased in the wild.
-    if 'loganalyticsworkspaceresourceid' in addon.config:
-        addon.config['logAnalyticsWorkspaceResourceID'] = addon.config.pop('loganalyticsworkspaceresourceid')
+    for key in list(addon.config):
+        if key.lower() == 'loganalyticsworkspaceresourceid' and key != 'logAnalyticsWorkspaceResourceID':
+            addon.config['logAnalyticsWorkspaceResourceID'] = addon.config.pop(key)
 
     workspace_resource_id = addon.config['logAnalyticsWorkspaceResourceID']
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -710,6 +710,15 @@ class AcsCustomCommandTest(unittest.TestCase):
         self.assertEqual(args[3]['resources'][0]['type'], "Microsoft.Resources/deployments")
         self.assertEqual(args[4]['workspaceResourceId']['value'], wsID)
 
+        # when addon config key is lower cased
+        addon.config = {
+            'loganalyticsworkspaceresourceid': wsID
+        }
+        self.assertTrue(_ensure_container_insights_for_monitoring(cmd, addon))
+        args, kwargs = invoke_def.call_args
+        self.assertEqual(args[3]['resources'][0]['type'], "Microsoft.Resources/deployments")
+        self.assertEqual(args[4]['workspaceResourceId']['value'], wsID)
+
     @mock.patch('azure.cli.command_modules.acs.custom._urlretrieve')
     @mock.patch('azure.cli.command_modules.acs.custom.logger')
     def test_k8s_install_kubectl_emit_warnings(self, logger_mock, mock_url_retrieve):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -659,7 +659,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         instance.addon_profiles['kubedashboard'] = ManagedClusterAddonProfile(enabled=True)
         instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
                                   'clitest000001', 'kube-dashboard', enable=False)
-        dashboard_addon_profile = instance.addon_profiles['kubedashboard']
+        dashboard_addon_profile = instance.addon_profiles['kubeDashboard']
         self.assertFalse(dashboard_addon_profile.enabled)
 
         # kube-dashboard enabled, there's existing dashboard addon profile
@@ -668,7 +668,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         instance.addon_profiles['kubedashboard'] = ManagedClusterAddonProfile(enabled=False)
         instance = _update_addons(cmd, instance, '00000000-0000-0000-0000-000000000000',
                                   'clitest000001', 'kube-dashboard', enable=True)
-        dashboard_addon_profile = instance.addon_profiles['kubedashboard']
+        dashboard_addon_profile = instance.addon_profiles['kubeDashboard']
         self.assertTrue(dashboard_addon_profile.enabled)
 
         # monitoring enabled and then enabled again should error


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
AKS server treats addon names and addon config keys as case insensitive, and store them in DB as it is in input. For example, we have both `logAnalyticsWorkspaceResourceID` and `loganalyticsworkspaceresourceid` in our DB and both are valid. However, in the public document we're only giving examples of `logAnalyticsWorkspaceResourceID`. 
This change makes Azure CLI always convert the keys to the name defined in Azure CLI. (The name defined in Azure CLI is the same as public document), so that customer get the right name back.

**Testing Guide**  
<!--Example commands with explanations.-->
1. Create a AKS cluster.
2. Run `az aks enable-addons -a kube-dashboard -g testrg -n testcluster`
3. The name of kube-dashboard addon name should be change from "KubeDashboard" to "kubeDashboard"

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
