### PR TITLE
[AppService] Fixes #15441: az webapp create-remote-connection fails with AttributeError: 'Thread' object has no attribute 'isAlive'

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3760,7 +3760,7 @@ def create_tunnel(cmd, resource_group_name, name, port=None, slot=None, timeout=
     if timeout:
         time.sleep(int(timeout))
     else:
-        while t.isAlive():
+        while t.is_alive():
             time.sleep(5)
 
 
@@ -3782,7 +3782,7 @@ def create_tunnel_and_session(cmd, resource_group_name, name, port=None, slot=No
     if timeout:
         time.sleep(int(timeout))
     else:
-        while s.isAlive() and t.isAlive():
+        while s.is_alive() and t.is_alive():
             time.sleep(5)
 
 


### PR DESCRIPTION
**Description**  

Thread.isAlive is removed since Python 3.9
- see https://bugs.python.org/issue37804
- Fixes #15441

**Testing Guide**  

```sh
brew install azure-cli

# use python 3.9
export PATH="$(brew --prefix)/opt/python@3.9/libexec/bin:$PATH"

# create remote conntection for webapp
az webapp create-remote-connection -g {} -n {}
```

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
