### PR TITLE
{Network} Fix dns loading issue in azure stack

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/commands.py
@@ -635,7 +635,7 @@ def load_command_table(self, _):
     # endregion
 
     # region DNS
-    with self.command_group('network dns', network_dns_reference_sdk) as g:
+    with self.command_group('network dns', network_dns_reference_sdk, resource_type=ResourceType.MGMT_NETWORK_DNS) as g:
         g.command('list-references', 'get_by_target_resources')
 
     with self.command_group('network dns zone', network_dns_zone_sdk) as g:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix issue in https://dev.azure.com/azure-sdk/public/_build/results?buildId=557475&view=logs&j=b21ded15-2ef6-5c2b-875f-d00fdf573f12&t=293d8450-9e65-5c81-f34e-5d7d70fd3ffc.

The root cause is that for network module, the default resource type is MGMT_NETWORK and it is applied to `az network dns` if no addition specification.
In previous profile, the issue doesn't happen because MGMT_NETWOR api version is lower than 2018-05-11. But in new 2020-09-01-hybrid profile, it is larger than 2018-05-01 and the command will be loaded but there is no such support in SDK, which will cause error as shown in CI.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
