### PR TITLE
{Core} Enrich user-agent for az rest

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -15,7 +15,7 @@ import json
 from azure.cli.core.util import \
     (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string,
      open_page_in_browser, can_launch_browser, handle_exception, ConfiguredDefaultSetter, send_raw_request,
-     should_disable_connection_verify, parse_proxy_resource_id, get_az_user_agent)
+     should_disable_connection_verify, parse_proxy_resource_id, get_az_user_agent, get_az_rest_user_agent)
 from azure.cli.core.mock import DummyCli
 
 
@@ -246,7 +246,7 @@ class TestUtils(unittest.TestCase):
         test_body = '{"b1": "v1"}'
 
         expected_header = {
-            'User-Agent': get_az_user_agent(),
+            'User-Agent': get_az_rest_user_agent(),
             'Accept-Encoding': 'gzip, deflate',
             'Accept': '*/*',
             'Connection': 'keep-alive',
@@ -375,7 +375,7 @@ class TestUtils(unittest.TestCase):
 
             get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id, subscription=subscription_id)
             request = send_mock.call_args.args[1]
-            self.assertEqual(request.headers['User-Agent'], get_az_user_agent() + ' env-ua ARG-UA')
+            self.assertEqual(request.headers['User-Agent'], get_az_rest_user_agent() + ' env-ua ARG-UA')
 
 
 class TestBase64ToHex(unittest.TestCase):

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -791,7 +791,7 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
         skip_authorization_header = True
 
     # Handle User-Agent
-    agents = [get_az_user_agent()]
+    agents = [get_az_rest_user_agent()]
 
     # Borrow AZURE_HTTP_USER_AGENT from msrest
     # https://github.com/Azure/msrest-for-python/blob/4cc8bc84e96036f03b34716466230fb257e27b36/msrest/pipeline/universal.py#L70
@@ -1073,6 +1073,22 @@ def get_az_user_agent():
     # https://github.com/Azure/msrest-for-python/blob/4cc8bc84e96036f03b34716466230fb257e27b36/msrest/pipeline/universal.py#L70
     # if ENV_ADDITIONAL_USER_AGENT in os.environ:
     #     agents.append(os.environ[ENV_ADDITIONAL_USER_AGENT])
+
+    return ' '.join(agents)
+
+
+def get_az_rest_user_agent():
+    """Get User-Agent for az rest calls"""
+
+    from msrest import __version__ as msrest_version
+    from msrestazure import __version__ as msrestazure_version
+
+    agents = ['python/{}'.format(platform.python_version()),
+              '({})'.format(platform.platform()),
+              'msrest/{}'.format(msrest_version),
+              'msrest_azure/{}'.format(msrestazure_version),
+              get_az_user_agent()
+              ]
 
     return ' '.join(agents)
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1080,13 +1080,8 @@ def get_az_user_agent():
 def get_az_rest_user_agent():
     """Get User-Agent for az rest calls"""
 
-    from msrest import __version__ as msrest_version
-    from msrestazure import __version__ as msrestazure_version
-
     agents = ['python/{}'.format(platform.python_version()),
               '({})'.format(platform.platform()),
-              'msrest/{}'.format(msrest_version),
-              'msrest_azure/{}'.format(msrestazure_version),
               get_az_user_agent()
               ]
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR adds more properties into az rest user-agent, making it align with the python-sdk based requests. This is suggested by our PM Arun so that we can get the python version and os info from the user agents.

Currently, a common user agent from az rest based requests could be
```
AZURECLI/2.11.1 (RPM)
```
a common user agent from python-sdk based requests could be
```
python/3.8.2 (Windows-10-10.0.18362-SP0) msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.12.1 (PIP)
```

The PR adds the following properties into az rest user agents:
- python-version
- os detail

These properties won't be added because they are not the dependencies of az rest.
- msrest version
- msrest_azure version


**Testing Guide**  
<!--Example commands with explanations.-->
Run the az rest command, e.g,
```
az rest --method GET --uri 'https://graph.microsoft.com/v1.0/applications/b4e4d2ab-e2cb-45d5-a31a-98eb3f364001' --debug
``` 
Previously, the userAgent is
```
AZURECLI/2.12.1 (PIP)
```
Now, the userAgent is
```
python/3.8.2 (Windows-10-10.0.18362-SP0) AZURECLI/2.12.1 (PIP)
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
