### PR TITLE
{Homebrew} Hotfix: Build with template to revert to python 3.8

### DIFF
--- a/scripts/release/homebrew/docker/formula_template.txt
+++ b/scripts/release/homebrew/docker/formula_template.txt
@@ -9,6 +9,11 @@ class AzureCli < Formula
   license "MIT"
   head "https://github.com/Azure/azure-cli.git"
 
+  livecheck do
+    url "https://github.com/Azure/azure-cli/releases/latest"
+    regex(%r{href=.*?/tag/azure-cli[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
 {{ bottle_hash }}
 
   depends_on "openssl@1.1"

--- a/scripts/release/homebrew/docker/formula_template.txt
+++ b/scripts/release/homebrew/docker/formula_template.txt
@@ -17,6 +17,7 @@ class AzureCli < Formula
 {{ bottle_hash }}
 
   depends_on "openssl@1.1"
+  # Azure CLI is not compatible with Python 3.9 yet
   depends_on "python@3.8"
 
   uses_from_macos "libffi"

--- a/scripts/release/homebrew/docker/run.sh
+++ b/scripts/release/homebrew/docker/run.sh
@@ -10,4 +10,6 @@ pip install -r /mnt/src/azure-cli/requirements.py3.Darwin.txt
 
 pip list
 
-python $root/formula_generate.py
+# default option is update_existing to build from homebrew master branch,
+# append '-b use_template' to build from formula_template.txt 
+python $root/formula_generate.py -b use_template


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
https://github.com/Homebrew/homebrew-core/pull/62253 migrated to Python 3.9 for Azure CLI, but Azure CLI is not compatible with Python 3.9 yet. ADO has not supported Python 3.9 either and it caused failures when testing homebrew formula, which blocked the release of our packages.

This PR updates the homebrew template to sync the changes with Homebrew master branch except that Python is still 3.8 and build the homebrew formula from the template.

**Testing Guide**  
<!--Example commands with explanations.-->
Tested the changes in `build_test` branch: https://dev.azure.com/azure-sdk/public/_build/results?buildId=570383&view=results

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
