### PR TITLE
{Account} az account get-access-token: Remove preview tag for --tenant

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -76,7 +76,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
 
         with self.argument_context('account get-access-token') as c:
             c.argument('resource_type', get_enum_type(cloud_resource_types), options_list=['--resource-type'], arg_group='', help='Type of well-known resource.')
-            c.argument('tenant', options_list=['--tenant', '-t'], is_preview=True, help='Tenant ID for which the token is acquired. Only available for user and service principal account, not for MSI or Cloud Shell account')
+            c.argument('tenant', options_list=['--tenant', '-t'], help='Tenant ID for which the token is acquired. Only available for user and service principal account, not for MSI or Cloud Shell account')
 
 
 COMMAND_LOADER_CLS = ProfileCommandsLoader


### PR DESCRIPTION
**Description<!--Mandatory-->**  
`--tenant` has been introduced for almost a year and has been proven to be stable.

Due to the warning message:

> argument --tenant is in preview, it may be removed/changed in a future release

some users are afraid that `--tenant` will be removed in the future (https://github.com/Azure/azure-cli/pull/11798#issuecomment-706841294). 

We can now make it GA to avoid confusion.
