### PR TITLE
{Core} Remove azext_ai_did_you_mean_this from ALWAYS_LOADED_EXTENSIONS

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -35,7 +35,7 @@ EVENT_FAILED_EXTENSION_LOAD = 'MainLoader.OnFailedExtensionLoad'
 # Modules that will always be loaded. They don't expose commands but hook into CLI core.
 ALWAYS_LOADED_MODULES = []
 # Extensions that will always be loaded if installed. They don't expose commands but hook into CLI core.
-ALWAYS_LOADED_EXTENSIONS = ['azext_ai_examples', 'azext_ai_did_you_mean_this']
+ALWAYS_LOADED_EXTENSIONS = ['azext_ai_examples']
 
 
 class AzCli(CLI):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Remove `azext_ai_did_you_mean_this` from `ALWAYS_LOADED_EXTENSIONS` as it has been retired (https://github.com/Azure/azure-cli-extensions/pull/2402).
