### PR TITLE
{KeyVault} Fix a filter bug while deleting role assignments

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
@@ -201,11 +201,12 @@ def data_plane_azure_keyvault_administration_backup_client(cli_ctx, command_args
     version = str(get_api_version(cli_ctx, ResourceType.DATA_KEYVAULT_ADMINISTRATION_BACKUP))
     profile = Profile(cli_ctx=cli_ctx)
     credential, _, _ = profile.get_login_credentials(resource='https://managedhsm.azure.net')
-    vault_url = command_args['hsm_name']
+    vault_url = \
+        command_args.get('hsm_name', None) or \
+        command_args.get('vault_base_url', None) or \
+        command_args.get('identifier', None)
     if not vault_url:
-        vault_url = command_args.get('vault_base_url', None)
-        if not vault_url:
-            raise RequiredArgumentMissingError('Please specify --hsm-name or --id')
+        raise RequiredArgumentMissingError('Please specify --hsm-name or --id')
     return KeyVaultBackupClient(
         vault_url=vault_url, credential=credential, api_version=version)
 
@@ -216,10 +217,11 @@ def data_plane_azure_keyvault_administration_access_control_client(cli_ctx, comm
     version = str(get_api_version(cli_ctx, ResourceType.DATA_KEYVAULT_ADMINISTRATION_ACCESS_CONTROL))
     profile = Profile(cli_ctx=cli_ctx)
     credential, _, _ = profile.get_login_credentials(resource='https://managedhsm.azure.net')
-    vault_url = command_args.get('hsm_name', None)
+    vault_url = \
+        command_args.get('hsm_name', None) or \
+        command_args.get('vault_base_url', None) or \
+        command_args.get('identifier', None)
     if not vault_url:
-        vault_url = command_args.get('vault_base_url', None)
-        if not vault_url:
-            raise RequiredArgumentMissingError('Please specify --hsm-name or --id')
+        raise RequiredArgumentMissingError('Please specify --hsm-name or --id')
     return KeyVaultAccessControlClient(
         vault_url=vault_url, credential=credential, api_version=version)

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
@@ -6,6 +6,7 @@
 from enum import Enum
 from knack.util import CLIError
 
+from azure.cli.core.azclierror import RequiredArgumentMissingError
 from azure.cli.core.commands import CliCommandType
 from azure.cli.core.profiles import get_api_version, ResourceType
 from azure.cli.core._profile import Profile
@@ -202,7 +203,9 @@ def data_plane_azure_keyvault_administration_backup_client(cli_ctx, command_args
     credential, _, _ = profile.get_login_credentials(resource='https://managedhsm.azure.net')
     vault_url = command_args['hsm_name']
     if not vault_url:
-        vault_url = command_args['vault_base_url']
+        vault_url = command_args.get('vault_base_url', None)
+        if not vault_url:
+            raise RequiredArgumentMissingError('Please specify --hsm-name or --id')
     return KeyVaultBackupClient(
         vault_url=vault_url, credential=credential, api_version=version)
 
@@ -213,8 +216,10 @@ def data_plane_azure_keyvault_administration_access_control_client(cli_ctx, comm
     version = str(get_api_version(cli_ctx, ResourceType.DATA_KEYVAULT_ADMINISTRATION_ACCESS_CONTROL))
     profile = Profile(cli_ctx=cli_ctx)
     credential, _, _ = profile.get_login_credentials(resource='https://managedhsm.azure.net')
-    vault_url = command_args['hsm_name']
+    vault_url = command_args.get('hsm_name', None)
     if not vault_url:
-        vault_url = command_args['vault_base_url']
+        vault_url = command_args.get('vault_base_url', None)
+        if not vault_url:
+            raise RequiredArgumentMissingError('Please specify --hsm-name or --id')
     return KeyVaultAccessControlClient(
         vault_url=vault_url, credential=credential, api_version=version)

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -8,7 +8,6 @@ import base64
 import binascii
 from datetime import datetime
 import re
-import sys
 
 from enum import Enum
 from knack.deprecation import Deprecated
@@ -16,6 +15,7 @@ from knack.util import CLIError
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.validators import validate_tags
+from azure.cli.core.azclierror import RequiredArgumentMissingError
 
 
 secret_text_encoding_values = ['utf-8', 'utf-16le', 'utf-16be', 'ascii']
@@ -435,6 +435,13 @@ def validate_subnet(cmd, namespace):
         namespace.subnet = _construct_vnet(cmd, namespace.resource_group_name, vnet, subnet)
     else:
         raise CLIError('incorrect usage: [--subnet ID | --subnet NAME --vnet-name NAME]')
+
+
+def validate_role_assignment_args(ns):
+    if not any([ns.role_assignment_name, ns.scope, ns.assignee, ns.assignee_object_id, ns.role, ns.ids]):
+        raise RequiredArgumentMissingError(
+            'Please specify at least one of these parameters: '
+            '--name, --scope, --assignee, --assignee-object-id, --role, --ids')
 
 
 def validate_vault_or_hsm(ns):

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -8,6 +8,7 @@ import base64
 import binascii
 from datetime import datetime
 import re
+import sys
 
 from enum import Enum
 from knack.deprecation import Deprecated

--- a/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
@@ -17,7 +17,7 @@ from azure.cli.command_modules.keyvault._transformers import (
 
 from azure.cli.command_modules.keyvault._validators import (
     process_secret_set_namespace, process_certificate_cancel_namespace,
-    validate_private_endpoint_connection_id)
+    validate_private_endpoint_connection_id, validate_role_assignment_args)
 
 
 def transform_assignment_list(result):
@@ -273,7 +273,7 @@ def load_command_table(self, _):
             pass
 
         with self.command_group('keyvault role assignment', data_access_control_entity.command_type) as g:
-            g.keyvault_custom('delete', 'delete_role_assignment')
+            g.keyvault_custom('delete', 'delete_role_assignment', validator=validate_role_assignment_args)
             g.keyvault_custom('list', 'list_role_assignments', table_transformer=transform_assignment_list)
             g.keyvault_custom('create', 'create_role_assignment')
 


### PR DESCRIPTION
When running `az keyvault role assignment delete --hsm-name xxx`, CLI will delete all assignments under that HSM without any confirmation. This is really user-unfriendly.

New behavior: throw an actionable error like this:
`RequiredArgumentMissingError: Please specify at least one of these parameters: --name, --scope, --assignee, --assignee-object-id, --role, --ids`

In addition, this PR fixed a validation bug within track 2 data-plane clients creation.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
