### PR TITLE
[ARM] `az deployment`: Fix parse errors with multiline strings

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -501,15 +501,15 @@ def read_file_content(file_path, allow_binary=False):
     raise CLIError('Failed to decode file {} - unknown decoding'.format(file_path))
 
 
-def shell_safe_json_parse(json_or_dict_string, preserve_order=False):
+def shell_safe_json_parse(json_or_dict_string, preserve_order=False, strict=True):
     """ Allows the passing of JSON or Python dictionary strings. This is needed because certain
     JSON strings in CMD shell are not received in main's argv. This allows the user to specify
     the alternative notation, which does not have this problem (but is technically not JSON). """
     try:
         if not preserve_order:
-            return json.loads(json_or_dict_string)
+            return json.loads(json_or_dict_string, strict=strict)
         from collections import OrderedDict
-        return json.loads(json_or_dict_string, object_pairs_hook=OrderedDict)
+        return json.loads(json_or_dict_string, object_pairs_hook=OrderedDict, strict=strict)
     except ValueError as json_ex:
         try:
             import ast

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -275,10 +275,8 @@ def _remove_comments_from_json(template, preserve_order=True, file_path=None):
     # It will affect the subsequent multi-line processing logic, so deal with this situation in advance here.
     template = re.sub(r'(^[\t ]*//[\s\S]*?\n)|(^[\t ]*/\*{1,2}[\s\S]*?\*/)', '', template, flags=re.M)
     minified = jsmin(template)
-    # Get rid of multi-line strings. Note, we are not sending it on the wire rather just extract parameters to prompt for values
-    result = re.sub(r'"[^"]*?\n[^"]*?(?<!\\)"', '"#Azure Cli#"', minified, re.DOTALL)
     try:
-        return shell_safe_json_parse(result, preserve_order)
+        return shell_safe_json_parse(minified, preserve_order, strict=False) # use strict=False to allow multiline strings
     except CLIError:
         # Because the processing of removing comments and compression will lead to misplacement of error location,
         # so the error message should be wrapped.

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -276,7 +276,7 @@ def _remove_comments_from_json(template, preserve_order=True, file_path=None):
     template = re.sub(r'(^[\t ]*//[\s\S]*?\n)|(^[\t ]*/\*{1,2}[\s\S]*?\*/)', '', template, flags=re.M)
     minified = jsmin(template)
     try:
-        return shell_safe_json_parse(minified, preserve_order, strict=False) # use strict=False to allow multiline strings
+        return shell_safe_json_parse(minified, preserve_order, strict=False)  # use strict=False to allow multiline strings
     except CLIError:
         # Because the processing of removing comments and compression will lead to misplacement of error location,
         # so the error message should be wrapped.

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_resource_group_deployment.yaml
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_resource_group_deployment.yaml
@@ -1,24 +1,24 @@
 interactions:
 - request:
-    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"},
-      \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\",
-      template:{\r\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n
-      \ \"contentVersion\": \"1.0.0.0\",\r\n  \"parameters\": {\r\n    \"location\":
-      {\r\n      \"type\": \"string\",\r\n      \"defaultValue\": \"[resourceGroup().location]\",\r\n
-      \     \"metadata\": {\r\n        \"description\": \"Location for the network
-      security group.\"\r\n      }\r\n    },\r\n    \"name\": {\r\n      \"type\":
-      \"string\",\r\n      \"metadata\": {\r\n        \"description\": \"Name of the
-      network security group.\"\r\n      }\r\n    }\r\n  },\r\n  \"variables\": {\r\n
-      \ },\r\n  \"resources\": [\r\n    {\r\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n
-      \     \"name\": \"[parameters('name')]\",\r\n      \"apiVersion\": \"2015-06-15\",\r\n
-      \     \"location\": \"[parameters('location')]\",\r\n      \"properties\": {\r\n
-      \       \"securityRules\": [\r\n        ]\r\n      },\r\n      \"dependsOn\":
-      [ ]\r\n    }\r\n  ],\r\n  \"outputs\": {\r\n    \"NewNSG\": {\r\n      /** comment1\r\n
-      \         comment2\r\n          comment3\r\n      **/\r\n      // comment\r\n
-      \     /** comment **/\r\n      \"type\": \"object\", /** comment **/\r\n      \"value\":
-      \"[reference(parameters('name'))]\" // comment\r\n      // comment\r\n      /**
-      comment **/\r\n      /** comment1\r\n          comment2\r\n          comment3\r\n
-      \     **/\r\n    }\r\n  } // comment\r\n}\r\n}}"
+    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"\
+      }, \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\"\
+      , template:{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\"\
+      ,\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"location\"\
+      : {\n      \"type\": \"string\",\n      \"defaultValue\": \"[resourceGroup().location]\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Location for the network\
+      \ security group.\"\n      }\n    },\n    \"name\": {\n      \"type\": \"string\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Name of the network security\
+      \ group.\"\n      }\n    }\n  },\n  \"variables\": {\n  },\n  \"resources\"\
+      : [\n    {\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\n \
+      \     \"name\": \"[parameters('name')]\",\n      \"apiVersion\": \"2015-06-15\"\
+      ,\n      \"location\": \"[parameters('location')]\",\n      \"properties\":\
+      \ {\n        \"securityRules\": [\n        ]\n      },\n      \"dependsOn\"\
+      : [ ]\n    }\n  ],\n  \"outputs\": {\n    \"NewNSG\": {\n      /** comment1\n\
+      \          comment2\n          comment3\n      **/\n      // comment\n     \
+      \ /** comment **/\n      \"type\": \"object\", /** comment **/\n      \"value\"\
+      : \"[reference(parameters('name'))]\" // comment\n      // comment\n      /**\
+      \ comment **/\n      /** comment1\n          comment2\n          comment3\n\
+      \      **/\n    }\n  } // comment\n}\n}}"
     headers:
       Accept:
       - application/json
@@ -29,30 +29,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1368'
+      - '1316'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --resource-group --template-file --parameters
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/simple_deploy","name":"simple_deploy","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-11-13T05:21:57.7635198Z","duration":"PT0S","correlationId":"83329ea9-e304-4f66-a35f-39b93616fe4a","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/simple_deploy","name":"simple_deploy","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-12-15T11:01:40.406556Z","duration":"PT0S","correlationId":"a61a783f-508c-4f98-9a59-953c6ee166b1","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1016'
+      - '1015'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:21:57 GMT
+      - Tue, 15 Dec 2020 11:01:40 GMT
       expires:
       - '-1'
       pragma:
@@ -71,42 +71,46 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "{\"properties\": {\"parameters\": {}, \"mode\": \"Incremental\", template:{\r\n
-      \   \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n
-      \   \"contentVersion\": \"1.0.0.0\",\r\n    \"parameters\": {\r\n    },\r\n
-      \   \"variables\": {\r\n        \"alertLocation\": \"japaneast\",\r\n        \"alertName\":
-      \"armtemplate-alert-japanese-utf8\",\r\n        \"alertDescription\": \"\u3053\u3053\u306B\u65E5\u672C\u8A9E\u3067\u8AAC\u660E\u3057\u307E\u3059\u3002\",\r\n
-      \       \"alertStatus\": \"true\",\r\n        \"alertSource\": {\r\n            \"Query\":
-      \"requests\",\r\n            \"SourceId\": \"/subscriptions/{subscriptionId}/resourceGroups/test-rg/providers/microsoft.insights/components/my-insight\",\r\n
-      \           \"Type\": \"ResultCount\"\r\n        },\r\n        \"alertSchedule\":
-      {\r\n            \"Frequency\": 15,\r\n            \"Time\": 60\r\n        },\r\n
-      \       \"alertActions\": {\r\n            \"SeverityLevel\": \"3\"\r\n        },\r\n
-      \       \"alertTrigger\": {\r\n            \"Operator\": \"GreaterThan\",\r\n
-      \           \"Threshold\": \"50\"\r\n        },\r\n        \"actionGrp\": {\r\n
-      \           \"ActionGroup\": \"/subscriptions/{subscriptionId}/resourcegroups/default-activitylogalerts/providers/microsoft.insights/actiongroups/send-email\",\r\n
-      \           \"Subject\": \"Customized Email Header\",\r\n            \"Webhook\":
-      \"{ \\\"alertname\\\":\\\"#alertrulename\\\", \\\"IncludeSearchResults\\\":true
-      }\"\r\n        }\r\n    },\r\n    \"resources\": [\r\n        {\r\n            \"name\":
-      \"[variables('alertName')]\",\r\n            \"type\": \"Microsoft.Insights/scheduledQueryRules\",\r\n
-      \           \"apiVersion\": \"2018-04-16\",\r\n            \"location\": \"[variables('alertLocation')]\",\r\n
-      \           \"properties\": {\r\n                \"description\": \"[variables('alertDescription')]\",\r\n
-      \               \"enabled\": \"[variables('alertStatus')]\",\r\n                \"source\":
-      {\r\n                    \"query\": \"[variables('alertSource').Query]\",\r\n
-      \                   \"dataSourceId\": \"[variables('alertSource').SourceId]\",\r\n
-      \                   \"queryType\": \"[variables('alertSource').Type]\"\r\n                },\r\n
-      \               \"schedule\": {\r\n                    \"frequencyInMinutes\":
-      \"[variables('alertSchedule').Frequency]\",\r\n                    \"timeWindowInMinutes\":
-      \"[variables('alertSchedule').Time]\"\r\n                },\r\n                \"action\":
-      {\r\n                    \"odata.type\": \"Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction\",\r\n
-      \                   \"severity\": \"[variables('alertActions').SeverityLevel]\",\r\n
-      \                   \"aznsAction\": {\r\n                        \"actionGroup\":
-      \"[array(variables('actionGrp').ActionGroup)]\",\r\n                        \"emailSubject\":
-      \"[variables('actionGrp').Subject]\",\r\n                        \"customWebhookPayload\":
-      \"[variables('actionGrp').Webhook]\"\r\n                    },\r\n                    \"trigger\":
-      {\r\n                        \"thresholdOperator\": \"[variables('alertTrigger').Operator]\",\r\n
-      \                       \"threshold\": \"[variables('alertTrigger').Threshold]\"\r\n
-      \                   }\r\n                }\r\n            }\r\n        }\r\n
-      \   ]\r\n}}}"
+    body: "{\"properties\": {\"parameters\": {}, \"mode\": \"Incremental\", template:{\n\
+      \    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\"\
+      ,\n    \"contentVersion\": \"1.0.0.0\",\n    \"parameters\": {\n    },\n   \
+      \ \"variables\": {\n        \"alertLocation\": \"japaneast\",\n        \"alertName\"\
+      : \"armtemplate-alert-japanese-utf8\",\n        \"alertDescription\": \"\u3053\
+      \u3053\u306B\u65E5\u672C\u8A9E\u3067\u8AAC\u660E\u3057\u307E\u3059\u3002\",\n\
+      \        \"alertStatus\": \"true\",\n        \"alertSource\": {\n          \
+      \  \"Query\": \"requests\",\n            \"SourceId\": \"/subscriptions/{subscriptionId}/resourceGroups/test-rg/providers/microsoft.insights/components/my-insight\"\
+      ,\n            \"Type\": \"ResultCount\"\n        },\n        \"alertSchedule\"\
+      : {\n            \"Frequency\": 15,\n            \"Time\": 60\n        },\n\
+      \        \"alertActions\": {\n            \"SeverityLevel\": \"3\"\n       \
+      \ },\n        \"alertTrigger\": {\n            \"Operator\": \"GreaterThan\"\
+      ,\n            \"Threshold\": \"50\"\n        },\n        \"actionGrp\": {\n\
+      \            \"ActionGroup\": \"/subscriptions/{subscriptionId}/resourcegroups/default-activitylogalerts/providers/microsoft.insights/actiongroups/send-email\"\
+      ,\n            \"Subject\": \"Customized Email Header\",\n            \"Webhook\"\
+      : \"{ \\\"alertname\\\":\\\"#alertrulename\\\", \\\"IncludeSearchResults\\\"\
+      :true }\"\n        }\n    },\n    \"resources\": [\n        {\n            \"\
+      name\": \"[variables('alertName')]\",\n            \"type\": \"Microsoft.Insights/scheduledQueryRules\"\
+      ,\n            \"apiVersion\": \"2018-04-16\",\n            \"location\": \"\
+      [variables('alertLocation')]\",\n            \"properties\": {\n           \
+      \     \"description\": \"[variables('alertDescription')]\",\n              \
+      \  \"enabled\": \"[variables('alertStatus')]\",\n                \"source\"\
+      : {\n                    \"query\": \"[variables('alertSource').Query]\",\n\
+      \                    \"dataSourceId\": \"[variables('alertSource').SourceId]\"\
+      ,\n                    \"queryType\": \"[variables('alertSource').Type]\"\n\
+      \                },\n                \"schedule\": {\n                    \"\
+      frequencyInMinutes\": \"[variables('alertSchedule').Frequency]\",\n        \
+      \            \"timeWindowInMinutes\": \"[variables('alertSchedule').Time]\"\n\
+      \                },\n                \"action\": {\n                    \"odata.type\"\
+      : \"Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction\"\
+      ,\n                    \"severity\": \"[variables('alertActions').SeverityLevel]\"\
+      ,\n                    \"aznsAction\": {\n                        \"actionGroup\"\
+      : \"[array(variables('actionGrp').ActionGroup)]\",\n                       \
+      \ \"emailSubject\": \"[variables('actionGrp').Subject]\",\n                \
+      \        \"customWebhookPayload\": \"[variables('actionGrp').Webhook]\"\n  \
+      \                  },\n                    \"trigger\": {\n                \
+      \        \"thresholdOperator\": \"[variables('alertTrigger').Operator]\",\n\
+      \                        \"threshold\": \"[variables('alertTrigger').Threshold]\"\
+      \n                    }\n                }\n            }\n        }\n    ]\n\
+      }}}"
     headers:
       Accept:
       - application/json
@@ -117,21 +121,21 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3060'
+      - '2994'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --resource-group --template-file
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/Japanese-characters-template","name":"Japanese-characters-template","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1888782782781528452","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-11-13T05:21:59.9083459Z","duration":"PT0S","correlationId":"19bc3f57-0c15-43e7-a92c-9ff9d6ac6956","providers":[{"namespace":"Microsoft.Insights","resourceTypes":[{"resourceType":"scheduledQueryRules","locations":["japaneast"]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Insights/scheduledQueryRules/armtemplate-alert-japanese-utf8"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/Japanese-characters-template","name":"Japanese-characters-template","type":"Microsoft.Resources/deployments","properties":{"templateHash":"1888782782781528452","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-12-15T11:01:43.4711613Z","duration":"PT0S","correlationId":"10468c6b-b206-463b-a137-087d36f22b45","providers":[{"namespace":"Microsoft.Insights","resourceTypes":[{"resourceType":"scheduledQueryRules","locations":["japaneast"]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Insights/scheduledQueryRules/armtemplate-alert-japanese-utf8"}]}}'
     headers:
       cache-control:
       - no-cache
@@ -140,7 +144,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:21:59 GMT
+      - Tue, 15 Dec 2020 11:01:43 GMT
       expires:
       - '-1'
       pragma:
@@ -159,27 +163,27 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"},
-      \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\",
-      template:{\r\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n
-      \ \"contentVersion\": \"1.0.0.0\",\r\n  \"parameters\": {\r\n    \"location\":
-      {\r\n      \"type\": \"string\",\r\n      \"defaultValue\": \"[resourceGroup().location]\",\r\n
-      \     \"metadata\": {\r\n        \"description\": \"Location for the network
-      security group.\"\r\n      }\r\n    },\r\n    \"name\": {\r\n      \"type\":
-      \"string\",\r\n      \"metadata\": {\r\n        \"description\": \"Name of the
-      network security group.\"\r\n      }\r\n    },\r\n    \"extra_param\": {\r\n
-      \     \"type\": \"string\",\r\n      \"metadata\": {\r\n        \"description\":
-      \"Useless redundant parameters.\"\r\n      }\r\n    }\r\n  },\r\n  \"variables\":
-      {\r\n  },\r\n  \"resources\": [\r\n    {\r\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n
-      \     \"name\": \"[parameters('name')]\",\r\n      \"apiVersion\": \"2015-06-15\",\r\n
-      \     \"location\": \"[parameters('location')]\",\r\n      \"properties\": {\r\n
-      \       \"securityRules\": [\r\n        ]\r\n      },\r\n      \"dependsOn\":
-      [ ]\r\n    }\r\n  ],\r\n  \"outputs\": {\r\n    \"NewNSG\": {\r\n      /** comment1\r\n
-      \         comment2\r\n          comment3\r\n      **/\r\n      // comment\r\n
-      \     /** comment **/\r\n      \"type\": \"object\", /** comment **/\r\n      \"value\":
-      \"[reference(parameters('name'))]\" // comment\r\n      // comment\r\n      /**
-      comment **/\r\n      /** comment1\r\n          comment2\r\n          comment3\r\n
-      \     **/\r\n    }\r\n  } // comment\r\n}\r\n}}"
+    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"\
+      }, \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\"\
+      , template:{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\"\
+      ,\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"location\"\
+      : {\n      \"type\": \"string\",\n      \"defaultValue\": \"[resourceGroup().location]\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Location for the \n   \
+      \     network security group.\"\n      }\n    },\n    \"name\": {\n      \"\
+      type\": \"string\",\n      \"metadata\": {\n        \"description\": \"\n  \
+      \                              string username = \\\"UNKNOWN\\\";\\r\\n\n  \
+      \                  \"\n      }\n    }\n  },\n  \"variables\": {\n  },\n  \"\
+      resources\": [\n    {\n      \"type\": \"Microsoft.Network/networkSecurityGroups\"\
+      ,\n      \"name\": \"[parameters('name')]\",\n      \"apiVersion\": \"2015-06-15\"\
+      ,\n      \"location\": \"[parameters('location')]\",\n      \"properties\":\
+      \ {\n        \"securityRules\": [\n        ]\n      },\n      \"dependsOn\"\
+      : [ ]\n    }\n  ],\n  \"outputs\": {\n    \"Empty\": {\n        \"type\": \"\
+      string\",\n        \"value\": \"\"\n    },\n    \"NewNSG\": {\n      /** comment1\n\
+      \          comment2\n          comment3\n      **/\n      // comment\n     \
+      \ /** comment **/\n      \"type\": \"object\", /** comment **/\n      \"value\"\
+      : \"[reference(parameters('name'))]\" // comment\n      // comment\n      /**\
+      \ comment **/\n      /** comment1\n          comment2\n          comment3\n\
+      \      **/\n    }\n  } // comment\n}\n}}"
     headers:
       Accept:
       - application/json
@@ -190,14 +194,87 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1509'
+      - '1446'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group --template-file --parameters
+      User-Agent:
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/simple_deploy_multiline","name":"simple_deploy_multiline","type":"Microsoft.Resources/deployments","properties":{"templateHash":"400053918026971351","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-12-15T11:01:46.4876517Z","duration":"PT0S","correlationId":"ad773241-b2d1-4350-be6e-67e9b891bfd7","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1034'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 11:01:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"\
+      }, \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\"\
+      , template:{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\"\
+      ,\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"location\"\
+      : {\n      \"type\": \"string\",\n      \"defaultValue\": \"[resourceGroup().location]\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Location for the network\
+      \ security group.\"\n      }\n    },\n    \"name\": {\n      \"type\": \"string\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Name of the network security\
+      \ group.\"\n      }\n    },\n    \"extra_param\": {\n      \"type\": \"string\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Useless redundant parameters.\"\
+      \n      }\n    }\n  },\n  \"variables\": {\n  },\n  \"resources\": [\n    {\n\
+      \      \"type\": \"Microsoft.Network/networkSecurityGroups\",\n      \"name\"\
+      : \"[parameters('name')]\",\n      \"apiVersion\": \"2015-06-15\",\n      \"\
+      location\": \"[parameters('location')]\",\n      \"properties\": {\n       \
+      \ \"securityRules\": [\n        ]\n      },\n      \"dependsOn\": [ ]\n    }\n\
+      \  ],\n  \"outputs\": {\n    \"NewNSG\": {\n      /** comment1\n          comment2\n\
+      \          comment3\n      **/\n      // comment\n      /** comment **/\n  \
+      \    \"type\": \"object\", /** comment **/\n      \"value\": \"[reference(parameters('name'))]\"\
+      \ // comment\n      // comment\n      /** comment **/\n      /** comment1\n\
+      \          comment2\n          comment3\n      **/\n    }\n  } // comment\n\
+      }\n}}"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - deployment group validate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1451'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --resource-group --template-file --parameters --no-prompt
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
@@ -216,7 +293,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:01 GMT
+      - Tue, 15 Dec 2020 11:01:49 GMT
       expires:
       - '-1'
       pragma:
@@ -233,25 +310,25 @@ interactions:
       code: 400
       message: Bad Request
 - request:
-    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"},
-      \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\",
-      template:{\r\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n
-      \ \"contentVersion\": \"1.0.0.0\",\r\n  \"parameters\": {\r\n    \"location\":
-      {\r\n      \"type\": \"string\",\r\n      \"defaultValue\": \"[resourceGroup().location]\",\r\n
-      \     \"metadata\": {\r\n        \"description\": \"Location for the network
-      security group.\"\r\n      }\r\n    },\r\n    \"name\": {\r\n      \"type\":
-      \"string\",\r\n      \"metadata\": {\r\n        \"description\": \"Name of the
-      network security group.\"\r\n      }\r\n    }\r\n  },\r\n  \"variables\": {\r\n
-      \ },\r\n  \"resources\": [\r\n    {\r\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n
-      \     \"name\": \"[parameters('name')]\",\r\n      \"apiVersion\": \"2015-06-15\",\r\n
-      \     \"location\": \"[parameters('location')]\",\r\n      \"properties\": {\r\n
-      \       \"securityRules\": [\r\n        ]\r\n      },\r\n      \"dependsOn\":
-      [ ]\r\n    }\r\n  ],\r\n  \"outputs\": {\r\n    \"NewNSG\": {\r\n      /** comment1\r\n
-      \         comment2\r\n          comment3\r\n      **/\r\n      // comment\r\n
-      \     /** comment **/\r\n      \"type\": \"object\", /** comment **/\r\n      \"value\":
-      \"[reference(parameters('name'))]\" // comment\r\n      // comment\r\n      /**
-      comment **/\r\n      /** comment1\r\n          comment2\r\n          comment3\r\n
-      \     **/\r\n    }\r\n  } // comment\r\n}\r\n}}"
+    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"\
+      }, \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\"\
+      , template:{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\"\
+      ,\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"location\"\
+      : {\n      \"type\": \"string\",\n      \"defaultValue\": \"[resourceGroup().location]\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Location for the network\
+      \ security group.\"\n      }\n    },\n    \"name\": {\n      \"type\": \"string\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Name of the network security\
+      \ group.\"\n      }\n    }\n  },\n  \"variables\": {\n  },\n  \"resources\"\
+      : [\n    {\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\n \
+      \     \"name\": \"[parameters('name')]\",\n      \"apiVersion\": \"2015-06-15\"\
+      ,\n      \"location\": \"[parameters('location')]\",\n      \"properties\":\
+      \ {\n        \"securityRules\": [\n        ]\n      },\n      \"dependsOn\"\
+      : [ ]\n    }\n  ],\n  \"outputs\": {\n    \"NewNSG\": {\n      /** comment1\n\
+      \          comment2\n          comment3\n      **/\n      // comment\n     \
+      \ /** comment **/\n      \"type\": \"object\", /** comment **/\n      \"value\"\
+      : \"[reference(parameters('name'))]\" // comment\n      // comment\n      /**\
+      \ comment **/\n      /** comment1\n          comment2\n          comment3\n\
+      \      **/\n    }\n  } // comment\n}\n}}"
     headers:
       Accept:
       - application/json
@@ -262,30 +339,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1368'
+      - '1316'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --resource-group -n --template-file --parameters
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-11-13T05:22:03.042067Z","duration":"PT0S","correlationId":"8c9e817b-da63-4652-879f-128edbe0c089","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-12-15T11:01:52.2921622Z","duration":"PT0S","correlationId":"5fdc770c-279b-48ec-a9f8-89fbcca66ac5","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1109'
+      - '1110'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:02 GMT
+      - Tue, 15 Dec 2020 11:01:52 GMT
       expires:
       - '-1'
       pragma:
@@ -299,30 +376,30 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 200
       message: OK
 - request:
-    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"},
-      \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\",
-      template:{\r\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n
-      \ \"contentVersion\": \"1.0.0.0\",\r\n  \"parameters\": {\r\n    \"location\":
-      {\r\n      \"type\": \"string\",\r\n      \"defaultValue\": \"[resourceGroup().location]\",\r\n
-      \     \"metadata\": {\r\n        \"description\": \"Location for the network
-      security group.\"\r\n      }\r\n    },\r\n    \"name\": {\r\n      \"type\":
-      \"string\",\r\n      \"metadata\": {\r\n        \"description\": \"Name of the
-      network security group.\"\r\n      }\r\n    }\r\n  },\r\n  \"variables\": {\r\n
-      \ },\r\n  \"resources\": [\r\n    {\r\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n
-      \     \"name\": \"[parameters('name')]\",\r\n      \"apiVersion\": \"2015-06-15\",\r\n
-      \     \"location\": \"[parameters('location')]\",\r\n      \"properties\": {\r\n
-      \       \"securityRules\": [\r\n        ]\r\n      },\r\n      \"dependsOn\":
-      [ ]\r\n    }\r\n  ],\r\n  \"outputs\": {\r\n    \"NewNSG\": {\r\n      /** comment1\r\n
-      \         comment2\r\n          comment3\r\n      **/\r\n      // comment\r\n
-      \     /** comment **/\r\n      \"type\": \"object\", /** comment **/\r\n      \"value\":
-      \"[reference(parameters('name'))]\" // comment\r\n      // comment\r\n      /**
-      comment **/\r\n      /** comment1\r\n          comment2\r\n          comment3\r\n
-      \     **/\r\n    }\r\n  } // comment\r\n}\r\n}}"
+    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"\
+      }, \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\"\
+      , template:{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\"\
+      ,\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"location\"\
+      : {\n      \"type\": \"string\",\n      \"defaultValue\": \"[resourceGroup().location]\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Location for the network\
+      \ security group.\"\n      }\n    },\n    \"name\": {\n      \"type\": \"string\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Name of the network security\
+      \ group.\"\n      }\n    }\n  },\n  \"variables\": {\n  },\n  \"resources\"\
+      : [\n    {\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\n \
+      \     \"name\": \"[parameters('name')]\",\n      \"apiVersion\": \"2015-06-15\"\
+      ,\n      \"location\": \"[parameters('location')]\",\n      \"properties\":\
+      \ {\n        \"securityRules\": [\n        ]\n      },\n      \"dependsOn\"\
+      : [ ]\n    }\n  ],\n  \"outputs\": {\n    \"NewNSG\": {\n      /** comment1\n\
+      \          comment2\n          comment3\n      **/\n      // comment\n     \
+      \ /** comment **/\n      \"type\": \"object\", /** comment **/\n      \"value\"\
+      : \"[reference(parameters('name'))]\" // comment\n      // comment\n      /**\
+      \ comment **/\n      /** comment1\n          comment2\n          comment3\n\
+      \      **/\n    }\n  } // comment\n}\n}}"
     headers:
       Accept:
       - application/json
@@ -333,24 +410,24 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1368'
+      - '1316'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --resource-group -n --template-file --parameters
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-11-13T05:22:06.5687926Z","duration":"PT2.3472306S","correlationId":"aac17ccc-e0c2-4f62-8db7-97fad1fb7f3d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-12-15T11:01:56.3258988Z","duration":"PT2.3885872S","correlationId":"d582f726-10e7-4846-9ff7-3e0128fc716b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002/operationStatuses/08585963619612560590?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002/operationStatuses/08585935767715403063?api-version=2020-06-01
       cache-control:
       - no-cache
       content-length:
@@ -358,7 +435,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:07 GMT
+      - Tue, 15 Dec 2020 11:01:57 GMT
       expires:
       - '-1'
       pragma:
@@ -386,10 +463,10 @@ interactions:
       ParameterSetName:
       - --resource-group -n --template-file --parameters
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585963619612560590?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585935767715403063?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -401,7 +478,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:38 GMT
+      - Tue, 15 Dec 2020 11:02:28 GMT
       expires:
       - '-1'
       pragma:
@@ -429,18 +506,18 @@ interactions:
       ParameterSetName:
       - --resource-group -n --template-file --parameters
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-11-13T05:22:19.4887606Z","duration":"PT15.2671986S","correlationId":"aac17ccc-e0c2-4f62-8db7-97fad1fb7f3d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"newNSG":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"b187f3b7-352a-4283-9811-675e2f69be7d","securityRules":[],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
-        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-12-15T11:02:25.1670782Z","duration":"PT31.2297666S","correlationId":"d582f726-10e7-4846-9ff7-3e0128fc716b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"newNSG":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"94843159-895d-455b-a9f0-5bf090fdf5da","securityRules":[],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
         all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}]}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}'
     headers:
       cache-control:
@@ -450,7 +527,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:39 GMT
+      - Tue, 15 Dec 2020 11:02:28 GMT
       expires:
       - '-1'
       pragma:
@@ -465,27 +542,27 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"},
-      \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\",
-      template:{\r\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n
-      \ \"contentVersion\": \"1.0.0.0\",\r\n  \"parameters\": {\r\n    \"location\":
-      {\r\n      \"type\": \"string\",\r\n      \"defaultValue\": \"[resourceGroup().location]\",\r\n
-      \     \"metadata\": {\r\n        \"description\": \"Location for the network
-      security group.\"\r\n      }\r\n    },\r\n    \"name\": {\r\n      \"type\":
-      \"string\",\r\n      \"metadata\": {\r\n        \"description\": \"Name of the
-      network security group.\"\r\n      }\r\n    },\r\n    \"extra_param\": {\r\n
-      \     \"type\": \"string\",\r\n      \"metadata\": {\r\n        \"description\":
-      \"Useless redundant parameters.\"\r\n      }\r\n    }\r\n  },\r\n  \"variables\":
-      {\r\n  },\r\n  \"resources\": [\r\n    {\r\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n
-      \     \"name\": \"[parameters('name')]\",\r\n      \"apiVersion\": \"2015-06-15\",\r\n
-      \     \"location\": \"[parameters('location')]\",\r\n      \"properties\": {\r\n
-      \       \"securityRules\": [\r\n        ]\r\n      },\r\n      \"dependsOn\":
-      [ ]\r\n    }\r\n  ],\r\n  \"outputs\": {\r\n    \"NewNSG\": {\r\n      /** comment1\r\n
-      \         comment2\r\n          comment3\r\n      **/\r\n      // comment\r\n
-      \     /** comment **/\r\n      \"type\": \"object\", /** comment **/\r\n      \"value\":
-      \"[reference(parameters('name'))]\" // comment\r\n      // comment\r\n      /**
-      comment **/\r\n      /** comment1\r\n          comment2\r\n          comment3\r\n
-      \     **/\r\n    }\r\n  } // comment\r\n}\r\n}}"
+    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"\
+      }, \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\"\
+      , template:{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\"\
+      ,\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"location\"\
+      : {\n      \"type\": \"string\",\n      \"defaultValue\": \"[resourceGroup().location]\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Location for the \n   \
+      \     network security group.\"\n      }\n    },\n    \"name\": {\n      \"\
+      type\": \"string\",\n      \"metadata\": {\n        \"description\": \"\n  \
+      \                              string username = \\\"UNKNOWN\\\";\\r\\n\n  \
+      \                  \"\n      }\n    }\n  },\n  \"variables\": {\n  },\n  \"\
+      resources\": [\n    {\n      \"type\": \"Microsoft.Network/networkSecurityGroups\"\
+      ,\n      \"name\": \"[parameters('name')]\",\n      \"apiVersion\": \"2015-06-15\"\
+      ,\n      \"location\": \"[parameters('location')]\",\n      \"properties\":\
+      \ {\n        \"securityRules\": [\n        ]\n      },\n      \"dependsOn\"\
+      : [ ]\n    }\n  ],\n  \"outputs\": {\n    \"Empty\": {\n        \"type\": \"\
+      string\",\n        \"value\": \"\"\n    },\n    \"NewNSG\": {\n      /** comment1\n\
+      \          comment2\n          comment3\n      **/\n      // comment\n     \
+      \ /** comment **/\n      \"type\": \"object\", /** comment **/\n      \"value\"\
+      : \"[reference(parameters('name'))]\" // comment\n      // comment\n      /**\
+      \ comment **/\n      /** comment1\n          comment2\n          comment3\n\
+      \      **/\n    }\n  } // comment\n}\n}}"
     headers:
       Accept:
       - application/json
@@ -496,14 +573,254 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1509'
+      - '1446'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group -n --template-file --parameters
+      User-Agent:
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"400053918026971351","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-12-15T11:02:32.113858Z","duration":"PT0S","correlationId":"3bf5ace0-508e-4114-bccf-4f4636cae1ba","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 11:02:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"\
+      }, \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\"\
+      , template:{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\"\
+      ,\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"location\"\
+      : {\n      \"type\": \"string\",\n      \"defaultValue\": \"[resourceGroup().location]\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Location for the \n   \
+      \     network security group.\"\n      }\n    },\n    \"name\": {\n      \"\
+      type\": \"string\",\n      \"metadata\": {\n        \"description\": \"\n  \
+      \                              string username = \\\"UNKNOWN\\\";\\r\\n\n  \
+      \                  \"\n      }\n    }\n  },\n  \"variables\": {\n  },\n  \"\
+      resources\": [\n    {\n      \"type\": \"Microsoft.Network/networkSecurityGroups\"\
+      ,\n      \"name\": \"[parameters('name')]\",\n      \"apiVersion\": \"2015-06-15\"\
+      ,\n      \"location\": \"[parameters('location')]\",\n      \"properties\":\
+      \ {\n        \"securityRules\": [\n        ]\n      },\n      \"dependsOn\"\
+      : [ ]\n    }\n  ],\n  \"outputs\": {\n    \"Empty\": {\n        \"type\": \"\
+      string\",\n        \"value\": \"\"\n    },\n    \"NewNSG\": {\n      /** comment1\n\
+      \          comment2\n          comment3\n      **/\n      // comment\n     \
+      \ /** comment **/\n      \"type\": \"object\", /** comment **/\n      \"value\"\
+      : \"[reference(parameters('name'))]\" // comment\n      // comment\n      /**\
+      \ comment **/\n      /** comment1\n          comment2\n          comment3\n\
+      \      **/\n    }\n  } // comment\n}\n}}"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - deployment group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1446'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group -n --template-file --parameters
+      User-Agent:
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"400053918026971351","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-12-15T11:02:36.3784283Z","duration":"PT2.1576892S","correlationId":"f802ab6c-d891-47f2-ba45-857cde559064","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002/operationStatuses/08585935767312568738?api-version=2020-06-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '863'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 11:02:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - deployment group create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group -n --template-file --parameters
+      User-Agent:
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585935767312568738?api-version=2020-06-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 11:03:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - deployment group create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group -n --template-file --parameters
+      User-Agent:
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"400053918026971351","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-12-15T11:02:52.2896026Z","duration":"PT18.0688635S","correlationId":"f802ab6c-d891-47f2-ba45-857cde559064","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"empty":{"type":"String","value":""},"newNSG":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"94843159-895d-455b-a9f0-5bf090fdf5da","securityRules":[],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}]}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5612'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 11:03:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"\
+      }, \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\"\
+      , template:{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\"\
+      ,\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"location\"\
+      : {\n      \"type\": \"string\",\n      \"defaultValue\": \"[resourceGroup().location]\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Location for the network\
+      \ security group.\"\n      }\n    },\n    \"name\": {\n      \"type\": \"string\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Name of the network security\
+      \ group.\"\n      }\n    },\n    \"extra_param\": {\n      \"type\": \"string\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Useless redundant parameters.\"\
+      \n      }\n    }\n  },\n  \"variables\": {\n  },\n  \"resources\": [\n    {\n\
+      \      \"type\": \"Microsoft.Network/networkSecurityGroups\",\n      \"name\"\
+      : \"[parameters('name')]\",\n      \"apiVersion\": \"2015-06-15\",\n      \"\
+      location\": \"[parameters('location')]\",\n      \"properties\": {\n       \
+      \ \"securityRules\": [\n        ]\n      },\n      \"dependsOn\": [ ]\n    }\n\
+      \  ],\n  \"outputs\": {\n    \"NewNSG\": {\n      /** comment1\n          comment2\n\
+      \          comment3\n      **/\n      // comment\n      /** comment **/\n  \
+      \    \"type\": \"object\", /** comment **/\n      \"value\": \"[reference(parameters('name'))]\"\
+      \ // comment\n      // comment\n      /** comment **/\n      /** comment1\n\
+      \          comment2\n          comment3\n      **/\n    }\n  } // comment\n\
+      }\n}}"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - deployment group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1451'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --resource-group -n --template-file --parameters --no-prompt
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
@@ -522,7 +839,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:39 GMT
+      - Tue, 15 Dec 2020 11:03:11 GMT
       expires:
       - '-1'
       pragma:
@@ -552,30 +869,30 @@ interactions:
       ParameterSetName:
       - --resource-group
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/?api-version=2020-06-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-11-13T05:22:19.4887606Z","duration":"PT15.2671986S","correlationId":"aac17ccc-e0c2-4f62-8db7-97fad1fb7f3d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"newNSG":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"b187f3b7-352a-4283-9811-675e2f69be7d","securityRules":[],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
-        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"400053918026971351","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-12-15T11:02:52.2896026Z","duration":"PT18.0688635S","correlationId":"f802ab6c-d891-47f2-ba45-857cde559064","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"empty":{"type":"String","value":""},"newNSG":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"94843159-895d-455b-a9f0-5bf090fdf5da","securityRules":[],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
         all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}]}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5589'
+      - '5624'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:41 GMT
+      - Tue, 15 Dec 2020 11:03:12 GMT
       expires:
       - '-1'
       pragma:
@@ -603,30 +920,30 @@ interactions:
       ParameterSetName:
       - --resource-group --filter
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/?$filter=provisioningState%20eq%20%27Succeeded%27&api-version=2020-06-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-11-13T05:22:19.4887606Z","duration":"PT15.2671986S","correlationId":"aac17ccc-e0c2-4f62-8db7-97fad1fb7f3d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"newNSG":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"b187f3b7-352a-4283-9811-675e2f69be7d","securityRules":[],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
-        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"400053918026971351","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-12-15T11:02:52.2896026Z","duration":"PT18.0688635S","correlationId":"f802ab6c-d891-47f2-ba45-857cde559064","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"empty":{"type":"String","value":""},"newNSG":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"94843159-895d-455b-a9f0-5bf090fdf5da","securityRules":[],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
         all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}]}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5589'
+      - '5624'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:42 GMT
+      - Tue, 15 Dec 2020 11:03:14 GMT
       expires:
       - '-1'
       pragma:
@@ -654,30 +971,30 @@ interactions:
       ParameterSetName:
       - --resource-group -n
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-11-13T05:22:19.4887606Z","duration":"PT15.2671986S","correlationId":"aac17ccc-e0c2-4f62-8db7-97fad1fb7f3d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"newNSG":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"b187f3b7-352a-4283-9811-675e2f69be7d","securityRules":[],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
-        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
-        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"af1566af-3f5b-4706-ac18-2c76f716c0c7\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002","name":"azure-cli-resource-group-deployment000002","type":"Microsoft.Resources/deployments","properties":{"templateHash":"400053918026971351","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-12-15T11:02:52.2896026Z","duration":"PT18.0688635S","correlationId":"f802ab6c-d891-47f2-ba45-857cde559064","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"empty":{"type":"String","value":""},"newNSG":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"94843159-895d-455b-a9f0-5bf090fdf5da","securityRules":[],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"b97a38cb-7182-4e8c-90db-8cc996a7ee01\"","type":"Microsoft.Network/networkSecurityGroups/defaultSecurityRules","properties":{"provisioningState":"Succeeded","description":"Deny
         all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}]}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5577'
+      - '5612'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:42 GMT
+      - Tue, 15 Dec 2020 11:03:15 GMT
       expires:
       - '-1'
       pragma:
@@ -707,8 +1024,8 @@ interactions:
       ParameterSetName:
       - --resource-group -n
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
@@ -716,133 +1033,17 @@ interactions:
   response:
     body:
       string: '{"template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"location":{"defaultValue":"[resourceGroup().location]","type":"String","metadata":{"description":"Location
-        for the network security group."}},"name":{"type":"String","metadata":{"description":"Name
-        of the network security group."}}},"variables":{},"resources":[{"type":"Microsoft.Network/networkSecurityGroups","apiVersion":"2015-06-15","name":"[parameters(''name'')]","location":"[parameters(''location'')]","dependsOn":[],"properties":{"securityRules":[]}}],"outputs":{"NewNSG":{"type":"Object","value":"[reference(parameters(''name''))]"}}}}'
+        for the \n        network security group."}},"name":{"type":"String","metadata":{"description":"\n                                string
+        username = \"UNKNOWN\";\r\n\n                    "}}},"variables":{},"resources":[{"type":"Microsoft.Network/networkSecurityGroups","apiVersion":"2015-06-15","name":"[parameters(''name'')]","location":"[parameters(''location'')]","dependsOn":[],"properties":{"securityRules":[]}}],"outputs":{"Empty":{"type":"String","value":""},"NewNSG":{"type":"Object","value":"[reference(parameters(''name''))]"}}}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '685'
+      - '787'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - deployment operation group list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group -n
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/deployments/mock-deployment/operations?api-version=2020-06-01
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002/operations/24269871294E65A5","operationId":"24269871294E65A5","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2020-11-13T05:22:18.3379468Z","duration":"PT9.9047642S","trackingId":"34562f69-1d63-41f4-a82f-2d3d3a1022c7","serviceRequestId":"8917cc22-6e6b-4f0a-b247-7a91221ee8fc","statusCode":"OK","targetResource":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"azure-cli-deploy-test-nsg1"}}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002/operations/08585963619612560590","operationId":"08585963619612560590","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2020-11-13T05:22:19.2772941Z","duration":"PT10.8441115S","trackingId":"d614c510-eb59-43f8-b44e-1b79ad5a4814","statusCode":"OK"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1513'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Nov 2020 05:22:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"},
-      \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\",
-      template:{\r\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n
-      \ \"contentVersion\": \"1.0.0.0\",\r\n  \"parameters\": {\r\n    \"location\":
-      {\r\n      \"type\": \"string\",\r\n      \"defaultValue\": \"[resourceGroup().location]\",\r\n
-      \     \"metadata\": {\r\n        \"description\": \"Location for the network
-      security group.\"\r\n      }\r\n    },\r\n    \"name\": {\r\n      \"type\":
-      \"string\",\r\n      \"metadata\": {\r\n        \"description\": \"Name of the
-      network security group.\"\r\n      }\r\n    }\r\n  },\r\n  \"variables\": {\r\n
-      \ },\r\n  \"resources\": [\r\n    {\r\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n
-      \     \"name\": \"[parameters('name')]\",\r\n      \"apiVersion\": \"2015-06-15\",\r\n
-      \     \"location\": \"[parameters('location')]\",\r\n      \"properties\": {\r\n
-      \       \"securityRules\": [\r\n        ]\r\n      },\r\n      \"dependsOn\":
-      [ ]\r\n    }\r\n  ],\r\n  \"outputs\": {\r\n    \"NewNSG\": {\r\n      /** comment1\r\n
-      \         comment2\r\n          comment3\r\n      **/\r\n      // comment\r\n
-      \     /** comment **/\r\n      \"type\": \"object\", /** comment **/\r\n      \"value\":
-      \"[reference(parameters('name'))]\" // comment\r\n      // comment\r\n      /**
-      comment **/\r\n      /** comment1\r\n          comment2\r\n          comment3\r\n
-      \     **/\r\n    }\r\n  } // comment\r\n}\r\n}}"
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - deployment group create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1368'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - --resource-group -n --template-file --parameters --no-wait
-      User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
-      accept-language:
-      - en-US
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2020-06-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000003","name":"azure-cli-resource-group-deployment000003","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-11-13T05:22:47.178064Z","duration":"PT0S","correlationId":"093cd599-6a7a-4ea5-b6f0-573bf388bf82","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1109'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 13 Nov 2020 05:22:47 GMT
+      - Tue, 15 Dec 2020 11:03:16 GMT
       expires:
       - '-1'
       pragma:
@@ -861,25 +1062,70 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"},
-      \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\",
-      template:{\r\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n
-      \ \"contentVersion\": \"1.0.0.0\",\r\n  \"parameters\": {\r\n    \"location\":
-      {\r\n      \"type\": \"string\",\r\n      \"defaultValue\": \"[resourceGroup().location]\",\r\n
-      \     \"metadata\": {\r\n        \"description\": \"Location for the network
-      security group.\"\r\n      }\r\n    },\r\n    \"name\": {\r\n      \"type\":
-      \"string\",\r\n      \"metadata\": {\r\n        \"description\": \"Name of the
-      network security group.\"\r\n      }\r\n    }\r\n  },\r\n  \"variables\": {\r\n
-      \ },\r\n  \"resources\": [\r\n    {\r\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n
-      \     \"name\": \"[parameters('name')]\",\r\n      \"apiVersion\": \"2015-06-15\",\r\n
-      \     \"location\": \"[parameters('location')]\",\r\n      \"properties\": {\r\n
-      \       \"securityRules\": [\r\n        ]\r\n      },\r\n      \"dependsOn\":
-      [ ]\r\n    }\r\n  ],\r\n  \"outputs\": {\r\n    \"NewNSG\": {\r\n      /** comment1\r\n
-      \         comment2\r\n          comment3\r\n      **/\r\n      // comment\r\n
-      \     /** comment **/\r\n      \"type\": \"object\", /** comment **/\r\n      \"value\":
-      \"[reference(parameters('name'))]\" // comment\r\n      // comment\r\n      /**
-      comment **/\r\n      /** comment1\r\n          comment2\r\n          comment3\r\n
-      \     **/\r\n    }\r\n  } // comment\r\n}\r\n}}"
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - deployment operation group list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group -n
+      User-Agent:
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/deployments/mock-deployment/operations?api-version=2020-06-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002/operations/C309AA6CB3E307E2","operationId":"C309AA6CB3E307E2","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2020-12-15T11:02:52.1179936Z","duration":"PT13.889387S","trackingId":"30f62e13-5f76-42ea-8f28-a8706986b574","serviceRequestId":"69d067be-bf5c-4828-a378-be03f0fa101e","statusCode":"OK","targetResource":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"azure-cli-deploy-test-nsg1"}}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000002/operations/08585935767312568738","operationId":"08585935767312568738","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2020-12-15T11:02:52.2687578Z","duration":"PT14.0401512S","trackingId":"a691bf69-11bf-45da-9d6d-228e98d62742","statusCode":"OK"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1513'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 11:03:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"\
+      }, \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\"\
+      , template:{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\"\
+      ,\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"location\"\
+      : {\n      \"type\": \"string\",\n      \"defaultValue\": \"[resourceGroup().location]\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Location for the network\
+      \ security group.\"\n      }\n    },\n    \"name\": {\n      \"type\": \"string\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Name of the network security\
+      \ group.\"\n      }\n    }\n  },\n  \"variables\": {\n  },\n  \"resources\"\
+      : [\n    {\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\n \
+      \     \"name\": \"[parameters('name')]\",\n      \"apiVersion\": \"2015-06-15\"\
+      ,\n      \"location\": \"[parameters('location')]\",\n      \"properties\":\
+      \ {\n        \"securityRules\": [\n        ]\n      },\n      \"dependsOn\"\
+      : [ ]\n    }\n  ],\n  \"outputs\": {\n    \"NewNSG\": {\n      /** comment1\n\
+      \          comment2\n          comment3\n      **/\n      // comment\n     \
+      \ /** comment **/\n      \"type\": \"object\", /** comment **/\n      \"value\"\
+      : \"[reference(parameters('name'))]\" // comment\n      // comment\n      /**\
+      \ comment **/\n      /** comment1\n          comment2\n          comment3\n\
+      \      **/\n    }\n  } // comment\n}\n}}"
     headers:
       Accept:
       - application/json
@@ -890,32 +1136,103 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1368'
+      - '1316'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --resource-group -n --template-file --parameters --no-wait
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000003","name":"azure-cli-resource-group-deployment000003","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-12-15T11:03:21.0834134Z","duration":"PT0S","correlationId":"2ce6cde8-1877-4f8e-890f-5d518058acf4","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"validatedResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Network/networkSecurityGroups/azure-cli-deploy-test-nsg1"}]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1110'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 11:03:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "{\"properties\": {\"parameters\": {\"location\": {\"value\": \"westus\"\
+      }, \"name\": {\"value\": \"azure-cli-deploy-test-nsg1\"}}, \"mode\": \"Incremental\"\
+      , template:{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\"\
+      ,\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"location\"\
+      : {\n      \"type\": \"string\",\n      \"defaultValue\": \"[resourceGroup().location]\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Location for the network\
+      \ security group.\"\n      }\n    },\n    \"name\": {\n      \"type\": \"string\"\
+      ,\n      \"metadata\": {\n        \"description\": \"Name of the network security\
+      \ group.\"\n      }\n    }\n  },\n  \"variables\": {\n  },\n  \"resources\"\
+      : [\n    {\n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\n \
+      \     \"name\": \"[parameters('name')]\",\n      \"apiVersion\": \"2015-06-15\"\
+      ,\n      \"location\": \"[parameters('location')]\",\n      \"properties\":\
+      \ {\n        \"securityRules\": [\n        ]\n      },\n      \"dependsOn\"\
+      : [ ]\n    }\n  ],\n  \"outputs\": {\n    \"NewNSG\": {\n      /** comment1\n\
+      \          comment2\n          comment3\n      **/\n      // comment\n     \
+      \ /** comment **/\n      \"type\": \"object\", /** comment **/\n      \"value\"\
+      : \"[reference(parameters('name'))]\" // comment\n      // comment\n      /**\
+      \ comment **/\n      /** comment1\n          comment2\n          comment3\n\
+      \      **/\n    }\n  } // comment\n}\n}}"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - deployment group create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1316'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --resource-group -n --template-file --parameters --no-wait
+      User-Agent:
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000003","name":"azure-cli-resource-group-deployment000003","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-11-13T05:22:50.369641Z","duration":"PT2.1354242S","correlationId":"8bba2e91-42b7-422c-9a6f-783d4bfc4aab","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000003","name":"azure-cli-resource-group-deployment000003","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-12-15T11:03:25.4797826Z","duration":"PT2.5727561S","correlationId":"dd56e62d-0069-424a-b4ec-b77c11294d15","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000003/operationStatuses/08585963619172434002?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000003/operationStatuses/08585935766825705883?api-version=2020-06-01
       cache-control:
       - no-cache
       content-length:
-      - '864'
+      - '865'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:51 GMT
+      - Tue, 15 Dec 2020 11:03:26 GMT
       expires:
       - '-1'
       pragma:
@@ -945,8 +1262,8 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
@@ -958,7 +1275,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Fri, 13 Nov 2020 05:22:55 GMT
+      - Tue, 15 Dec 2020 11:03:29 GMT
       expires:
       - '-1'
       pragma:
@@ -986,24 +1303,24 @@ interactions:
       ParameterSetName:
       - -n -g --custom
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000003","name":"azure-cli-resource-group-deployment000003","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Canceled","timestamp":"2020-11-13T05:22:54.1563058Z","duration":"PT5.922089S","correlationId":"8bba2e91-42b7-422c-9a6f-783d4bfc4aab","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000003","name":"azure-cli-resource-group-deployment000003","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Canceled","timestamp":"2020-12-15T11:03:28.6291414Z","duration":"PT5.7221149S","correlationId":"dd56e62d-0069-424a-b4ec-b77c11294d15","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '864'
+      - '865'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:55 GMT
+      - Tue, 15 Dec 2020 11:03:30 GMT
       expires:
       - '-1'
       pragma:
@@ -1031,24 +1348,24 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.1
+      - python/3.8.5 (Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.29) msrest/0.6.18
+        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000003","name":"azure-cli-resource-group-deployment000003","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Canceled","timestamp":"2020-11-13T05:22:54.1563058Z","duration":"PT5.922089S","correlationId":"8bba2e91-42b7-422c-9a6f-783d4bfc4aab","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_resource_group_deployment000001/providers/Microsoft.Resources/deployments/azure-cli-resource-group-deployment000003","name":"azure-cli-resource-group-deployment000003","type":"Microsoft.Resources/deployments","properties":{"templateHash":"18214098974183646216","parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"azure-cli-deploy-test-nsg1"}},"mode":"Incremental","provisioningState":"Canceled","timestamp":"2020-12-15T11:03:28.6291414Z","duration":"PT5.7221149S","correlationId":"dd56e62d-0069-424a-b4ec-b77c11294d15","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '864'
+      - '865'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 13 Nov 2020 05:22:56 GMT
+      - Tue, 15 Dec 2020 11:03:31 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/simple_deploy_multiline.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/simple_deploy_multiline.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for the 
+        network security group."
+      }
+    },
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "
+                                string username = \"UNKNOWN\";\r\n
+                    "
+      }
+    }
+  },
+  "variables": {
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[parameters('name')]",
+      "apiVersion": "2015-06-15",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+        ]
+      },
+      "dependsOn": [ ]
+    }
+  ],
+  "outputs": {
+    "Empty": {
+        "type": "string",
+        "value": ""
+    },
+    "NewNSG": {
+      /** comment1
+          comment2
+          comment3
+      **/
+      // comment
+      /** comment **/
+      "type": "object", /** comment **/
+      "value": "[reference(parameters('name'))]" // comment
+      // comment
+      /** comment **/
+      /** comment1
+          comment2
+          comment3
+      **/
+    }
+  } // comment
+}

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -1049,6 +1049,7 @@ class DeploymentTestAtResourceGroup(ScenarioTest):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         self.kwargs.update({
             'tf': os.path.join(curr_dir, 'simple_deploy.json').replace('\\', '\\\\'),
+            'tf_multiline': os.path.join(curr_dir, 'simple_deploy_multiline.json').replace('\\', '\\\\'),
             'tf_invalid': os.path.join(curr_dir, 'simple_deploy_invalid.json').replace('\\', '\\\\'),
             'extra_param_tf': os.path.join(curr_dir, 'simple_extra_param_deploy.json').replace('\\', '\\\\'),
             'params': os.path.join(curr_dir, 'simple_deploy_parameters.json').replace('\\', '\\\\'),
@@ -1066,6 +1067,10 @@ class DeploymentTestAtResourceGroup(ScenarioTest):
             self.check('properties.provisioningState', 'Succeeded')
         ])
 
+        self.cmd('deployment group validate --resource-group {rg} --template-file "{tf_multiline}" --parameters @"{params}"', checks=[
+            self.check('properties.provisioningState', 'Succeeded')
+        ])
+
         with self.assertRaises(CLIError) as err:
             self.cmd('deployment group validate --resource-group {rg} --template-file "{extra_param_tf}" --parameters @"{params}" --no-prompt true')
             self.assertTrue("Deployment template validation failed" in str(err.exception))
@@ -1079,6 +1084,10 @@ class DeploymentTestAtResourceGroup(ScenarioTest):
             self.assertTrue("Missing input parameters" in str(err.exception))
 
         self.cmd('deployment group create --resource-group {rg} -n {dn} --template-file "{tf}" --parameters @"{params}"', checks=[
+            self.check('properties.provisioningState', 'Succeeded'),
+        ])
+
+        self.cmd('deployment group create --resource-group {rg} -n {dn} --template-file "{tf_multiline}" --parameters @"{params}"', checks=[
             self.check('properties.provisioningState', 'Succeeded'),
         ])
 


### PR DESCRIPTION
**Description**  
For more complex multiline strings (such as policies for Azure API Management), `az deploy` will fail with message: ` Failed to parse ... , please check whether it is a valid JSON format`, because multiline string contains block quotes within the string.

This PR adds test case that's failing with current az and naive proposal to improve detection of such situation. I couldn't find a regexp that is solving all cases, that's why I just slightly changed existing one and added check with replacement. The regex is already quite complex and I think it's already on the bridge of being understandable.

**Testing Guide**  
Test cases are provided within PR.

**History Notes**  
[resource] Fix parsing JSON files with multi-line strings  

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
