### PR TITLE
{Packaging} Remove azure-devtools as a dependency

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -106,7 +106,6 @@ MarkupSafe==1.1.1
 mock==4.0.2
 msrest==0.6.18
 msrestazure==0.6.3
-multidict==4.5.2
 oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -11,7 +11,6 @@ azure-cli-telemetry==1.0.6
 azure-common==1.1.22
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
-azure-devtools==1.2.0
 azure-functions-devops-build==0.0.22
 azure-graphrbac==0.60.0
 azure-keyvault==1.1.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -106,7 +106,6 @@ MarkupSafe==1.1.1
 mock==4.0.2
 msrest==0.6.18
 msrestazure==0.6.3
-multidict==4.5.2
 oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -11,7 +11,6 @@ azure-cli-telemetry==1.0.6
 azure-common==1.1.22
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
-azure-devtools==1.2.0
 azure-functions-devops-build==0.0.22
 azure-graphrbac==0.60.0
 azure-keyvault==1.1.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -133,3 +133,4 @@ wcwidth==0.1.7
 websocket-client==0.56.0
 xmltodict==0.12.0
 yarl==1.6.0
+multidict==4.7.6

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -132,3 +132,4 @@ vsts-cd-manager==1.0.2
 wcwidth==0.1.7
 websocket-client==0.56.0
 xmltodict==0.12.0
+yarl==1.6.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -11,7 +11,6 @@ azure-cli-telemetry==1.0.6
 azure-common==1.1.22
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
-azure-devtools==1.2.0
 azure-functions-devops-build==0.0.22
 azure-graphrbac==0.60.0
 azure-keyvault==1.1.0
@@ -132,5 +131,3 @@ vsts-cd-manager==1.0.2
 wcwidth==0.1.7
 websocket-client==0.56.0
 xmltodict==0.12.0
-yarl==1.6.0
-multidict==4.7.6


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
MSI package building failed in CI caused by building the latest `yarl` and `multidict` packages from source. Details in below [comment](https://github.com/Azure/azure-cli/pull/15508#issuecomment-708127006).

These 2 packages are implicitly downloaded as they are in the dependency tree of `azure-devtools`. `azure-devtools` is only needed for development and testing and should be removed as a dependency in `requirements.txt` for building `azure-cli` packages. The `setup.py` for `azure-cli` does not contain `azure-devtools`.

`yarl` is used in [`storage-blob-preview`](https://github.com/Azure/azure-cli-extensions/blob/master/src/storage-blob-preview/azext_storage_blob_preview/vendored_sdks/azure_storage_blob/v2019_12_12/_shared/authentication.py#L17), but the code has [workaround](https://github.com/Azure/azure-cli-extensions/blob/master/src/storage-blob-preview/azext_storage_blob_preview/vendored_sdks/azure_storage_blob/v2019_12_12/_shared/authentication.py#L80-L87) when `yarl` is not available. So it's OK to remove it. Besides, if users install through `pip install azure-cli`, `yarl` is not installed either and we haven't received relative issues.

**Testing Guide**  
<!--Example commands with explanations.-->
Packages tested in `build_test` branch: https://dev.azure.com/azure-sdk/public/_build/results?buildId=573646&view=results

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
