### PR TITLE
[Batch] Fix #15464: Update check for pfx file without password in batch create_certificate

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/batch/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/custom.py
@@ -238,7 +238,7 @@ def create_application_package(cmd, client,
 @transfer_doc(CertificateAddParameter)
 def create_certificate(client, certificate_file, thumbprint, password=None):
     thumbprint_algorithm = 'sha1'
-    certificate_format = 'pfx' if password else 'cer'
+    certificate_format = 'pfx' if password or certificate_file.endswith('.pfx') else 'cer'
     with open(certificate_file, "rb") as f:
         data_bytes = f.read()
     data = base64.b64encode(data_bytes).decode('utf-8')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Add a check for file ending when determining certificate format of certificate uploaded to batch account. When a .pfx-certificate is uploaded without a password, the extra check is needed to not parse it as .cer-file.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
