### PR TITLE
[acr] check-health should display client external ip for firewall check

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -238,6 +238,13 @@ def _get_registry_status(login_server, registry_name, ignore_errors):
     from requests.exceptions import SSLError, RequestException
     from azure.cli.core.util import should_disable_connection_verify
 
+    # Get client's external ip, useful for firewall allowed ip list check. Note, Python doesn't have built-in support on this,
+    # so we use external endpoint as a best of effort
+    try:
+        print_pass("Your IP address: {}".format(requests.get('https://api.ipify.org').text))
+    except Exception as ex:  # pylint: disable=broad-except
+        logger.error("Failed to retrieve IP address due to ex: %s", ex)
+
     try:
         challenge = requests.get('https://' + login_server + '/v2/', verify=(not should_disable_connection_verify()))
     except SSLError:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
As title. Customers have trouble to understand why they can't connect to ACR even their ips are in the whitelist. The root cause is local ip might be different from external ip, and the external ip is the one getting checked by ACR VNET


- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
