### PR TITLE
{KeyVault} Add new profile `2020-09-01-hybrid` in function `is_azure_stack_profile`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
@@ -110,6 +110,7 @@ def get_client(cli_ctx, resource_type, client_name=''):
 
 def is_azure_stack_profile(cmd):
     return cmd.cli_ctx.cloud.profile in [
+        '2020-09-01-hybrid',
         '2019-03-01-hybrid',
         '2018-03-01-hybrid',
         '2017-03-09-profile'


### PR DESCRIPTION
This function is used for determining whether to enable HSM functionality.

```python
def is_azure_stack_profile(cmd):
    return cmd.cli_ctx.cloud.profile in [
        '2020-09-01-hybrid',
        '2019-03-01-hybrid',
        '2018-03-01-hybrid',
        '2017-03-09-profile'
    ]
```

e.g:
```python
def delete_vault_or_hsm(cmd, client, resource_group_name=None, vault_name=None, hsm_name=None, no_wait=False):
    if is_azure_stack_profile(cmd) or vault_name:
        return client.delete(resource_group_name=resource_group_name, vault_name=vault_name)

    assert hsm_name
    hsm_client = get_client_factory(ResourceType.MGMT_KEYVAULT, Clients.managed_hsms)(cmd.cli_ctx, None)
    return sdk_no_wait(
        no_wait, hsm_client.begin_delete,
        resource_group_name=resource_group_name,
        name=hsm_name
    )
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
